### PR TITLE
Fix HiddenField ignoreSetter propery not working for one letter fields, issue #730

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -412,8 +412,8 @@ public class HiddenFieldCheck
         // we should not capitalize the first character if the second
         // one is a capital one, since according to JavBeans spec
         // setXYzz() is a setter for XYzz property, not for xYzz one.
-        if (name != null && name.length() > 0
-            && (name.length() > 1 && !Character.isUpperCase(name.charAt(1))))
+        if (name != null && (name.length() == 1
+                || (name.length() > 1 && !Character.isUpperCase(name.charAt(1)))))
         {
             setterName = name.substring(0, 1).toUpperCase() + name.substring(1);
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
@@ -99,6 +99,7 @@ public class HiddenFieldCheckTest
             "253:40: " + getCheckMessage(MSG_KEY, "prop"),
             "267:29: " + getCheckMessage(MSG_KEY, "prop"),
             "278:41: " + getCheckMessage(MSG_KEY, "prop2"),
+            "290:19: " + getCheckMessage(MSG_KEY, "i"),
         };
         verify(checkConfig, getPath("InputHiddenField.java"), expected);
     }
@@ -271,6 +272,7 @@ public class HiddenFieldCheckTest
             "253:40: " + getCheckMessage(MSG_KEY, "prop"),
             "267:29: " + getCheckMessage(MSG_KEY, "prop"),
             "278:41: " + getCheckMessage(MSG_KEY, "prop2"),
+            "290:19: " + getCheckMessage(MSG_KEY, "i"),
         };
         verify(checkConfig, getPath("InputHiddenField.java"), expected);
     }
@@ -348,6 +350,7 @@ public class HiddenFieldCheckTest
             "253:40: " + getCheckMessage(MSG_KEY, "prop"),
             "267:29: " + getCheckMessage(MSG_KEY, "prop"),
             "278:41: " + getCheckMessage(MSG_KEY, "prop2"),
+            "290:19: " + getCheckMessage(MSG_KEY, "i"),
         };
         verify(checkConfig, getPath("InputHiddenField.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputHiddenField.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputHiddenField.java
@@ -281,3 +281,14 @@ enum PropertySetter4 {
         return this;
     }
 }
+
+/** Tests setter for one letter field (issue #730). */
+class OneLetterField
+{
+    int i;
+
+    void setI(int i)
+    {
+        this.i = i;
+    }
+}


### PR DESCRIPTION
Bug was introduced with [these changes](https://github.com/checkstyle/checkstyle/commit/6784e5bcd5baa6b5086bf8b63709856d685a74c8#diff-bd2095a110f21178164b052b84a3eb32R373).

Method `capitalize()` since Checkstyle 6.3 didn't work for one letter input.