### PR TITLE
[typo] consistently use commas in operator list

### DIFF
--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1113,7 +1113,7 @@ public void func() {}    // empty method</source>
              <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">STAR</a>,
              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">STAR_ASSIGN</a>
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">STAR_ASSIGN</a>,
              <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">TYPE_EXTENSION_AND</a>
             </td>


### PR DESCRIPTION
Follow on from 1cdaeaaa4fbf02a7388f1fcbea1c86ef0ea32fed.
