### PR TITLE
Illegal Type Check, fixed false positives on same file names, issue #78

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -93,4 +93,51 @@ public class IllegalTypeCheckTest extends BaseCheckTestSupport
 
         verify(mCheckConfig, getPath("coding" + File.separator + "InputIllegalType.java"), expected);
     }
+
+    @Test
+    public void testSameFileNameFalsePositive() throws Exception
+    {
+        mCheckConfig.addAttribute("illegalClassNames", "java.util.GregorianCalendar, SubCalendar, "
+                + "java.util.List");
+
+        String[] expected = {
+            "12:5: Declaring variables, return values or parameters of type 'SubCalendar' is not allowed.",
+        };
+
+        verify(mCheckConfig, getPath("coding" + File.separator
+                + "InputIllegalTypeSameFileName.java"), expected);
+    }
+
+    @Test
+    public void testSameFileNameGeneral() throws Exception
+    {
+        mCheckConfig.addAttribute("illegalClassNames", "List, GregorianCalendar, java.io.File,"
+                + "java.util.*");
+        String[] expected = {
+            "4:1: Declaring variables, return values or parameters of type 'java.util.*' is not allowed.",
+            "10:5: Declaring variables, return values or parameters of type 'GregorianCalendar' is not allowed.",
+            "16:23: Declaring variables, return values or parameters of type 'GregorianCalendar' is not allowed.",
+            "24:9: Declaring variables, return values or parameters of type 'List' is not allowed.",
+            "25:9: Declaring variables, return values or parameters of type 'java.io.File' is not allowed.",
+        };
+        verify(mCheckConfig, getPath("coding" + File.separator
+                + "InputIllegalTypeSameFileName.java"), expected);
+    }
+
+    @Test
+    public void testStarImports() throws Exception
+    {
+        mCheckConfig.addAttribute("illegalClassNames", "java.util.*, java.*,"
+                + "org.abego.treelayout.*, List");
+
+        String[] expected = {
+            "3:1: Declaring variables, return values or parameters of type 'java.*' is not allowed.",
+            "4:1: Declaring variables, return values or parameters of type 'java.util.*' is not allowed.",
+            "5:1: Declaring variables, return values or parameters of type 'org.abego.treelayout.*' is not allowed.",
+            "10:5: Declaring variables, return values or parameters of type 'List' is not allowed.",
+        };
+
+        verify(mCheckConfig, getPath("coding" + File.separator
+                + "InputIllegalTypeStarImports.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/coding/GregorianCalendar.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/coding/GregorianCalendar.java
@@ -1,0 +1,8 @@
+package com.puppycrawl.tools.checkstyle.coding;
+
+public class GregorianCalendar
+{
+    class SubCalendar {
+        
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputIllegalTypeSameFileName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputIllegalTypeSameFileName.java
@@ -1,0 +1,27 @@
+package com.puppycrawl.tools.checkstyle.coding;
+
+import java.awt.List;
+import java.util.*;
+import com.puppycrawl.tools.checkstyle.coding.GregorianCalendar; 
+import com.puppycrawl.tools.checkstyle.coding.GregorianCalendar.SubCalendar;
+
+public class InputIllegalTypeSameFileName
+{
+    GregorianCalendar cal = AnObject.getInstance();
+    java.util.Date date = null;
+    SubCalendar subCalendar = null;
+    
+    private static class AnObject extends GregorianCalendar {
+
+        public static GregorianCalendar getInstance()
+        {
+            return null;
+        }
+        
+    }
+    
+    private void foo() {
+        List l;
+        java.io.File file = null;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputIllegalTypeStarImports.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputIllegalTypeStarImports.java
@@ -1,0 +1,11 @@
+package com.puppycrawl.tools.checkstyle.coding;
+
+import java.*;
+import java.util.*;
+import org.abego.treelayout.*;
+import com.*;
+
+public class InputIllegalTypeStarImports
+{
+    List<Integer> l = new LinkedList<>();
+}


### PR DESCRIPTION
According to #78 

Fixed false positives on same name files in classpath, e.g.:

We force Check to warn on java.util.List variables, methods, etc. 
The problem was if we have something like:
import java.awt.List;
....
List list; //There was a false-positive
