### PR TITLE
Logging of exceptions to console, issue #546

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -197,6 +197,8 @@ public final class TreeWalker
             return;
         }
 
+        final String msg = "%s occurred during the analysis of file %s .";
+
         try {
             final FileText text = FileText.fromLines(aFile, aLines);
             final FileContents contents = new FileContents(text);
@@ -211,8 +213,8 @@ public final class TreeWalker
             walk(astWithComments, contents, AstState.WITH_COMMENTS);
         }
         catch (final RecognitionException re) {
-            Utils.getExceptionLogger()
-                .debug("RecognitionException occured.", re);
+            final String exceptionMsg = String.format(msg, "RecognitionException", fileName);
+            Utils.getExceptionLogger().error(exceptionMsg);
             getMessageCollector().add(
                 new LocalizedMessage(
                     re.getLine(),
@@ -224,8 +226,9 @@ public final class TreeWalker
                     this.getClass(), null));
         }
         catch (final TokenStreamRecognitionException tre) {
-            Utils.getExceptionLogger()
-                .debug("TokenStreamRecognitionException occured.", tre);
+            final String exceptionMsg = String.format(msg, "TokenStreamRecognitionException",
+                     fileName);
+            Utils.getExceptionLogger().error(exceptionMsg);
             final RecognitionException re = tre.recog;
             if (re != null) {
                 getMessageCollector().add(
@@ -251,8 +254,9 @@ public final class TreeWalker
             }
         }
         catch (final TokenStreamException te) {
-            Utils.getExceptionLogger()
-                .debug("TokenStreamException occured.", te);
+            final String exceptionMsg = String.format(msg,
+                    "TokenStreamException", fileName);
+            Utils.getExceptionLogger().error(exceptionMsg);
             getMessageCollector().add(
                 new LocalizedMessage(
                     0,
@@ -263,8 +267,9 @@ public final class TreeWalker
                     this.getClass(), null));
         }
         catch (final Throwable err) {
+            final String exceptionMsg = String.format(msg, "Exception", fileName);
+            Utils.getExceptionLogger().error(exceptionMsg);
             err.printStackTrace();
-            Utils.getExceptionLogger().debug("Throwable occured.", err);
             getMessageCollector().add(
                 new LocalizedMessage(
                     0,


### PR DESCRIPTION
According to #546 

Now exceptions are logged to console output, e.g.:
while mvn clean verify:

```
Exception happened at PATH: com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck
java.lang.NullPointerException
	at com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck.isCstyleMultiDimensionalArrayDeclaration(NoWhitespaceAfterCheck.java:294)
	at com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck.getArrayTypeOrIdentifier(NoWhitespaceAfterCheck.java:183)
	at com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck.getPreceded(NoWhitespaceAfterCheck.java:139)
	at com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck.visitToken(NoWhitespaceAfterCheck.java:111)
	at com.puppycrawl.tools.checkstyle.TreeWalker.notifyVisit(TreeWalker.java:449)
	at com.puppycrawl.tools.checkstyle.TreeWalker.processIter(TreeWalker.java:548)
	at com.puppycrawl.tools.checkstyle.TreeWalker.walk(TreeWalker.java:373)
	at com.puppycrawl.tools.checkstyle.TreeWalker.processFiltered(TreeWalker.java:207)
	at com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.process(AbstractFileSetCheck.java:77)
	at com.puppycrawl.tools.checkstyle.Checker.process(Checker.java:263)
	at com.puppycrawl.tools.checkstyle.CheckStyleTask.realExecute(CheckStyleTask.java:318)
	at com.puppycrawl.tools.checkstyle.CheckStyleTask.execute(CheckStyleTask.java:262)
	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:291)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
	at org.apache.tools.ant.Task.perform(Task.java:348)
	at org.apache.tools.ant.Target.execute(Target.java:390)
	at org.apache.tools.ant.Target.performTasks(Target.java:411)
	at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1399)
	at org.apache.tools.ant.helper.SingleCheckExecutor.executeTargets(SingleCheckExecutor.java:38)
	at org.apache.tools.ant.Project.executeTargets(Project.java:1251)
	at org.apache.tools.ant.taskdefs.Ant.execute(Ant.java:442)
	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:291)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
	at org.apache.tools.ant.Task.perform(Task.java:348)
	at org.apache.tools.ant.Target.execute(Target.java:390)
	at org.apache.tools.ant.Target.performTasks(Target.java:411)
	at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1399)
	at org.apache.tools.ant.Project.executeTarget(Project.java:1368)
	at org.apache.maven.plugin.antrun.AntRunMojo.execute(AntRunMojo.java:327)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:132)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:120)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:347)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:154)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:582)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:214)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:158)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
[checkstyle] /home/asus/sources/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java:450:13: '}' should be alone on a line.
```
