### PR TITLE
Fixes for suppression examples - issue #289

### DIFF
--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -816,7 +816,7 @@
         </source>
 
         <p>
-          Suppress checks for non-java text files:
+          Suppress checks for non-java files:
         </p>
 
         <source>
@@ -824,11 +824,19 @@
         </source>
 
         <p>
-          Suppress all checks generated sources:
+          Suppress all checks in generated sources:
         </p>
 
         <source>
-&lt;suppress checks=&quot;FileLength&quot;files=&quot;com[\\/]mycompany[\\/]app[\\/].*IT.java&quot;/&gt;
+&lt;suppress checks=&quot;.*&quot; files=&quot;com[\\/]mycompany[\\/]app[\\/]gen[\\/]&quot;/&gt;
+        </source>
+
+        <p>
+          Suppress FileLength check on integration tests in certain folder:
+        </p>
+
+        <source>
+&lt;suppress checks=&quot;FileLength&quot; files=&quot;com[\\/]mycompany[\\/]app[\\/].*IT.java&quot;/&gt;
         </source>
 
       </subsection>


### PR DESCRIPTION
Fixed incorrect description for integration tests suppression. Added missing suppression for generated sources. Added space between  '&quot;' and 'files'. Not all file extensions given were text files - so removed word 'text'.