### PR TITLE
Boolean Expression Complexity Check, fixed NPE, issue #654

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
@@ -125,16 +125,33 @@ public final class BooleanExpressionComplexityCheck extends Check
             case TokenTypes.EXPR:
                 visitExpr();
                 break;
+            case TokenTypes.BOR:
+                if (!isPipeOperator(ast)) {
+                    context.visitBooleanOperator();
+                }
+                break;
             case TokenTypes.LAND:
             case TokenTypes.BAND:
             case TokenTypes.LOR:
-            case TokenTypes.BOR:
             case TokenTypes.BXOR:
                 context.visitBooleanOperator();
                 break;
             default:
                 throw new IllegalStateException(ast.toString());
         }
+    }
+
+    /**
+     * Checks if {@link TokenTypes#BOR binary OR} is applied to exceptions
+     * in
+     * <a href="http://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.20">
+     * multi-catch</a> (pipe-syntax).
+     * @param binaryOr {@link TokenTypes#BOR binary or}
+     * @return true if binary or is applied to exceptions in multi-catch.
+     */
+    private static boolean isPipeOperator(DetailAST binaryOr)
+    {
+        return binaryOr.getParent().getType() == TokenTypes.TYPE;
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
@@ -55,4 +55,16 @@ public class BooleanExpressionComplexityCheckTest extends BaseCheckTestSupport
 
         verify(checkConfig, getPath("metrics" + File.separator + "BooleanExpressionComplexityCheckTestInput.java"), expected);
     }
+
+    @Test
+    public void testNPE() throws Exception
+    {
+        DefaultConfiguration checkConfig =
+            createCheckConfig(BooleanExpressionComplexityCheck.class);
+
+        String[] expected = {
+        };
+
+        verify(checkConfig, getPath("metrics" + File.separator + "InputBooleanExpressionComplexityNPE.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/metrics/InputBooleanExpressionComplexityNPE.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/metrics/InputBooleanExpressionComplexityNPE.java
@@ -1,0 +1,12 @@
+package com.puppycrawl.tools.checkstyle.metrics;
+
+public class InputBooleanExpressionComplexityNPE
+{
+    static {
+        try {
+            System.out.println("a");
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
According to #654 

Fixed NPE, added UT and input.

Npe occurred because multi-catch pipe operator wasn't in consideration of <b>binary or</b> operator possible usage.

Detailed exception's information is coming from TreeWalker and exception between 
Audit started...
and
Audit finished.

Is coming from Checker. But in Checker there's no catch block for such exceptions, that's why it looks like swallowing.