### PR TITLE
Fix bugs in EmptyLineSeparator , issue #706

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -237,6 +237,7 @@ public class EmptyLineSeparatorCheck extends Check
                                  nextToken.getText());
                         }
                         else if ((!allowNoEmptyLineBetweenFields || !allowMultipleEmptyLines)
+                                 && nextToken.getType() != TokenTypes.VARIABLE_DEF
                                  && nextToken.getType() != TokenTypes.RCURLY)
                         {
                             log(nextToken.getLineNo(), MSG_SHOULD_BE_SEPARATED,
@@ -256,7 +257,7 @@ public class EmptyLineSeparatorCheck extends Check
                     {
                         log(nextToken.getLineNo(), MSG_SHOULD_BE_SEPARATED, nextToken.getText());
                     }
-                    if (!allowMultipleEmptyLines && isPrePreviousLineEmpty(ast)) {
+                    if (!allowMultipleEmptyLines && isTwoPreviousLineEmpty(ast)) {
                         log(ast.getLineNo(), MSG_MULTIPLE_LINES, ast.getText());
                     }
                     break;
@@ -276,6 +277,16 @@ public class EmptyLineSeparatorCheck extends Check
                     }
             }
         }
+    }
+
+    /**
+     * Checks if a token has empty two previous lines
+     * @param token DetailAST token
+     * @return true, if token has empty two lines before
+     */
+    private boolean isTwoPreviousLineEmpty(DetailAST token)
+    {
+        return isPrePreviousLineEmpty(token) && hasEmptyLineBefore(token);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -39,7 +39,6 @@ public class EmptyLineSeparatorCheckTest
         final String[] expected = {
             "21: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "import"),
             "35: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "CLASS_DEF"),
-            "38: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "VARIABLE_DEF"),
             "39: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "STATIC_INIT"),
             "77: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "INTERFACE_DEF"),
         };
@@ -96,5 +95,27 @@ public class EmptyLineSeparatorCheckTest
 
         };
         verify(checkConfig, getPath("whitespace/InputEmptyLineSeparatorFormerException.java"), expected);
+    }
+
+    @Test
+    public void testAllowMultipleImportSeparatedFromPackage() throws Exception
+    {
+        DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
+        final String[] expected = {
+
+        };
+        verify(checkConfig, getPath("whitespace/InputEmptyLineSeparatorMultipleImportEmptyClass.java"), expected);
+    }
+
+    @Test
+    public void testAllowMultipleFieldInClass() throws Exception
+    {
+        DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
+        final String[] expected = {
+
+        };
+        verify(checkConfig, getPath("whitespace/InputEmptyLineSeparatorMultipleFieldsInClass.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/whitespace/InputEmptyLineSeparatorMultipleFieldsInClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/whitespace/InputEmptyLineSeparatorMultipleFieldsInClass.java
@@ -1,0 +1,7 @@
+package com.puppycrawl.tools.checkstyle.whitespace;
+
+public class InputEmptyLineSeparatorMultipleFieldsInClass
+{
+    int first;
+    int second;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/whitespace/InputEmptyLineSeparatorMultipleImportEmptyClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/whitespace/InputEmptyLineSeparatorMultipleImportEmptyClass.java
@@ -1,0 +1,8 @@
+package com.puppycrawl.tools.checkstyle.whitespace;
+
+import java.util.Calendar;
+import java.util.Date;
+
+public class InputEmptyLineSeparatorMultipleImportEmptyClass
+{
+}


### PR DESCRIPTION
It fixes two problems that occured in issue #706. First of all when pre previous line of import was empty it raises "'import' has more than 1 empty lines before" - test case for this is testAllowMultipleImportSeparatedFromPackage. Second issue was that when one field was declared line after another is raises "'VARIABLE_DEF' should be separated from previous statement" , test case is InputEmptyLineSeparatorMultipleImportEmptyClass
