### PR TITLE
New Check: Empty Catch Block Check, issue #571

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
@@ -29,7 +29,6 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractOptionCheck;
  * <p> By default the check will check the following blocks:
  *  {@link TokenTypes#LITERAL_WHILE LITERAL_WHILE},
  *  {@link TokenTypes#LITERAL_TRY LITERAL_TRY},
- *  {@link TokenTypes#LITERAL_CATCH LITERAL_CATCH},
  *  {@link TokenTypes#LITERAL_FINALLY LITERAL_FINALLY},
  *  {@link TokenTypes#LITERAL_DO LITERAL_DO},
  *  {@link TokenTypes#LITERAL_IF LITERAL_IF},
@@ -46,12 +45,12 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractOptionCheck;
  * </pre>
  *
  * <p> An example of how to configure the check for the {@link
- * BlockOption#TEXT} policy and only catch blocks is:
+ * BlockOption#TEXT} policy and only try blocks is:
  * </p>
  *
  * <pre>
  * &lt;module name="EmptyBlock"&gt;
- *    &lt;property name="tokens" value="LITERAL_CATCH"/&gt;
+ *    &lt;property name="tokens" value="LITERAL_TRY"/&gt;
  *    &lt;property name="option" value="text"/&gt;
  * &lt;/module&gt;
  * </pre>
@@ -83,6 +82,24 @@ public class EmptyBlockCheck
 
     @Override
     public int[] getDefaultTokens()
+    {
+        return new int[] {
+            TokenTypes.LITERAL_WHILE,
+            TokenTypes.LITERAL_TRY,
+            TokenTypes.LITERAL_FINALLY,
+            TokenTypes.LITERAL_DO,
+            TokenTypes.LITERAL_IF,
+            TokenTypes.LITERAL_ELSE,
+            TokenTypes.LITERAL_FOR,
+            TokenTypes.INSTANCE_INIT,
+            TokenTypes.STATIC_INIT,
+            TokenTypes.LITERAL_SWITCH,
+            //TODO: does this handle TokenTypes.LITERAL_SYNCHRONIZED?
+        };
+    }
+
+    @Override
+    public int[] getAcceptableTokens()
     {
         return new int[] {
             TokenTypes.LITERAL_WHILE,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheck.java
@@ -1,0 +1,296 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2014  Oliver Burn
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.blocks;
+
+import java.util.regex.Pattern;
+
+import com.puppycrawl.tools.checkstyle.api.Check;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * <p>
+ * Checks for empty catch blocks. There are two options to make validation less strict:
+ * </p>
+ * <p>
+ * <b>exceptionVariableName</b> - the name of variable associated with exception,
+ * if Check meets variable name matching specified value - empty block is suppressed.<br>
+ *  default value: &quot;^$&quot;
+ * </p>
+ * <p>
+ * <b>commentFormat</b> - the format of the first comment inside empty catch
+ * block, if Check meets comment inside empty catch block matching specified format
+ *  - empty block is suppressed. If it is multi-line comment - only its first line is analyzed.<br>
+ * default value: &quot;.*&quot;
+ * </p>
+ * <p>
+ * If both options are specified - they are applied by <b>any of them is matching</b>.
+ * </p>
+ * Examples:
+ * <p>
+ * To configure the Check to suppress empty catch block if exception's variable name is
+ *  <b>expected</b> or <b>ignore</b>:
+ * </p>
+ * <p>
+ * <pre>
+ * &lt;module name=&quot;EmptyCatchBlock&quot;&gt;
+ *    &lt;property name=&quot;exceptionVariableName&quot; value=&quot;ignore|expected;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * </p>
+ * Such empty blocks would be both suppressed:<br>
+ * <p>
+ * <pre>
+ * <code>
+ * try {
+ *     throw new RuntimeException();
+ * } catch (RuntimeException expected) {
+ * }
+ * </code>
+ * <code>
+ * try {
+ *     throw new RuntimeException();
+ * } catch (RuntimeException ignore) {
+ * }
+ * </code>
+ * </pre>
+ * </p>
+ * <p>
+ * To configure the Check to suppress empty catch block if single-line comment inside
+ *  is &quot;//This is expected&quot;:
+ * </p>
+ * <p>
+ * <pre>
+ * &lt;module name=&quot;EmptyCatchBlock&quot;&gt;
+ *    &lt;property name=&quot;commentFormat&quot; value=&quot;This is expected&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * </p>
+ * Such empty block would be suppressed:<br>
+ * <p>
+ * <pre>
+ * <code>
+ * try {
+ *     throw new RuntimeException();
+ * } catch (RuntimeException e) {
+ *     //This is expected
+ * }
+ * </code>
+ * </pre>
+ * To configure the Check to suppress empty catch block if single-line comment inside
+ *  is &quot;//This is expected&quot; or exception's variable name is &quot;myException&quot;:
+ * </p>
+ * <p>
+ * <pre>
+ * &lt;module name=&quot;EmptyCatchBlock&quot;&gt;
+ *    &lt;property name=&quot;commentFormat&quot; value=&quot;This is expected&quot;/&gt;
+ *    &lt;property name=&quot;exceptionVariableName&quot; value=&quot;myException&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * </p>
+ * Such empty blocks would be both suppressed:<br>
+ * <p>
+ * <pre>
+ * <code>
+ * try {
+ *     throw new RuntimeException();
+ * } catch (RuntimeException e) {
+ *     //This is expected
+ * }
+ * </code>
+ * <code>
+ * try {
+ *     throw new RuntimeException();
+ * } catch (RuntimeException myException) {
+ *
+ * }
+ * </code>
+ * </pre>
+ * </p>
+ * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
+ */
+public class EmptyCatchBlockCheck extends Check
+{
+
+    /**
+     * A key is pointing to the warning message text in "messages.properties"
+     * file.
+     */
+    public static final String MSG_KEY_CATCH_BLOCK_EMPTY = "catch.block.empty";
+
+    /** Format of skipping exception's variable name. */
+    private String exceptionVariableName = "^$";
+
+    /** Format of comment. */
+    private String commentFormat = ".*";
+
+    /**
+     * Regular expression pattern compiled from exception's variable name.
+     */
+    private Pattern variableNameRegexp = Pattern.compile(exceptionVariableName);
+
+    /**
+     * Regular expression pattern compiled from comment's format.
+     */
+    private Pattern commentRegexp = Pattern.compile(commentFormat);
+
+    /**
+     * Setter for exception's variable name format.
+     * @param exceptionVariableName format of exception's variable name.
+     */
+    public void setExceptionVariableName(String exceptionVariableName)
+    {
+        this.exceptionVariableName = exceptionVariableName;
+        variableNameRegexp = Pattern.compile(exceptionVariableName);
+    }
+
+    /**
+     * Setter for comment format.
+     * @param commentFormat format of comment.
+     */
+    public void setCommentFormat(String commentFormat)
+    {
+        this.commentFormat = commentFormat;
+        commentRegexp = Pattern.compile(commentFormat);
+    }
+
+    @Override
+    public int[] getDefaultTokens()
+    {
+        return new int[] {
+            TokenTypes.LITERAL_CATCH,
+        };
+    }
+
+    @Override
+    public int[] getAcceptableTokens()
+    {
+        return new int[] {
+            TokenTypes.LITERAL_CATCH,
+        };
+    }
+
+    @Override
+    public boolean isCommentNodesRequired()
+    {
+        return true;
+    }
+
+    @Override
+    public void visitToken(DetailAST ast)
+    {
+        visitCatchBlock(ast);
+    }
+
+    /**
+     * Visits catch ast node, if it is empty catch block - checks it according to
+     *  Check's options. If exception's variable name or comment inside block are matching
+     *   specified regexp - skips from consideration, else - puts violation.
+     * @param catchAst {@link TokenTypes#LITERAL_CATCH LITERAL_CATCH}
+     */
+    private void visitCatchBlock(DetailAST catchAst)
+    {
+        if (isEmptyCatchBlock(catchAst)) {
+            final String commentContent = getCommentFirstLine(catchAst);
+            if (isVerifiable(catchAst, commentContent)) {
+                log(catchAst.getLineNo(), MSG_KEY_CATCH_BLOCK_EMPTY);
+            }
+        }
+    }
+
+    /**
+     * Gets the first line of comment in catch block. If comment is single-line -
+     *  returns it fully, else if comment is multi-line - returns the first line.
+     * @param catchAst {@link TokenTypes#LITERAL_CATCH LITERAL_CATCH}
+     * @return the first line of comment in catch block, "" if no comment was found.
+     */
+    private static String getCommentFirstLine(DetailAST catchAst)
+    {
+        final DetailAST slistToken = catchAst.getLastChild();
+        final DetailAST firstElementInBlock = slistToken.getFirstChild();
+        String commentContent = "";
+        if (firstElementInBlock.getType() == TokenTypes.SINGLE_LINE_COMMENT) {
+            commentContent = firstElementInBlock.getFirstChild().getText();
+        }
+        else if (firstElementInBlock.getType() == TokenTypes.BLOCK_COMMENT_BEGIN) {
+            commentContent = firstElementInBlock.getFirstChild().getText();
+            final String[] lines = commentContent.split(System.getProperty("line.separator"));
+            for (int i = 0; i < lines.length; i++) {
+                if (!lines[i].isEmpty()) {
+                    commentContent = lines[i];
+                    break;
+                }
+            }
+        }
+        return commentContent;
+    }
+
+    /**
+     * Checks if current empty catch block is verifiable according to Check's options
+     *  (exception's variable name and comment format are both in consideration).
+     * @param emptyCatchAst empty catch {@link TokenTypes#LITERAL_CATCH LITERAL_CATCH} block.
+     * @param commentContent text of comment.
+     * @return true if empty catch block is verifiable by Check.
+     */
+    private boolean isVerifiable(DetailAST emptyCatchAst, String commentContent)
+    {
+        final String exceptionVariableName = getExceptionVariableName(emptyCatchAst);
+        final boolean isMatchingVariableName = variableNameRegexp.
+                matcher(exceptionVariableName).find();
+        final boolean isMatchingCommentContent = !commentContent.isEmpty()
+                 && commentRegexp.matcher(commentContent).find();
+        return !isMatchingVariableName && !isMatchingCommentContent;
+    }
+
+
+    /**
+     * Checks if catch block is empty or contains only comments.
+     * @param catchAst {@link TokenTypes#LITERAL_CATCH LITERAL_CATCH}
+     * @return true if catch block is empty.
+     */
+    private static boolean isEmptyCatchBlock(DetailAST catchAst)
+    {
+        boolean result = true;
+        final DetailAST slistToken = catchAst.findFirstToken(TokenTypes.SLIST);
+        DetailAST catchBlockStmt = slistToken.getFirstChild();
+        while (catchBlockStmt.getType() != TokenTypes.RCURLY) {
+            if (catchBlockStmt.getType() != TokenTypes.SINGLE_LINE_COMMENT
+                 && catchBlockStmt.getType() != TokenTypes.BLOCK_COMMENT_BEGIN)
+            {
+                result = false;
+                break;
+            }
+            catchBlockStmt = catchBlockStmt.getNextSibling();
+        }
+        return result;
+    }
+
+    /**
+     * Gets variable's name associated with exception.
+     * @param catchAst {@link TokenTypes#LITERAL_CATCH LITERAL_CATCH}
+     * @return Variable's name associated with exception.
+     */
+    private static String getExceptionVariableName(DetailAST catchAst)
+    {
+        final DetailAST parameterDef = catchAst.findFirstToken(TokenTypes.PARAMETER_DEF);
+        final DetailAST variableName = parameterDef.findFirstToken(TokenTypes.IDENT);
+        return variableName.getText();
+    }
+
+}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages.properties
@@ -2,6 +2,8 @@ block.empty=Empty {0} block.
 block.nested=Avoid nested blocks.
 block.noStmt=Must have at least one statement.
 
+catch.block.empty=Empty catch block.
+
 line.alone=''{0}'' should be alone on a line.
 line.new=''{0}'' should be on a new line.
 line.previous=''{0}'' should be on the previous line.

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -54,7 +54,7 @@
         <module name="NoLineWrap"/>
         <module name="EmptyBlock">
             <property name="option" value="TEXT"/>
-            <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
         <module name="LeftCurly">
@@ -196,5 +196,8 @@
              value="Method name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="SingleLineJavadoc"/>
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected"/>
+        </module>
     </module>
 </module>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
@@ -36,11 +36,6 @@ public class EmptyBlockCheckTest
         final DefaultConfiguration checkConfig =
             createCheckConfig(EmptyBlockCheck.class);
         final String[] expected = {
-            "52:65: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "54:41: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "71:38: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "72:52: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "73:45: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
             "75:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
             "77:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
             "79:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
@@ -58,9 +53,6 @@ public class EmptyBlockCheckTest
             createCheckConfig(EmptyBlockCheck.class);
         checkConfig.addAttribute("option", BlockOption.TEXT.toString());
         final String[] expected = {
-            "52:65: " + getCheckMessage(MSG_KEY_BLOCK_EMPTY, "catch"),
-            "72:52: " + getCheckMessage(MSG_KEY_BLOCK_EMPTY, "catch"),
-            "73:45: " + getCheckMessage(MSG_KEY_BLOCK_EMPTY, "catch"),
             "75:13: " + getCheckMessage(MSG_KEY_BLOCK_EMPTY, "try"),
             "77:17: " + getCheckMessage(MSG_KEY_BLOCK_EMPTY, "finally"),
             "178:5: " + getCheckMessage(MSG_KEY_BLOCK_EMPTY, "INSTANCE_INIT"),
@@ -76,11 +68,6 @@ public class EmptyBlockCheckTest
             createCheckConfig(EmptyBlockCheck.class);
         checkConfig.addAttribute("option", BlockOption.STMT.toString());
         final String[] expected = {
-            "52:65: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "54:41: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "71:38: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "72:52: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "73:45: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
             "75:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
             "77:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
             "79:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
@@ -1,0 +1,63 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2014  Oliver Burn
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.blocks;
+
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+
+/**
+ *
+ * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
+ *
+ */
+public class EmptyCatchBlockCheckTest extends BaseCheckTestSupport
+{
+    @Test
+    public void testDefault() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(EmptyCatchBlockCheck.class);
+        final String[] expected = {
+            "35: Empty catch block.",
+            "42: Empty catch block.",
+        };
+        verify(checkConfig, getPath("InputEmptyCatchBlockCheck.java"), expected);
+    }
+
+    @Test
+    public void testWithUserSetValues() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(EmptyCatchBlockCheck.class);
+        checkConfig.addAttribute("exceptionVariableName", "expected|ignore|myException");
+        checkConfig.addAttribute("commentFormat", "This is expected");
+        final String[] expected = {
+            "35: Empty catch block.",
+            "63: Empty catch block.",
+            "97: Empty catch block.",
+            "186: Empty catch block.",
+            "195: Empty catch block.",
+            "214: Empty catch block.",
+            "230: Empty catch block.",
+        };
+        verify(checkConfig, getPath("InputEmptyCatchBlockCheck.java"), expected);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputEmptyCatchBlockCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputEmptyCatchBlockCheck.java
@@ -1,0 +1,235 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2014  Oliver Burn
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle;
+import java.io.IOException;
+public class InputEmptyCatchBlockCheck
+{
+    
+    private void foo() {
+        try {
+            throw new RuntimeException();
+        } catch (Exception expected) {
+            //Expected
+        }
+    }
+    
+    private void foo1() {
+        try {
+            throw new RuntimeException();
+        } catch (Exception e) {}
+        
+    }
+    
+    private void foo2() {
+        try {
+            throw new IOException();
+        } catch (IOException | NullPointerException | ArithmeticException ignore) {
+        }
+    }
+    
+    private void foo3() { // comment
+        try {
+            throw new IOException();
+        } catch (IOException | NullPointerException | ArithmeticException e) { //This is expected
+        }
+    }
+    
+    private void foo4() {
+        try {
+            throw new IOException();
+        } catch (IOException | NullPointerException | ArithmeticException e) { /* This is expected*/
+        }
+    }
+    
+    private void foo5() {
+        try {
+            throw new IOException();
+        } catch (IOException | NullPointerException | ArithmeticException e) { // Some singleline comment
+        }
+    }
+    
+    private void foo6() {
+        try {
+            throw new IOException();
+        } catch (IOException expected) { // This is expected
+            int k = 0;
+        }
+    }
+    
+    public void testTryCatch()
+    {
+        try {
+            int y=0;
+            int u=8;
+            int e=u-y;
+            return; 
+        } 
+        catch (Exception e) {
+            System.out.println(e);
+            return; 
+        }
+        finally
+        {
+            return; 
+        }
+    }
+    
+    public void testTryCatch2()
+    {
+        try {
+        } 
+        catch (Exception e) { //OK
+            //This is expected
+            /* This is expected */
+            /**This is expected */
+        }
+        finally
+        {
+        }
+    }
+    
+    public void testTryCatch3()
+    {
+        try {
+            int y=0;
+            int u=8;
+            int e=u-y;
+        } 
+        catch (IllegalArgumentException e) {
+            System.out.println(e); //some comment
+            return; 
+        }
+        catch (IllegalStateException ex) {
+                System.out.println(ex);
+                return; 
+        }
+    }
+    
+    public void testTryCatch4()
+    {
+        int y=0;
+        int u=8;
+        try {
+            int e=u-y;
+        } 
+        catch (IllegalArgumentException e) {
+            System.out.println(e);
+            return; 
+        }
+    }
+    public void setFormats() {
+        try {
+            int k = 4;
+        } catch (Exception e) {
+            Object k = null;
+            if (k != null)
+                k = "ss";
+            else {
+                return; 
+            }
+        }
+    }
+    public void setFormats1() {
+        try {
+            int k = 4;
+        } catch (Exception e) {
+            Object k = null;
+            if (k != null) {
+                k = "ss";
+            } else {
+                return; 
+            }
+        }
+    }
+    public void setFormats2() {
+        try {
+            int k = 4;
+        } catch (Exception e) {
+            Object k = null;
+            if (k != null) {
+                k = "ss";
+                return;
+            } 
+        }
+    }
+    public void setFormats3() {
+        try {
+            int k = 4;
+        } catch (Exception e) {
+            Object k = null;
+            if (k != null) {
+                k = "ss";
+                
+            } 
+        }
+    }
+    
+    private void some() {
+        try {
+            throw new IOException();
+        } catch (IOException e) {
+            /* ololo
+             * blalba
+             */
+        }
+    }
+    private void some1() {
+        try {
+            throw new IOException();
+        } catch (IOException e) {
+            /* lalala
+             * This is expected
+             */
+        }
+    }
+    private void some2() {
+        try {
+            throw new IOException();
+        } catch (IOException e) {
+            /*
+             * This is expected
+             * lalala
+             */
+        }
+    }
+    private void some3() {
+        try {
+            throw new IOException();
+        } catch (IOException e) {
+            // some comment
+            //This is expected
+        }
+    }
+    private void some4() {
+        try {
+            throw new IOException();
+        } catch (IOException e) {
+            //This is expected
+            // some comment
+        }
+    }
+    private void some5() {
+        try {
+            throw new IOException();
+        } catch (IOException e) {
+            /* some comment */
+            //This is expected
+        }
+    }
+}

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -36,8 +36,6 @@
 
             <td>
               subset of tokens <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
-              <a
                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
                <a
                 href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
@@ -72,13 +70,100 @@
 
         <p>
           To configure the check for the <code>text</code>
-          policy and only <code> catch</code> blocks:
+          policy and only <code> try</code> blocks:
         </p>
         <source>
 &lt;module name=&quot;EmptyBlock&quot;&gt;
     &lt;property name=&quot;option&quot; value=&quot;text&quot;/&gt;
-    &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_CATCH&quot;/&gt;
+    &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_TRY&quot;/&gt;
 &lt;/module&gt;
+        </source>
+      </subsection>
+
+      <subsection name="Package">
+        <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
+      </subsection>
+
+      <subsection name="Parent Module">
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
+      </subsection>
+    </section>
+
+    <section name="EmptyCatchBlock">
+      <subsection name="Description">
+        <p>
+          Checks for empty catch blocks. There are two options to make validation less strict:
+        </p>
+      </subsection>
+
+      <subsection name="Properties">
+        <table>
+          <tr>
+            <th>name</th>
+            <th>description</th>
+            <th>type</th>
+            <th>default value</th>
+          </tr>
+          <tr>
+            <td>exceptionVariableName</td>
+            <td>The name of variable associated with exception</td>
+            <td><a href="property_types.html#string">String</a></td>
+            <td>^$</td>
+          </tr>
+          <tr>
+            <td>commentFormat</td>
+            <td>The format of the first comment inside empty catch</td>
+            <td><a href="property_types.html#string">string</a></td>
+            <td>.*</td>
+          </tr>
+        </table>
+      </subsection>
+
+      <subsection name="Examples">
+        <p>
+          To configure the Check to suppress empty catch block if exception's variable name is
+           <code>expected</code> or <code>ignore</code>:
+        </p>
+        <source>
+&lt;module name=&quot;EmptyCatchBlock&quot;&gt;
+    &lt;property name=&quot;exceptionVariableName&quot; value=&quot;expected|ignore&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          To configure the Check to suppress empty catch block if single-line comment inside
+           is &quot;//This is expected&quot;:
+        </p>
+        <source>
+&lt;module name=&quot;EmptyCatchBlock&quot;&gt;
+    &lt;property name=&quot;commentFormat&quot; value=&quot;This is expected&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          To configure the Check to suppress empty catch block if single-line comment inside
+           is &quot;//This is expected&quot; or exception's
+            variable name is &quot;myException&quot; (any option is matching):
+        </p>
+        <source>
+&lt;module name=&quot;EmptyCatchBlock&quot;&gt;
+    &lt;property name=&quot;commentFormat&quot; value=&quot;This is expected&quot;/&gt;
+    &lt;property name=&quot;exceptionVariableName&quot; value=&quot;myException&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Such empty blocks would be both suppressed:
+        </p>
+        <source>
+try {
+    throw new RuntimeException();
+} catch (RuntimeException e) {
+    //This is expected
+}
+...
+try {
+    throw new RuntimeException();
+} catch (RuntimeException myException) {
+
+}
         </source>
       </subsection>
 

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -483,6 +483,24 @@
                                 <img
                                     src="images/ok_green.png"
                                     alt="" />
+                                <a href="config_blocks.html#EmptyBlock">EmptyCatchBlock</a>
+                            </td>
+                            <td>
+                                <a
+                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml#L59">config</a><br/>
+                                <a
+                                    href="https://github.com/checkstyle/google-style-config-test/blob/master/src/test/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyCatchBlockTest.java">test</a>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <a
+                                    href="http://google-styleguide.googlecode.com/svn/trunk/javaguide.html#s4.1.3-braces-empty-blocks">4.1.3 Empty blocks: may be concise </a>
+                            </td>
+                            <td>
+                                <img
+                                    src="images/ok_green.png"
+                                    alt="" />
                                 <a
                                     href="config_misc.html#Indentation">Indentation</a>
                             </td>


### PR DESCRIPTION
According to #571 

New Check was added, EmptyCatchBlockCheck is fully covered by UTs, EmptyBlockCheck was updated: removed references to checking catch blocks, updated UTs.

Updated docs.

What exactly have I do to update Coverage page (http://checkstyle.sourceforge.net/google_style.html) ?
Shouldn't it be updated automatically?

https://github.com/checkstyle/google-style-config-test will be updated asap