### PR TITLE
Linkcheck plugin, excluded broken links until corresponding plugins will...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -660,6 +660,13 @@
             <excludedLink>https://coveralls.io/r/checkstyle/checkstyle</excludedLink>
             <excludedLink>http://search.maven.org/*</excludedLink>
             <excludedLink>hhttp://junit.org</excludedLink>
+            <!-- Excluded due to checkstyle's issue #549 until http://jira.codehaus.org/browse/MJAVADOC-425
+            and http://jira.codehaus.org/browse/DOXIA-525 will be fixed -->
+            <excludedLink>**/com/puppycrawl/**</excludedLink>
+            <!-- Excluded due to checkstyle's issue #549 until http://jira.codehaus.org/browse/MJAVADOC-425 will be fixed -->
+            <excludedLink>http://docs.oracle.com/javase/7/docs/api/org/xml/sax/helpers.DefaultHandler.html?*</excludedLink>
+            <!-- Excluded due to checkstyle's issue #549 until http://jira.codehaus.org/browse/MLINKCHECK-21 will be fixed -->
+            <excludedLink>**/xref**</excludedLink>
           </excludedLinks>
           <excludedHttpStatusErrors>
             <excludedHttpStatusError>401</excludedHttpStatusError>


### PR DESCRIPTION
... be fixed, issue #549

According to #549 

Detailed analyze of the problem in links determined that most of problems are not on our side (such problems are already fixed), so due to these problems I have opened 3 issues on:

1) maven-javadoc-plugin, which uses outdated doxia's version: http://jira.codehaus.org/browse/MJAVADOC-425
2) maven-linkcheck-plugin: http://jira.codehaus.org/browse/MPLINKCHECK-32
3) doxia, which renders links in velocity templates very weird (for example it break parentheses): http://jira.codehaus.org/browse/DOXIA-525

Until these issues will be resolved - corresponding links are excluded, after updating of plugins and testing they will be returned on their places.

List of excluded links:

1) Links to javadoc methods in apidocs (spaces in links are not supported by linkcheck-plugin)
2) http://docs.oracle.com/javase/7/docs/api/org/xml/sax/helpers/DefaultHandler.html?is-external=true
from AbtractLoader class which is mostly used in filters, maven-javadoc-plugin generates links on <b>filters</b> package, e.g. http://alexkravin.github.io/linkcheck/apidocs/com/puppycrawl/tools/checkstyle/filters/package-tree.html
and specifies links from inherited classes too, as you can see link to Default handler is broken
http://docs.oracle.com/javase/7/docs/api/org/xml/sax/helpers<b>.</b>DefaultHandler.html?is-external=true

all other links to classes at docs.oracle/... are ok.

3) Links to xref-sources. We use the last version of jxr plugin (2.4), but links are broken, e.g.:
./xref/com/puppycrawl/tools/checkstyle/api/FullIdent.html#91
should be
./xref/com/puppycrawl/tools/checkstyle/api/FullIdent.html#<b>L</b>91

The same problem we can see here http://maven.apache.org/plugins/maven-checkstyle-plugin/taglist.html
Just click to any line number - it won't redirect you to proper line in xref-sources. I think this problem is in scope of maven-linkcheck-plugin too

Current Linkcheck report:
http://alexkravin.github.io/currentlinks/linkcheck.html
there're some errors, but all of them are of 2 types:
1) Timeout 2000ms (my connection is not fast enough)
2) 403 forbidden - that's because of my location.