### PR TITLE
Fix bugs with multiple fields, part of issue #706

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -236,7 +236,7 @@ public class EmptyLineSeparatorCheck extends Check
                             log(nextToken.getLineNo(), MSG_SHOULD_BE_SEPARATED,
                                  nextToken.getText());
                         }
-                        else if ((!allowNoEmptyLineBetweenFields || !allowMultipleEmptyLines)
+                        else if (!allowNoEmptyLineBetweenFields
                                  && nextToken.getType() != TokenTypes.RCURLY)
                         {
                             log(nextToken.getLineNo(), MSG_SHOULD_BE_SEPARATED,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -97,4 +97,17 @@ public class EmptyLineSeparatorCheckTest
         };
         verify(checkConfig, getPath("whitespace/InputEmptyLineSeparatorFormerException.java"), expected);
     }
+
+    @Test
+    public void testAllowMultipleFieldInClass() throws Exception
+    {
+        DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
+        checkConfig.addAttribute("allowNoEmptyLineBetweenFields", "true");
+        final String[] expected = {
+
+        };
+        verify(checkConfig, getPath("whitespace/InputEmptyLineSeparatorMultipleFieldsInClass.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/whitespace/InputEmptyLineSeparatorMultipleFieldsInClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/whitespace/InputEmptyLineSeparatorMultipleFieldsInClass.java
@@ -1,0 +1,7 @@
+package com.puppycrawl.tools.checkstyle.whitespace;
+
+public class InputEmptyLineSeparatorMultipleFieldsInClass
+{
+    int first;
+    int second;
+}


### PR DESCRIPTION
Fixing part of issue #706. Problem was that , if line after type field was not empty and allowNoEmptyLineBetweenFields was false it was checking additionally is allowMultipleEmptyLines is false, what was totally useless(because we already knew that next line is not empty from previous condition)