### PR TITLE
Ignore non-private members in VisibilityModifierCheck when annotated.

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AnnotationUtility.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AnnotationUtility.java
@@ -18,6 +18,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.puppycrawl.tools.checkstyle.api;
 
+import java.util.regex.Pattern;
 
 /**
  * Contains utility methods designed to work with annotations.
@@ -157,6 +158,61 @@ public final class AnnotationUtility
                 final String aName =
                     FullIdent.createFullIdent(at.getNextSibling()).getText();
                 if (aAnnotation.equals(aName)) {
+                    return child;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks whether the AST is annotated with
+     * an annotation containing the passed in regular
+     * expression and return the AST representing that
+     * annotation.
+     *
+     * <p>
+     * This method will not look for imports or package
+     * statements to detect the passed in annotation.
+     * </p>
+     *
+     * <p>
+     * To check if an AST contains a passed in annotation
+     * taking into account fully-qualified names
+     * (ex: java.lang.Override, Override)
+     * this method will need to be called twice. Once for each
+     * name given.
+     * </p>
+     *
+     * @param aAST the current node
+     * @param aAnnotationPattern the annotation pattern to check for
+     * @return the AST representing the first such annotation or null if
+     *         no such annotation was found
+     * @throws NullPointerException if the aAST or
+     * aAnnotationPattern is null
+     */
+    public static DetailAST containsMatchingAnnotation(final DetailAST aAST,
+        Pattern aAnnotationPattern)
+    {
+        if (aAST == null) {
+            throw new NullPointerException("the aAST is null");
+        }
+
+        if (aAnnotationPattern == null) {
+            throw new NullPointerException("the aAnnotationPattern is null");
+        }
+
+        final DetailAST holder = AnnotationUtility.getAnnotationHolder(aAST);
+
+        for (DetailAST child = holder.getFirstChild();
+            child != null; child = child.getNextSibling())
+        {
+            if (child.getType() == TokenTypes.ANNOTATION) {
+                final DetailAST at = child.getFirstChild();
+                final String aName =
+                    FullIdent.createFullIdent(at.getNextSibling()).getText();
+                if (aAnnotationPattern.matcher(aName).matches()) {
                     return child;
                 }
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -22,6 +22,7 @@ import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import org.junit.Test;
+import java.io.File;
 
 public class VisibilityModifierCheckTest
     extends BaseCheckTestSupport
@@ -88,5 +89,82 @@ public class VisibilityModifierCheckTest
             "46:16: Variable 'aFreddo' must be private and have accessor methods.",
         };
         verify(getChecker(), getPath("InputPublicOnly.java"), expected);
+    }
+
+    @Test
+    public void testIgnoreAnnotationPatternsFalse() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("ignoreAnnotated", "false");
+        final String[] expected = {
+            "15:28: Variable 'publicJUnitRule' must be private and have accessor methods.",
+            "18:28: Variable 'fqPublicJUnitRule' must be private and have accessor methods.",
+
+            "21:19: Variable 'googleCommonsAnnotatedPublic' must be private and have accessor methods.",
+            "24:12: Variable 'googleCommonsAnnotatedPackage' must be private and have accessor methods.",
+            "27:22: Variable 'googleCommonsAnnotatedProtected' must be private and have accessor methods.",
+            "30:19: Variable 'fqGoogleCommonsAnnotatedPublic' must be private and have accessor methods.",
+            "33:12: Variable 'fqGoogleCommonsAnnotatedPackage' must be private and have accessor methods.",
+            "36:22: Variable 'fqGoogleCommonsAnnotatedProtected' must be private and have accessor methods.",
+
+            "39:19: Variable 'customAnnotatedPublic' must be private and have accessor methods.",
+            "42:12: Variable 'customAnnotatedPackage' must be private and have accessor methods.",
+            "45:22: Variable 'customAnnotatedProtected' must be private and have accessor methods.",
+
+            "47:19: Variable 'unannotatedPublic' must be private and have accessor methods.",
+            "48:12: Variable 'unannotatedPackage' must be private and have accessor methods.",
+            "49:22: Variable 'unannotatedProtected' must be private and have accessor methods.",
+        };
+        verify(checkConfig,
+               getPath("design" + File.separator + "AnnotatedVisibility.java"),
+               expected);
+    }
+
+    @Test
+    public void testDefaultAnnotationPatterns() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("ignoreAnnotated", "true");
+        final String[] expected = {
+            "39:19: Variable 'customAnnotatedPublic' must be private and have accessor methods.",
+            "42:12: Variable 'customAnnotatedPackage' must be private and have accessor methods.",
+            "45:22: Variable 'customAnnotatedProtected' must be private and have accessor methods.",
+
+            "47:19: Variable 'unannotatedPublic' must be private and have accessor methods.",
+            "48:12: Variable 'unannotatedPackage' must be private and have accessor methods.",
+            "49:22: Variable 'unannotatedProtected' must be private and have accessor methods.",
+        };
+        verify(checkConfig,
+               getPath("design" + File.separator + "AnnotatedVisibility.java"),
+               expected);
+    }
+
+    @Test
+    public void testCustomAnnotationPatterns() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("ignoreAnnotated", "true");
+        checkConfig.addAttribute("ignoredAnnotationPattern", "^CustomAnnotation$");
+        final String[] expected = {
+            "15:28: Variable 'publicJUnitRule' must be private and have accessor methods.",
+            "18:28: Variable 'fqPublicJUnitRule' must be private and have accessor methods.",
+
+            "21:19: Variable 'googleCommonsAnnotatedPublic' must be private and have accessor methods.",
+            "24:12: Variable 'googleCommonsAnnotatedPackage' must be private and have accessor methods.",
+            "27:22: Variable 'googleCommonsAnnotatedProtected' must be private and have accessor methods.",
+            "30:19: Variable 'fqGoogleCommonsAnnotatedPublic' must be private and have accessor methods.",
+            "33:12: Variable 'fqGoogleCommonsAnnotatedPackage' must be private and have accessor methods.",
+            "36:22: Variable 'fqGoogleCommonsAnnotatedProtected' must be private and have accessor methods.",
+
+            "47:19: Variable 'unannotatedPublic' must be private and have accessor methods.",
+            "48:12: Variable 'unannotatedPackage' must be private and have accessor methods.",
+            "49:22: Variable 'unannotatedProtected' must be private and have accessor methods.",
+        };
+        verify(checkConfig,
+               getPath("design" + File.separator + "AnnotatedVisibility.java"),
+               expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/design/AnnotatedVisibility.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/design/AnnotatedVisibility.java
@@ -1,0 +1,56 @@
+package com.puppycrawl.tools.checkstyle.design;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+public class AnnotatedVisibility {
+    @Rule
+    public TemporaryFolder publicJUnitRule = new TemporaryFolder();
+
+    @org.junit.Rule
+    public TemporaryFolder fqPublicJUnitRule = new TemporaryFolder();
+
+    @VisibleForTesting
+    public String googleCommonsAnnotatedPublic;
+
+    @VisibleForTesting
+    String googleCommonsAnnotatedPackage;
+
+    @VisibleForTesting
+    protected String googleCommonsAnnotatedProtected;
+
+    @com.google.common.annotations.VisibleForTesting
+    public String fqGoogleCommonsAnnotatedPublic;
+
+    @com.google.common.annotations.VisibleForTesting
+    String fqGoogleCommonsAnnotatedPackage;
+
+    @com.google.common.annotations.VisibleForTesting
+    protected String fqGoogleCommonsAnnotatedProtected;
+
+    @CustomAnnotation
+    public String customAnnotatedPublic;
+
+    @CustomAnnotation
+    String customAnnotatedPackage;
+
+    @CustomAnnotation
+    protected String customAnnotatedProtected;
+
+    public String unannotatedPublic;
+    String unannotatedPackage;
+    protected String unannotatedProtected;
+    private String unannotatedPrivate;
+
+    @Retention(value=RetentionPolicy.RUNTIME)
+    @Target(value={ElementType.FIELD})
+    public @interface CustomAnnotation {
+    }
+}


### PR DESCRIPTION
This PR is in response to an old feature request (http://sourceforge.net/p/checkstyle/feature-requests/597/) that I also wanted. :)