### PR TITLE
fix for SF-667 JavadocStyle checkHTML bad Extra HTML tag found errors

### DIFF
--- a/src/checkstyle/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/checkstyle/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -61,9 +61,9 @@ public class JavadocStyleCheck
     private static final Set<String> ALLOWED_TAGS = ImmutableSortedSet.of(
             "a", "abbr", "acronym", "address", "area", "b", "bdo", "big",
             "blockquote", "br", "caption", "cite", "code", "colgroup", "dd",
-            "del", "div", "dfn", "dl", "dt", "em", "fieldset", "h1", "h2",
-            "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd", "li",
-            "ol", "p", "pre", "q", "samp", "small", "span", "strong",
+            "del", "div", "dfn", "dl", "dt", "em", "fieldset", "font", "h1",
+            "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd",
+            "li", "ol", "p", "pre", "q", "samp", "small", "span", "strong",
             "style", "sub", "sup", "table", "tbody", "td", "tfoot", "th",
             "thead", "tr", "tt", "ul");
 

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -580,11 +580,11 @@ public boolean isSomething()
             Check for allowed HTML tags. The list of allowed HTML tags
             is "a", "abbr", "acronym", "address", "area", "b", "bdo",
             "big", "blockquote", "br", "caption", "cite", "code",
-            "colgroup", "dd", "del", "div", "dfn", "dl", "dt", "em", "fieldset",
-            "h1" to "h6", "hr", "i", "img", "ins", "kbd", "li", "ol",
-            "p", "pre", "q", "samp", "small", "span", "strong", "sub",
-            "sup", "table", "tbody", "td", "tfoot", "th", "thread",
-            "tr", "tt", "ul".
+            "colgroup", "dd", "del", "div", "dfn", "dl", "dt", "em",
+            "fieldset", "font", "h1" to "h6", "hr", "i", "img", "ins",
+            "kbd", "li", "ol", "p", "pre", "q", "samp", "small", "span",
+            "strong", "sub", "sup", "table", "tbody", "td", "tfoot", "th",
+            "thread", "tr", "tt", "ul".
           </li>
         </ul>
 


### PR DESCRIPTION
fix for SourceForge issue 667.

New tags "dd", "dt" were added.

Sorry for extra formatting but it was required to satisfy build.
