### PR TITLE
Fix comma replaced with period in docs

### DIFF
--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1508,7 +1508,7 @@ foo(i
         <source>
 s.
     isEmpty();
-foo(i.
+foo(i,
     s);
         </source>
         <p>


### PR DESCRIPTION
In config_whitespace, a comma was incorrectly replaced with a period.