### PR TITLE
Fixed false-positive in GenericWhitespaceCheck issue #51

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -161,10 +161,7 @@ public class GenericWhitespaceCheck extends Check
                         log(aAST.getLineNo(), after, "ws.followed", ">");
                     }
                 }
-                else if ((line.charAt(after) != '>')
-                         && (line.charAt(after) != ',')
-                         && (line.charAt(after) != '['))
-                {
+                else if (line.charAt(after) == ' ') {
                     log(aAST.getLineNo(), after, "ws.followed", ">");
                 }
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -83,4 +83,14 @@ public class GenericWhitespaceCheckTest
         final String[] expected = {};
         verify(mCheckConfig, getPath("whitespace/Gh47.java"), expected);
     }
+
+    @Test
+    public void testInnerClass() throws Exception
+    {
+        final String[] expected = {
+
+        };
+        verify(mCheckConfig, getPath("whitespace/"
+                + "InputGenericWhitespaceInnerClassCheck.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/whitespace/InputGenericWhitespaceInnerClassCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/whitespace/InputGenericWhitespaceInnerClassCheck.java
@@ -1,0 +1,11 @@
+package com.puppycrawl.tools.checkstyle.whitespace;
+
+import java.util.List;
+
+public class InputGenericWhitespaceInnerClassCheck<T>
+{
+    private List<InputGenericWhitespaceInnerClassCheck<? extends T>.InnerClass> field;
+
+    public class InnerClass {
+    }
+}


### PR DESCRIPTION
According to #51:
1.  The value of the field InputGenericWhitespaceInnerClassCheck.field is not 
   used is optional compiler violation, turned off in test-resources folder.
2.   '>' is followed by white space. Does not appear anymore.
