### PR TITLE
added support for a separate throws indentation configuration

### DIFF
--- a/src/checkstyle/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
+++ b/src/checkstyle/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
@@ -103,6 +103,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * @author jrichard
  * @author o_sukhodolsky
+ * @author Maikel Steneker
  */
 public class IndentationCheck extends Check
 {
@@ -117,6 +118,9 @@ public class IndentationCheck extends Check
 
     /** how far brace should be indented when on next line */
     private int mBraceAdjustment;
+
+    /** how far throws should be indented when on next line */
+    private int mThrowsIndentationAmount = DEFAULT_INDENTATION;
 
     /** handlers currently in use */
     private final FastStack<ExpressionHandler> mHandlers =
@@ -188,6 +192,26 @@ public class IndentationCheck extends Check
     public int getCaseIndent()
     {
         return mCaseIndentationAmount;
+    }
+
+    /**
+     * Set the throws indentation level.
+     *
+     * @param aThrowsIndent the throws indentation level
+     */
+    public void setThrowsIndent(int aThrowsIndent)
+    {
+        mThrowsIndentationAmount = aThrowsIndent;
+    }
+
+    /**
+     * Get the throws indentation level.
+     *
+     * @return the throws indentation level
+     */
+    public int getThrowsIndent()
+    {
+        return this.mThrowsIndentationAmount;
     }
 
     /**

--- a/src/checkstyle/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
+++ b/src/checkstyle/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Handler for method definitions.
  *
  * @author jrichard
+ * @author Maikel Steneker
  */
 public class MethodDefHandler extends BlockParentHandler
 {
@@ -75,7 +76,7 @@ public class MethodDefHandler extends BlockParentHandler
 
         final int columnNo = expandedTabsColumnNo(throwsAst);
         final IndentLevel expectedColumnNo =
-            new IndentLevel(getLevel(), getBasicOffset());
+            new IndentLevel(getLevel(), getIndentCheck().getThrowsIndent());
 
         if (startsLine(throwsAst)
             && !expectedColumnNo.accept(columnNo))

--- a/src/testinputs/com/puppycrawl/tools/checkstyle/indentation/InvalidInputThrowsIndent.java
+++ b/src/testinputs/com/puppycrawl/tools/checkstyle/indentation/InvalidInputThrowsIndent.java
@@ -1,0 +1,21 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation;
+
+public class InvalidInputThrowsIndent {
+
+    public InvalidInputThrowsIndent()
+    {
+    }
+
+    // This should pass for our reconfigured throwsIndent test.
+    private void myFunc()
+            throws Exception
+    {
+    }
+
+    // This is the out of the box default configuration, but should fail
+    // for our reconfigured test.
+    private void myFunc()
+        throws Exception
+    {
+    }
+}

--- a/src/tests/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/tests/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -681,6 +681,17 @@ public class IndentationCheckTest extends BaseCheckTestSupport
     }
 
     @Test
+    public void testThrowsIndentationLevel() throws Exception
+    {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+        checkConfig.addAttribute("throwsIndent", Integer.valueOf(8).toString());
+        final String[] expected = {
+            "18: method def throws at indentation level 8 not at correct indentation, 12",
+        };
+        verify(checkConfig, getPath("indentation/InvalidInputThrowsIndent.java"), expected);
+    }
+
+    @Test
     public void testCaseLevel() throws Exception
     {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -803,6 +803,12 @@ messages.properties: Key 'ok' missing.
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>4</td>
           </tr>
+          <tr>
+            <td>throwsIndent</td>
+            <td>how far throws should be indented when on next line</td>
+            <td><a href="property_types.html#integer">Integer</a></td>
+            <td>4</td>
+          </tr>
         </table>
       </subsection>
 


### PR DESCRIPTION
Hi,

This pull request addresses issue #63 (in GitHub).  It also addresses the older sourceforge ticket: http://sourceforge.net/p/checkstyle/feature-requests/294/

It gives you the ability to define a separate indentation for "throws".  It's mostly not my code, but Maikel Steneker's (@maikelsteneker).  Maikel had forked the original checkstyle repo and added support for a separate throws indentation (and then made it available on GitHub).  I found Maikel's repo awhile back and have been using it.  It works great with Maven and Eclipse.

I just added a unit test to what Maikel had already created and set up this branch so that I could submit it as a pull request since checkstyle development is picking up again.  I think this should be an easy merge?

Thanks for looking into it.
