### PR TITLE
Abstract Class Name Check, updated default regex, issue #595

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
@@ -41,7 +41,7 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractFormatCheck;
 public final class AbstractClassNameCheck extends AbstractFormatCheck
 {
     /** Default format for abstract class names */
-    private static final String DEFAULT_FORMAT = "^Abstract.*$|^.*Factory$";
+    private static final String DEFAULT_FORMAT = "^Abstract.+$|^.*Factory$";
 
     /** whether to ignore checking the modifier */
     private boolean ignoreModifier;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckTest.java
@@ -34,10 +34,10 @@ public class AbstractClassNameCheckTest extends BaseCheckTestSupport
         checkConfig.addAttribute("ignoreModifier", "true");
 
         final String[] expected = {
-            "3:1: Name 'InputAbstractClassName' must match pattern '^Abstract.*$|^.*Factory$'.",
-            "6:1: Name 'NonAbstractClassName' must match pattern '^Abstract.*$|^.*Factory$'.",
-            "9:1: Name 'FactoryWithBadName' must match pattern '^Abstract.*$|^.*Factory$'.",
-            "13:5: Name 'NonAbstractInnerClass' must match pattern '^Abstract.*$|^.*Factory$'.",
+            "3:1: Name 'InputAbstractClassName' must match pattern '^Abstract.+$|^.*Factory$'.",
+            "6:1: Name 'NonAbstractClassName' must match pattern '^Abstract.+$|^.*Factory$'.",
+            "9:1: Name 'FactoryWithBadName' must match pattern '^Abstract.+$|^.*Factory$'.",
+            "13:5: Name 'NonAbstractInnerClass' must match pattern '^Abstract.+$|^.*Factory$'.",
         };
 
         verify(checkConfig, getPath("naming" + File.separator + "InputAbstractClassName.java"), expected);
@@ -68,10 +68,10 @@ public class AbstractClassNameCheckTest extends BaseCheckTestSupport
         checkConfig.addAttribute("ignoreModifier", "false");
 
         final String[] expected = {
-            "3:1: Name 'InputAbstractClassName' must match pattern '^Abstract.*$|^.*Factory$'.",
-            "6:1: Name 'NonAbstractClassName' must match pattern '^Abstract.*$|^.*Factory$'.",
-            "9:1: Name 'FactoryWithBadName' must match pattern '^Abstract.*$|^.*Factory$'.",
-            "13:5: Name 'NonAbstractInnerClass' must match pattern '^Abstract.*$|^.*Factory$'.",
+            "3:1: Name 'InputAbstractClassName' must match pattern '^Abstract.+$|^.*Factory$'.",
+            "6:1: Name 'NonAbstractClassName' must match pattern '^Abstract.+$|^.*Factory$'.",
+            "9:1: Name 'FactoryWithBadName' must match pattern '^Abstract.+$|^.*Factory$'.",
+            "13:5: Name 'NonAbstractInnerClass' must match pattern '^Abstract.+$|^.*Factory$'.",
             "26:1: Class 'AbstractClass' must be declared as 'abstract'.",
             "29:1: Class 'Class1Factory' must be declared as 'abstract'.",
             "33:5: Class 'AbstractInnerClass' must be declared as 'abstract'.",
@@ -79,5 +79,20 @@ public class AbstractClassNameCheckTest extends BaseCheckTestSupport
         };
 
         verify(checkConfig, getPath("naming" + File.separator + "InputAbstractClassName.java"), expected);
+    }
+
+    @Test
+    public void testFalsePositive() throws Exception
+    {
+        final DefaultConfiguration checkConfig = createCheckConfig(AbstractClassNameCheck.class);
+//        checkConfig.addAttribute("ignoreName", "false");
+//        checkConfig.addAttribute("ignoreModifier", "false");
+
+        final String[] expected = {
+            "9:5: Class 'AbstractClass' must be declared as 'abstract'.",
+        };
+
+        verify(checkConfig, getPath("naming" + File.separator
+                 + "InputAbstractClassNameFormerFalsePositive.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/naming/InputAbstractClassNameFormerFalsePositive.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/naming/InputAbstractClassNameFormerFalsePositive.java
@@ -1,0 +1,12 @@
+package com.puppycrawl.tools.checkstyle.naming;
+
+public class InputAbstractClassNameFormerFalsePositive
+{
+    class Abstract {
+        
+    }
+    
+    class AbstractClass {
+        
+    }
+}

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -46,7 +46,7 @@
         <tr>
           <td><code>AbstractClassName</code></td>
           <td><code>abstract</code> classes</td>
-          <td><code>^Abstract.*$|^.*Factory$</code></td>
+          <td><code>^Abstract.+$|^.*Factory$</code></td>
         </tr>
         <tr>
           <td><code>ClassTypeParameterName</code></td>


### PR DESCRIPTION
According to #595 

If I have understood problem described here https://twitter.com/deveth0/status/558596474465189888?s=09 right..
Updated regex of default format of abstract class from "zero or more after Abstract" to "one or more after Abstract"