### PR TITLE
Summary Javadoc Check, added 'specify period' option, issue #472

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -43,9 +43,18 @@ import com.puppycrawl.tools.checkstyle.api.Utils;
  *     value=&quot;^This method returns.*&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>
+ * To specify period symbol at the end of first javadoc sentence - use following config:
+ * <pre>
+ * &lt;module name=&quot;SummaryJavadocCheck&quot;&gt;
+ *     &lt;property name=&quot;period&quot;
+ *     value=&quot;period&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * </p>
  *
  * @author max
- *
+ * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
  */
 public class SummaryJavadocCheck extends AbstractJavadocCheck
 {
@@ -56,12 +65,26 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck
     private Pattern mForbiddenSummaryFragments = Utils.createPattern("^$");
 
     /**
+     * Period symbol at the end of first javadoc sentence.
+     */
+    private String mPeriod = ".";
+
+    /**
      * Sets custom value of regular expression for forbidden summary fragments.
      * @param aPattern user's value.
      */
     public void setForbiddenSummaryFragments(String aPattern)
     {
         mForbiddenSummaryFragments = Utils.createPattern(aPattern);
+    }
+
+    /**
+     * Sets value of period symbol at the end of first javadoc sentence.
+     * @param aPeriod period's value.
+     */
+    public void setPeriod(String aPeriod)
+    {
+        mPeriod = aPeriod;
     }
 
     @Override
@@ -76,7 +99,7 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck
     public void visitJavadocToken(DetailNode aAst)
     {
         String firstSentence = getFirstSentence(aAst);
-        final int endOfSentence = firstSentence.lastIndexOf(".");
+        final int endOfSentence = firstSentence.lastIndexOf(mPeriod);
         if (endOfSentence == -1) {
             log(aAst.getLineNumber(), "summary.first.sentence");
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -60,4 +60,26 @@ public class SummaryJavadocCheckTest extends BaseCheckTestSupport
         };
         verify(mCheckConfig, getPath("javadoc/InputIncorrectSummaryJavaDocCheck.java"), expected);
     }
+
+    @Test
+    public void testPeriod() throws Exception
+    {
+        mCheckConfig.addAttribute("period", "_");
+        final String[] expected = {
+            "5: First sentence should be present.",
+            "10: First sentence should be present.",
+        };
+
+        verify(mCheckConfig, getPath("javadoc/InputSummaryJavadocCheckPeriod.java"), expected);
+    }
+
+    @Test
+    public void testNoPeriod() throws Exception
+    {
+        mCheckConfig.addAttribute("period", "");
+        final String[] expected = {
+        };
+
+        verify(mCheckConfig, getPath("javadoc/InputSummaryJavadocCheckNoPeriod.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputSummaryJavadocCheckNoPeriod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputSummaryJavadocCheckNoPeriod.java
@@ -1,0 +1,17 @@
+package com.puppycrawl.tools.checkstyle.javadoc;
+
+public class InputSummaryJavadocCheckNoPeriod
+{
+    /**
+     * As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}
+     */
+    void foo3() {}
+    
+    /**
+     * Blabla
+     */
+    void foo4() throws Exception {}
+    
+    /** An especially short bit of Javadoc */
+    void foo5() {}
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputSummaryJavadocCheckPeriod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputSummaryJavadocCheckPeriod.java
@@ -1,0 +1,22 @@
+package com.puppycrawl.tools.checkstyle.javadoc;
+
+public class InputSummaryJavadocCheckPeriod
+{
+    /**
+     * As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}
+     */
+    void foo3() {}
+    
+    /**
+     * Blabla
+     */
+    void foo4() throws Exception {}
+    
+    /** An especially short bit of Javadoc_ */
+    void foo5() {}
+
+    /**
+     * An especially short bit of Javadoc_
+     */
+    void foo6() {}
+}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -954,6 +954,12 @@ public boolean isSomething()
             <td><a href="property_types.html#regexp">regular expression</a></td>
             <td><code>^$</code></td>
           </tr>
+          <tr>
+            <td>period</td>
+            <td>period symbol at the end of first javadoc sentence</td>
+            <td><a href="property_types.html#string">String literal</a></td>
+            <td><code>.</code></td>
+          </tr>
         </table>
       </subsection>
 
@@ -970,6 +976,14 @@ public boolean isSomething()
         <source>
 &lt;module name=&quot;SummaryJavadocCheck&quot;&gt;
     &lt;property name=&quot;forbiddenSummaryFragments&quot; value=&quot;^This method returns.*&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          To specify period symbol at the end of first javadoc sentence:
+        </p>
+        <source>
+&lt;module name=&quot;SummaryJavadocCheck&quot;&gt;
+    &lt;property name=&quot;period&quot; value=&quot;STRING_LITERAL&quot;/&gt;
 &lt;/module&gt;
         </source>
       </subsection>


### PR DESCRIPTION
According to #472 

Added option for specifying period symbol at the end of first javadoc sentence.
Added UTs and corresponding inputs.
