### PR TITLE
Generic Whitespace Check, fixed bug - '>' is followed by an illegal char...

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -136,7 +136,7 @@ public class GenericWhitespaceCheck extends Check
                 else if (!Character.isWhitespace(charAfter)
                     && ('(' != charAfter) && (')' != charAfter)
                     && (',' != charAfter) && ('[' != charAfter)
-                    && ('.' != charAfter))
+                    && ('.' != charAfter) && (':' != charAfter))
                 {
                     log(aAST.getLineNo(), after, "ws.illegalFollow", ">");
                 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -21,7 +21,10 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 import com.google.common.collect.Maps;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+
+import java.io.File;
 import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -92,5 +95,14 @@ public class GenericWhitespaceCheckTest
         };
         verify(mCheckConfig, getPath("whitespace/"
                 + "InputGenericWhitespaceInnerClassCheck.java"), expected);
+    }
+
+    @Test
+    public void testMethodReferences() throws Exception
+    {
+        final String[] expected = {};
+        verify(mCheckConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/grammars/java8/"
+                + "InputMethodReferencesTest3.java").getCanonicalPath(), expected);
     }
 }


### PR DESCRIPTION
...acter while referencing methods issue #350 

According to #350 

Check wasn't able to process cases involved in Java8 (in context of Check - method references '::')
Added UT for this case. Now Check does not put violation if '>' follows by ':' (it reacts on next character after  generic-end '>'), as found no way of usage generic type (not the object of this type) in ternary operator I don't expect following false-negatives.

---

This fix changes the same files as #488, so there will be need of merge.
