### PR TITLE
added hidden field ignore rule for builder setter methods

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
@@ -93,6 +93,10 @@ public class HiddenFieldCheckTest
             "223:13: 'hiddenStatic' hides a field.",
             "230:41: 'x' hides a field.",
             "236:30: 'xAxis' hides a field.",
+            "244:49: 'prop' hides a field.",
+            "254:40: 'prop' hides a field.",
+            "259:41: 'prop' hides a field.",
+            "264:36: 'hidden' hides a field.",
         };
         verify(checkConfig, getPath("InputHiddenField.java"), expected);
     }
@@ -131,6 +135,10 @@ public class HiddenFieldCheckTest
             "223:13: 'hiddenStatic' hides a field.",
             "230:41: 'x' hides a field.",
             "236:30: 'xAxis' hides a field.",
+            "244:49: 'prop' hides a field.",
+            "254:40: 'prop' hides a field.",
+            "259:41: 'prop' hides a field.",
+            "264:36: 'hidden' hides a field.",
         };
         verify(checkConfig, getPath("InputHiddenField.java"), expected);
     }
@@ -173,6 +181,56 @@ public class HiddenFieldCheckTest
             "217:13: 'hidden' hides a field.",
             "223:13: 'hiddenStatic' hides a field.",
             "230:41: 'x' hides a field.",
+            "244:49: 'prop' hides a field.",
+            "254:40: 'prop' hides a field.",
+            "259:41: 'prop' hides a field.",
+            "264:36: 'hidden' hides a field.",
+        };
+        verify(checkConfig, getPath("InputHiddenField.java"), expected);
+    }
+
+    /** tests ignoreBuilderSetter property */
+    @Test
+    public void testIgnoreBuilderSetter()
+        throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(HiddenFieldCheck.class);
+        checkConfig.addAttribute("ignoreBuilderSetter", "true");
+        final String[] expected = {
+            "18:13: 'hidden' hides a field.",
+            "21:33: 'hidden' hides a field.",
+            "27:13: 'hidden' hides a field.",
+            "32:18: 'hidden' hides a field.",
+            "36:33: 'hidden' hides a field.",
+            "46:17: 'innerHidden' hides a field.",
+            "49:26: 'innerHidden' hides a field.",
+            "55:17: 'innerHidden' hides a field.",
+            "56:17: 'hidden' hides a field.",
+            "61:22: 'innerHidden' hides a field.",
+            "64:22: 'hidden' hides a field.",
+            "69:17: 'innerHidden' hides a field.",
+            "70:17: 'hidden' hides a field.",
+            "76:17: 'innerHidden' hides a field.",
+            "77:17: 'hidden' hides a field.",
+            "82:13: 'hidden' hides a field.",
+            "100:29: 'prop' hides a field.",
+            "106:29: 'prop' hides a field.",
+            "112:29: 'prop' hides a field.",
+            "124:28: 'prop' hides a field.",
+            "138:13: 'hidden' hides a field.",
+            "143:13: 'hidden' hides a field.",
+            "148:13: 'hidden' hides a field.",
+            "152:13: 'hidden' hides a field.",
+            "179:23: 'y' hides a field.",
+            "200:17: 'hidden' hides a field.",
+            "210:20: 'hidden' hides a field.",
+            "217:13: 'hidden' hides a field.",
+            "223:13: 'hiddenStatic' hides a field.",
+            "230:41: 'x' hides a field.",
+            "236:30: 'xAxis' hides a field.",
+            "244:49: 'prop' hides a field.",
+            "264:36: 'hidden' hides a field.",
         };
         verify(checkConfig, getPath("InputHiddenField.java"), expected);
     }
@@ -214,6 +272,10 @@ public class HiddenFieldCheckTest
             "223:13: 'hiddenStatic' hides a field.",
             "230:41: 'x' hides a field.",
             "236:30: 'xAxis' hides a field.",
+            "244:49: 'prop' hides a field.",
+            "254:40: 'prop' hides a field.",
+            "259:41: 'prop' hides a field.",
+            "264:36: 'hidden' hides a field.",
         };
         verify(checkConfig, getPath("InputHiddenField.java"), expected);
     }
@@ -288,6 +350,10 @@ public class HiddenFieldCheckTest
             "217:13: 'hidden' hides a field.",
             "223:13: 'hiddenStatic' hides a field.",
             "236:30: 'xAxis' hides a field.",
+            "244:49: 'prop' hides a field.",
+            "254:40: 'prop' hides a field.",
+            "259:41: 'prop' hides a field.",
+            "264:36: 'hidden' hides a field.",
         };
         verify(checkConfig, getPath("InputHiddenField.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputHiddenField.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputHiddenField.java
@@ -82,7 +82,7 @@ class InputHiddenField
         int hidden = 0;//shadows field
     }       
 }
-    
+
 interface NothingHidden
 {
     public static int notHidden = 0;
@@ -235,5 +235,34 @@ class Bug3370946 {
 
     public void setxAxis(int xAxis) {
         this.xAxis = xAxis;
+    }
+}
+
+class WrongBuilderClassName {
+    private String prop;
+
+    public WrongBuilderClassName setProp(String prop) {
+        this.prop = prop;
+        return this;
+    }
+}
+
+class ValidBuilder {
+    private String prop;
+    private String hidden;
+
+    public ValidBuilder setProp(String prop) {
+        this.prop = prop;
+        return this;
+    }
+
+    public ValidBuilder withProp(String prop) {
+        this.prop = prop;
+        return this;
+    }
+
+    public String setHidden(String hidden) {
+        this.hidden = hidden;
+        return hidden;
     }
 }

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -440,6 +440,19 @@ number.equals(i + j);
           </tr>
 
           <tr>
+            <td>ignoreBuilderSetter</td>
+            <td>
+              Controls whether to ignore the parameter of a property setter
+              method for types which names end with "Builder", where the
+              property setter method for field &quot;xyz&quot; returns the
+              defining type, has name &quot;setXyz&quot; or &quot;withXyz&quot;
+              and accepts one parameter named &quot;xyz&quot;.
+            </td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>false</code></td>
+          </tr>
+
+          <tr>
             <td>ignoreAbstractMethods</td>
             <td>Controls whether to ignore parameters of abstract methods.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
@@ -493,6 +506,16 @@ number.equals(i + j);
         <source>
 &lt;module name=&quot;HiddenField&quot;&gt;
     &lt;property name=&quot;ignoreSetter&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+
+        <p>
+          To configure the check so that it ignores the parameter of builder
+          setter methods:
+        </p>
+        <source>
+&lt;module name=&quot;HiddenField&quot;&gt;
+    &lt;property name=&quot;ignoreBuilderSetter&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
       </subsection>


### PR DESCRIPTION
Currently `HiddenField` module has an option to ignore only simple setter methods returning `void`. Assume the `checkstyle.cfg` has the following:

``` xml
...
<module name="HiddenField">
    <property name="ignoreSetter" value="true"/>
</module>
...
```

Then this source file would be flagged:

``` java
class MyBuilder {
    String prop;
    public void setProp(String prop) { // this gets correctly ignored due to 'ignoreSetter'
        this.prop = prop;
    }

    public MyBuilder withProp(String prop) { // this gets flagged
        this.prop = prop;
        return this;
    }
}
```

The proposed improvement is to add another boolean property 'ignoreBuilderSetter' to `HiddenField` module which would for all types named as `.*Builder` allow to ignore setter methods named either `withX` or `setX` and returning the defining type.

See committed xdoc for details.
