### PR TITLE
removing lines array cloning to reduce GC-pressure

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -280,13 +280,12 @@ public final class FileText extends AbstractList<String>
 
     /**
      * Returns an array of all lines.
-     * {@code text.toLinesArray()} is equivalent to
-     * {@code text.toArray(new String[text.size()])}.
+     * {@code text.toLinesArray()} returns shared array.
      * @return an array of all lines of the text
      */
     public String[] toLinesArray()
     {
-        return mLines.clone();
+        return mLines;
     }
 
     /**


### PR DESCRIPTION
Originally submitted as past of one big PR #136

This change is the most controversial one, but added as a separate PR for the sake of completeness. As far as I understand the general consensus is to not apply this change no matter how big performance gain we can achieve:
1. Ivan (me) - for applying this PR/further investigation of performance benefits of this particular change
2. Every other maintainer - for rejecting this change due to lack of defending of our internal data-structures from the custom checks.
