### PR TITLE
Resolving linkcheck plugin errors, issue #549

### DIFF
--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -540,7 +540,7 @@ class FooBar {
 
         <p>
           For an example import control file, look at the file called <a
-          href="https://github.com/checkstyle/checkstyle/blob/master/import-control.xml">import-control.xml</a>
+          href="https://github.com/checkstyle/checkstyle/blob/master/config/import-control.xml">import-control.xml</a>
           which is part of the Checkstyle distribution.
         </p>
       </subsection>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -409,7 +409,7 @@ public boolean isSomething()
           <tr>
             <td>ignoreMethodNamesRegex</td>
             <td>ignore method whose names are matching specified regex</td>
-            <td><a href="property_types.html#regex">regular expression</a></td>
+            <td><a href="property_types.html#regexp">regular expression</a></td>
             <td><code>null</code> (tag not required)</td>
           </tr>
           <tr>

--- a/src/xdocs/sun_style.xml
+++ b/src/xdocs/sun_style.xml
@@ -23,7 +23,7 @@
                 </p>
                 <p>
                     <a
-                        href="https://github.com/checkstyle/checkstyle/blob/master/sun_checks.xml">
+                        href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/sun_checks.xml">
                     incomplete Checkstyle configuration for 'Sun's Java Style'</a>
                 </p>
          </subsection>


### PR DESCRIPTION
According to #549 

Here's report after my updates:
http://alexkravin.github.io/linkcheck/linkcheck.html

There're 25 errors, but as you can see all of them because of ping timeout - that's because I used vpn connection during building, seems to be it's not fast enough, these links are ok.

