### PR TITLE
Custom Import Order Check compilable UT inputs

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -151,8 +151,9 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport
             "11: Import statement is in the wrong order. Should be in the 'STATIC' group.",
         };
 
-        verify(checkConfig, getPath("imports" + File.separator
-                + "InputCustomImportOrderSamePackage.java"), expected);
+        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/imports/"
+                + "InputCustomImportOrderSamePackage.java").getCanonicalPath(), expected);
     }
 
     @Test
@@ -170,8 +171,9 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport
             "9: Import statement is in the wrong order. Should be in the 'SAME_PACKAGE' group.",
         };
 
-        verify(checkConfig, getPath("imports" + File.separator
-                + "InputCustomImportOrderSamePackage2.java"), expected);
+        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/imports/"
+                + "InputCustomImportOrderSamePackage2.java").getCanonicalPath(), expected);
     }
 
     @Test
@@ -194,8 +196,9 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport
             "11: Import statement is in the wrong order. Should be in the 'STATIC' group.",
         };
 
-        verify(checkConfig, getPath("imports" + File.separator
-                + "InputCustomImportOrderSamePackage.java"), expected);
+        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/imports/"
+                + "InputCustomImportOrderSamePackage.java").getCanonicalPath(), expected);
     }
 
     @Test

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackage.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackage.java
@@ -12,5 +12,5 @@ import static java.io.File.createTempFile;
 import com.*;
 import org.apache.*;
 
-public class InputImportOrder {
+public class InputCustomImportOrderSamePackage {
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackage2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackage2.java
@@ -8,5 +8,5 @@ import java.util.*;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.*;
 
-public class InputImportOrder {
+public class InputCustomImportOrderSamePackage2 {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder.java
@@ -20,5 +20,5 @@ import com.puppycrawl.tools.*;
 import com.google.common.*;
 import org.apache.*;
 
-public class InputImportOrder {
+public class InputCustomImportOrder {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder2.java
@@ -16,5 +16,5 @@ import com.*;
 import com.google.common.*;
 import org.apache.*;
 
-public class InputImportOrder {
+public class InputCustomImportOrder2 {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder3.java
@@ -16,5 +16,5 @@ import com.*;
 import com.google.common.*;
 import org.apache.*;
 
-public class InputImportOrder {
+public class InputCustomImportOrder3 {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderNoValid.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderNoValid.java
@@ -1,8 +1,8 @@
-package com.google.common.cache;
+package com.puppycrawl.tools.checkstyle.imports;
 
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 
-public class InputImportOrder {
+public class InputCustomImportOrderNoValid {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderTemp.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderTemp.java
@@ -1,4 +1,4 @@
-package com.google.common.base;
+package com.puppycrawl.tools.checkstyle.imports;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -14,5 +14,5 @@ import java.net.URLClassLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class InputImportOrder {
+public class InputCustomImportOrderTemp {
 }


### PR DESCRIPTION
2 inputs were moved to resources-noncompilable folder because they reproduce compilable cases, but only in case if some lib file or smth else is importing from package where class is located. So it was done to not lose test cases.
