### PR TITLE
Final Local Variable Check, fixed false-positive - native method's param...

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -103,7 +103,7 @@ public class FinalLocalVariableCheck extends Check
 
         case TokenTypes.PARAMETER_DEF:
             if (ScopeUtils.inInterfaceBlock(aAST)
-                || inAbstractMethod(aAST))
+                || inAbstractOrNativeMethod(aAST))
             {
                 break;
             }
@@ -147,18 +147,19 @@ public class FinalLocalVariableCheck extends Check
     }
 
     /**
-     * Determines whether an AST is a descentant of an abstract method.
+     * Determines whether an AST is a descendant of an abstract or native method.
      * @param aAST the AST to check.
-     * @return true if aAST is a descentant of an abstract method.
+     * @return true if aAST is a descendant of an abstract or native method.
      */
-    private boolean inAbstractMethod(DetailAST aAST)
+    private static boolean inAbstractOrNativeMethod(DetailAST aAST)
     {
         DetailAST parent = aAST.getParent();
         while (parent != null) {
             if (parent.getType() == TokenTypes.METHOD_DEF) {
                 final DetailAST modifiers =
                     parent.findFirstToken(TokenTypes.MODIFIERS);
-                return modifiers.branchContains(TokenTypes.ABSTRACT);
+                return modifiers.branchContains(TokenTypes.ABSTRACT)
+                        || modifiers.branchContains(TokenTypes.LITERAL_NATIVE);
             }
             parent = parent.getParent();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -69,4 +69,17 @@ public class FinalLocalVariableCheckTest
         };
         verify(checkConfig, getPath("coding/InputFinalLocalVariable.java"), expected);
     }
+
+    @Test
+    public void testNativeMethods() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(FinalLocalVariableCheck.class);
+        checkConfig.addAttribute("tokens", "PARAMETER_DEF");
+
+        final String[] expected = {
+
+        };
+        verify(checkConfig, getPath("coding/InputFinalLocalVariableNativeMethods.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputFinalLocalVariableNativeMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputFinalLocalVariableNativeMethods.java
@@ -1,0 +1,23 @@
+package com.puppycrawl.tools.checkstyle.coding;
+
+public class InputFinalLocalVariableNativeMethods
+{
+    public native String nativeFoo(int a, int b);    
+    private native double average(int n1, int n2);
+
+     static {
+         System.loadLibrary("foo");
+     }        
+
+     public void print () {
+         String str = nativeFoo(1, 4);
+         System.out.println(str);
+     }
+
+     public static void main(final String[] args) {
+         (new InputFinalLocalVariableNativeMethods()).print();
+         System.out.println("In Java, the average is " +
+             new InputFinalLocalVariableNativeMethods().average(3, 2));
+         return;
+     }
+}


### PR DESCRIPTION
... should be declared final, issue #158

According to #158 

Fixed false-positive "Variable should be declared final" if it is param of native method (this case is similar to abstract methods in context of this Check)
1. Added UT and corresponding input for this case.
2. Extended method inAbstractMethod( ... ) to inAbstractOrNativeMethod( ... ) to let it catch these cases.
3. Added static modifier to inAbstractOrNativeMethod( ... ) to get rid of single warning in Check's class.
