### PR TITLE
Suppress Warnings Check, fixed bug - annotation param in constant, creat...

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -156,23 +156,28 @@ public class SuppressWarningsCheck extends AbstractFormatCheck
         while (warning != null) {
             if (warning.getType() == TokenTypes.EXPR) {
                 final DetailAST fChild = warning.getFirstChild();
-
+                switch (fChild.getType()) {
                 //typical case
-                if (fChild.getType() == TokenTypes.STRING_LITERAL) {
+                case TokenTypes.STRING_LITERAL:
                     final String warningText =
                         this.removeQuotes(warning.getFirstChild().getText());
                     this.logMatch(warning.getLineNo(),
                         warning.getColumnNo(), warningText);
-
-     //conditional case
-     //ex: @SuppressWarnings((false) ? (true) ? "unchecked" : "foo" : "unused")
-                }
-                else if (fChild.getType() == TokenTypes.QUESTION) {
+                    break;
+                //conditional case
+                //ex: @SuppressWarnings((false) ? (true) ? "unchecked" : "foo" : "unused")
+                case TokenTypes.QUESTION:
                     this.walkConditional(fChild);
-                }
-                else {
-                    assert false : "Should never get here, type: "
-                        + fChild.getType() + " text: " + fChild.getText();
+                    break;
+                //param in constant case
+                //ex: public static final String UNCHECKED = "unchecked";
+                //@SuppressWarnings(UNCHECKED) or @SuppressWarnings(SomeClass.UNCHECKED)
+                case TokenTypes.IDENT:
+                case TokenTypes.DOT:
+                    break;
+                default:
+                    throw new IllegalStateException("Should never get here, type: "
+                        + fChild.getType() + " text: " + fChild.getText());
                 }
             }
             warning = warning.getNextSibling();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsTest.java
@@ -822,4 +822,17 @@ public class SuppressWarningsTest extends BaseCheckTestSupport
 
         verify(checkConfig, getPath("annotation" + File.separator + "SuppressWarningsExpanded.java"), expected);
     }
+
+    @Test
+    public void testUncheckedInConstant() throws Exception
+    {
+        DefaultConfiguration checkConfig = createCheckConfig(SuppressWarningsCheck.class);
+
+        String[] expected = {
+
+        };
+
+        verify(checkConfig, getPath("annotation" + File.separator
+                + "SuppressWarningsConstants.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/annotation/SuppressWarningsConstants.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/annotation/SuppressWarningsConstants.java
@@ -1,0 +1,16 @@
+package com.puppycrawl.tools.checkstyle.annotation;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class SuppressWarningsConstants
+{
+    public static final String UNCHECKED = "unchecked";
+
+    public static void test() {
+        @SuppressWarnings(UNCHECKED)
+        final List<String> dummyOne = (List<String>) new ArrayList();
+        @SuppressWarnings(SuppressWarningsConstants.UNCHECKED)
+        final List<String> dummyTwo = (List<String>) new ArrayList();
+    }
+}


### PR DESCRIPTION
...ed UT and input for this case, issue#268

According to #268 

Before this fix Check used to work good in Checkstyle-plugin (eclipse), there were no errors or even warnings  on test-input file, after adding UT using this input, tests ran without failures in eclipse too, but there was a failure during maven-test. 

The problem was in lack of possible cases in loop's conditions.

Now:

> java -jar checkstyle-6.2-SNAPSHOT-all.jar -c checkstyle.xml src/Test.java 
> Starting audit...
> Audit done.
