### PR TITLE
Added method to clear cache

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -248,7 +248,7 @@ public final class LocalizedMessage
                 aSourceClass, aCustomMessage);
     }
 
-    /** Clears the cache */
+    /** Clears the cache. */
     public static void clearCache()
     {
         synchronized (BUNDLE_CACHE) {


### PR DESCRIPTION
Since there is no way to clear the cache, let's make it possible for the Checkstyle API users. Cache makes it impossible to change language for error messages at runtime.
