### PR TITLE
Linkcheck plugin, excluded broken links until corresponding plugins will...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -652,6 +652,8 @@
             <excludedPage>pmd.html</excludedPage>
             <excludedPage>findbugs.html</excludedPage>
             <excludedPage>surefire-report.html</excludedPage>
+            <!-- Excluded due to checkstyle's issue #549 until http://jira.codehaus.org/browse/MTAGLIST-69 will be fixed -->
+            <excludedPage>taglist.html</excludedPage>
           </excludedPages>
           <excludedLinks>
             <excludedLink>reports/google-style/guava</excludedLink>
@@ -660,6 +662,11 @@
             <excludedLink>https://coveralls.io/r/checkstyle/checkstyle</excludedLink>
             <excludedLink>http://search.maven.org/*</excludedLink>
             <excludedLink>hhttp://junit.org</excludedLink>
+            <!-- Excluded due to checkstyle's issue #549 until http://jira.codehaus.org/browse/MJAVADOC-425
+            and http://jira.codehaus.org/browse/DOXIA-525 and http://jira.codehaus.org/browse/MLINKCHECK-21 will be fixed -->
+            <excludedLink>**/com/puppycrawl/**</excludedLink>
+            <!-- Excluded due to checkstyle's issue #549 until http://jira.codehaus.org/browse/MJAVADOC-425 will be fixed -->
+            <excludedLink>http://docs.oracle.com/javase/7/docs/api/org/xml/sax/helpers.DefaultHandler.html?*</excludedLink>
           </excludedLinks>
           <excludedHttpStatusErrors>
             <excludedHttpStatusError>401</excludedHttpStatusError>


### PR DESCRIPTION
... be fixed, issue #549 

Some parts of links are excluded from verifying in maven-linkcheck-plugin until resolving some bugs in plugins:

1) Excluded page taglist.html until http://jira.codehaus.org/browse/MTAGLIST-69 will be resolved.

2) Excluded links to apidocs until http://jira.codehaus.org/browse/MJAVADOC-425 http://jira.codehaus.org/browse/MLINKCHECK-21 http://jira.codehaus.org/browse/DOXIA-525 will be resolved.

3) Excluded one link to http://docs.oracle.com/javase/7/docs/api/org/xml/sax/helpers.DefaultHandler.html
as it's broken due to javadoc generation until http://jira.codehaus.org/browse/MJAVADOC-425 will be resolved

My test project where these problems were analyzed within Checkstyle project:
https://github.com/alexkravin/linkstest

In all issues except for maven-javadoc-plugin steps of reproducing the problems are shown with test project.
In issue against javadoc-plugin these steps are shown with Checkstyle project itself because most of problems are with this plugin and I could lose some cases pointing at test project.