### PR TITLE
Illegal Type Check, updated default illegal types, added memberModifiers...

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -42,8 +42,8 @@ public class IllegalTypeCheckTest extends BaseCheckTestSupport
             "9:13: Declaring variables, return values or parameters of type "
                 + "'com.puppycrawl.tools.checkstyle.coding.InputIllegalType.AbstractClass'"
                 + " is not allowed.",
-            "16:13: Declaring variables, return values or parameters of type 'java.util.Hashtable' is not allowed.",
-            "17:13: Declaring variables, return values or parameters of type 'Hashtable' is not allowed.",
+            "16:13: Declaring variables, return values or parameters of type 'java.util.TreeSet' is not allowed.",
+            "17:13: Declaring variables, return values or parameters of type 'TreeSet' is not allowed.",
         };
 
         verify(checkConfig, getPath("coding" + File.separator + "InputIllegalType.java"), expected);
@@ -59,7 +59,7 @@ public class IllegalTypeCheckTest extends BaseCheckTestSupport
             "9:13: Declaring variables, return values or parameters of type "
                 + "'com.puppycrawl.tools.checkstyle.coding.InputIllegalType.AbstractClass'"
                 + " is not allowed.",
-            "16:13: Declaring variables, return values or parameters of type 'java.util.Hashtable' is not allowed.",
+            "16:13: Declaring variables, return values or parameters of type 'java.util.TreeSet' is not allowed.",
         };
 
         verify(checkConfig, getPath("coding" + File.separator + "InputIllegalType.java"), expected);
@@ -71,8 +71,8 @@ public class IllegalTypeCheckTest extends BaseCheckTestSupport
         checkConfig.addAttribute("format", "^$");
 
         String[] expected = {
-            "16:13: Declaring variables, return values or parameters of type 'java.util.Hashtable' is not allowed.",
-            "17:13: Declaring variables, return values or parameters of type 'Hashtable' is not allowed.",
+            "16:13: Declaring variables, return values or parameters of type 'java.util.TreeSet' is not allowed.",
+            "17:13: Declaring variables, return values or parameters of type 'TreeSet' is not allowed.",
         };
 
         verify(checkConfig, getPath("coding" + File.separator + "InputIllegalType.java"), expected);
@@ -87,8 +87,8 @@ public class IllegalTypeCheckTest extends BaseCheckTestSupport
             "9:13: Declaring variables, return values or parameters of type "
                 + "'com.puppycrawl.tools.checkstyle.coding.InputIllegalType.AbstractClass'"
                 + " is not allowed.",
-            "16:13: Declaring variables, return values or parameters of type 'java.util.Hashtable' is not allowed.",
-            "17:13: Declaring variables, return values or parameters of type 'Hashtable' is not allowed.",
+            "16:13: Declaring variables, return values or parameters of type 'java.util.TreeSet' is not allowed.",
+            "17:13: Declaring variables, return values or parameters of type 'TreeSet' is not allowed.",
         };
 
         verify(checkConfig, getPath("coding" + File.separator + "InputIllegalType.java"), expected);
@@ -151,5 +151,28 @@ public class IllegalTypeCheckTest extends BaseCheckTestSupport
 
         verify(checkConfig, getPath("coding" + File.separator
                 + "InputIllegalTypeStaticImports.java"), expected);
+    }
+
+    @Test
+    public void testMemberModifiers() throws Exception
+    {
+        checkConfig.addAttribute("memberModifiers", "LITERAL_PRIVATE, LITERAL_PROTECTED,"
+                + " LITERAL_STATIC");
+        String[] expected = {
+            "6:13: Declaring variables, return values or parameters of type 'AbstractClass' is not allowed.",
+            "9:13: Declaring variables, return values or parameters of type "
+                + "'com.puppycrawl.tools.checkstyle.coding.InputIllegalTypeMemberModifiers.AbstractClass'"
+                + " is not allowed.",
+            "16:13: Declaring variables, return values or parameters of type 'java.util.TreeSet' is not allowed.",
+            "17:13: Declaring variables, return values or parameters of type 'TreeSet' is not allowed.",
+            "23:15: Declaring variables, return values or parameters of type "
+                    + "'com.puppycrawl.tools.checkstyle.coding.InputIllegalTypeMemberModifiers.AbstractClass'"
+                    + " is not allowed.",
+            "25:25: Declaring variables, return values or parameters of type 'java.util.TreeSet' is not allowed.",
+            "33:15: Declaring variables, return values or parameters of type 'AbstractClass' is not allowed.",
+        };
+
+        verify(checkConfig, getPath("coding" + File.separator
+                + "InputIllegalTypeMemberModifiers.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputIllegalType.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputIllegalType.java
@@ -1,5 +1,5 @@
 package com.puppycrawl.tools.checkstyle.coding;
-
+import java.util.TreeSet;
 import java.util.Hashtable;
 //configuration: default
 public class InputIllegalType {
@@ -13,8 +13,8 @@ public class InputIllegalType {
 
     private class NotAnAbstractClass {}
 
-    private java.util.Hashtable table1() { return null; } //WARNING
-    private Hashtable table2() { return null; } //WARNING
+    private java.util.TreeSet table1() { return null; } //WARNING
+    private TreeSet table2() { return null; } //WARNING
     static class SomeStaticClass {
         
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputIllegalTypeMemberModifiers.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputIllegalTypeMemberModifiers.java
@@ -1,0 +1,34 @@
+package com.puppycrawl.tools.checkstyle.coding;
+import java.util.TreeSet;
+import java.util.Hashtable;
+//configuration: default
+public class InputIllegalTypeMemberModifiers {
+    private AbstractClass a = null; //WARNING
+    private NotAnAbstractClass b = null; /*another comment*/
+
+    private com.puppycrawl.tools.checkstyle.coding.InputIllegalTypeMemberModifiers.AbstractClass c = null; //WARNING
+    private com.puppycrawl.tools.checkstyle.coding.InputIllegalTypeMemberModifiers.NotAnAbstractClass d = null;
+
+    private abstract class AbstractClass {/*one more comment*/}
+
+    private class NotAnAbstractClass {}
+
+    private java.util.TreeSet table1() { return null; } //WARNING
+    private TreeSet table2() { return null; } //WARNING
+    static class SomeStaticClass {
+        
+    }
+    
+    //WARNING if memberModifiers is set and contains TokenTypes.LITERAL_PROTECTED
+    protected com.puppycrawl.tools.checkstyle.coding.InputIllegalTypeMemberModifiers.AbstractClass c1 = null;
+    //NO WARNING if memberModifiers is set and does not contain TokenTypes.LITERAL_PUBLIC
+    public final static java.util.TreeSet table3() { return null; }
+    
+    java.util.TreeSet table4() { java.util.TreeSet treeSet = null; return null; }
+    
+    private class Some {
+        java.util.TreeSet treeSet = null;
+    }
+    //WARNING if memberModifiers is set and contains TokenTypes.LITERAL_PROTECTED
+    protected AbstractClass a1 = null;
+}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -1750,11 +1750,9 @@ if (&quot;something&quot;.equals(x))
             <td>Classes that should not be used as types in variable
             declarations, return values or parameters</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td>&quot;java.util.GregorianCalendar, java.util.Hashtable,
-            java.util.HashSet, java.util.HashMap, java.util.ArrayList,
-            java.util.LinkedList, java.util.LinkedHashMap,
+            <td>&quot;java.util.HashSet, java.util.HashMap, java.util.LinkedHashMap,
             java.util.LinkedHashSet, java.util.TreeSet,
-            java.util.TreeMap, java.util.Vector&quot;</td>
+            java.util.TreeMap&quot;</td>
           </tr>
           <tr>
           <td>legalAbstractClassNames</td>
@@ -1774,6 +1772,12 @@ if (&quot;something&quot;.equals(x))
             <td><a href="property_types.html#regexp">regular expression</a></td>
             <td><code>^(.*[\\.])?Abstract.*$</code></td>
           </tr>
+          <tr>
+            <td>memberModifiers</td>
+            <td>Check methods and fields with only corresponding modifiers.</td>
+            <td><a href="property_types.html#intSet">List of integers</a></td>
+            <td><code>null</code></td>
+          </tr>
         </table>
       </subsection>
 
@@ -1784,6 +1788,16 @@ if (&quot;something&quot;.equals(x))
         <source>
 &lt;module name=&quot;IllegalType&quot;&gt;
     &lt;property name=&quot;ignoredMethodNames&quot; value=&quot;getInstance&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          To configure the Check so that it verifies only public, protected and static
+           methods and fields:
+        </p>
+        <source>
+&lt;module name=&quot;IllegalType&quot;&gt;
+    &lt;property name=&quot;memberModifiers&quot; value=&quot;LITERAL_PUBLIC,
+     LITERAL_PROTECTED, LITERAL_STATIC&quot;/&gt;
 &lt;/module&gt;
         </source>
       </subsection>


### PR DESCRIPTION
... option, issue #567 

According to #567 

Updated default illegal types list and UTs, added information about them to docs.

Added new option <b>memberModifiers</b> which allows to only verify methods and fields with specified access modifiers.
It is string array as I think it's more obvious for user to specify option as "protected, public" than "TokenTypes.LITERAL_PROTECTED, TokenTypes.LITERAL_PUBLIC"

Added UT and input for testing sources with new option.