### PR TITLE
Added missed @Test annotation on test-case

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -75,6 +75,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport
         verify(checkConfig, getPath("indentation/InputAndroidStyle.java"), expected);
     }
 
+    @Test
     public void testMethodCallLineWrap() throws Exception
     {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);


### PR DESCRIPTION
This commit adds missed @Test annotation on 'IndentationCheckTest.testMethodCallLineWrap' test-case. After adding annotation UT IndentationCheckTest runs successfully.