### PR TITLE
Fixed AbstractTypeAwareCheck for generics in interfaces (issue #473)

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -110,6 +110,7 @@ public abstract class AbstractTypeAwareCheck extends Check
             TokenTypes.PACKAGE_DEF,
             TokenTypes.IMPORT,
             TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
         };
     }
@@ -136,6 +137,7 @@ public abstract class AbstractTypeAwareCheck extends Check
             processImport(aAST);
         }
         else if ((aAST.getType() == TokenTypes.CLASS_DEF)
+                 || (aAST.getType() == TokenTypes.INTERFACE_DEF)
                  || (aAST.getType() == TokenTypes.ENUM_DEF))
         {
             processClass(aAST);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RedundantThrowsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RedundantThrowsCheck.java
@@ -83,6 +83,7 @@ public class RedundantThrowsCheck extends AbstractTypeAwareCheck
             TokenTypes.PACKAGE_DEF,
             TokenTypes.IMPORT,
             TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -233,6 +233,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
     {
         return new int[] {TokenTypes.PACKAGE_DEF, TokenTypes.IMPORT,
                           TokenTypes.CLASS_DEF, TokenTypes.ENUM_DEF,
+                          TokenTypes.INTERFACE_DEF,
                           TokenTypes.METHOD_DEF, TokenTypes.CTOR_DEF,
                           TokenTypes.ANNOTATION_FIELD_DEF,
         };

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/TestGenerics.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/TestGenerics.java
@@ -45,4 +45,19 @@ public class TestGenerics <E extends java.lang.Exception,
         {
         }
     }
+
+    /**
+     * @param <T> some parameter
+     * @param <E2> some exception parameter
+     */
+    public interface InnerInterface<T, E2 extends Throwable> {
+        /**
+         * Some javadoc.
+         * @param t a parameter
+         * @throws E2 in some case.
+         * @return some string
+         */
+        public abstract String doStuff(T t) throws E2;
+    }
 }
+


### PR DESCRIPTION
AbstractTypeAwareCheck did not take generic parameters in interface definitions into account, which seems to be the cause for (sourceforge) issue #473.

It seems to me that the additional "TokenType" must be added in every subclass of AbstractTypeAwareCheck. I fixed it for the standard checks but naturally couldn't fix it for custom checks "out in the wild". Perhaps Check should somehow be refactored to make it easier for the "default tokens" to be the union of the needed tokens of all classes in the check's supertype hierarchy.
