### PR TITLE
removing ignoreDirectoryName option from PackageDeclarationCheck

### DIFF
--- a/contrib/examples/checks/all-checkstyle-checks.xml
+++ b/contrib/examples/checks/all-checkstyle-checks.xml
@@ -506,9 +506,7 @@
 
         <!-- Ensure a class has a package declaration. !-->
         <!-- See http://checkstyle.sf.net/config_coding.html !-->
-        <module name="PackageDeclaration">
-            <property name="ignoreDirectoryName" value="false"/>
-        </module>
+        <module name="PackageDeclaration"/>
 
         <!-- Disallow assignment of parameters. !-->
         <!-- See http://checkstyle.sf.net/config_coding.html !-->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java
@@ -20,9 +20,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import java.io.File;
 
 /**
  * Ensures there is a package declaration.
@@ -36,17 +34,6 @@ public final class PackageDeclarationCheck extends Check
 {
     /** is package defined. */
     private boolean mDefined;
-    /** whether to ignore the directory name matches the package. */
-    private boolean mIgnoreDirectoryName;
-
-    /**
-     * Set whether to ignore checking the directory name.
-     * @param aValue the new value.
-     */
-    public void setIgnoreDirectoryName(boolean aValue)
-    {
-        mIgnoreDirectoryName = aValue;
-    }
 
     @Override
     public int[] getDefaultTokens()
@@ -78,27 +65,5 @@ public final class PackageDeclarationCheck extends Check
     public void visitToken(DetailAST aAST)
     {
         mDefined = true;
-        if (mIgnoreDirectoryName) {
-            return;
-        }
-
-        // Calculate the directory name, but stripping off the last
-        // part.
-        final String fname = getFileContents().getFilename();
-        final int lastPos = fname.lastIndexOf(File.separatorChar);
-        final String dirname = fname.substring(0, lastPos);
-
-        // Convert the found package name into the expected directory name.
-        final DetailAST nameAST = aAST.getLastChild().getPreviousSibling();
-        final FullIdent full = FullIdent.createFullIdent(nameAST);
-        final String expected = full.getText().replace('.', File.separatorChar);
-
-        // Finally see that the real directory ends with the expected directory
-        if (!dirname.endsWith(expected)) {
-            log(full.getLineNo(),
-                full.getColumnNo(),
-                "package.dir.mismatch",
-                expected);
-        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheckTest.java
@@ -36,30 +36,4 @@ public class PackageDeclarationCheckTest extends BaseCheckTestSupport
 
         verify(checkConfig, getPath("coding" + File.separator + "InputNoPackage.java"), expected);
     }
-
-    @Test
-    public void testDefault1() throws Exception
-    {
-        DefaultConfiguration checkConfig = createCheckConfig(PackageDeclarationCheck.class);
-        final String dname = "com/puppycrawl/tools/checkstyle/checks/coding"
-            .replace('/', File.separatorChar);
-
-        String[] expected = {
-            "1:9: Package declaration does not match directory '" + dname + "'.",
-        };
-
-        verify(checkConfig, getPath("coding" + File.separator + "InputIllegalCatchCheck.java"), expected);
-    }
-
-    @Test
-    public void testQuiet() throws Exception
-    {
-        DefaultConfiguration checkConfig = createCheckConfig(PackageDeclarationCheck.class);
-        checkConfig.addAttribute("ignoreDirectoryName", "true");
-
-        String[] expected = {
-        };
-
-        verify(checkConfig, getPath("coding" + File.separator + "InputIllegalCatchCheck.java"), expected);
-    }
 }

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -1638,27 +1638,6 @@ if (&quot;something&quot;.equals(x))
         </p>
       </subsection>
 
-      <subsection name="Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-          </tr>
-          <tr>
-            <td>ignoreDirectoryName</td>
-            <td>
-              whether to ignore checking that the package declaration matches
-              the source directory name
-            </td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
-            <td><code>false</code></td>
-          </tr>
-        </table>
-      </subsection>
-
-
       <subsection name="Examples">
         <p>
           To configure the check:


### PR DESCRIPTION
This option duplicates compilation error and has no sense to be run
on successfully compiled java sources.

This change breaks backward compatibility so it is not meant for immediate merge. Actually we can either wait for several breaking changes (we already discussed some) to arrive in the pool, or we can abandon this change. The major drawback of this function is that it need non-compilable input for its operation.
