### PR TITLE
Replace StringBuffer with StringBuilder to improve performance

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -382,7 +382,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher
             dosWithDrive = true;
 
             final char[] ca = path.replace('/', '\\').toCharArray();
-            final StringBuffer sbRoot = new StringBuffer();
+            final StringBuilder sbRoot = new StringBuilder();
             for (int i = 0; i < colon; i++) {
                 sbRoot.append(Character.toUpperCase(ca[i]));
             }
@@ -393,7 +393,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher
             root = sbRoot.toString();
 
             // Eliminate consecutive slashes after the drive spec
-            final StringBuffer sbPath = new StringBuffer();
+            final StringBuilder sbPath = new StringBuilder();
             for (int i = colon + 1; i < ca.length; i++) {
                 if ((ca[i] != '\\') || ((ca[i] == '\\') && (ca[i - 1] != '\\')))
                 {
@@ -439,7 +439,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher
             }
         }
 
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < s.size(); i++) {
             if (i > 1) {
                 // not before the filesystem root and not after it, since root

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -460,7 +460,7 @@ public final class ConfigurationLoader
         final List<String> propertyRefs = Lists.newArrayList();
         parsePropertyString(value, fragments, propertyRefs);
 
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
         final Iterator<String> i = fragments.iterator();
         final Iterator<String> j = propertyRefs.iterator();
         while (i.hasNext()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
@@ -103,7 +103,7 @@ public class DefaultLogger
             // avoid StringBuffer.expandCapacity
             final int bufLen = fileName.length() + message.length()
                 + BUFFER_CUSHION;
-            final StringBuffer sb = new StringBuffer(bufLen);
+            final StringBuilder sb = new StringBuilder(bufLen);
 
             sb.append(fileName);
             sb.append(':').append(evt.getLine());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -107,7 +107,7 @@ public final class PackageNamesLoader
      */
     private String getPackageName()
     {
-        final StringBuffer buf = new StringBuffer();
+        final StringBuilder buf = new StringBuilder();
         for (String subPackage : packageStack) {
             buf.append(subPackage);
             if (!subPackage.endsWith(".")) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -222,7 +222,7 @@ final class PropertyCacheFile
      */
     private static String hexEncode(byte[] byteArray)
     {
-        final StringBuffer buf = new StringBuffer(2 * byteArray.length);
+        final StringBuilder buf = new StringBuilder(2 * byteArray.length);
         for (final byte b : byteArray) {
             final int low = b & MASK_0X0F;
             final int high = (b >> SHIFT_4) & MASK_0X0F;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -170,7 +170,7 @@ public class XMLLogger
      */
     public String encode(String value)
     {
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < value.length(); i++) {
             final char c = value.charAt(i);
             switch (c) {


### PR DESCRIPTION
Thread-safety given by `StringBuffer` doesn't give any benefit when used within one method, so in such cases `StringBuilder` is safe and more efficient replacement.