### PR TITLE
Generic Whitespace Check, updated method references processing, issue #6...

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -61,6 +61,8 @@ import com.puppycrawl.tools.checkstyle.api.Utils;
  * OrderedPair&lt;String, Box&lt;Integer&gt;&gt; p;              // Generic type reference
  * boolean same = Util.&lt;Integer, String&gt;compare(p1, p2);   // Generic preceded method name
  * Pair&lt;Integer, String&gt; p1 = new Pair&lt;&gt;(1, "apple");// Diamond operator
+ * List&lt;T&gt; list = ImmutableList.Builder&lt;T&gt;::new;     // Method reference
+ * sort(list, Comparable::&lt;String&gt;compareTo);              // Method reference
  * </pre>
  * @author Oliver Burn
  */
@@ -155,10 +157,11 @@ public class GenericWhitespaceCheck extends Check
                 //                        ^
                 //                        +--- whitespace not allowed
                 if ((ast.getParent().getType() == TokenTypes.TYPE_ARGUMENTS)
-                    && (ast.getParent().getParent().getType()
-                        == TokenTypes.DOT)
-                    && (ast.getParent().getParent().getParent().getType()
-                        == TokenTypes.METHOD_CALL))
+                        && ((ast.getParent().getParent().getType()
+                            == TokenTypes.DOT)
+                        && (ast.getParent().getParent().getParent().getType()
+                            == TokenTypes.METHOD_CALL))
+                    || isAfterMethodReference(ast))
                 {
                     if (Character.isWhitespace(charAfter)) {
                         log(ast.getLineNo(), after, WS_FOLLOWED, ">");
@@ -167,7 +170,8 @@ public class GenericWhitespaceCheck extends Check
                 else if (!Character.isWhitespace(charAfter)
                     && ('(' != charAfter) && (')' != charAfter)
                     && (',' != charAfter) && ('[' != charAfter)
-                    && ('.' != charAfter) && (':' != charAfter))
+                    && ('.' != charAfter) && (':' != charAfter)
+                    && !isAfterMethodReference(ast))
                 {
                     log(ast.getLineNo(), after, WS_ILLEGAL_FOLLOW, ">");
                 }
@@ -197,6 +201,17 @@ public class GenericWhitespaceCheck extends Check
                 }
             }
         }
+    }
+
+    /**
+     * Checks if current generic end ('>') is located after
+     * {@link TokenTypes#METHOD_REF method reference operator}.
+     * @param genericEnd {@link TokenTypes#GENERIC_END}
+     * @return true if '>' follows after method reference.
+     */
+    private static boolean isAfterMethodReference(DetailAST genericEnd)
+    {
+        return genericEnd.getParent().getParent().getType() == TokenTypes.METHOD_REF;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -112,4 +112,15 @@ public class GenericWhitespaceCheckTest
                 + "checkstyle/grammars/java8/"
                 + "InputMethodReferencesTest3.java").getCanonicalPath(), expected);
     }
+
+    @Test
+    public void testMethodReferences2() throws Exception
+    {
+        final String[] expected = {
+            "7:69: " + getCheckMessage(WS_FOLLOWED, ">"),
+        };
+        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/whitespace/"
+                + "InputGenericWhitespaceMethodRef.java").getCanonicalPath(), expected);
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/whitespace/InputGenericWhitespaceMethodRef.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/whitespace/InputGenericWhitespaceMethodRef.java
@@ -1,0 +1,8 @@
+//Compilable with Java8
+package com.puppycrawl.tools.checkstyle.whitespace;
+
+public class InputGenericWhitespaceMethodRef
+{
+    final Supplier<Optional<Integer>> function = Optional::<Integer>empty;
+    final Supplier<Optional<Integer>> function = Optional::<Integer> empty;
+}

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -44,6 +44,8 @@ class name&lt;T1, T2, ..., Tn&gt; {}                         // Generic type def
 OrderedPair&lt;String, Box&lt;Integer&gt;&gt; p;                   // Generic type reference
 boolean same = Util.&lt;Integer, String&gt;compare(p1, p2);  // Generic preceded method name
 Pair&lt;Integer, String> p1 = new Pair&lt;&gt;(1, "apple");     // Diamond operator
+List&lt;T&gt; list = ImmutableList.Builder&lt;T&gt;::new;          // Method reference
+sort(list, Comparable::&lt;String&gt;compareTo);             // Method reference
         </source>
       </subsection>
 


### PR DESCRIPTION
...77

According to #677 

Fixed false-positive in case if generic's end follows with whitespace after method reference, e.g.:

```java
final Supplier<Optional<Integer>> function = Optional::<Integer>empty;
```

Also updated the Check so it warns if in such case generic will be followed by whitespace:

```java
final Supplier<Optional<Integer>> function = Optional::<Integer> empty; // warn here
```