### PR TITLE
Added file extensions property to Checker & TreeWalker, issue #25

### DIFF
--- a/checkstyle_checks.xml
+++ b/checkstyle_checks.xml
@@ -16,6 +16,8 @@
 
   <property name="severity" value="error"/>
 
+  <property name="fileExtensions" value="java, properties, xml"/>
+
   <module name="SuppressionFilter">
     <property name="file" value="${checkstyle.suppressions.file}"/>
   </module>

--- a/import-control.xml
+++ b/import-control.xml
@@ -18,6 +18,7 @@
   <allow pkg="org.apache.commons.beanutils"/>
   <allow pkg="org.apache.commons.logging"/>
   <allow pkg="org.xml.sax"/>
+  <allow pkg="com.puppycrawl.tools.checkstyle"/>
 
   <!-- The local ones -->
   <allow class="java.security.MessageDigest" local-only="true"/>
@@ -33,6 +34,8 @@
     <allow class="com.puppycrawl.tools.checkstyle.grammars.CommentListener"
            local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaTokenTypes"
+           local-only="true"/>
+    <allow class="com.puppycrawl.tools.checkstyle.Utils"
            local-only="true"/>
   </subpackage>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -48,6 +48,8 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.StringTokenizer;
 
+import static com.puppycrawl.tools.checkstyle.Utils.fileExtensionMatches;
+
 /**
  * This class provides the functionality to check a set of files.
  * @author Oliver Burn
@@ -89,6 +91,9 @@ public class Checker extends AutomaticBean implements MessageDispatcher
 
     /** The audit event filters */
     private final FilterSet filters = new FilterSet();
+
+    /** the file extensions that are accepted */
+    private String[] fileExtensions = {};
 
     /**
      * The severity level of any violations found by submodules.
@@ -253,6 +258,9 @@ public class Checker extends AutomaticBean implements MessageDispatcher
 
         // Process each file
         for (final File f : files) {
+            if (!fileExtensionMatches(f, fileExtensions)) {
+                continue;
+            }
             final String fileName = f.getAbsolutePath();
             fireFileStarted(fileName);
             final SortedSet<LocalizedMessage> fileMessages = Sets.newTreeSet();
@@ -521,6 +529,31 @@ public class Checker extends AutomaticBean implements MessageDispatcher
                 for (final AuditListener listener : listeners) {
                     listener.addError(evt);
                 }
+            }
+        }
+    }
+
+    /**
+     * Sets the file extensions that identify the files that pass the
+     * filter of this FileSetCheck.
+     * @param extensions the set of file extensions. A missing
+     * initial '.' character of an extension is automatically added.
+     */
+    public final void setFileExtensions(String[] extensions)
+    {
+        if (extensions == null) {
+            fileExtensions = null;
+            return;
+        }
+
+        fileExtensions = new String[extensions.length];
+        for (int i = 0; i < extensions.length; i++) {
+            final String extension = extensions[i];
+            if (extension.startsWith(".")) {
+                fileExtensions[i] = extension;
+            }
+            else {
+                fileExtensions[i] = "." + extension;
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -55,6 +55,8 @@ import com.puppycrawl.tools.checkstyle.api.Utils;
 import com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaLexer;
 import com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaRecognizer;
 
+import static com.puppycrawl.tools.checkstyle.Utils.fileExtensionMatches;
+
 /**
  * Responsible for walking an abstract syntax tree and notifying interested
  * checks at each each node.
@@ -116,6 +118,9 @@ public final class TreeWalker
     /** logger for debug purpose */
     private static final Log LOG =
         LogFactory.getLog("com.puppycrawl.tools.checkstyle.TreeWalker");
+
+    /** the file extensions that are accepted */
+    private String[] fileExtensions;
 
     /**
      * Creates a new <code>TreeWalker</code> instance.
@@ -193,7 +198,9 @@ public final class TreeWalker
         // check if already checked and passed the file
         final String fileName = file.getPath();
         final long timestamp = file.lastModified();
-        if (cache.alreadyChecked(fileName, timestamp)) {
+        if (cache.alreadyChecked(fileName, timestamp)
+                 || !fileExtensionMatches(file, fileExtensions))
+        {
             return;
         }
 
@@ -757,4 +764,5 @@ public final class TreeWalker
         }
         return new SimpleEntry<Integer, Integer>(lines, columns);
     }
+
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
@@ -1,0 +1,72 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2014  Oliver Burn
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle;
+
+import java.io.File;
+
+/**
+ * Contains utility methods.
+ *
+ * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
+ */
+public final class Utils
+{
+
+    /** stop instances being created **/
+    private Utils()
+    {
+    }
+
+    /**
+     * Returns whether the file extension matches what we are meant to
+     * process.
+     * @param file the file to be checked.
+     * @param fileExtensions files extensions, empty property in config makes it matches to all.
+     * @return whether there is a match.
+     */
+    public static boolean fileExtensionMatches(File file, String[] fileExtensions)
+    {
+        boolean result = false;
+        if ((fileExtensions == null) || (fileExtensions.length == 0)) {
+            result = true;
+        }
+        else {
+            // normalize extensions so all of them have a leading dot
+            final String[] withDotExtensions = new String[fileExtensions.length];
+            for (int i = 0; i < fileExtensions.length; i++) {
+                final String extension = fileExtensions[i];
+                if (extension.startsWith(".")) {
+                    withDotExtensions[i] = extension;
+                }
+                else {
+                    withDotExtensions[i] = "." + extension;
+                }
+            }
+
+            final String fileName = file.getName();
+            for (final String fileExtension : withDotExtensions) {
+                if (fileName.endsWith(fileExtension)) {
+                    result = true;
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.util.List;
 import java.util.TreeSet;
 
+import com.puppycrawl.tools.checkstyle.Utils;
+
 /**
  * Provides common functionality for many FileSetChecks.
  *
@@ -73,7 +75,7 @@ public abstract class AbstractFileSetCheck
     {
         getMessageCollector().reset();
         // Process only what interested in
-        if (fileExtensionMatches(file)) {
+        if (Utils.fileExtensionMatches(file, fileExtensions)) {
             processFiltered(file, lines);
         }
         return getMessageCollector().getMessages();
@@ -174,39 +176,5 @@ public abstract class AbstractFileSetCheck
                 .getMessages();
         getMessageCollector().reset();
         getMessageDispatcher().fireErrors(fileName, errors);
-    }
-
-    /**
-     * Returns whether the file extension matches what we are meant to
-     * process.
-     * @param file the file to be checked.
-     * @return whether there is a match.
-     */
-    private boolean fileExtensionMatches(File file)
-    {
-        if ((null == fileExtensions) || (fileExtensions.length == 0)) {
-            return true;
-        }
-
-        // normalize extensions so all of them have a leading dot
-        final String[] withDotExtensions = new String[fileExtensions.length];
-        for (int i = 0; i < fileExtensions.length; i++) {
-            final String extension = fileExtensions[i];
-            if (extension.startsWith(".")) {
-                withDotExtensions[i] = extension;
-            }
-            else {
-                withDotExtensions[i] = "." + extension;
-            }
-        }
-
-        final String fileName = file.getName();
-        for (final String fileExtension : withDotExtensions) {
-            if (fileName.endsWith(fileExtension)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -25,7 +25,8 @@
     <property name="charset" value="UTF-8"/>
     
     <property name="severity" value="warning"/>
-    
+
+    <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
         <module name="FileTabCharacter">

--- a/src/main/resources/sun_checks.xml
+++ b/src/main/resources/sun_checks.xml
@@ -39,6 +39,8 @@
         <property name="basedir" value="${basedir}"/>
     -->
 
+    <property name="fileExtensions" value="java, properties, xml"/>
+
     <!-- Checks that a package-info.java file exists for each package.     -->
     <!-- See http://checkstyle.sf.net/config_javadoc.html#JavadocPackage -->
     <module name="JavadocPackage"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.TreeSet;
 import org.junit.Test;
 
@@ -244,5 +246,20 @@ public class CheckerTest
         assertTrue("Checker.fireErrors() doesn't call filter", f2.wasCalled());
         assertFalse("Checker.fireErrors() does call removed filter", f.wasCalled());
 
+    }
+
+    @Test
+    public void testFileExtensions() throws Exception
+    {
+        final Checker c = new Checker();
+        final List<File> files = new ArrayList<>();
+        File f = new File("file.pdf");
+        files.add(f);
+        f = new File("file.java");
+        files.add(f);
+        final String[] fileExtensions = {"java", "xml", "properties"};
+        c.setFileExtensions(fileExtensions);
+        final int counter = c.process(files);
+        assertEquals(counter, 1); // comparing to 1 as there is only one legal file in input
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -1,0 +1,65 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2014  Oliver Burn
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.Writer;
+
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
+
+public class TreeWalkerTest extends BaseCheckTestSupport
+{
+    @Test
+    public void testProperFileExtension() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(ConstantNameCheck.class);
+        final String content = "public class Main { public static final int k = 5 + 4; }";
+        final File file = File.createTempFile("file", ".java");
+        final Writer writer = new BufferedWriter(new FileWriter(file));
+        writer.write(content);
+        writer.close();
+        final String[] expected1 = {
+            "1:45: Name 'k' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+        };
+        verify(checkConfig, file.getCanonicalPath(), expected1);
+        file.delete();
+    }
+
+    @Test
+    public void testImproperFileExtension() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(ConstantNameCheck.class);
+        final File file = File.createTempFile("file", ".pdf");
+        final String content = "public class Main { public static final int k = 5 + 4; }";
+        final BufferedWriter writer = new BufferedWriter(new FileWriter(file));
+        writer.write(content);
+        writer.close();
+        final String[] expected = {
+
+        };
+        verify(checkConfig, file.getCanonicalPath(), expected);
+        file.delete();
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
@@ -19,11 +19,18 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.puppycrawl.tools.checkstyle.api.Utils;
+
+import java.io.File;
 import java.util.regex.Pattern;
+
 import org.apache.commons.beanutils.ConversionException;
 import org.junit.Test;
+
+import static com.puppycrawl.tools.checkstyle.Utils.fileExtensionMatches;
 
 public class UtilsTest
 {
@@ -60,5 +67,16 @@ public class UtilsTest
     public void testBadRegex()
     {
         Utils.createPattern("[");
+    }
+
+    @Test
+    public void testFileExtensions()
+    {
+        final String[] fileExtensions = {"java"};
+        File file = new File("file.pdf");
+        assertFalse(fileExtensionMatches(file, fileExtensions));
+        assertTrue(fileExtensionMatches(file, null));
+        file = new File("file.java");
+        assertTrue(fileExtensionMatches(file, fileExtensions));
     }
 }

--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -299,6 +299,12 @@
           <td><a href="property_types.html#string">String</a></td>
           <td>System property &quot;file.encoding&quot;</td>
         </tr>
+        <tr>
+          <td>fileExtensions</td>
+          <td>file extensions that are accepted</td>
+          <td><a href="property_types.html#string">String</a> array</td>
+          <td><code>null</code></td>
+        </tr>
       </table>
 
       <p>
@@ -327,6 +333,37 @@
       <source>
 &lt;module name=&quot;Checker&quot;&gt;
     &lt;property name=&quot;charset&quot; value=&quot;UTF-8&quot;/&gt;
+    ...
+&lt;/module&gt;
+      </source>
+
+      <p>
+        To configure a <code>Checker</code> so that it
+        handles files with the <code>java, xml, properties</code> extensions:
+      </p>
+
+      <source>
+&lt;module name=&quot;Checker&quot;&gt;
+    &lt;property name=&quot;fileExtensions&quot; value=&quot;java, xml, properties&quot;/&gt;
+    ...
+&lt;/module&gt;
+      </source>
+
+      <p>
+        To configure a <code>Checker</code> so that it
+        handles files with any extension:
+      </p>
+
+      <source>
+&lt;module name=&quot;Checker&quot;&gt;
+    &lt;property name=&quot;fileExtensions&quot; value=&quot;null&quot;/&gt;
+    ...
+&lt;/module&gt;
+
+OR
+
+&lt;module name=&quot;Checker&quot;&gt;
+    &lt;property name=&quot;fileExtensions&quot; value=&quot;&quot;/&gt;
     ...
 &lt;/module&gt;
       </source>
@@ -403,6 +440,38 @@
         &lt;property name=&quot;fileExtensions&quot; value=&quot;java,ejb,jpf&quot;/&gt;
         ...
       </source>
+
+      <p>
+        To configure <code>TreeWalker</code> so that it
+        handles files with the <code>java</code> extension:
+      </p>
+
+      <source>
+&lt;module name=&quot;TreeWalker&quot;&gt;
+    &lt;property name=&quot;fileExtensions&quot; value=&quot;java&quot;/&gt;
+    ...
+&lt;/module&gt;
+      </source>
+
+      <p>
+        To configure <code>TreeWalker</code> so that it
+        handles files with any extension:
+      </p>
+
+      <source>
+&lt;module name=&quot;TreeWalker&quot;&gt;
+    &lt;property name=&quot;fileExtensions&quot; value=&quot;null&quot;/&gt;
+    ...
+&lt;/module&gt;
+
+OR
+
+&lt;module name=&quot;TreeWalker&quot;&gt;
+    &lt;property name=&quot;fileExtensions&quot; value=&quot;&quot;/&gt;
+    ...
+&lt;/module&gt;
+      </source>
+
     </section>
 
     <section name="TreeWalker Checks">


### PR DESCRIPTION
Added <b>fileExtensions</b> property to Checker and TreeWalker, updated sun_checks.xml

```xml
<module name="Checker">
    <property name="fileExtensions" value="java, properties, xml"/>
...
<module name="TreeWalker">

        <property name="fileExtensions" value="java"/>
...
```

Tested on pdf file:

```
$ java -jar checkstyle-6.3-SNAPSHOT-all.jar -c /sun_checks.xml Books/Spring\ in\ Action\,\ 3rd\ Edition.pdf 
Starting audit...
Audit done.
```