### PR TITLE
HiddenField module can now accept setterCanReturnItsClass attribute;

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
@@ -93,6 +93,9 @@ public class HiddenFieldCheckTest
             "223:13: 'hiddenStatic' hides a field.",
             "230:41: 'x' hides a field.",
             "236:30: 'xAxis' hides a field.",
+            "253:40: 'prop' hides a field.",
+            "267:29: 'prop' hides a field.",
+            "278:41: 'prop2' hides a field.",
         };
         verify(checkConfig, getPath("InputHiddenField.java"), expected);
     }
@@ -131,6 +134,9 @@ public class HiddenFieldCheckTest
             "223:13: 'hiddenStatic' hides a field.",
             "230:41: 'x' hides a field.",
             "236:30: 'xAxis' hides a field.",
+            "253:40: 'prop' hides a field.",
+            "267:29: 'prop' hides a field.",
+            "278:41: 'prop2' hides a field.",
         };
         verify(checkConfig, getPath("InputHiddenField.java"), expected);
     }
@@ -143,6 +149,51 @@ public class HiddenFieldCheckTest
         final DefaultConfiguration checkConfig =
             createCheckConfig(HiddenFieldCheck.class);
         checkConfig.addAttribute("ignoreSetter", "true");
+        final String[] expected = {
+            "18:13: 'hidden' hides a field.",
+            "21:33: 'hidden' hides a field.",
+            "27:13: 'hidden' hides a field.",
+            "32:18: 'hidden' hides a field.",
+            "36:33: 'hidden' hides a field.",
+            "46:17: 'innerHidden' hides a field.",
+            "49:26: 'innerHidden' hides a field.",
+            "55:17: 'innerHidden' hides a field.",
+            "56:17: 'hidden' hides a field.",
+            "61:22: 'innerHidden' hides a field.",
+            "64:22: 'hidden' hides a field.",
+            "69:17: 'innerHidden' hides a field.",
+            "70:17: 'hidden' hides a field.",
+            "76:17: 'innerHidden' hides a field.",
+            "77:17: 'hidden' hides a field.",
+            "82:13: 'hidden' hides a field.",
+            "106:29: 'prop' hides a field.",
+            "112:29: 'prop' hides a field.",
+            "124:28: 'prop' hides a field.",
+            "138:13: 'hidden' hides a field.",
+            "143:13: 'hidden' hides a field.",
+            "148:13: 'hidden' hides a field.",
+            "152:13: 'hidden' hides a field.",
+            "179:23: 'y' hides a field.",
+            "200:17: 'hidden' hides a field.",
+            "210:20: 'hidden' hides a field.",
+            "217:13: 'hidden' hides a field.",
+            "223:13: 'hiddenStatic' hides a field.",
+            "230:41: 'x' hides a field.",
+            "253:40: 'prop' hides a field.",
+            "278:41: 'prop2' hides a field.",
+        };
+        verify(checkConfig, getPath("InputHiddenField.java"), expected);
+    }
+
+    /** tests ignoreSetter and setterCanReturnItsClass properties */
+    @Test
+    public void testIgnoreChainSetter()
+        throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(HiddenFieldCheck.class);
+        checkConfig.addAttribute("ignoreSetter", "true");
+        checkConfig.addAttribute("setterCanReturnItsClass", "true");
         final String[] expected = {
             "18:13: 'hidden' hides a field.",
             "21:33: 'hidden' hides a field.",
@@ -214,6 +265,9 @@ public class HiddenFieldCheckTest
             "223:13: 'hiddenStatic' hides a field.",
             "230:41: 'x' hides a field.",
             "236:30: 'xAxis' hides a field.",
+            "253:40: 'prop' hides a field.",
+            "267:29: 'prop' hides a field.",
+            "278:41: 'prop2' hides a field.",
         };
         verify(checkConfig, getPath("InputHiddenField.java"), expected);
     }
@@ -288,6 +342,9 @@ public class HiddenFieldCheckTest
             "217:13: 'hidden' hides a field.",
             "223:13: 'hiddenStatic' hides a field.",
             "236:30: 'xAxis' hides a field.",
+            "253:40: 'prop' hides a field.",
+            "267:29: 'prop' hides a field.",
+            "278:41: 'prop2' hides a field.",
         };
         verify(checkConfig, getPath("InputHiddenField.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputHiddenField.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputHiddenField.java
@@ -237,3 +237,47 @@ class Bug3370946 {
         this.xAxis = xAxis;
     }
 }
+
+/** tests chain-setter */
+class PropertySetter3
+{
+    private int prop;
+
+    /** 
+     * if setterCanReturnItsClass == false then 
+     *     error - not a void method
+     * 
+     * if setterCanReturnItsClass == true then 
+     *     success as it is then considered to be a setter  
+     */
+    public PropertySetter3 setProp(int prop)
+    {
+        this.prop = prop;
+        return this;
+    }
+}
+
+/** tests setters (both regular and the chain one) on the enum */ 
+enum PropertySetter4 {
+    INSTANCE;
+    
+    private int prop;
+    private int prop2;
+    
+    public void setProp(int prop) {
+        this.prop = prop;
+    }
+
+    /** 
+     * if setterCanReturnItsClass == false then 
+     *     error - not a void method
+     * 
+     * if setterCanReturnItsClass == true then 
+     *     success as it is then considered to be a setter  
+     */
+    public PropertySetter4 setProp2(int prop2)
+    {
+        this.prop2 = prop2;
+        return this;
+    }
+}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -433,7 +433,33 @@ number.equals(i + j);
               Controls whether to ignore the parameter of a property setter
               method, where the property setter method for field
               &quot;xyz&quot; has name &quot;setXyz&quot;, one parameter named
-              &quot;xyz&quot;, and return type <code>void</code>.
+              &quot;xyz&quot; and return type of <code>void</code>
+              ( default behavior) or class in which method is declared (only
+              if property <code>setterCanReturnItsClass</code> is set
+              to <code>true</code>).
+            </td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>false</code></td>
+          </tr>
+
+          <tr>
+            <td>setterCanReturnItsClass</td>
+            <td>
+              Used in conjunction with <code>ignoreSetter</code> property it
+              controls rule that recognizes method as a setter. By default
+              setter is a method with signature of type
+              <pre>
+                void setXyz(${someType} xyz)
+              </pre>
+              By setting this property (<code>setterCanReturnItsClass</code>)
+              to <code>true</code> we expand definition of setter to also
+              include returning class in which setter is defined. For example
+              <pre>
+                class Foo {
+                    int prop;
+                    Foo setProp(int prop) { this.prop = prop; }
+                }
+              </pre>
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
@@ -493,6 +519,18 @@ number.equals(i + j);
         <source>
 &lt;module name=&quot;HiddenField&quot;&gt;
     &lt;property name=&quot;ignoreSetter&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+
+        <p>
+          To configure the check so that it ignores the parameter of setter
+          methods recognizing setter as returning either <code>void</code> or
+              a class in which it is declared:
+        </p>
+        <source>
+&lt;module name=&quot;HiddenField&quot;&gt;
+    &lt;property name=&quot;ignoreSetter&quot; value=&quot;true&quot;/&gt;
+    &lt;property name=&quot;setterCanReturnItsClass&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
       </subsection>


### PR DESCRIPTION
When set to true it means that setter methods can return either instance
of the class in which they are declared or void, which is different from
current behaviour where setters must return void.