### PR TITLE
Custom Import Order Check, updated third-party package property's defaul...

### DIFF
--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -155,7 +155,6 @@
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
-            <property name="thirdPartyPackageRegExp" value=".*"/>
             <property name="specialImportsRegExp" value="com.google"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -267,4 +267,38 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport
         verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
                 + "checkstyle/imports/InputDefaultPackage.java").getCanonicalPath(), expected);
     }
+
+    @Test
+    public void testWithoutThirdPartyPackage() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
+        checkConfig.addAttribute("separateLineBetweenGroups", "true");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE###STATIC");
+        final String[] expected = {
+
+        };
+
+        verify(checkConfig, getPath("imports" + File.separator
+                + "InputCustomImportOrderThirdPartyPackage.java"), expected);
+    }
+
+    @Test
+    public void testThirdPartyAndSpecialImports() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("specialImportsRegExp", "antlr.*");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STATIC###"
+                + "SPECIAL_IMPORTS");
+        final String[] expected = {
+            "11: Import statement is in the wrong order. Should be in the 'THIRD_PARTY_PACKAGE' group.",
+        };
+
+        verify(checkConfig, getPath("imports" + File.separator
+                + "InputCustomImportOrderThirdPartyAndSpecial.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderThirdPartyAndSpecial.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderThirdPartyAndSpecial.java
@@ -1,0 +1,18 @@
+package com.puppycrawl.tools.checkstyle.imports;
+
+import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.Beta;
+import com.google.common.annotations.VisibleForTesting;
+
+import org.abego.treelayout.Configuration;
+
+import static sun.tools.util.ModifierFilter.ALL_ACCESS;
+
+import com.google.common.annotations.GwtCompatible;
+
+import antlr.*;
+
+public class InputCustomImportOrderThirdPartyAndSpecial
+{
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderThirdPartyPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderThirdPartyPackage.java
@@ -1,0 +1,16 @@
+package com.puppycrawl.tools.checkstyle.imports;
+
+import org.abego.treelayout.*;
+
+import org.junit.*;
+
+import java.*;
+import javax.*;
+
+import static sun.tools.util.CommandLine.parse;
+import static sun.tools.util.ModifierFilter.ALL_ACCESS;
+
+public class InputCustomImportOrderThirdPartyPackage
+{
+    
+}

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -598,7 +598,7 @@ class FooBar {
         <p>
           3) THIRD_PARTY_PACKAGE group. This group sets ordering of third party imports.
           Third party imports are all imports except STATIC,
-          SAME_PACKAGE(n) and STANDARD_JAVA_PACKAGE.
+          SAME_PACKAGE(n), STANDARD_JAVA_PACKAGE and SPECIAL_IMPORTS.
         </p>
         <p>
           4) STANDARD_JAVA_PACKAGE group. This group sets ordering of standard java (java|javax) imports.
@@ -639,7 +639,7 @@ class FooBar {
             <td>thirdPartyPackageRegExp</td>
             <td>RegExp for THIRDPARTY_PACKAGE group imports.</td>
             <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^$</code></td>
+            <td><code>.*</code></td>
           </tr>
           <tr>
             <td>specialImportsRegExp</td>
@@ -696,6 +696,34 @@ class FooBar {
        <source>
 &lt;module name=&quot;CustomImportOrder&quot;&gt;
     &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+       </source>
+       <p>
+         To force checking imports sequence such as:
+       </p>
+       <source>
+package com.puppycrawl.tools.checkstyle.imports;
+
+import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.Beta;
+import com.google.common.annotations.VisibleForTesting;
+
+import org.abego.treelayout.Configuration;
+
+import static sun.tools.util.ModifierFilter.ALL_ACCESS;
+
+import com.google.common.annotations.GwtCompatible; // violation here - should be in the
+                                                    // THIRD_PARTY_PACKAGE group
+import android.*;
+       </source>
+       <p>
+         configure as follows:
+       </p>
+       <source>
+&lt;module name=&quot;CustomImportOrder&quot;&gt;
+    &lt;property name=&quot;customImportOrderRules&quot;
+    value=&quot;SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STATIC###SPECIAL_IMPORTS&quot;/&gt;
+    &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;android.*&quot;/&gt;
 &lt;/module&gt;
        </source>
       </subsection>


### PR DESCRIPTION
...t value, issue #515

According to #515 

Modified the default value of <b>thirdPartyPackageRegExp</b> from empty string (^$) to either empty or not string (^.*$), so now user is able to not specifying this value as it's said in docs:
```
THIRD_PARTY_PACKAGE group. This group sets ordering of third party imports. Third party imports are all imports except STATIC, SAME_PACKAGE(n) and STANDARD_JAVA_PACKAGE.
```

Added corresponding UT and input.