### PR TITLE
Update UnusedImportsCheck to correctly detect classes in parameters and inline tags nested within block tags.

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -45,6 +45,15 @@ public class UnusedImportsCheckTest extends BaseCheckTestSupport
             "33:8: Unused import - java.util.Date.",
             "34:8: Unused import - java.util.Calendar.",
             "35:8: Unused import - java.util.BitSet.",
+            "37:8: Unused import - com.test.TestClass1.",
+            "38:8: Unused import - com.test.TestClass2.",
+            "39:8: Unused import - com.test.TestClass3.",
+            "40:8: Unused import - com.test.TestClass4.",
+            "41:8: Unused import - com.test.TestClass5.",
+            "42:8: Unused import - com.test.TestClass6.",
+            "43:8: Unused import - com.test.TestClass7.",
+            "44:8: Unused import - com.test.TestClass8.",
+            "45:8: Unused import - com.test.TestClass9.",
         };
         verify(checkConfig, getPath("imports" + File.separator
                 + "InputImport.java"), expected);
@@ -66,6 +75,7 @@ public class UnusedImportsCheckTest extends BaseCheckTestSupport
             "27:15: Unused import - java.io.File.createTempFile.",
             //"29:8: Unused import - java.awt.Component.", // Should be detected
             "32:8: Unused import - java.awt.Label.",
+            "45:8: Unused import - com.test.TestClass9.",
         };
         verify(checkConfig, getPath("imports" + File.separator
                 + "InputImport.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputImport.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputImport.java
@@ -34,6 +34,16 @@ import java.util.Date;
 import java.util.Calendar;
 import java.util.BitSet;
 
+import com.test.TestClass1;
+import com.test.TestClass2;
+import com.test.TestClass3;
+import com.test.TestClass4;
+import com.test.TestClass5;
+import com.test.TestClass6;
+import com.test.TestClass7;
+import com.test.TestClass8;
+import com.test.TestClass9;
+
 /**
  * Test case for imports
  * Here's an import used only by javadoc: {@link Date}.
@@ -87,4 +97,14 @@ class InputImport
      * @exception HeadlessException if no graphis environment can be found.
      */
     public void render() {}
+
+    /**
+     * First is a class with a method with arguments {@link TestClass1#method1(TestClass2)}.
+     * Next is a class with typed method {@link TestClass3#method2(TestClass4, TestClass5)}.
+     *
+     * @param param1  with a link {@link TestClass6}
+     * @throws TestClass7 when broken
+     * @deprecated in 1 for removal in 2. Use {@link TestClass8}
+     */
+    public void aMethodWithManyLinks() {}
 }


### PR DESCRIPTION
Hey guys,

Like the title says, I've extended UnusedImportsCheck to more correctly parse Javadoc. This should also fix https://github.com/checkstyle/checkstyle/issues/88. 

do you have a schedule for a 5.8 release?

cheers,
James
