### PR TITLE
Extended Method Name Check to ignore overriden methods, issue #430

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
@@ -18,6 +18,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
+import com.puppycrawl.tools.checkstyle.api.AnnotationUtility;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
@@ -35,6 +36,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * The default is false (it is not allowed).  It is legal in Java to have
  * method with the same name as a class.  As long as a return type is specified
  * it is a method and not a constructor which it could be easily confused as.
+ * <h3>Does not check-style the name of an overriden methods</h3> because the developer does not
+ * have a choice in renaming such methods.
  * </p>
  *
  * <p>
@@ -64,6 +67,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </pre>
  * @author Oliver Burn
  * @author Travis Schneeberger
+ * @author Utkarsh Srivastava
  * @version 1.1
  */
 public class MethodNameCheck
@@ -73,6 +77,16 @@ public class MethodNameCheck
      * for allowing method name to be the same as the class name.
      */
     private boolean mAllowClassName;
+
+    /**
+     * {@link Override Override} annotation name.
+     */
+    private static final String OVERRIDE = "Override";
+
+    /**
+     * Canonical {@link Override Override} annotation name.
+     */
+    private static final String CANONICAL_OVERRIDE = "java.lang." + OVERRIDE;
 
     /** Creates a new <code>MethodNameCheck</code> instance. */
     public MethodNameCheck()
@@ -89,7 +103,11 @@ public class MethodNameCheck
     @Override
     public void visitToken(DetailAST aAst)
     {
-        super.visitToken(aAst); // Will check the name against the format.
+        if (!AnnotationUtility.containsAnnotation(aAst, OVERRIDE)
+            && !AnnotationUtility.containsAnnotation(aAst, CANONICAL_OVERRIDE))
+        {
+            super.visitToken(aAst); // Will check the name against the format.
+        }
 
         if (!mAllowClassName) {
             final DetailAST method =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
@@ -111,4 +111,18 @@ public class MethodNameCheckTest
 
         verify(checkConfig, getPath("naming/InputMethodNameExtra.java"), expected);
     }
+
+    @Test
+    public void testOverridenMethods() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(MethodNameCheck.class);
+
+        final String[] expected = {
+            "17:17: Name 'PUBLICfoo' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "20:20: Name 'PROTECTEDfoo' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        };
+
+        verify(checkConfig, getPath("naming/InputMethodNameOverridenMethods.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/naming/InputMethodNameOverridenMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/naming/InputMethodNameOverridenMethods.java
@@ -1,0 +1,23 @@
+package com.puppycrawl.tools.checkstyle.naming;
+
+public class InputMethodNameOverridenMethods extends SomeClass 
+{
+    @Override
+    public void PUBLICfoo() { //Ignored due to impossibility of change by developer
+        
+    }
+    
+    @java.lang.Override
+    protected void PROTECTEDfoo() { //Ignored due to impossibility of change by developer
+        
+    }
+}
+
+class SomeClass {
+    public void PUBLICfoo() { //Warning (broken naming convention)
+        
+    }
+    protected void PROTECTEDfoo() { //Warning (broken naming convention)
+        
+    }
+}


### PR DESCRIPTION
from https://github.com/twitter/commons/blob/master/src/java/com/twitter/common/checkstyle/NonOverriddenMethodNameCheck.java

There's extension to Method Name Check - do not check-style overriden methods because programmer has no choice in their naming.
Added UT and corresponding input.
