### PR TITLE
Annotation Location Check, fixed typo in property name, issue #585

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -52,7 +52,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </li>
  *
  * <li>
- * allowSamelineParametrizedAnnotation - to allow parameterized annotation
+ * allowSamelineParameterizedAnnotation - to allow parameterized annotation
  * to be located on the same line as target element. Default value is false.
  * </li>
  * </ul>
@@ -70,7 +70,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *    &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;false&quot;/&gt;
  *    &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
  *    value=&quot;true&quot;/&gt;
- *    &lt;property name=&quot;allowSamelineParametrizedAnnotation&quot; value=&quot;false&quot;/&gt;
+ *    &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;
+ *    /&gt;
  * &lt;/module&gt;
  * </pre>
  * <br/>
@@ -87,7 +88,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *    &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;true&quot;/&gt;
  *    &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
  *    value=&quot;true&quot;/&gt;
- *    &lt;property name=&quot;allowSamelineParametrizedAnnotation&quot; value=&quot;true&quot;/&gt;
+ *    &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;true&quot;
+ *    /&gt;
  * &lt;/module&gt;
  * </pre>
  * <br/>
@@ -104,7 +106,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *    &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;true&quot;/&gt;
  *    &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
  *    value=&quot;true&quot;/&gt;
- *    &lt;property name=&quot;allowSamelineParametrizedAnnotation&quot; value=&quot;false&quot;/&gt;
+ *    &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;
+ *    /&gt;
  * &lt;/module&gt;
  * </pre>
  *
@@ -132,7 +135,7 @@ public class AnnotationLocationCheck extends Check
     /**
      * Some javadoc.
      */
-    private boolean allowSamelineParametrizedAnnotation;
+    private boolean allowSamelineParameterizedAnnotation;
 
     /**
      * Some javadoc.
@@ -154,7 +157,7 @@ public class AnnotationLocationCheck extends Check
      */
     public final void setAllowSamelineParametrizedAnnotation(boolean allow)
     {
-        allowSamelineParametrizedAnnotation = allow;
+        allowSamelineParameterizedAnnotation = allow;
     }
 
     /**
@@ -221,7 +224,7 @@ public class AnnotationLocationCheck extends Check
      */
     private boolean isCorrectLocation(DetailAST annotation, boolean hasParams)
     {
-        final boolean allowingCondition = hasParams ? allowSamelineParametrizedAnnotation
+        final boolean allowingCondition = hasParams ? allowSamelineParameterizedAnnotation
             : allowSamelineSingleParameterlessAnnotation;
         return allowingCondition && !hasNodeBefore(annotation)
             || !allowingCondition && !hasNodeBeside(annotation)

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -455,8 +455,8 @@ public String getNameIfPresent() { ... }
             <td><code>true</code></td>
           </tr>
           <tr>
-            <td>allowSamelineParametrizedAnnotation</td>
-            <td>To allow parametrized annotation to be located on the same line as target element.</td>
+            <td>allowSamelineParameterizedAnnotation</td>
+            <td>To allow parameterized annotation to be located on the same line as target element.</td>
             <td><a href="property_types.html#boolean">boolean</a></td>
             <td><code>false</code></td>
           </tr>
@@ -477,11 +477,11 @@ public String getNameIfPresent() { ... }
 &lt;module name=&quot;AnnotationLocation&quot;&gt;
     &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;false&quot;/&gt;
     &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot; value=&quot;true&quot;/&gt;
-    &lt;property name=&quot;allowSamelineParametrizedAnnotation&quot; value=&quot;false&quot;/&gt;
+    &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
-          Example to allow multiple parametrized annotations on the same line
+          Example to allow multiple parameterized annotations on the same line
         </p>
         <source>
 @SuppressWarnings("deprecation") @Mock DataLoader loader;
@@ -493,7 +493,7 @@ public String getNameIfPresent() { ... }
 &lt;module name=&quot;AnnotationLocation&quot;&gt;
     &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;true&quot;/&gt;
     &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot; value=&quot;true&quot;/&gt;
-    &lt;property name=&quot;allowSamelineParametrizedAnnotation&quot; value=&quot;true&quot;/&gt;
+    &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
@@ -509,7 +509,7 @@ public String getNameIfPresent() { ... }
 &lt;module name=&quot;AnnotationLocation&quot;&gt;
     &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;true&quot;/&gt;
     &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot; value=&quot;true&quot;/&gt;
-    &lt;property name=&quot;allowSamelineParametrizedAnnotation&quot; value=&quot;false&quot;/&gt;
+    &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
       </subsection>


### PR DESCRIPTION
Fixed typo in property name <b>allowSamelineParameterizedAnnotation</b> instead of <b>allowSamelineParametrizedAnnotation</b>

Fixed in sources and xdoc config.