### PR TITLE
Visibility Modifier Check, ignore annotated fields

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -18,12 +18,13 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.puppycrawl.tools.checkstyle.checks.design;
 
+import static com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck.MSG_KEY;
+
+import org.junit.Test;
+
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import org.junit.Test;
-
-import static com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck.MSG_KEY;
 
 public class VisibilityModifierCheckTest
     extends BaseCheckTestSupport
@@ -180,4 +181,78 @@ public class VisibilityModifierCheckTest
         verify(checkConfig, getPath("InputImmutableStarImport2.java"), expected);
     }
 
+    @Test
+    public void testDefaultAnnotationPatterns() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        final String[] expected = {
+            "39:19: " + getCheckMessage(MSG_KEY, "customAnnotatedPublic"),
+            "42:12: " + getCheckMessage(MSG_KEY, "customAnnotatedPackage"),
+            "45:22: " + getCheckMessage(MSG_KEY, "customAnnotatedProtected"),
+            "47:19: " + getCheckMessage(MSG_KEY, "unannotatedPublic"),
+            "48:12: " + getCheckMessage(MSG_KEY, "unannotatedPackage"),
+            "49:22: " + getCheckMessage(MSG_KEY, "unannotatedProtected"),
+        };
+        verify(checkConfig, getPath("AnnotatedVisibility.java"), expected);
+    }
+
+    @Test
+    public void testCustomAnnotationPatterns() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("ignoreAnnotationCanonicalNames",
+                "com.puppycrawl.tools.checkstyle.AnnotatedVisibility.CustomAnnotation");
+        final String[] expected = {
+            "15:28: " + getCheckMessage(MSG_KEY, "publicJUnitRule"),
+            "18:28: " + getCheckMessage(MSG_KEY, "fqPublicJUnitRule"),
+            "21:19: " + getCheckMessage(MSG_KEY, "googleCommonsAnnotatedPublic"),
+            "24:12: " + getCheckMessage(MSG_KEY, "googleCommonsAnnotatedPackage"),
+            "27:22: " + getCheckMessage(MSG_KEY, "googleCommonsAnnotatedProtected"),
+            "30:19: " + getCheckMessage(MSG_KEY, "fqGoogleCommonsAnnotatedPublic"),
+            "33:12: " + getCheckMessage(MSG_KEY, "fqGoogleCommonsAnnotatedPackage"),
+            "36:22: " + getCheckMessage(MSG_KEY, "fqGoogleCommonsAnnotatedProtected"),
+            "47:19: " + getCheckMessage(MSG_KEY, "unannotatedPublic"),
+            "48:12: " + getCheckMessage(MSG_KEY, "unannotatedPackage"),
+            "49:22: " + getCheckMessage(MSG_KEY, "unannotatedProtected"),
+        };
+        verify(checkConfig, getPath("AnnotatedVisibility.java"), expected);
+    }
+
+    @Test
+    public void testIgnoreAnnotationNoPattern() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("ignoreAnnotationCanonicalNames", "");
+        final String[] expected = {
+            "15:28: " + getCheckMessage(MSG_KEY, "publicJUnitRule"),
+            "18:28: " + getCheckMessage(MSG_KEY, "fqPublicJUnitRule"),
+            "21:19: " + getCheckMessage(MSG_KEY, "googleCommonsAnnotatedPublic"),
+            "24:12: " + getCheckMessage(MSG_KEY, "googleCommonsAnnotatedPackage"),
+            "27:22: " + getCheckMessage(MSG_KEY, "googleCommonsAnnotatedProtected"),
+            "30:19: " + getCheckMessage(MSG_KEY, "fqGoogleCommonsAnnotatedPublic"),
+            "33:12: " + getCheckMessage(MSG_KEY, "fqGoogleCommonsAnnotatedPackage"),
+            "36:22: " + getCheckMessage(MSG_KEY, "fqGoogleCommonsAnnotatedProtected"),
+            "39:19: " + getCheckMessage(MSG_KEY, "customAnnotatedPublic"),
+            "42:12: " + getCheckMessage(MSG_KEY, "customAnnotatedPackage"),
+            "45:22: " + getCheckMessage(MSG_KEY, "customAnnotatedProtected"),
+            "47:19: " + getCheckMessage(MSG_KEY, "unannotatedPublic"),
+            "48:12: " + getCheckMessage(MSG_KEY, "unannotatedPackage"),
+            "49:22: " + getCheckMessage(MSG_KEY, "unannotatedProtected"),
+        };
+        verify(checkConfig, getPath("AnnotatedVisibility.java"), expected);
+    }
+
+    @Test
+    public void testIgnoreAnnotationSameName() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        final String[] expected = {
+            "10:28: " + getCheckMessage(MSG_KEY, "publicJUnitRule"),
+        };
+        verify(checkConfig, getPath("AnnotatedVisibilitySameTypeName.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/AnnotatedVisibility.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/AnnotatedVisibility.java
@@ -1,0 +1,56 @@
+package com.puppycrawl.tools.checkstyle;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+public class AnnotatedVisibility {
+    @Rule
+    public TemporaryFolder publicJUnitRule = new TemporaryFolder();
+
+    @org.junit.Rule
+    public TemporaryFolder fqPublicJUnitRule = new TemporaryFolder();
+
+    @VisibleForTesting
+    public String googleCommonsAnnotatedPublic;
+
+    @VisibleForTesting
+    String googleCommonsAnnotatedPackage;
+
+    @VisibleForTesting
+    protected String googleCommonsAnnotatedProtected;
+
+    @com.google.common.annotations.VisibleForTesting
+    public String fqGoogleCommonsAnnotatedPublic;
+
+    @com.google.common.annotations.VisibleForTesting
+    String fqGoogleCommonsAnnotatedPackage;
+
+    @com.google.common.annotations.VisibleForTesting
+    protected String fqGoogleCommonsAnnotatedProtected;
+
+    @CustomAnnotation
+    public String customAnnotatedPublic;
+
+    @CustomAnnotation
+    String customAnnotatedPackage;
+
+    @CustomAnnotation
+    protected String customAnnotatedProtected;
+
+    public String unannotatedPublic;
+    String unannotatedPackage;
+    protected String unannotatedProtected;
+    private String unannotatedPrivate;
+
+    @Retention(value=RetentionPolicy.RUNTIME)
+    @Target(value={ElementType.FIELD})
+    public @interface CustomAnnotation {
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/AnnotatedVisibilitySameTypeName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/AnnotatedVisibilitySameTypeName.java
@@ -1,0 +1,11 @@
+package com.puppycrawl.tools.checkstyle;
+
+import org.junit.rules.TemporaryFolder;
+
+import com.puppycrawl.tools.checkstyle.LocalAnnotations.Rule;
+
+public class AnnotatedVisibilitySameTypeName
+{
+    @Rule
+    public TemporaryFolder publicJUnitRule = new TemporaryFolder();
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/LocalAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/LocalAnnotations.java
@@ -1,0 +1,8 @@
+package com.puppycrawl.tools.checkstyle;
+
+public class LocalAnnotations
+{
+    public @interface Rule {
+        
+    }
+}

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -13,9 +13,9 @@
     <section name="VisibilityModifier">
       <subsection name="Description">
         <p>
-          Checks visibility of class members. Only static final or immutable members
-          may be public; other class members must be private unless the
-          property <code>protectedAllowed</code> or <code>packageAllowed</code> is set.
+          Checks visibility of class members. Only static final, immutable or annotated
+          by specified annotation members may be public; other class members must be private
+          unless the property <code>protectedAllowed</code> or <code>packageAllowed</code> is set.
         </p>
 
         <p>
@@ -33,7 +33,12 @@
           Rationale: Enforce encapsulation.
         </p>
         <p>
-          Check also has an option making it less strict:
+          Check also has options making it less strict:
+        </p>
+        <p>
+          <b>ignoreAnnotationCanonicalNames</b> - the list of annotations which ignore variables
+          in consideration. If user will provide short annotation name that type will match to any
+          named the same type without consideration of package
         </p>
         <p>
           <b>allowPublicImmutableFields</b> - which allows immutable fields be declared as
@@ -107,6 +112,12 @@
             java.lang.StackTraceElement, java.math.BigInteger, java.math.BigDecimal, java.io.File,
             java.util.Locale, java.util.UUID, java.net.URL, java.net.URI,
             java.net.Inet4Address, java.net.Inet6Address, java.net.InetSocketAddress,</td>
+          </tr>
+          <tr>
+            <td>ignoreAnnotationCanonicalNames</td>
+            <td>ignore annotations canonical names</td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
+            <td>org.junit.Rule, com.google.common.annotations.VisibleForTesting</td>
           </tr>
         </table>
       </subsection>
@@ -194,6 +205,73 @@ public class ImmutableClass
         this.notes = notes;
         this.someValue = someValue;
     }
+}
+        </source>
+
+        <p>
+          To configure the Check passing fields annotated with @com.annotation.CustomAnnotation:
+        </p>
+        <source>
+&lt;module name=&quot;VisibilityModifier&quot;&gt;
+  &lt;property name=&quot;ignoreAnnotationCanonicalNames&quot; value=
+  &quot;com.annotation.CustomAnnotation&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example of allowed field:
+        </p>
+        <source>
+class SomeClass
+{
+    @com.annotation.CustomAnnotation
+    String annotatedString; // no warning
+    @CustomAnnotation
+    String shortCustomAnnotated; // no warning
+}
+        </source>
+
+        <p>
+          To configure the Check passing fields annotated with @org.junit.Rule and
+          @com.google.common.annotations.VisibleForTesting annotations:
+        </p>
+        <source>
+&lt;module name=&quot;VisibilityModifier&quot;/&gt;
+        </source>
+        <p>
+          Example of allowed fields:
+        </p>
+        <source>
+class SomeClass
+{
+    @org.junit.Rule
+    public TemporaryFolder publicJUnitRule = new TemporaryFolder(); // no warning
+    @com.google.common.annotations.VisibleForTesting
+    public String testString = ""; // no warning
+}
+        </source>
+
+        <p>
+          To configure the Check passing fields annotated with short annotation name:
+        </p>
+        <source>
+&lt;module name=&quot;VisibilityModifier&quot;&gt;
+  &lt;property name=&quot;ignoreAnnotationCanonicalNames&quot;
+  value=&quot;CustomAnnotation&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example of allowed fields:
+        </p>
+        <source>
+class SomeClass
+{
+    @CustomAnnotation
+    String customAnnotated; // no warning
+    @com.annotation.CustomAnnotation
+    String customAnnotated1; // no warning
+    @mypackage.annotation.CustomAnnotation
+    String customAnnotatedAnotherPackage; // another package but short name matches
+                                          // so no violation
 }
         </source>
       </subsection>


### PR DESCRIPTION
Based on Pull #584

Requested points to fix:
```
Some items to fix before merge:

1)

mIgnoredAnnotationFormat
please make it static final private.

2)

mIgnoreAnnotated
mIgnoredAnnotationPattern
too much class members, please keep only mIgnoredAnnotationPattern with default value from mIgnoredAnnotationFormat, get exp should be applied each time.

3)

throw new ConversionException("unable to parse " + aPattern, e);
rethrow to top, Check do not know what to do on failure, it is business of top level

4)

final DetailAST firstIgnoredAnnotation =
AnnotationUtility.containsMatchingAnnotation(aAST, getIgnoredAnnotationPatternRegex());
final boolean hasIgnoredAnnotation = mIgnoreAnnotated
&& firstIgnoredAnnotation != null;
please make it like a function and move after " !"private" " condition , the easiest conditions go first.

5)

public static DetailAST containsMatchingAnnotation(final DetailAST aAST,
Pattern aAnnotationPattern)
please move that method to check as static function. Changes to API package is not allowed. I am sorry that we have utils in API, we will fix that soon.
Additionally please use 1 return point from method.

6)

throw new NullPointerException("the aAST is null");
please never throw NPE, use IllegalAgrument
```

1) Done

2) Only 2 fields are remained

3) Rethrowing to top

4) This code chunk is in separate boolean method and does not complex condition

5, 6) private static in Check's class, has one return point, no throwing of NPE, IllegalArgument used instead

P.S.

Something strange with coverage report as introduced code is fully-covered except for throwing exceptions