### PR TITLE
Issue #49. Caching DetailNode trees in AbstractJavadocCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
@@ -245,6 +245,18 @@ public final class JavadocUtils
     }
 
     /**
+     * Get content of Javadoc comment.
+     * @param aJavadocCommentBegin
+     *        Javadoc comment AST
+     * @return content of Javadoc comment.
+     */
+    public static String getJavadocCommentContent(DetailAST aJavadocCommentBegin)
+    {
+        final DetailAST commentContent = aJavadocCommentBegin.getFirstChild();
+        return commentContent.getText().substring(1);
+    }
+
+    /**
      * Returns the first child token that has a specified type.
      * @param aNode
      *        Javadoc AST node

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -1,7 +1,7 @@
-javadoc.parse.token.error=Javadoc comment parse error. Details: {0}
-javadoc.parse.rule.error=Javadoc comment parse error. Details: {0} while parsing {1}
-javadoc.missed.html.close=Javadoc comment parse error. Missed HTML close tag ''{0}''. Sometimes it means that close tag missed for one of previous tags.
-javadoc.wrong.singleton.html.tag=Javadoc comment parse error. It is forbidden to close singleton HTML tags. Tag: {0}.
+javadoc.parse.token.error=Javadoc comment at column {0} has parse error. Details: {1}
+javadoc.parse.rule.error=Javadoc comment at column {0} has parse error. Details: {1} while parsing {2}
+javadoc.missed.html.close=Javadoc comment at column {0} has parse error. Missed HTML close tag ''{1}''. Sometimes it means that close tag missed for one of previous tags.
+javadoc.wrong.singleton.html.tag=Javadoc comment at column {0} has parse error. It is forbidden to close singleton HTML tags. Tag: {1}.
 
 javadoc.classInfo=Unable to get class information for {0} tag ''{1}''.
 javadoc.expectedTag=Expected {0} tag for ''{1}''.


### PR DESCRIPTION
Added cache that stores DetailNode trees and error message (if parsing failed).
