### PR TITLE
Issue #572 BooleanExpressionComplexity misidentifies integer expression ...

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
@@ -37,6 +37,8 @@ public class BooleanExpressionComplexityCheckTest extends BaseCheckTestSupport
         String[] expected = {
             "13:9: " + getCheckMessage(MSG_KEY, 4, 3),
             "32:9: " + getCheckMessage(MSG_KEY, 6, 3),
+            "38:34: " + getCheckMessage(MSG_KEY, 4, 3),
+            "40:34: " + getCheckMessage(MSG_KEY, 4, 3),
         };
 
         verify(checkConfig, getPath("metrics" + File.separator + "BooleanExpressionComplexityCheckTestInput.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/metrics/BooleanExpressionComplexityCheckTestInput.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/metrics/BooleanExpressionComplexityCheckTestInput.java
@@ -31,4 +31,41 @@ public class BooleanExpressionComplexityCheckTestInput {
     {
         return (((_a & (_b & _c)) | (_c ^ _d) | (_a & _d)));
     }
+
+    public void notIgnoredMethodParameters()
+    {
+        new Settings(Settings.FALSE && Settings.FALSE && Settings.FALSE
+                && Settings.TRUE && Settings.TRUE);
+        new Settings(Settings.FALSE || Settings.FALSE || Settings.FALSE
+                || Settings.TRUE || Settings.TRUE);
+    }
+
+    public void ignoredMethodParameters()
+    {
+        new Settings(Settings.RESIZABLE | Settings.SCROLLBARS | Settings.LOCATION_BAR
+                | Settings.MENU_BAR | Settings.TOOL_BAR);
+        new Settings(Settings.RESIZABLE & Settings.SCROLLBARS & Settings.LOCATION_BAR
+                & Settings.MENU_BAR & Settings.TOOL_BAR);
+        new Settings(Settings.RESIZABLE ^ Settings.SCROLLBARS ^ Settings.LOCATION_BAR
+                ^ Settings.MENU_BAR ^ Settings.TOOL_BAR);
+    }
+
+    private class Settings {
+        public final static int RESIZABLE = 1;
+        public final static int SCROLLBARS = 2;
+        public final static int LOCATION_BAR = 3;
+        public final static int MENU_BAR = 4;
+        public final static int TOOL_BAR = 5;
+
+        public final static boolean TRUE = true;
+        public final static boolean FALSE = false;
+
+        public Settings(int flag)
+        {
+        }
+
+        public Settings(boolean flag)
+        {
+        }
+    }
 }

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -28,8 +28,14 @@
           Note that the operators <code>&#x26;</code> and
           <code>|</code> are not only integer bitwise operators, they are also the
           <a href="http://java.sun.com/docs/books/jls/third_edition/html/expressions.html#15.22.2">
-          non-shortcut versions</a> of the boolean operators
+          non-shortcut versions</a> of the boolean operators.
           <code>&#x26;&#x26;</code> and <code>||</code>.
+        </p>
+        <p>
+          Note that <code>&#x26;</code>, <code>|</code> and <code>^</code> are not checked
+          if they are part of constructor or method call
+          because they can be applied to non boolean variables and
+          Checkstyle does not know types of methods from different classes.
         </p>
       </subsection>
 


### PR DESCRIPTION
...as boolean expression.
The fix will ignore &,| and ^ only, since only they can be used with non boolean variables.