### PR TITLE
removing unnecessary char[] copying to reduce GC-pressure

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Utils.java
@@ -121,9 +121,8 @@ public final class Utils
                                          int aTabWidth)
     {
         int len = 0;
-        final char[] chars = aString.toCharArray();
         for (int idx = 0; idx < aToIdx; idx++) {
-            if (chars[idx] == '\t') {
+            if (aString.charAt(idx) == '\t') {
                 len = (len / aTabWidth + 1) * aTabWidth;
             }
             else {


### PR DESCRIPTION
Originally submitted as part of one big PR #136

According to http://shipilev.net/talks/joker-Oct2014-string-catechism.pdf (starting on slide 74) there is no reason to make a char[] copy before waling content of the string. And removing this will reduce gc-pressure as well.
