### PR TITLE
Pom changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
+      <artifactId>guava-jdk5</artifactId>
       <version>14.0.1</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
In another project I needed to specify the scm connection to github to use with maven-release-plugin and copy&pasted configuration from checkstyle changing the project name, but it didn't work. I googled and this seems to be valid format.

Guava by default uses Java6. Since we are going to make another Java5 release - we should use special guava artifact (officially done by Google) supporting java5.
