### PR TITLE
fix for MultiMap empty collections garbage

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -432,9 +432,15 @@ public final class TreeWalker
         final String tokenType = TokenTypes.getTokenName(aAST.getType());
 
         if (aAstState == AstState.WITH_COMMENTS) {
+            if (!mTokenToCommentChecks.containsKey(tokenType)) {
+                return;
+            }
             visitors = mTokenToCommentChecks.get(tokenType);
         }
         else {
+            if (!mTokenToOrdinaryChecks.containsKey(tokenType)) {
+                return;
+            }
             visitors = mTokenToOrdinaryChecks.get(tokenType);
         }
 
@@ -455,9 +461,15 @@ public final class TreeWalker
         final String tokenType = TokenTypes.getTokenName(aAST.getType());
 
         if (aAstState == AstState.WITH_COMMENTS) {
+            if (!mTokenToCommentChecks.containsKey(tokenType)) {
+                return;
+            }
             visitors = mTokenToCommentChecks.get(tokenType);
         }
         else {
+            if (!mTokenToOrdinaryChecks.containsKey(tokenType)) {
+                return;
+            }
             visitors = mTokenToOrdinaryChecks.get(tokenType);
         }
 


### PR DESCRIPTION
Originally submitted as past of one big PR #136

Every MultiMap.get() for non-contained key creates new collection. After that calling iterator on this new empty collection creates another throw-away not-used object.
