### PR TITLE
fixes for AbstractClassCouplingCheck

### DIFF
--- a/src/tests/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
+++ b/src/tests/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
@@ -32,9 +32,10 @@ public class ClassDataAbstractionCouplingCheckTest extends BaseCheckTestSupport
             createCheckConfig(ClassDataAbstractionCouplingCheck.class);
 
         checkConfig.addAttribute("max", "0");
+        checkConfig.addAttribute("excludedClasses", "InnerClass");
 
         String[] expected = {
-            "6:1: Class Data Abstraction Coupling is 4 (max allowed is 0) classes [AnotherInnerClass, HashMap, HashSet, InnerClass].",
+            "6:1: Class Data Abstraction Coupling is 4 (max allowed is 0) classes [AnotherInnerClass, HashMap, HashSet, int].",
             "7:5: Class Data Abstraction Coupling is 1 (max allowed is 0) classes [ArrayList].",
             "27:1: Class Data Abstraction Coupling is 2 (max allowed is 0) classes [HashMap, HashSet].",
         };

--- a/src/tests/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/tests/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -33,9 +33,7 @@ public class ClassFanOutComplexityCheckTest extends BaseCheckTestSupport
         checkConfig.addAttribute("max", "0");
 
         String[] expected = {
-            "6:1: Class Fan-Out Complexity is 7 (max allowed is 0).",
-            "7:5: Class Fan-Out Complexity is 2 (max allowed is 0).",
-            "27:1: Class Fan-Out Complexity is 4 (max allowed is 0).",
+            "6:1: Class Fan-Out Complexity is 3 (max allowed is 0).",
         };
 
         verify(checkConfig,

--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -885,7 +885,7 @@
     ...
     &lt;module name=&quot;SuppressionCommentFilter&quot;/&gt;
     ...
-&lt;/module&gt;        
+&lt;/module&gt;
       </source>
 
       <p>

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -144,6 +144,23 @@
             <td><a href="property_types.html#integer">integer</a></td>
             <td><code>7</code></td>
           </tr>
+          <tr>
+            <td>excludedClasses</td>
+            <td>User-configured class names to ignore</td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
+            <td>boolean, byte, char, double, float, int,
+                long, short, void, Boolean, Byte, Character, Double, Float,
+                Integer, Long, Short, Void,
+                Object, Class, String, StringBuffer, StringBuilder,
+                ArrayIndexOutOfBoundsException, Exception,
+                RuntimeException, IllegalArgumentException,
+                IllegalStateException, IndexOutOfBoundsException,
+                NullPointerException, Throwable, SecurityException,
+                UnsupportedOperationException,
+                List, ArrayList, Deque, Queue, LinkedList,
+                Set, HashSet, SortedSet, TreeSet,
+                Map, HashMap, SortedMap, TreeMap</td>
+          </tr>
         </table>
       </subsection>
 
@@ -201,6 +218,23 @@
             <td>the maximum threshold allowed</td>
             <td><a href="property_types.html#integer">integer</a></td>
             <td><code>20</code></td>
+          </tr>
+          <tr>
+            <td>excludedClasses</td>
+            <td>User-configured class names to ignore</td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
+            <td>boolean, byte, char, double, float, int,
+                long, short, void, Boolean, Byte, Character, Double, Float,
+                Integer, Long, Short, Void,
+                Object, Class, String, StringBuffer, StringBuilder,
+                ArrayIndexOutOfBoundsException, Exception,
+                RuntimeException, IllegalArgumentException,
+                IllegalStateException, IndexOutOfBoundsException,
+                NullPointerException, Throwable, SecurityException,
+                UnsupportedOperationException,
+                List, ArrayList, Deque, Queue, LinkedList,
+                Set, HashSet, SortedSet, TreeSet,
+                Map, HashMap, SortedMap, TreeMap</td>
           </tr>
         </table>
       </subsection>


### PR DESCRIPTION
Fix for issues #31 and #33 

Changes from the issue:
"Locale" is not added to the default set of classes to ignore, since it seems not very "core" to me. In addition to Map, List, HashMap and ArrayList collections Deque, Queue, LinkedList, Set, HashSet, SortedSet, TreeSet, SortedMap, TreeMap are added. Also StringBuilder was added since StringBuffer was already there.

For reference this is closely connected with #36 (another issue, that should be rejected IMO),  #34, #35, #37 (PRs for these issues that were rejected for bureaucratic reasons).

I feel really strange rejecting contributions from the author of the book about Maven that I used to learn. So lets push this changes if he needs them.
