### PR TITLE
Suppress Warnings Holder - fixed throwing exception if annotation uses c...

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -395,13 +395,17 @@ public class SuppressWarningsHolder
     {
         if (aAST != null && aAST.getType() == TokenTypes.EXPR) {
             final DetailAST firstChild = aAST.getFirstChild();
-            if (firstChild.getType() == TokenTypes.STRING_LITERAL) {
+            switch (firstChild.getType()) {
+            case TokenTypes.STRING_LITERAL:
                 // NOTE: escaped characters are not unescaped
                 final String quotedText = firstChild.getText();
                 return quotedText.substring(1, quotedText.length() - 1);
+            case TokenTypes.IDENT:
+                return firstChild.getText();
+            default:
+                throw new IllegalArgumentException("String literal AST expected: "
+                        + firstChild);
             }
-            throw new IllegalArgumentException("String literal AST expected: "
-                + firstChild);
         }
         throw new IllegalArgumentException("Expression AST expected: " + aAST);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/InputSuppressWarningsFilter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/InputSuppressWarningsFilter.java
@@ -62,4 +62,9 @@ class InputSuppressWarningsFilter
         @SuppressWarnings("rawtypes")
         ELEMENT;
     }
+    private static final String UNUSED="UnusedDeclaration";
+
+    @SuppressWarnings(UNUSED)
+    public void annotationUsingStringConstantValue(){
+    }
 }


### PR DESCRIPTION
...onstant value, issue #539 

According to #539 

Fixed problem in SuppressionHolder (which inflicted problem on SuppressionFilter) with using constants as annotation's value
