### PR TITLE
Replace verbose type arguments with diamond type <>

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -760,7 +760,7 @@ public final class TreeWalker
                     columns++;
             }
         }
-        return new SimpleEntry<Integer, Integer>(lines, columns);
+        return new SimpleEntry<>(lines, columns);
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FastStack.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FastStack.java
@@ -136,6 +136,6 @@ public class FastStack<E> implements Iterable<E>
      */
     public static <T> FastStack<T> newInstance()
     {
-        return new FastStack<T>();
+        return new FastStack<>();
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -152,7 +152,7 @@ public final class FileText extends AbstractList<String>
         // Use the BufferedReader to break down the lines as this
         // is about 30% faster than using the
         // LINE_TERMINATOR.split(fullText, -1) method
-        final ArrayList<String> lines = new ArrayList<String>();
+        final ArrayList<String> lines = new ArrayList<>();
         final BufferedReader br =
             new BufferedReader(new StringReader(fullText));
         for (;;) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
@@ -441,10 +441,10 @@ public enum JavadocTagInfo
     static
     {
         final ImmutableMap.Builder<String, JavadocTagInfo> textToTagBuilder =
-            new ImmutableMap.Builder<String, JavadocTagInfo>();
+            new ImmutableMap.Builder<>();
 
         final ImmutableMap.Builder<String, JavadocTagInfo> nameToTagBuilder =
-            new ImmutableMap.Builder<String, JavadocTagInfo>();
+            new ImmutableMap.Builder<>();
 
         for (final JavadocTagInfo tag : JavadocTagInfo.values()) {
             textToTagBuilder.put(tag.getText(), tag);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/FileContentsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/FileContentsHolder.java
@@ -33,8 +33,7 @@ public class FileContentsHolder
     extends Check
 {
     /** The current file contents. */
-    private static final ThreadLocal<FileContents> FILE_CONTENTS =
-        new ThreadLocal<FileContents>();
+    private static final ThreadLocal<FileContents> FILE_CONTENTS = new ThreadLocal<>();
 
     /** @return the current file contents. */
     public static FileContents getContents()

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -56,15 +56,13 @@ public class SuppressWarningsHolder
     private static final String CHECK_SUFFIX = "Check";
 
     /** a map from check source names to suppression aliases */
-    private static final Map<String, String> CHECK_ALIAS_MAP =
-        new HashMap<String, String>();
+    private static final Map<String, String> CHECK_ALIAS_MAP = new HashMap<>();
 
     /**
      * a thread-local holder for the list of suppression entries for the last
      * file parsed
      */
-    private static final ThreadLocal<List<Entry>> ENTRIES =
-        new ThreadLocal<List<Entry>>();
+    private static final ThreadLocal<List<Entry>> ENTRIES = new ThreadLocal<>();
 
     /** records a particular suppression for a region of a file */
     private static class Entry

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -90,7 +90,7 @@ public final class IllegalCatchCheck extends AbstractIllegalCheck
     public List<DetailAST> getAllExceptionTypes(DetailAST parentToken)
     {
         DetailAST currentNode = parentToken.getFirstChild();
-        final List<DetailAST> exceptionTypes = new LinkedList<DetailAST>();
+        final List<DetailAST> exceptionTypes = new LinkedList<>();
         if (currentNode.getType() == TokenTypes.BOR) {
             exceptionTypes.addAll(getAllExceptionTypes(currentNode));
             currentNode = currentNode.getNextSibling();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -457,7 +457,7 @@ public final class IllegalTypeCheck extends AbstractFormatCheck
      */
     public void setMemberModifiers(String modifiers)
     {
-        final List<Integer> modifiersList = new ArrayList<Integer>(modifiers.length());
+        final List<Integer> modifiersList = new ArrayList<>(modifiers.length());
         for (String modifier : modifiers.split(", ")) {
             modifiersList.add(TokenTypes.getTokenId(modifier));
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
@@ -88,8 +88,8 @@ public class OverloadMethodsDeclarationOrderCheck extends Check
     {
         final int allowedDistance = 1;
         DetailAST currentToken = objectBlock.getFirstChild();
-        final Map<String, Integer> methodIndexMap = new HashMap<String, Integer>();
-        final Map<String, Integer> methodLineNumberMap = new HashMap<String, Integer>();
+        final Map<String, Integer> methodIndexMap = new HashMap<>();
+        final Map<String, Integer> methodLineNumberMap = new HashMap<>();
         int currentIndex = 0;
         while (currentToken != null) {
             if (currentToken.getType() == TokenTypes.METHOD_DEF) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -456,7 +456,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check
             dist = 0;
         }
 
-        return new SimpleEntry<DetailAST, Integer>(variableUsageAst, dist);
+        return new SimpleEntry<>(variableUsageAst, dist);
     }
 
     /**
@@ -476,7 +476,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check
         DetailAST currentScopeAst = ast;
         DetailAST variableUsageAst = null;
         while (currentScopeAst != null) {
-            final List<DetailAST> variableUsageExpressions = new ArrayList<DetailAST>();
+            final List<DetailAST> variableUsageExpressions = new ArrayList<>();
             DetailAST currentStatementAst = currentScopeAst;
             currentScopeAst = null;
             while (currentStatementAst != null
@@ -548,7 +548,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check
                 variableUsageAst = null;
             }
         }
-        return new SimpleEntry<DetailAST, Integer>(variableUsageAst, dist);
+        return new SimpleEntry<>(variableUsageAst, dist);
     }
 
     /**
@@ -623,7 +623,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check
         if (!isVariableInOperatorExpr(block, variable)) {
             DetailAST currentNode = block.getLastChild();
             final List<DetailAST> variableUsageExpressions =
-                    new ArrayList<DetailAST>();
+                    new ArrayList<>();
 
             while (currentNode != null
                     && currentNode.getType() == TokenTypes.LITERAL_ELSE)
@@ -688,7 +688,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check
             DetailAST currentNode = block
                     .findFirstToken(TokenTypes.CASE_GROUP);
             final List<DetailAST> variableUsageExpressions =
-                    new ArrayList<DetailAST>();
+                    new ArrayList<>();
 
             // Checking variable usage inside all CASE blocks.
             while (currentNode != null
@@ -731,7 +731,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check
     {
         DetailAST currentNode = block.getFirstChild();
         final List<DetailAST> variableUsageExpressions =
-                new ArrayList<DetailAST>();
+                new ArrayList<>();
 
         // Checking variable usage inside TRY block.
         if (isChild(currentNode, variable)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheck.java
@@ -87,8 +87,7 @@ public class OneTopLevelClassCheck extends Check
     private boolean publicTypeFound;
 
     /** Mapping between type names and line numbers of the type declarations.*/
-    private TreeMap<Integer, String> lineNumberTypeMap =
-            new TreeMap<Integer, String>();
+    private TreeMap<Integer, String> lineNumberTypeMap = new TreeMap<>();
 
     @Override
     public int[] getDefaultTokens()

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -203,15 +203,13 @@ public class CustomImportOrderCheck extends Check
     private boolean sortImportsInGroupAlphabetically;
 
     /** List of order declaration customizing by user */
-    private final List<String> customImportOrderRules =
-            new ArrayList<String>();
+    private final List<String> customImportOrderRules = new ArrayList<>();
 
     /** Number of first domains for SAME_PACKAGE group. */
     private int samePackageMatchingDepth = 2;
 
     /** Contains objects with import attributes */
-    private List<ImportDetails> importToGroupList =
-            new ArrayList<CustomImportOrderCheck.ImportDetails>();
+    private List<ImportDetails> importToGroupList = new ArrayList<>();
 
     /**
      * Sets standardRegExp specified by user.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -58,8 +58,7 @@ final class ImportControlLoader extends AbstractLoader
     private final FastStack<PkgControl> stack = FastStack.newInstance();
 
     /** the map to lookup the resource name by the id */
-    private static final Map<String, String> DTD_RESOURCE_BY_ID =
-        new HashMap<String, String>();
+    private static final Map<String, String> DTD_RESOURCE_BY_ID = new HashMap<>();
 
     /** Initialise the map */
     static {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -239,7 +239,7 @@ public class UnusedImportsCheck extends Check
      */
     private Set<String> processJavadoc(TextBlock cmt)
     {
-        final Set<String> references = new HashSet<String>();
+        final Set<String> references = new HashSet<>();
         // process all the @link type tags
         // INLINEs inside BLOCKs get hidden when using ALL
         for (final JavadocTag tag
@@ -280,7 +280,7 @@ public class UnusedImportsCheck extends Check
      */
     private Set<String> processJavadocTag(JavadocTag tag)
     {
-        final Set<String> references = new HashSet<String>();
+        final Set<String> references = new HashSet<>();
         final String identifier = tag.getArg1().trim();
         for (Pattern pattern : new Pattern[]
         {FIRST_CLASS_NAME, ARGUMENT_NAME})
@@ -299,7 +299,7 @@ public class UnusedImportsCheck extends Check
      */
     private Set<String> matchPattern(String identifier, Pattern pattern)
     {
-        final Set<String> references = new HashSet<String>();
+        final Set<String> references = new HashSet<>();
         final Matcher matcher = pattern.matcher(identifier);
         while (matcher.find()) {
             references.add(matcher.group(1));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -193,7 +193,7 @@ public class LineWrappingHandler
      */
     private NavigableMap<Integer, DetailAST> collectFirstNodes()
     {
-        final NavigableMap<Integer, DetailAST> result = new TreeMap<Integer, DetailAST>();
+        final NavigableMap<Integer, DetailAST> result = new TreeMap<>();
 
         result.put(firstNode.getLineNo(), firstNode);
         DetailAST curNode = firstNode.getFirstChild();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -69,7 +69,7 @@ public abstract class AbstractJavadocCheck extends Check
      * key is "line:column"
      * value is DetailNode tree
      */
-    private static final Map<String, ParseStatus> TREE_CACHE = new HashMap<String, ParseStatus>();
+    private static final Map<String, ParseStatus> TREE_CACHE = new HashMap<>();
 
     /**
      * Custom error listener.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -98,7 +98,7 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck
      */
     public void setTarget(String target)
     {
-        final List<Integer> customTarget = new ArrayList<Integer>();
+        final List<Integer> customTarget = new ArrayList<>();
         for (String type : target.split(", ")) {
             customTarget.add(TokenTypes.getTokenId(type));
         }
@@ -111,7 +111,7 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck
      */
     public void setTagOrder(String order)
     {
-        final List<String> customOrder = new ArrayList<String>();
+        final List<String> customOrder = new ArrayList<>();
         Collections.addAll(customOrder, order.split(", "));
         tagOrder = customOrder;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -186,7 +186,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
      */
     public void setAllowedAnnotations(String userAnnotations)
     {
-        final List<String> annotations = new ArrayList<String>();
+        final List<String> annotations = new ArrayList<>();
         Collections.addAll(annotations, userAnnotations.split(", "));
         allowedAnnotations = annotations;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -96,7 +96,7 @@ public class JavadocTagContinuationIndentationCheck extends AbstractJavadocCheck
      */
     private List<DetailNode> getAllNewlineNodes(DetailNode descriptionNode)
     {
-        final List<DetailNode> textNodes = new ArrayList<DetailNode>();
+        final List<DetailNode> textNodes = new ArrayList<>();
         DetailNode node = JavadocUtils.getFirstChild(descriptionNode);
         while (JavadocUtils.getNextSibling(node) != null) {
             if (node.getType() == JavadocTokenTypes.NEWLINE) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -166,7 +166,7 @@ public class JavaNCSSCheck extends Check
     @Override
     public void beginTree(DetailAST rootAST)
     {
-        counters = new FastStack<Counter>();
+        counters = new FastStack<>();
 
         //add a counter for the file
         counters.push(new Counter());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -101,7 +101,7 @@ public class AbbreviationAsWordInNameCheck extends Check
     /**
      * Set of allowed abbreviation to ignore in check.
      */
-    private Set<String> allowedAbbreviations = new HashSet<String>();
+    private Set<String> allowedAbbreviations = new HashSet<>();
 
     /** Allows to ignore variables with 'final' modifier. */
     private boolean ignoreFinal = true;
@@ -162,7 +162,7 @@ public class AbbreviationAsWordInNameCheck extends Check
     public void setAllowedAbbreviations(String allowedAbbreviations)
     {
         if (allowedAbbreviations != null) {
-            this.allowedAbbreviations = new HashSet<String>(
+            this.allowedAbbreviations = new HashSet<>(
                     Arrays.asList(allowedAbbreviations.split(",")));
         }
     }
@@ -353,7 +353,7 @@ public class AbbreviationAsWordInNameCheck extends Check
      */
     private static List<DetailAST> getChildren(final DetailAST node)
     {
-        final List<DetailAST> result = new LinkedList<DetailAST>();
+        final List<DetailAST> result = new LinkedList<>();
         DetailAST curNode = node.getFirstChild();
         while (curNode != null) {
             result.add(curNode);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
@@ -42,8 +42,7 @@ public final class MethodCountCheck extends Check
     private static class MethodCounter
     {
         /** Maintains the counts. */
-        private final EnumMap<Scope, Integer> counts =
-            new EnumMap<Scope, Integer>(Scope.class);
+        private final EnumMap<Scope, Integer> counts = new EnumMap<>(Scope.class);
         /** indicated is an interface, in which case all methods are public */
         private final boolean inInterface;
         /** tracks the total. */
@@ -105,7 +104,7 @@ public final class MethodCountCheck extends Check
     private int maxTotal = DEFAULT_MAX_METHODS;
     /** Maintains stack of counters, to support inner types. */
     private final FastStack<MethodCounter> counters =
-        new FastStack<MethodCounter>();
+        new FastStack<>();
 
     @Override
     public int[] getDefaultTokens()

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -299,8 +299,7 @@ public class SuppressWithNearbyCommentFilter
      * and FileContentsHolder are reassigned to the next FileContents,
      * at which time filtering for the current FileContents is finished.
      */
-    private WeakReference<FileContents> fileContentsReference =
-        new WeakReference<FileContents>(null);
+    private WeakReference<FileContents> fileContentsReference = new WeakReference<>(null);
 
     /**
      * Constructs a SuppressionCommentFilter.
@@ -351,7 +350,7 @@ public class SuppressWithNearbyCommentFilter
      */
     public void setFileContents(FileContents fileContents)
     {
-        fileContentsReference = new WeakReference<FileContents>(fileContents);
+        fileContentsReference = new WeakReference<>(fileContents);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -290,8 +290,7 @@ public class SuppressionCommentFilter
      * and FileContentsHolder are reassigned to the next FileContents,
      * at which time filtering for the current FileContents is finished.
      */
-    private WeakReference<FileContents> fileContentsReference =
-        new WeakReference<FileContents>(null);
+    private WeakReference<FileContents> fileContentsReference = new WeakReference<>(null);
 
     /**
      * Constructs a SuppressionCoontFilter.
@@ -349,7 +348,7 @@ public class SuppressionCommentFilter
      */
     public void setFileContents(FileContents fileContents)
     {
-        fileContentsReference = new WeakReference<FileContents>(fileContents);
+        fileContentsReference = new WeakReference<>(fileContents);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -65,7 +65,7 @@ public class ParseTreeInfoPanel extends JPanel
     private File lastDirectory = null;
     private File currentFile = null;
     private final Action reloadAction;
-    private final List<Integer>   lines2position  = new ArrayList<Integer>();
+    private final List<Integer>   lines2position  = new ArrayList<>();
 
     private static class JavaFileFilter extends FileFilter
     {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -83,7 +83,7 @@ public class UniquePropertiesCheckTest extends BaseFileSetCheckTestSupport
     public void testNotFoundKey() throws Exception
     {
         final UniquePropertiesCheck check = new UniquePropertiesCheck();
-        final List<String> testStrings = new ArrayList<String>(3);
+        final List<String> testStrings = new ArrayList<>(3);
         testStrings.add("");
         testStrings.add("0 = 0");
         testStrings.add("445");


### PR DESCRIPTION
This syntax is not supported under Java 6 or earlier, but Checkstyle codebase uses Java 7 already.