### PR TITLE
TreeWalker update, logging warning if AcceptableTokens are broken, issue...

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -309,21 +309,14 @@ public final class TreeWalker
             final int[] acceptableTokens = check.getAcceptableTokens();
             Arrays.sort(acceptableTokens);
             for (String token : checkTokens) {
-                try {
-                    final int tokenId = TokenTypes.getTokenId(token);
-                    if (Arrays.binarySearch(acceptableTokens, tokenId) >= 0) {
-                        registerCheck(token, check);
-                    }
-                    else {
-                        throw new IllegalArgumentException("Token \""
-                            + token + "\" was not found in Acceptable tokens list"
-                                    + " in check " + check);
-                    }
+                final int tokenId = TokenTypes.getTokenId(token);
+                if (Arrays.binarySearch(acceptableTokens, tokenId) >= 0) {
+                    registerCheck(token, check);
                 }
-                catch (final IllegalArgumentException ex) {
+                else {
                     throw new CheckstyleException("Token \""
                         + token + "\" was not found in Acceptable tokens list"
-                                + " in check " + check, ex);
+                                + " in check " + check);
                 }
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -314,11 +314,16 @@ public final class TreeWalker
                     if (Arrays.binarySearch(acceptableTokens, tokenId) >= 0) {
                         registerCheck(token, check);
                     }
-                    // TODO: else log warning
+                    else {
+                        throw new IllegalArgumentException("Token \""
+                            + token + "\" was not found in Acceptable tokens list"
+                                    + " in check " + check);
+                    }
                 }
                 catch (final IllegalArgumentException ex) {
-                    throw new CheckstyleException("illegal token \""
-                        + token + "\" in check " + check, ex);
+                    throw new CheckstyleException("Token \""
+                        + token + "\" was not found in Acceptable tokens list"
+                                + " in check " + check, ex);
                 }
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheck.java
@@ -42,6 +42,12 @@ public class ArrayTypeStyleCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.ARRAY_DECLARATOR};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final DetailAST typeAST = ast.getParent();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -203,6 +203,12 @@ public class AvoidEscapedUnicodeCharactersCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.STRING_LITERAL, TokenTypes.CHAR_LITERAL};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
@@ -55,6 +55,15 @@ public class OuterTypeFilenameCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.CLASS_DEF, TokenTypes.INTERFACE_DEF,
+            TokenTypes.ENUM_DEF, TokenTypes.ANNOTATION_DEF,
+        };
+    }
+
+    @Override
     public void beginTree(DetailAST ast)
     {
         fileName = getFileName();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheck.java
@@ -86,6 +86,12 @@ public class TodoCommentCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.COMMENT_CONTENT };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final String[] lines = ast.getText().split("\n");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -86,6 +86,16 @@ public class UncommentedMainCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.METHOD_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.PACKAGE_DEF,
+        };
+    }
+
+    @Override
     public int[] getRequiredTokens()
     {
         return getDefaultTokens();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UpperEllCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UpperEllCheck.java
@@ -56,6 +56,12 @@ public class UpperEllCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.NUM_LONG};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if (ast.getText().endsWith("l")) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -183,6 +183,28 @@ public class AnnotationLocationCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.PARAMETER_DEF,
+            TokenTypes.ANNOTATION_DEF,
+            TokenTypes.TYPECAST,
+            TokenTypes.LITERAL_THROWS,
+            TokenTypes.IMPLEMENTS_CLAUSE,
+            TokenTypes.TYPE_ARGUMENT,
+            TokenTypes.LITERAL_NEW,
+            TokenTypes.DOT,
+            TokenTypes.ANNOTATION_FIELD_DEF,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final DetailAST modifiersNode = ast.findFirstToken(TokenTypes.MODIFIERS);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheck.java
@@ -105,6 +105,12 @@ public class AvoidNestedBlocksCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.SLIST};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final DetailAST parent = ast.getParent();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
@@ -101,6 +101,28 @@ public class EmptyBlockCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.LITERAL_WHILE,
+            TokenTypes.LITERAL_TRY,
+            TokenTypes.LITERAL_CATCH,
+            TokenTypes.LITERAL_FINALLY,
+            TokenTypes.LITERAL_DO,
+            TokenTypes.LITERAL_IF,
+            TokenTypes.LITERAL_ELSE,
+            TokenTypes.LITERAL_FOR,
+            TokenTypes.INSTANCE_INIT,
+            TokenTypes.STATIC_INIT,
+            TokenTypes.LITERAL_SWITCH,
+            TokenTypes.LITERAL_CASE,
+            TokenTypes.LITERAL_SWITCH,
+            TokenTypes.LITERAL_DEFAULT,
+            TokenTypes.ARRAY_INIT,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final DetailAST slistToken = ast.findFirstToken(TokenTypes.SLIST);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -148,6 +148,30 @@ public class LeftCurlyCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ANNOTATION_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.LITERAL_WHILE,
+            TokenTypes.LITERAL_TRY,
+            TokenTypes.LITERAL_CATCH,
+            TokenTypes.LITERAL_FINALLY,
+            TokenTypes.LITERAL_SYNCHRONIZED,
+            TokenTypes.LITERAL_SWITCH,
+            TokenTypes.LITERAL_DO,
+            TokenTypes.LITERAL_IF,
+            TokenTypes.LITERAL_ELSE,
+            TokenTypes.LITERAL_FOR,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final DetailAST startToken;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -97,6 +97,21 @@ public class NeedBracesCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.LITERAL_DO,
+            TokenTypes.LITERAL_ELSE,
+            TokenTypes.LITERAL_FOR,
+            TokenTypes.LITERAL_IF,
+            TokenTypes.LITERAL_WHILE,
+            TokenTypes.LITERAL_CASE,
+            TokenTypes.LITERAL_DEFAULT,
+            TokenTypes.LAMBDA,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final DetailAST slistAST = ast.findFirstToken(TokenTypes.SLIST);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalMethodCheck.java
@@ -52,6 +52,12 @@ public abstract class AbstractIllegalMethodCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.METHOD_DEF};
+    }
+
+    @Override
     public void visitToken(DetailAST aAST)
     {
         final DetailAST mid = aAST.findFirstToken(TokenTypes.IDENT);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -101,6 +101,15 @@ public abstract class AbstractSuperCheck
         };
     }
 
+    @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.METHOD_DEF,
+            TokenTypes.LITERAL_SUPER,
+        };
+    }
+
     /**
      * Returns the name of the overriding method.
      * @return the name of the overriding method.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
@@ -47,6 +47,12 @@ public class ArrayTrailingCommaCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.ARRAY_INIT};
+    }
+
+    @Override
     public void visitToken(DetailAST arrayInit)
     {
         final DetailAST rcurly = arrayInit.findFirstToken(TokenTypes.RCURLY);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidInlineConditionalsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidInlineConditionalsCheck.java
@@ -51,6 +51,12 @@ public class AvoidInlineConditionalsCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[]{TokenTypes.QUESTION};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         // the only place a QUESTION token can occur is in inline conditionals

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheck.java
@@ -59,6 +59,12 @@ public class CovariantEqualsCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.CLASS_DEF, TokenTypes.LITERAL_NEW, };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         equalsMethods.clear();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -105,6 +105,17 @@ public class DeclarationOrderCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.MODIFIERS,
+            TokenTypes.OBJBLOCK,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final int parentType = ast.getParent().getType();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EmptyStatementCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EmptyStatementCheck.java
@@ -52,6 +52,12 @@ public class EmptyStatementCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.EMPTY_STAT};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         log(ast.getLineNo(), ast.getColumnNo(), "empty.statement");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -98,6 +98,12 @@ public class EqualsAvoidNullCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.METHOD_CALL};
+    }
+
+    @Override
     public void visitToken(final DetailAST methodCall)
     {
         final DetailAST dot = methodCall.getFirstChild();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
@@ -65,6 +65,12 @@ public class EqualsHashCodeCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.METHOD_DEF};
+    }
+
+    @Override
     public void beginTree(DetailAST rootAST)
     {
         objBlockEquals.clear();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -63,6 +63,12 @@ public class ExplicitInitializationCheck extends Check
     }
 
     @Override
+    public final int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.VARIABLE_DEF};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         // do not check local variables and

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -92,6 +92,12 @@ public class FallThroughCheck extends Check
         return getDefaultTokens();
     }
 
+    @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[]{TokenTypes.CASE_GROUP};
+    }
+
     /**
      * Set the relief pattern.
      *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -58,6 +58,12 @@ public final class IllegalCatchCheck extends AbstractIllegalCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.LITERAL_CATCH};
+    }
+
+    @Override
     public void visitToken(DetailAST detailAST)
     {
         final DetailAST paradef =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
@@ -85,6 +85,12 @@ public final class IllegalThrowsCheck extends AbstractIllegalCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.LITERAL_THROWS};
+    }
+
+    @Override
     public void visitToken(DetailAST detailAST)
     {
         final DetailAST methodDef = detailAST.getParent();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -148,6 +148,17 @@ public final class IllegalTypeCheck extends AbstractFormatCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.PARAMETER_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.IMPORT,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         switch (ast.getType()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
@@ -118,6 +118,25 @@ public class InnerAssignmentCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.ASSIGN,            // '='
+            TokenTypes.DIV_ASSIGN,        // "/="
+            TokenTypes.PLUS_ASSIGN,       // "+="
+            TokenTypes.MINUS_ASSIGN,      //"-="
+            TokenTypes.STAR_ASSIGN,       // "*="
+            TokenTypes.MOD_ASSIGN,        // "%="
+            TokenTypes.SR_ASSIGN,         // ">>="
+            TokenTypes.BSR_ASSIGN,        // ">>>="
+            TokenTypes.SL_ASSIGN,         // "<<="
+            TokenTypes.BXOR_ASSIGN,       // "^="
+            TokenTypes.BOR_ASSIGN,        // "|="
+            TokenTypes.BAND_ASSIGN,       // "&="
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if (isInContext(ast, ALLOWED_ASSIGMENT_CONTEXT)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -85,6 +85,17 @@ public class MagicNumberCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.NUM_DOUBLE,
+            TokenTypes.NUM_FLOAT,
+            TokenTypes.NUM_INT,
+            TokenTypes.NUM_LONG,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if (ignoreAnnotation && isInAnnotation(ast)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -70,6 +70,33 @@ public final class ModifiedControlVariableCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.OBJBLOCK,
+            TokenTypes.LITERAL_FOR,
+            TokenTypes.FOR_ITERATOR,
+            TokenTypes.FOR_EACH_CLAUSE,
+            TokenTypes.ASSIGN,
+            TokenTypes.PLUS_ASSIGN,
+            TokenTypes.MINUS_ASSIGN,
+            TokenTypes.STAR_ASSIGN,
+            TokenTypes.DIV_ASSIGN,
+            TokenTypes.MOD_ASSIGN,
+            TokenTypes.SR_ASSIGN,
+            TokenTypes.BSR_ASSIGN,
+            TokenTypes.SL_ASSIGN,
+            TokenTypes.BAND_ASSIGN,
+            TokenTypes.BXOR_ASSIGN,
+            TokenTypes.BOR_ASSIGN,
+            TokenTypes.INC,
+            TokenTypes.POST_INC,
+            TokenTypes.DEC,
+            TokenTypes.POST_DEC,
+        };
+    }
+
+    @Override
     public void beginTree(DetailAST rootAST)
     {
         // clear data

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -115,6 +115,12 @@ public class MultipleStringLiteralsCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.STRING_LITERAL};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if (isInIgnoreOccurrenceContext(ast)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleVariableDeclarationsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleVariableDeclarationsCheck.java
@@ -56,6 +56,12 @@ public class MultipleVariableDeclarationsCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.VARIABLE_DEF};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         DetailAST nextNode = ast.getNextSibling();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheck.java
@@ -58,6 +58,12 @@ public final class NestedForDepthCheck extends AbstractNestedDepthCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.LITERAL_FOR};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if (TokenTypes.LITERAL_FOR == ast.getType()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedIfDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedIfDepthCheck.java
@@ -45,6 +45,12 @@ public final class NestedIfDepthCheck extends AbstractNestedDepthCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.LITERAL_IF};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         switch (ast.getType()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedTryDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedTryDepthCheck.java
@@ -43,6 +43,12 @@ public final class NestedTryDepthCheck extends AbstractNestedDepthCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.LITERAL_TRY};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         switch (ast.getType()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
@@ -49,6 +49,15 @@ public final class OneStatementPerLineCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.EXPR, TokenTypes.SEMI, TokenTypes.FOR_INIT,
+            TokenTypes.FOR_ITERATOR,
+        };
+    }
+
+    @Override
     public void beginTree(DetailAST rootAST)
     {
         exprDepth = 0;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
@@ -58,6 +58,14 @@ public class OverloadMethodsDeclarationOrderCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.OBJBLOCK,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final int parentType = ast.getParent().getType();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java
@@ -48,6 +48,12 @@ public final class PackageDeclarationCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.PACKAGE_DEF};
+    }
+
+    @Override
     public void beginTree(DetailAST ast)
     {
         defined = false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
@@ -79,6 +79,31 @@ public final class ParameterAssignmentCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.ASSIGN,
+            TokenTypes.PLUS_ASSIGN,
+            TokenTypes.MINUS_ASSIGN,
+            TokenTypes.STAR_ASSIGN,
+            TokenTypes.DIV_ASSIGN,
+            TokenTypes.MOD_ASSIGN,
+            TokenTypes.SR_ASSIGN,
+            TokenTypes.BSR_ASSIGN,
+            TokenTypes.SL_ASSIGN,
+            TokenTypes.BAND_ASSIGN,
+            TokenTypes.BXOR_ASSIGN,
+            TokenTypes.BOR_ASSIGN,
+            TokenTypes.INC,
+            TokenTypes.POST_INC,
+            TokenTypes.DEC,
+            TokenTypes.POST_DEC,
+        };
+    }
+
+    @Override
     public void beginTree(DetailAST rootAST)
     {
         // clear data

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -120,6 +120,14 @@ public class RequireThisCheck extends DeclarationCollector
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.IDENT,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         super.visitToken(ast);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
@@ -74,6 +74,16 @@ public final class ReturnCountCheck extends AbstractFormatCheck
         };
     }
 
+    @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.LITERAL_RETURN,
+        };
+    }
+
     /**
      * Getter for max property.
      * @return maximum allowed number of return statements.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
@@ -48,6 +48,12 @@ public class SimplifyBooleanReturnCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.LITERAL_IF};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         // LITERAL_IF has the following four or five children:

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -44,6 +44,12 @@ public class StringLiteralEqualityCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.EQUAL, TokenTypes.NOT_EQUAL};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         // no need to check for nulls here, == and != always have two children

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -124,6 +124,35 @@ public class UnnecessaryParenthesesCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.EXPR,
+            TokenTypes.IDENT,
+            TokenTypes.NUM_DOUBLE,
+            TokenTypes.NUM_FLOAT,
+            TokenTypes.NUM_INT,
+            TokenTypes.NUM_LONG,
+            TokenTypes.STRING_LITERAL,
+            TokenTypes.LITERAL_NULL,
+            TokenTypes.LITERAL_FALSE,
+            TokenTypes.LITERAL_TRUE,
+            TokenTypes.ASSIGN,
+            TokenTypes.BAND_ASSIGN,
+            TokenTypes.BOR_ASSIGN,
+            TokenTypes.BSR_ASSIGN,
+            TokenTypes.BXOR_ASSIGN,
+            TokenTypes.DIV_ASSIGN,
+            TokenTypes.MINUS_ASSIGN,
+            TokenTypes.MOD_ASSIGN,
+            TokenTypes.PLUS_ASSIGN,
+            TokenTypes.SL_ASSIGN,
+            TokenTypes.SR_ASSIGN,
+            TokenTypes.STAR_ASSIGN,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final int type = ast.getType();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -253,6 +253,12 @@ public class VariableDeclarationUsageDistanceCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.VARIABLE_DEF};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final int parentType = ast.getParent().getType();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -64,6 +64,12 @@ public class DesignForExtensionCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.METHOD_DEF};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         // nothing to do for Interfaces

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -50,6 +50,12 @@ public class FinalClassCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[]{TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -41,6 +41,12 @@ public class HideUtilityClassConstructorCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.CLASS_DEF};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if (isAbstract(ast)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheck.java
@@ -39,6 +39,12 @@ public class InnerTypeLastCheck extends Check
         return new int[] {TokenTypes.CLASS_DEF, TokenTypes.INTERFACE_DEF};
     }
 
+    @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.CLASS_DEF, TokenTypes.INTERFACE_DEF};
+    }
+
     /** Meet a root class. */
     private boolean rootClass = true;
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheck.java
@@ -59,6 +59,12 @@ public final class InterfaceIsTypeCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.INTERFACE_DEF};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final DetailAST objBlock =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
@@ -76,6 +76,12 @@ public final class MutableExceptionCheck extends AbstractFormatCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.CLASS_DEF, TokenTypes.VARIABLE_DEF};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         switch (ast.getType()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
@@ -68,6 +68,14 @@ public final class ThrowsCountCheck extends Check
         return getDefaultTokens();
     }
 
+    @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.LITERAL_THROWS,
+        };
+    }
+
     /**
      * Getter for max property.
      * @return maximum allowed throws statements.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -129,6 +129,12 @@ public class VisibilityModifierCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.VARIABLE_DEF, TokenTypes.OBJBLOCK};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if ((ast.getType() != TokenTypes.VARIABLE_DEF)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
@@ -80,6 +80,12 @@ public class AvoidStarImportCheck
         return new int[] {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
     }
 
+    @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
+    }
+
     /**
      * Sets the list of packages or classes to be exempt from the check.
      * The excludes can contain a .* or not.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
@@ -74,6 +74,12 @@ public class AvoidStaticImportCheck
         return new int[] {TokenTypes.STATIC_IMPORT};
     }
 
+    @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.STATIC_IMPORT};
+    }
+
     /**
      * Sets the list of classes or static members to be exempt from the check.
      * @param excludes a list of fully-qualified class names/specific

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -297,6 +297,16 @@ public class CustomImportOrderCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.IMPORT,
+            TokenTypes.STATIC_IMPORT,
+            TokenTypes.PACKAGE_DEF,
+        };
+    }
+
+    @Override
     public void beginTree(DetailAST rootAST)
     {
         importToGroupList.clear();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
@@ -88,6 +88,12 @@ public class IllegalImportCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final FullIdent imp;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -62,6 +62,13 @@ public class ImportControlCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.PACKAGE_DEF, TokenTypes.IMPORT,
+                          TokenTypes.STATIC_IMPORT, };
+    }
+
+    @Override
     public void beginTree(final DetailAST rootAST)
     {
         currentLeaf = null;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -204,6 +204,12 @@ public class ImportOrderCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
+    }
+
+    @Override
     public void beginTree(DetailAST rootAST)
     {
         lastGroup = Integer.MIN_VALUE;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
@@ -79,6 +79,15 @@ public class RedundantImportCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[]
+        {TokenTypes.IMPORT,
+         TokenTypes.STATIC_IMPORT,
+         TokenTypes.PACKAGE_DEF, };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if (ast.getType() == TokenTypes.PACKAGE_DEF) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -111,7 +111,7 @@ public class UnusedImportsCheck extends Check
             TokenTypes.IDENT,
             TokenTypes.IMPORT,
             TokenTypes.STATIC_IMPORT,
-            // Definitions that may contain Javdoc...
+            // Definitions that may contain Javadoc...
             TokenTypes.PACKAGE_DEF,
             TokenTypes.ANNOTATION_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,
@@ -129,6 +129,27 @@ public class UnusedImportsCheck extends Check
     public int[] getRequiredTokens()
     {
         return getDefaultTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.IDENT,
+            TokenTypes.IMPORT,
+            TokenTypes.STATIC_IMPORT,
+            // Definitions that may contain Javadoc...
+            TokenTypes.PACKAGE_DEF,
+            TokenTypes.ANNOTATION_DEF,
+            TokenTypes.ANNOTATION_FIELD_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.VARIABLE_DEF,
+        };
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -113,6 +113,23 @@ public class JavadocStyleCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ANNOTATION_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.ANNOTATION_FIELD_DEF,
+            TokenTypes.PACKAGE_DEF,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if (shouldCheck(ast)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -148,6 +148,17 @@ public class JavadocTypeCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.ANNOTATION_DEF,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if (shouldCheck(ast)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -101,6 +101,15 @@ public class JavadocVariableCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if (shouldCheck(ast)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
@@ -74,6 +74,21 @@ public final class BooleanExpressionComplexityCheck extends Check
         };
     }
 
+    @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.EXPR,
+            TokenTypes.LAND,
+            TokenTypes.BAND,
+            TokenTypes.LOR,
+            TokenTypes.BOR,
+            TokenTypes.BXOR,
+        };
+    }
+
     /**
      * Getter for maximum allowed complexity.
      * @return value of maximum allowed complexity.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
@@ -53,6 +53,18 @@ public final class ClassDataAbstractionCouplingCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.PACKAGE_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.LITERAL_NEW,
+        };
+    }
+
+    @Override
     protected String getLogMessageId()
     {
         return "classDataAbstractionCoupling";

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
@@ -55,6 +55,21 @@ public final class ClassFanOutComplexityCheck extends AbstractClassCouplingCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.PACKAGE_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.TYPE,
+            TokenTypes.LITERAL_NEW,
+            TokenTypes.LITERAL_THROWS,
+            TokenTypes.ANNOTATION_DEF,
+        };
+    }
+
+    @Override
     protected String getLogMessageId()
     {
         return "classFanOutComplexity";

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheck.java
@@ -67,6 +67,26 @@ public class CyclomaticComplexityCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.INSTANCE_INIT,
+            TokenTypes.STATIC_INIT,
+            TokenTypes.LITERAL_WHILE,
+            TokenTypes.LITERAL_DO,
+            TokenTypes.LITERAL_FOR,
+            TokenTypes.LITERAL_IF,
+            TokenTypes.LITERAL_CASE,
+            TokenTypes.LITERAL_CATCH,
+            TokenTypes.QUESTION,
+            TokenTypes.LAND,
+            TokenTypes.LOR,
+        };
+    }
+
+    @Override
     protected final void visitTokenHook(DetailAST ast)
     {
         incrementCurrentValue(BigInteger.ONE);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -129,6 +129,41 @@ public class JavaNCSSCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[]{
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.INSTANCE_INIT,
+            TokenTypes.STATIC_INIT,
+            TokenTypes.PACKAGE_DEF,
+            TokenTypes.IMPORT,
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.CTOR_CALL,
+            TokenTypes.SUPER_CTOR_CALL,
+            TokenTypes.LITERAL_IF,
+            TokenTypes.LITERAL_ELSE,
+            TokenTypes.LITERAL_WHILE,
+            TokenTypes.LITERAL_DO,
+            TokenTypes.LITERAL_FOR,
+            TokenTypes.LITERAL_SWITCH,
+            TokenTypes.LITERAL_BREAK,
+            TokenTypes.LITERAL_CONTINUE,
+            TokenTypes.LITERAL_RETURN,
+            TokenTypes.LITERAL_THROW,
+            TokenTypes.LITERAL_SYNCHRONIZED,
+            TokenTypes.LITERAL_CATCH,
+            TokenTypes.LITERAL_FINALLY,
+            TokenTypes.EXPR,
+            TokenTypes.LABELED_STAT,
+            TokenTypes.LITERAL_CASE,
+            TokenTypes.LITERAL_DEFAULT,
+        };
+    }
+
+    @Override
     public void beginTree(DetailAST rootAST)
     {
         counters = new FastStack<Counter>();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
@@ -68,6 +68,27 @@ public final class NPathComplexityCheck extends AbstractComplexityCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.STATIC_INIT,
+            TokenTypes.INSTANCE_INIT,
+            TokenTypes.LITERAL_WHILE,
+            TokenTypes.LITERAL_DO,
+            TokenTypes.LITERAL_FOR,
+            TokenTypes.LITERAL_IF,
+            TokenTypes.LITERAL_ELSE,
+            TokenTypes.LITERAL_SWITCH,
+            TokenTypes.LITERAL_CASE,
+            TokenTypes.LITERAL_TRY,
+            TokenTypes.LITERAL_CATCH,
+            TokenTypes.QUESTION,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         switch (ast.getType()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
@@ -82,6 +82,12 @@ public class ModifierOrderCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.MODIFIERS};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final List<DetailAST> mods = Lists.newArrayList();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
@@ -52,6 +52,17 @@ public class RedundantModifierCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.METHOD_DEF,
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.ANNOTATION_FIELD_DEF,
+            TokenTypes.INTERFACE_DEF,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if (TokenTypes.INTERFACE_DEF == ast.getType()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -183,6 +183,22 @@ public class AbbreviationAsWordInNameCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.ANNOTATION_DEF,
+            TokenTypes.ANNOTATION_FIELD_DEF,
+            TokenTypes.PARAMETER_DEF,
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
@@ -86,11 +86,15 @@ public final class AbstractClassNameCheck extends AbstractFormatCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[]{TokenTypes.CLASS_DEF};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
-        if (TokenTypes.CLASS_DEF == ast.getType()) {
-            visitClassDef(ast);
-        }
+        visitClassDef(ast);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.java
@@ -56,6 +56,14 @@ public abstract class AbstractTypeParameterNameCheck
     }
 
     @Override
+    public final int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.TYPE_PARAMETER,
+        };
+    }
+
+    @Override
     public final void init()
     {
         this.location = getLocation();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
@@ -70,6 +70,12 @@ public class ConstantNameCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.VARIABLE_DEF};
+    }
+
+    @Override
     protected final boolean mustCheckName(DetailAST ast)
     {
         boolean retVal = false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheck.java
@@ -68,6 +68,15 @@ public class LocalFinalVariableNameCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.PARAMETER_DEF,
+        };
+    }
+
+    @Override
     protected final boolean mustCheckName(DetailAST ast)
     {
         final DetailAST modifiersAST =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheck.java
@@ -104,6 +104,15 @@ public class LocalVariableNameCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.PARAMETER_DEF,
+        };
+    }
+
+    @Override
     protected final boolean mustCheckName(DetailAST ast)
     {
         final DetailAST modifiersAST =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheck.java
@@ -65,6 +65,12 @@ public class MemberNameCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.VARIABLE_DEF};
+    }
+
+    @Override
     protected final boolean mustCheckName(DetailAST ast)
     {
         final DetailAST modifiersAST =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
@@ -101,6 +101,12 @@ public class MethodNameCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.METHOD_DEF, };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if (!AnnotationUtility.containsAnnotation(ast, OVERRIDE)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
@@ -81,6 +81,12 @@ public class PackageNameCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.PACKAGE_DEF};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final DetailAST nameAST = ast.getLastChild().getPreviousSibling();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -65,6 +65,12 @@ public class ParameterNameCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.PARAMETER_DEF};
+    }
+
+    @Override
     protected boolean mustCheckName(DetailAST ast)
     {
         return !(

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheck.java
@@ -63,6 +63,12 @@ public class StaticVariableNameCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.VARIABLE_DEF};
+    }
+
+    @Override
     protected final boolean mustCheckName(DetailAST ast)
     {
         final DetailAST modifiersAST =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java
@@ -71,4 +71,14 @@ public class TypeNameCheck
                           TokenTypes.ANNOTATION_DEF,
         };
     }
+
+    @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.CLASS_DEF,
+                          TokenTypes.INTERFACE_DEF,
+                          TokenTypes.ENUM_DEF,
+                          TokenTypes.ANNOTATION_DEF,
+        };
+    }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/AnonInnerLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/AnonInnerLengthCheck.java
@@ -70,6 +70,12 @@ public class AnonInnerLengthCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.LITERAL_NEW};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final DetailAST openingBrace = ast.findFirstToken(TokenTypes.OBJBLOCK);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
@@ -67,6 +67,18 @@ public final class ExecutableStatementCountCheck
         return new int[] {TokenTypes.SLIST};
     }
 
+    @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.INSTANCE_INIT,
+            TokenTypes.STATIC_INIT,
+            TokenTypes.SLIST,
+        };
+    }
+
     /**
      * Gets the maximum threshold.
      * @return the maximum threshold.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
@@ -120,6 +120,18 @@ public final class MethodCountCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.METHOD_DEF,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if ((TokenTypes.CLASS_DEF == ast.getType())

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java
@@ -71,6 +71,12 @@ public class MethodLengthCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.METHOD_DEF, TokenTypes.CTOR_DEF};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final DetailAST openingBrace = ast.findFirstToken(TokenTypes.SLIST);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheck.java
@@ -43,6 +43,13 @@ public class OuterTypeNumberCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.CLASS_DEF, TokenTypes.INTERFACE_DEF,
+            TokenTypes.ENUM_DEF, TokenTypes.ANNOTATION_DEF, };
+    }
+
+    @Override
     public void beginTree(DetailAST ast)
     {
         currentDepth = 0;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
@@ -107,6 +107,12 @@ public class ParameterNumberCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.METHOD_DEF, TokenTypes.CTOR_DEF};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final DetailAST params = ast.findFirstToken(TokenTypes.PARAMETERS);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
@@ -66,6 +66,13 @@ public class EmptyForInitializerPadCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.FOR_INIT,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if (ast.getChildCount() == 0) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
@@ -66,6 +66,13 @@ public class EmptyForIteratorPadCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.FOR_ITERATOR,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         if (ast.getChildCount() == 0) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -203,6 +203,23 @@ public class EmptyLineSeparatorCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.PACKAGE_DEF,
+            TokenTypes.IMPORT,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.STATIC_INIT,
+            TokenTypes.INSTANCE_INIT,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.VARIABLE_DEF,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final DetailAST nextToken = ast.getNextSibling();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -76,6 +76,12 @@ public class GenericWhitespaceCheck extends Check
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.GENERIC_START, TokenTypes.GENERIC_END};
+    }
+
+    @Override
     public void beginTree(DetailAST rootAST)
     {
         // Reset for each tree, just incase there are errors in preceeding

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
@@ -90,6 +90,18 @@ public class MethodParamPadCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.CTOR_DEF,
+            TokenTypes.LITERAL_NEW,
+            TokenTypes.METHOD_CALL,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.SUPER_CTOR_CALL,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final DetailAST parenAST;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
@@ -76,6 +76,17 @@ public class ParenPadCheck extends AbstractParenPadCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.RPAREN,
+                          TokenTypes.LPAREN,
+                          TokenTypes.CTOR_CALL,
+                          TokenTypes.SUPER_CTOR_CALL,
+                          TokenTypes.METHOD_CALL,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         DetailAST theAst = ast;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheck.java
@@ -63,6 +63,12 @@ public class TypecastParenPadCheck extends AbstractParenPadCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {TokenTypes.RPAREN, TokenTypes.TYPECAST};
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         // Strange logic in this method to guard against checking RPAREN tokens

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java
@@ -66,6 +66,16 @@ public class WhitespaceAfterCheck
     }
 
     @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.COMMA,
+            TokenTypes.SEMI,
+            TokenTypes.TYPECAST,
+        };
+    }
+
+    @Override
     public void visitToken(DetailAST ast)
     {
         final Object[] message;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -225,6 +225,63 @@ public class WhitespaceAroundCheck extends Check
         };
     }
 
+    @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.ASSIGN,
+            TokenTypes.BAND,
+            TokenTypes.BAND_ASSIGN,
+            TokenTypes.BOR,
+            TokenTypes.BOR_ASSIGN,
+            TokenTypes.BSR,
+            TokenTypes.BSR_ASSIGN,
+            TokenTypes.BXOR,
+            TokenTypes.BXOR_ASSIGN,
+            TokenTypes.COLON,
+            TokenTypes.DIV,
+            TokenTypes.DIV_ASSIGN,
+            TokenTypes.DO_WHILE,
+            TokenTypes.EQUAL,
+            TokenTypes.GE,
+            TokenTypes.GT,
+            TokenTypes.LAND,
+            TokenTypes.LCURLY,
+            TokenTypes.LE,
+            TokenTypes.LITERAL_CATCH,
+            TokenTypes.LITERAL_DO,
+            TokenTypes.LITERAL_ELSE,
+            TokenTypes.LITERAL_FINALLY,
+            TokenTypes.LITERAL_FOR,
+            TokenTypes.LITERAL_IF,
+            TokenTypes.LITERAL_RETURN,
+            TokenTypes.LITERAL_SWITCH,
+            TokenTypes.LITERAL_SYNCHRONIZED,
+            TokenTypes.LITERAL_TRY,
+            TokenTypes.LITERAL_WHILE,
+            TokenTypes.LOR,
+            TokenTypes.LT,
+            TokenTypes.MINUS,
+            TokenTypes.MINUS_ASSIGN,
+            TokenTypes.MOD,
+            TokenTypes.MOD_ASSIGN,
+            TokenTypes.NOT_EQUAL,
+            TokenTypes.PLUS,
+            TokenTypes.PLUS_ASSIGN,
+            TokenTypes.QUESTION,
+            TokenTypes.RCURLY,
+            TokenTypes.SL,
+            TokenTypes.SLIST,
+            TokenTypes.SL_ASSIGN,
+            TokenTypes.SR,
+            TokenTypes.SR_ASSIGN,
+            TokenTypes.STAR,
+            TokenTypes.STAR_ASSIGN,
+            TokenTypes.LITERAL_ASSERT,
+            TokenTypes.TYPE_EXTENSION_AND,
+        };
+    }
+
     /**
      * Sets whether or not empty method bodies are allowed.
      * @param allow <code>true</code> to allow empty method bodies.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -23,8 +23,11 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.Writer;
 
+import org.junit.Assert;
 import org.junit.Test;
 
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 
 public class TreeWalkerTest extends BaseCheckTestSupport
@@ -61,5 +64,30 @@ public class TreeWalkerTest extends BaseCheckTestSupport
         };
         verify(checkConfig, file.getCanonicalPath(), expected);
         file.delete();
+    }
+
+
+    @Test
+    public void testAcceptableTokens()
+        throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(HiddenFieldCheck.class);
+        checkConfig.addAttribute("tokens", "VARIABLE_DEF, ENUM_DEF, CLASS_DEF, METHOD_DEF,"
+                + "IMPORT");
+        final String[] expected = {
+
+        };
+        try {
+            verify(checkConfig, getPath("InputHiddenField.java"), expected);
+            Assert.fail();
+        }
+        catch (CheckstyleException e) {
+            String errorMsg = e.getMessage();
+            Assert.assertTrue(errorMsg.contains("cannot initialize module"
+                    + " com.puppycrawl.tools.checkstyle.TreeWalker - Token \"IMPORT\""
+                    + " was not found in Acceptable tokens list in check"
+                    + " com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck"));
+        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
@@ -18,9 +18,10 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import org.junit.Test;
+
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import org.junit.Test;
 
 public class HiddenFieldCheckTest
     extends BaseCheckTestSupport
@@ -348,4 +349,5 @@ public class HiddenFieldCheckTest
         };
         verify(checkConfig, getPath("InputHiddenField.java"), expected);
     }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/comments/AllBlockCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/comments/AllBlockCommentsTest.java
@@ -51,6 +51,12 @@ public class AllBlockCommentsTest extends BaseCheckTestSupport
         }
 
         @Override
+        public int[] getAcceptableTokens()
+        {
+            return new int[] {TokenTypes.BLOCK_COMMENT_BEGIN};
+        }
+
+        @Override
         public void init()
         {
             allComments.addAll(Arrays.asList("0", "1", "2", "3", "4", "5", "6",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/comments/AllSinglelineCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/comments/AllSinglelineCommentsTest.java
@@ -51,6 +51,12 @@ public class AllSinglelineCommentsTest extends BaseCheckTestSupport
         }
 
         @Override
+        public int[] getAcceptableTokens()
+        {
+            return new int[] {TokenTypes.SINGLE_LINE_COMMENT};
+        }
+
+        @Override
         public void init()
         {
             allComments.addAll(Arrays.asList("0\n", "1\n", "2\n", "3\n", "4\n", "5\n", "6\n",


### PR DESCRIPTION
... #342

According to #342 

I investigated registerCheck() method and found no problems with getAcceptableTokens(), by default it's copy of getDefaultTokens() array, but if it's specified in Check - it will get corresponding values, but there was a comment after checking input token for acceptableTokens accessory 
```
//TODO: else log warning
```

So, if acceptableTokens are broken - there's need to put a violation - in that case there's explicit throwing of IllegalArgumentException which is handled on the next line and rethrown as CheckstyleException (before this update CheckstyleException could be thrown only in case if 
```java
final int tokenId = TokenTypes.getTokenId(token);
```
threw IllegalArgumentException, it is possible only if there's no such token at all).



Updated UT for AbbreviationAsWordInNameCheck:
there're passing the ENUM_CONSTANT_DEF token in several UTs, but there's no corresponding support in Check's code and even in test inputs, so instead of adding it to defaultTokens array just removed from UTs as it wasn't covered, perhaps there is some special meaning, if so - explain me, please and I'll look for a better way of solution.
