### PR TITLE
Added enum processing to TypeNameCheck

### DIFF
--- a/src/checkstyle/com/puppycrawl/tools/checkstyle/checks/naming/AbstractNameCheck.java
+++ b/src/checkstyle/com/puppycrawl/tools/checkstyle/checks/naming/AbstractNameCheck.java
@@ -33,6 +33,11 @@ public abstract class AbstractNameCheck
     extends AbstractFormatCheck
 {
     /**
+     * Message key for invalid pattern error.
+     */
+    public static final String MSG_INVALID_PATTERN = "name.invalidPattern";
+
+    /**
      * Creates a new <code>AbstractNameCheck</code> instance.
      * @param aFormat format to check with
      */
@@ -61,7 +66,7 @@ public abstract class AbstractNameCheck
             if (!getRegexp().matcher(nameAST.getText()).find()) {
                 log(nameAST.getLineNo(),
                     nameAST.getColumnNo(),
-                    "name.invalidPattern",
+                    MSG_INVALID_PATTERN,
                     nameAST.getText(),
                     getFormat());
             }

--- a/src/checkstyle/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java
+++ b/src/checkstyle/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java
@@ -49,11 +49,16 @@ public class TypeNameCheck
 {
 
     /**
+     * default pattern for type name.
+     */
+    public static final String DEFAULT_PATTERN = "^[A-Z][a-zA-Z0-9]*$";
+
+    /**
      * Creates a new <code>TypeNameCheck</code> instance.
      */
     public TypeNameCheck()
     {
-        super("^[A-Z][a-zA-Z0-9]*$");
+        super(DEFAULT_PATTERN);
     }
 
     /** {@inheritDoc} */
@@ -61,6 +66,8 @@ public class TypeNameCheck
     public int[] getDefaultTokens()
     {
         return new int[] {TokenTypes.CLASS_DEF,
-                          TokenTypes.INTERFACE_DEF, };
+                          TokenTypes.INTERFACE_DEF,
+                          TokenTypes.ENUM_DEF,
+        };
     }
 }

--- a/src/testinputs/com/puppycrawl/tools/checkstyle/naming/InputTypeName.java
+++ b/src/testinputs/com/puppycrawl/tools/checkstyle/naming/InputTypeName.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.naming;
+
+class inputHeaderClass {
+
+    public interface inputHeaderInterface {};
+
+    public enum inputHeaderEnum { one, two };
+
+}

--- a/src/tests/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheckTest.java
+++ b/src/tests/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheckTest.java
@@ -18,23 +18,42 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
+import java.io.File;
+import java.io.IOException;
+import java.text.MessageFormat;
+
+import org.junit.Test;
+
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import org.junit.Test;
 
 public class TypeNameCheckTest
     extends BaseCheckTestSupport
 {
+
+    /**
+     * Localized error message from @link {@link TypeNameCheck}.
+     */
+    private final String msg = getCheckMessage(AbstractNameCheck.MSG_INVALID_PATTERN);
+
+    private final String inputFilename;
+
+    public TypeNameCheckTest() throws IOException
+    {
+        inputFilename = getPath("naming" + File.separator
+                + "InputTypeName.java");
+    }
+
     @Test
     public void testSpecified()
         throws Exception
     {
         final DefaultConfiguration checkConfig =
-            createCheckConfig(TypeNameCheck.class);
+                createCheckConfig(TypeNameCheck.class);
         checkConfig.addAttribute("format", "^inputHe");
         final String[] expected = {
         };
-        verify(checkConfig, getPath("inputHeader.java"), expected);
+        verify(checkConfig, inputFilename, expected);
     }
 
     @Test
@@ -42,10 +61,65 @@ public class TypeNameCheckTest
         throws Exception
     {
         final DefaultConfiguration checkConfig =
-            createCheckConfig(TypeNameCheck.class);
+                createCheckConfig(TypeNameCheck.class);
         final String[] expected = {
-            "1:48: Name 'inputHeader' must match pattern '^[A-Z][a-zA-Z0-9]*$'.",
+                buildMesssage(3, 7, "inputHeaderClass",
+                        TypeNameCheck.DEFAULT_PATTERN),
+                buildMesssage(5, 22, "inputHeaderInterface",
+                        TypeNameCheck.DEFAULT_PATTERN),
+                buildMesssage(7, 17, "inputHeaderEnum",
+                        TypeNameCheck.DEFAULT_PATTERN),
         };
-        verify(checkConfig, getPath("inputHeader.java"), expected);
+        verify(checkConfig, inputFilename, expected);
     }
+
+    @Test
+    public void testClassSpecific()
+        throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(TypeNameCheck.class);
+        checkConfig.addAttribute("tokens", "CLASS_DEF");
+        final String[] expected = {
+                buildMesssage(3, 7, "inputHeaderClass",
+                        TypeNameCheck.DEFAULT_PATTERN),
+        };
+        verify(checkConfig, inputFilename, expected);
+    }
+
+    @Test
+    public void testInterfaceSpecific()
+        throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(TypeNameCheck.class);
+        checkConfig.addAttribute("tokens", "INTERFACE_DEF");
+        final String[] expected = {
+                buildMesssage(5, 22, "inputHeaderInterface",
+                        TypeNameCheck.DEFAULT_PATTERN),
+        };
+        verify(checkConfig, inputFilename, expected);
+    }
+
+    @Test
+    public void testEnumSpecific()
+        throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(TypeNameCheck.class);
+        checkConfig.addAttribute("tokens", "ENUM_DEF");
+        final String[] expected = {
+                buildMesssage(7, 17, "inputHeaderEnum",
+                        TypeNameCheck.DEFAULT_PATTERN),
+        };
+        verify(checkConfig, inputFilename, expected);
+    }
+
+    private String buildMesssage(int lineNumber, int colNumber, String name,
+            String pattern)
+    {
+        return lineNumber + ":" + colNumber + ": "
+                + MessageFormat.format(msg, name, pattern);
+    }
+
 }

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -111,7 +111,7 @@
         </tr>
         <tr>
           <td><code>TypeName</code></td>
-          <td>classes and interfaces</td>
+          <td>classes, interfaces and enums</td>
           <td><code>^[A-Z][a-zA-Z0-9]*$</code></td>
         </tr>
       </table>
@@ -142,8 +142,9 @@
         <p>
           Module <code>TypeName</code> also has property
           <code>tokens</code> which can be used to control whether the
-          check applies to classes or interfaces through tokens
-          <code>CLASS_DEF</code> and <code>INTERFACE_DEF</code>.  For
+          check applies to classes, interfaces and enums through tokens
+          <code>CLASS_DEF</code>, <code>INTERFACE_DEF</code> and
+          <code>ENUM_DEF</code>.  For
           example, the following configuration element ensures that
           interface names begin with <code>"I_"</code>, followed by
           letters and digits:


### PR DESCRIPTION
For now, there is not check for enum class name in TypeNameCheck, which is restricted to check only for classes and interfaces.
