### PR TITLE
FileContents.getLines performance fix

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
@@ -180,6 +180,16 @@ public abstract class Check extends AbstractViolationReporter
     }
 
     /**
+     * Returns the line associated with the tree.
+     * @param aIndex index of the line
+     * @return the line from the file contents
+     */
+    public final String getLine(int aIndex)
+    {
+        return getFileContents().getLine(aIndex);
+    }
+
+    /**
      * Set the file contents associated with the tree.
      * @param aContents the manager
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -249,6 +249,16 @@ public final class FileContents implements CommentListener
         return mText.toLinesArray();
     }
 
+    /**
+     * Get the line from text of the file.
+     * @param aIndex index of the line
+     * @return line from text of the file
+     */
+    public String getLine(int aIndex)
+    {
+        return mText.get(aIndex);
+    }
+
     /** @return the name of the file */
     public String getFilename()
     {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -271,7 +271,7 @@ public class AvoidEscapedUnicodeCharactersCheck
 
         if (semi != null) {
             final int lineNo = semi.getLineNo();
-            final String currentLine = getLines()[lineNo - 1];
+            final String currentLine = getLine(lineNo - 1);
 
             if (currentLine != null && sCommentRegexp.matcher(currentLine).find()) {
                 result = true;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -253,15 +253,14 @@ public class LeftCurlyCheck
     private void verifyBrace(final DetailAST aBrace,
                              final DetailAST aStartToken)
     {
-        final String braceLine = getLines()[aBrace.getLineNo() - 1];
+        final String braceLine = getLine(aBrace.getLineNo() - 1);
 
         // calculate the previous line length without trailing whitespace. Need
         // to handle the case where there is no previous line, cause the line
         // being check is the first line in the file.
         final int prevLineLen = (aBrace.getLineNo() == 1)
             ? mMaxLineLength
-            : Utils.lengthMinusTrailingWhitespace(
-                getLines()[aBrace.getLineNo() - 2]);
+            : Utils.lengthMinusTrailingWhitespace(getLine(aBrace.getLineNo() - 2));
 
         // Check for being told to ignore, or have '{}' which is a special case
         if ((braceLine.length() > (aBrace.getColumnNo() + 1))

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -612,7 +612,7 @@ public class CustomImportOrderCheck extends Check
     {
         //  [lineNo - 2] is the number of the previous line
         //  because the numbering starts from zero.
-        final String lineBefore = getLines()[aLineNo - 2];
+        final String lineBefore = getLine(aLineNo - 2);
         return lineBefore.trim().isEmpty();
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ExpressionHandler.java
@@ -218,7 +218,7 @@ public abstract class ExpressionHandler
      */
     protected final int getLineStart(DetailAST aAst)
     {
-        final String line = mIndentCheck.getLines()[aAst.getLineNo() - 1];
+        final String line = mIndentCheck.getLine(aAst.getLineNo() - 1);
         return getLineStart(line);
     }
 
@@ -277,7 +277,7 @@ public abstract class ExpressionHandler
         final int startCol = aLines.firstLineCol();
 
         final int realStartCol =
-            getLineStart(mIndentCheck.getLines()[startLine - 1]);
+            getLineStart(mIndentCheck.getLine(startLine - 1));
 
         if (realStartCol == startCol) {
             checkSingleLine(startLine, startCol, aIndentLevel,
@@ -318,7 +318,7 @@ public abstract class ExpressionHandler
      */
     private void checkSingleLine(int aLineNum, IndentLevel aIndentLevel)
     {
-        final String line = mIndentCheck.getLines()[aLineNum - 1];
+        final String line = mIndentCheck.getLine(aLineNum - 1);
         final int start = getLineStart(line);
         if (aIndentLevel.gt(start)) {
             logChildError(aLineNum, start, aIndentLevel);
@@ -337,7 +337,7 @@ public abstract class ExpressionHandler
     private void checkSingleLine(int aLineNum, int aColNum,
         IndentLevel aIndentLevel, boolean aMustMatch)
     {
-        final String line = mIndentCheck.getLines()[aLineNum - 1];
+        final String line = mIndentCheck.getLine(aLineNum - 1);
         final int start = getLineStart(line);
         // if must match is set, it is an error if the line start is not
         // at the correct indention level; otherwise, it is an only an
@@ -417,7 +417,7 @@ public abstract class ExpressionHandler
         final int firstLine = getFirstLine(Integer.MAX_VALUE, aTree);
         if (aFirstLineMatches && !aAllowNesting) {
             subtreeLines.addLineAndCol(firstLine,
-                getLineStart(mIndentCheck.getLines()[firstLine - 1]));
+                getLineStart(mIndentCheck.getLine(firstLine - 1)));
         }
         findSubtreeLines(subtreeLines, aTree, aAllowNesting);
 
@@ -462,7 +462,7 @@ public abstract class ExpressionHandler
     protected final int expandedTabsColumnNo(DetailAST aAST)
     {
         final String line =
-            mIndentCheck.getLines()[aAST.getLineNo() - 1];
+            mIndentCheck.getLine(aAST.getLineNo() - 1);
 
         return Utils.lengthExpandedTabs(line, aAST.getColumnNo(),
             mIndentCheck.getIndentationTabWidth());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -102,7 +102,7 @@ public class GenericWhitespaceCheck extends Check
      */
     private void processEnd(DetailAST aAST)
     {
-        final String line = getLines()[aAST.getLineNo() - 1];
+        final String line = getLine(aAST.getLineNo() - 1);
         final int before = aAST.getColumnNo() - 1;
         final int after = aAST.getColumnNo() + 1;
 
@@ -177,7 +177,7 @@ public class GenericWhitespaceCheck extends Check
      */
     private void processStart(DetailAST aAST)
     {
-        final String line = getLines()[aAST.getLineNo() - 1];
+        final String line = getLine(aAST.getLineNo() - 1);
         final int before = aAST.getColumnNo() - 1;
         final int after = aAST.getColumnNo() + 1;
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -104,7 +104,7 @@ public class NoWhitespaceAfterCheck extends Check
         if (targetAST.getType() == TokenTypes.TYPECAST) {
             targetAST = targetAST.findFirstToken(TokenTypes.RPAREN);
         }
-        final String line = getLines()[aAST.getLineNo() - 1];
+        final String line = getLine(aAST.getLineNo() - 1);
         final int after =
             targetAST.getColumnNo() + targetAST.getText().length();
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
@@ -88,8 +88,7 @@ public class NoWhitespaceBeforeCheck
     @Override
     public void visitToken(DetailAST aAST)
     {
-        final String[] lines = getLines();
-        final String line = lines[aAST.getLineNo() - 1];
+        final String line = getLine(aAST.getLineNo() - 1);
         final int before = aAST.getColumnNo() - 1;
 
         if ((before < 0) || Character.isWhitespace(line.charAt(before))) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
@@ -188,7 +188,7 @@ public class OperatorWrapCheck
         final String text = aAST.getText();
         final int colNo = aAST.getColumnNo();
         final int lineNo = aAST.getLineNo();
-        final String currentLine = getLines()[lineNo - 1];
+        final String currentLine = getLine(lineNo - 1);
 
         // TODO: Handle comments before and after operator
         // Check if rest of line is whitespace, and not just the operator

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java
@@ -79,7 +79,7 @@ public class WhitespaceAfterCheck
             targetAST = aAST;
             message = new Object[]{aAST.getText()};
         }
-        final String line = getLines()[targetAST.getLineNo() - 1];
+        final String line = getLine(targetAST.getLineNo() - 1);
         final int after =
             targetAST.getColumnNo() + targetAST.getText().length();
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -327,8 +327,7 @@ public class WhitespaceAroundCheck extends Check
             return;
         }
 
-        final String[] lines = getLines();
-        final String line = lines[aAST.getLineNo() - 1];
+        final String line = getLine(aAST.getLineNo() - 1);
         final int before = aAST.getColumnNo() - 1;
         final int after = aAST.getColumnNo() + aAST.getText().length();
 


### PR DESCRIPTION
Inspired by #136 and #346 part. I was testing on the spring-boot project with the following config:

```
<module name="TreeWalker">
    <module name="LeftCurly"/>
    <module name="FallThrough"/>
    <module name="CustomImportOrder"/>
    <module name="LineLength"/>
    <module name="GenericWhitespace"/>
    <module name="NoWhitespaceAfter"/>
    <module name="NoWhitespaceBefore"/>
    <module name="OperatorWrap"/>
    <module name="WhitespaceAfter"/>
    <module name="WhitespaceAround"/>
</module>
```

Using checkstyle before this fix gived me 71 MB of String[] allocations. After this fix Only 2.4 MB of String[] were allocated. Execution time (that is not stable and was not properly measured) reduced insignificantly - both executions were less than 5s.
