### PR TITLE
Issue #49. Newline in html attribute.

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocLexer.g4
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocLexer.g4
@@ -380,6 +380,7 @@ fragment Z:('z'|'Z');
 //////////////////////////////////////////////////////////////////////////////////////
 mode htmlAttr;
 Leading_asterisk7: LEADING_ASTERISK -> type(LEADING_ASTERISK);
+NewLine8: NEWLINE -> type(NEWLINE);
 
 ATTR_VALUE  : '"' ~[<"]* '"'        {attributeCatched=true;}
             | '\'' ~[<']* '\''      {attributeCatched=true;}


### PR DESCRIPTION
Bug fix. Parser fails when html attribute has newline symbol. For example:
- <a href=
- "http://code.google.com/p/guava-libraries/wiki/NewCollectionTypesExplained#Multiset">
