### PR TITLE
Final Parameters Check, added option allows ignoring primitive types as ...

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheckTest.java
@@ -104,4 +104,22 @@ public class FinalParametersCheckTest extends BaseCheckTestSupport
         };
         verify(checkConfig, getPath("InputFinalParameters.java"), expected);
     }
+
+    @Test
+    public void testIgnorePrimitiveTypesParameters() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(FinalParametersCheck.class);
+        checkConfig.addAttribute("ignorePrimitiveTypes", "true");
+        final String[] expected = {
+            "6:22: Parameter k should be final.",
+            "7:15: Parameter s should be final.",
+            "7:25: Parameter o should be final.",
+            "8:15: Parameter array should be final.",
+            "9:31: Parameter s should be final.",
+            "10:22: Parameter l should be final.",
+            "10:32: Parameter s should be final.",
+        };
+        verify(checkConfig, getPath("InputFinalParametersPrimitiveTypes.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputFinalParametersPrimitiveTypes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputFinalParametersPrimitiveTypes.java
@@ -1,0 +1,11 @@
+package com.puppycrawl.tools.checkstyle;
+
+public class InputFinalParametersPrimitiveTypes
+{
+    void foo(int i) {} //no warning
+    void foo1(int i, String k, float s) {} //no warning on 'i' and 's'
+    void foo2(String s, Object o, long l) {} //no warning on 'l'
+    void foo3(int[] array) {} //warning
+    void foo4(int i, float x, int[] s) {} //warning on 's'
+    void foo5(int x, long[] l, String s) {} //warning on 'l' and 's'
+}

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -459,6 +459,12 @@ messages.properties: Key 'ok' missing.
             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a></td>
 
           </tr>
+          <tr>
+            <td>ignorePrimitiveTypes</td>
+            <td>ignore primitive types as parameters</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>false</code></td>
+          </tr>
         </table>
       </subsection>
 
@@ -478,6 +484,16 @@ messages.properties: Key 'ok' missing.
         <source>
 &lt;module name=&quot;FinalParameters&quot;&gt;
     &lt;property name=&quot;tokens&quot; value=&quot;CTOR_DEF&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          To configure the check to allow ignoring
+          <a href="http://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html">
+           primitive datatypes</a> as parameters:
+        </p>
+        <source>
+&lt;module name=&quot;FinalParameters&quot;&gt;
+    &lt;property name=&quot;ignorePrimitiveTypes&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
       </subsection>


### PR DESCRIPTION
...params, issue #446 

According to #446 

Added option <b>ignorePrimitiveTypes</b> allows ignoring primitive types as params, e.g.:

void foo(int x) { ... }

Added UT and corresponding inputs
