### PR TITLE
MutableException check requires class to explicitly extend some other class (#60)

### DIFF
--- a/contrib/examples/checks/all-checkstyle-checks.xml
+++ b/contrib/examples/checks/all-checkstyle-checks.xml
@@ -281,7 +281,8 @@
             <property name="allowMarkerInterfaces" value="true"/>
         </module>
 
-        <!-- Ensures that exceptions (defined as any class name conforming to some regular expression) are immutable. !-->
+        <!-- Ensures that exceptions (classes with names conforming to some regular expression !-->
+        <!-- and explicitly extending some other classes) are immutable. !-->
         <!-- That is, have only final fields. !-->
         <!-- See http://checkstyle.sf.net/config_design.html !-->
         <module name="MutableException">

--- a/contrib/examples/conf/template_config.xml
+++ b/contrib/examples/conf/template_config.xml
@@ -637,8 +637,8 @@
         </module>
         
         <!-- See http://checkstyle.sf.net/config_design.html -->
-        <!-- Ensures that exceptions (defined as any class name conforming 
-            to some regular expression) are immutable. That is, have only final fields. -->
+        <!-- Ensures that exceptions (classes with names conforming to some regular
+            expression and explicitly extending some other classes) are immutable. !-->
             <!-- <property name="format" value="^.*Exception$|^.*Error$"/> -->
         <module name="MutableException">
         </module>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
@@ -24,9 +24,9 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.AbstractFormatCheck;
 
 /**
- * <p> Ensures that exceptions (defined as any class name conforming
- * to some regular expression) are immutable. That is, have only final
- * fields.</p>
+ * <p> Ensures that exceptions (classes with names conforming to some
+ * regular expression and explicitly extending some other classes)
+ * are immutable. That is, have only final fields.</p>
  * <p> Rationale: Exception instances should represent an error
  * condition. Having non final fields not only allows the state to be
  * modified by accident and therefore mask the original condition but
@@ -97,8 +97,7 @@ public final class MutableExceptionCheck extends AbstractFormatCheck
     private void visitClassDef(DetailAST aAST)
     {
         mCheckingStack.push(mChecking ? Boolean.TRUE : Boolean.FALSE);
-        mChecking =
-            isExceptionClass(aAST.findFirstToken(TokenTypes.IDENT).getText());
+        mChecking = isExceptionClass(aAST);
     }
 
     /** Called when we leave class definition. */
@@ -125,11 +124,13 @@ public final class MutableExceptionCheck extends AbstractFormatCheck
     }
 
     /**
-     * @param aClassName class name to check
+     * @param aAST class definition node
      * @return true if a given class name confirms specified format
      */
-    private boolean isExceptionClass(String aClassName)
-    {
-        return getRegexp().matcher(aClassName).find();
+    private boolean isExceptionClass(DetailAST aAST) {
+        String className = aAST.findFirstToken(TokenTypes.IDENT).getText();
+        boolean isClassNamedAsException = getRegexp().matcher(className).find();
+        boolean isExtendsPresent = aAST.findFirstToken(TokenTypes.EXTENDS_CLAUSE) != null;
+        return isClassNamedAsException && isExtendsPresent;
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/design/InputMutableException.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/design/InputMutableException.java
@@ -1,7 +1,7 @@
 package com.puppycrawl.tools.checkstyle.design;
 
 public class InputMutableException {
-    public class FooException {
+    public class FooException extends Exception {
         private final int _finalErrorCode;
         private int _errorCode = 1;
 
@@ -9,7 +9,7 @@ public class InputMutableException {
             _finalErrorCode = 1;
         }
 
-        public class FooExceptionThisIsNot {
+        public class FooExceptionThisIsNot extends RuntimeException {
             private final int _finalErrorCode;
             private int _errorCode = 1;
             /** constructor */
@@ -19,7 +19,11 @@ public class InputMutableException {
         }
     }
 
-    public class FooError {
+    public class FooError extends Error {
+        private int _errorCode;
+    }
+
+    public class BarDoesNotExtendError {
         private int _errorCode;
     }
 }

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -314,8 +314,8 @@ public class StringUtils // not final to allow subclassing
       <subsection name="Description">
         <p>
           Ensures that exception classes (classes with names conforming to
-          some regular expression) are immutable, that is, that they have only final
-          fields.
+          some regular expression and explicitly extending some other classes)
+          are immutable, that is, that they have only final fields.
         </p>
 
         <p>


### PR DESCRIPTION
My attempt to fix #60.

In order to be exception/error in Java, a class must inherit from Throwable. As in Checkstyle we don't have an access to types, at least we can check that a class extends anything.

What do you think? I'm not sure if we should introduce pattern for class being extended. E.g. java.lang.ThreadDeath is an error, but doesn't have Error in name.
