### PR TITLE
No Whitespace After Check - added support of array declarations, issue #...

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -28,7 +28,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Checks that there is no whitespace after a token.
  * More specifically, it checks that it is not followed by whitespace,
  * or (if linebreaks are allowed) all characters on the line after are
- * whitespace. To forbid linebreaks afer a token, set property
+ * whitespace. To forbid linebreaks after a token, set property
  * allowLineBreaks to false.
  * </p>
   * <p> By default the check will check the following operators:
@@ -39,6 +39,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *  {@link TokenTypes#INC INC},
  *  {@link TokenTypes#LNOT LNOT},
  *  {@link TokenTypes#UNARY_MINUS UNARY_MINUS},
+ *  {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR},
  *  {@link TokenTypes#UNARY_PLUS UNARY_PLUS}. It also supports the operator
  *  {@link TokenTypes#TYPECAST TYPECAST}.
  * </p>
@@ -78,6 +79,7 @@ public class NoWhitespaceAfterCheck extends Check
             TokenTypes.BNOT,
             TokenTypes.LNOT,
             TokenTypes.DOT,
+            TokenTypes.ARRAY_DECLARATOR,
         };
     }
 
@@ -94,6 +96,7 @@ public class NoWhitespaceAfterCheck extends Check
             TokenTypes.LNOT,
             TokenTypes.DOT,
             TokenTypes.TYPECAST,
+            TokenTypes.ARRAY_DECLARATOR,
         };
     }
 
@@ -104,9 +107,30 @@ public class NoWhitespaceAfterCheck extends Check
         if (targetAST.getType() == TokenTypes.TYPECAST) {
             targetAST = targetAST.findFirstToken(TokenTypes.RPAREN);
         }
+        else {
+            if (targetAST.getType() == TokenTypes.ARRAY_DECLARATOR) {
+                final DetailAST arrayType = targetAST.getFirstChild();
+                if (!isCstyleArrayDeclaration(targetAST)) {
+                    targetAST = arrayType;
+                }
+                else {
+                    targetAST = targetAST.getParent().getNextSibling();
+                }
+            }
+        }
         final String line = getLine(aAST.getLineNo() - 1);
-        final int after =
-            targetAST.getColumnNo() + targetAST.getText().length();
+        int after = 0;
+        //If target of possible redundant whitespace is in method definition
+        if (targetAST.getType() == TokenTypes.IDENT
+                && targetAST.getNextSibling().getType() == TokenTypes.LPAREN)
+        {
+            final DetailAST methodDef = targetAST.getParent();
+            final DetailAST endOfParams = methodDef.findFirstToken(TokenTypes.RPAREN);
+            after = endOfParams.getColumnNo() + 1;
+        }
+        else {
+            after = targetAST.getColumnNo() + targetAST.getText().length();
+        }
 
         if ((after >= line.length())
             || Character.isWhitespace(line.charAt(after)))
@@ -132,5 +156,28 @@ public class NoWhitespaceAfterCheck extends Check
     public void setAllowLineBreaks(boolean aAllowLineBreaks)
     {
         mAllowLineBreaks = aAllowLineBreaks;
+    }
+
+    /**
+     * Checks if current array is declared in C style, e.g.:
+     * <p>
+     * <code>
+     * int array[] = { ... }; //C style
+     * </code>
+     * </p>
+     * <p>
+     * <code>
+     * int[] array = { ... }; //Java style
+     * </code>
+     * </p>
+     * @param aArrayDeclaration Array Declaration node
+     * @return true if array is declared in C style
+     */
+    private static boolean isCstyleArrayDeclaration(DetailAST aArrayDeclaration)
+    {
+        final DetailAST identifier = aArrayDeclaration.getParent().getNextSibling();
+        final int arrayDeclarationStart = aArrayDeclaration.getColumnNo();
+        final int identifierEnd = identifier.getColumnNo() + identifier.getText().length();
+        return arrayDeclarationStart == identifierEnd || arrayDeclarationStart > identifierEnd;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
@@ -78,4 +78,21 @@ public class NoWhitespaceAfterCheckTest
         verify(checkConfig, getPath("InputWhitespace.java"), expected);
     }
 
+    @Test
+    public void testArrayDeclarations() throws Exception
+    {
+        checkConfig.addAttribute("tokens", "ARRAY_DECLARATOR");
+        final String[] expected = {
+            "6:11: 'Object' is followed by whitespace.",
+            "8:22: 'someStuff3' is followed by whitespace.",
+            "9:8: 'int' is followed by whitespace.",
+            "10:13: 's' is followed by whitespace.",
+            "11:13: 'd' is followed by whitespace.",
+            "16:14: 'get' is followed by whitespace.",
+            "18:8: 'int' is followed by whitespace.",
+            "19:34: 'get1' is followed by whitespace.",
+        };
+        verify(checkConfig, getPath("whitespace/InputNoWhitespaceAfterArrayDeclarations.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/whitespace/InputNoWhitespaceAfterArrayDeclarations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/whitespace/InputNoWhitespaceAfterArrayDeclarations.java
@@ -1,0 +1,22 @@
+package com.puppycrawl.tools.checkstyle.whitespace;
+
+public class InputNoWhitespaceAfterArrayDeclarations
+{
+    Object[] someStuff = {}; //Correct
+    Object [] someStuff1 = {}; //Incorrect
+    Object someStuff2[] = {}; //Correct
+    Object someStuff3 [] = {}; //Incorrect
+    int [] a = {}; //Incorrect
+    String s [] = {}; //Incorrect
+    double d [] = {}; //Incorrect
+    char[] c = {}; //Correct
+    short sh[] = {}; //Correct
+    long[] l = {}; //Correct
+    byte b[] = {}; //Correct
+    int get() [] { //Incorrect
+        return a;}
+    int [] receive() { return a; } //Incorrect
+    int get1(int k, int c, int b) [] { //Incorrect
+        return null;
+    }
+}

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -359,6 +359,8 @@ for (Iterator foo = very.long.line.iterator();
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">UNARY_MINUS</a>,
               <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR">ARRAY_DECLARATOR</a>,
+              <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">UNARY_PLUS</a>,
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">TYPECAST</a>


### PR DESCRIPTION
...68

According to #68 

Added support of array declarations. 
Added UT for such cases and corresponding input.
Updated JavaDoc.

As arrays can be declared in both, Java and C style, e.g.:
1. int[] array = { ... }; //Java style
2. int array[] = { ... }; //C style

And both these cases are represented identically in AST, there was a need to make a method checking style of declaration.

Furthermore, return type of methods can be declared in both styles too, e.g.:
1. int[] get(params_list) { return null;} //Java style
2. int get(params_list)[] { return null;} //C style

And in second case Check has to put violation after the end of params list.

All these cases are covered by UT.
