### PR TITLE
Repair Sonarqube problems found in Checkstyle for issue #46

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -299,7 +299,7 @@ public final class TreeWalker
             tokens = aCheck.getRequiredTokens();
 
             //register configured tokens
-            final int acceptableTokens[] = aCheck.getAcceptableTokens();
+            final int[] acceptableTokens = aCheck.getAcceptableTokens();
             Arrays.sort(acceptableTokens);
             for (String token : checkTokens) {
                 try {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
@@ -116,7 +116,7 @@ public class NewlineAtEndOfFileCheck
             return false;
         }
         aRandomAccessFile.seek(aRandomAccessFile.length() - len);
-        final byte lastBytes[] = new byte[len];
+        final byte[] lastBytes = new byte[len];
         final int readBytes = aRandomAccessFile.read(lastBytes);
         if (readBytes != len) {
             throw new IOException("Unable to read " + len + " bytes, got "

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -151,7 +151,7 @@ public class LeftCurlyCheck
             final DetailAST objBlock = aAST.findFirstToken(TokenTypes.OBJBLOCK);
             brace = (objBlock == null)
                 ? null
-                : (DetailAST) objBlock.getFirstChild();
+                : objBlock.getFirstChild();
             break;
 
         case TokenTypes.LITERAL_WHILE:

--- a/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
@@ -111,7 +111,7 @@ public final class TokenTypesDoclet
      * @param aReporter the reporter to report errors.
      * @return true if only valid options was specified
      */
-    public static boolean validOptions(String aOptions[][],
+    public static boolean validOptions(String[][] aOptions,
                                        DocErrorReporter aReporter)
     {
         boolean foundDestFileOption = false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
@@ -79,7 +79,7 @@ class FileDrop
     // that the panel layout does not change during the DnD operation.
 
     private transient Border normalBorder;
-    private transient final DropTargetListener dropListener;
+    private final transient DropTargetListener dropListener;
 
     // TODO: Blue is not a nice color in all LookAndFeels
     /* Default border color */


### PR DESCRIPTION
Fixes for [Modifiers should be declared in the correct order](http://nemo.sonarqube.org/component/index#component=com.puppycrawl.tools%3Acheckstyle%3Asrc%2Fmain%2Fjava%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fgui%2FFileDrop.java&currentIssue=2b96e517-b6fc-4303-8fab-23390d63905a), [Redundant casts should not be used](http://nemo.sonarqube.org/component/index#component=com.puppycrawl.tools%3Acheckstyle%3Asrc%2Fmain%2Fjava%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks%2FLeftCurlyCheck.java&currentIssue=7af2868f-f17d-4811-b117-a3a7972ba3d1) and [Array designators "[]" should be on the type, not the variable](http://nemo.sonarqube.org/component/index#component=com.puppycrawl.tools%3Acheckstyle%3Asrc%2Fmain%2Fjava%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fdoclets%2FTokenTypesDoclet.java&currentIssue=b896a3b6-df3f-4eb1-aff8-c99ebb082b84)