### PR TITLE
Fixed JavaDoc wrong method reference

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -170,7 +170,7 @@ public class JavadocStyleCheck
      * @param aAST the AST of the element being documented
      * @param aComment the source lines that make up the Javadoc comment.
      *
-     * @see #checkFirstSentence(TextBlock)
+     * @see #checkFirstSentence(DetailAST, TextBlock)
      * @see #checkHtml(DetailAST, TextBlock)
      */
     private void checkComment(final DetailAST aAST, final TextBlock aComment)


### PR DESCRIPTION
`checkComment()` has JavaDoc tag `@see` referencing `checkFirstSentence()` method. However, there was no such method as `checkFirstSentence(TextBlock)`.
