### PR TITLE
Fix bug with multiple imports, part of issue #706

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -243,8 +243,7 @@ public class EmptyLineSeparatorCheck extends Check
                                  nextToken.getText());
                         }
                     }
-                    if (!allowMultipleEmptyLines && isTypeField(ast)
-                             && isPrePreviousLineEmpty(ast))
+                    if (isTypeField(ast) && hasNotAllowedTwoEmptyLinesBefore(ast))
                     {
                         log(ast.getLineNo(), MSG_MULTIPLE_LINES, ast.getText());
                     }
@@ -256,7 +255,7 @@ public class EmptyLineSeparatorCheck extends Check
                     {
                         log(nextToken.getLineNo(), MSG_SHOULD_BE_SEPARATED, nextToken.getText());
                     }
-                    if (!allowMultipleEmptyLines && isPrePreviousLineEmpty(ast)) {
+                    if (hasNotAllowedTwoEmptyLinesBefore(ast)) {
                         log(ast.getLineNo(), MSG_MULTIPLE_LINES, ast.getText());
                     }
                     break;
@@ -264,18 +263,29 @@ public class EmptyLineSeparatorCheck extends Check
                     if (ast.getLineNo() > 1 && !hasEmptyLineBefore(ast)) {
                         log(ast.getLineNo(), MSG_SHOULD_BE_SEPARATED, ast.getText());
                     }
-                    if (!allowMultipleEmptyLines && isPrePreviousLineEmpty(ast)) {
+                    if (hasNotAllowedTwoEmptyLinesBefore(ast)) {
                         log(ast.getLineNo(), MSG_MULTIPLE_LINES, ast.getText());
                     }
                 default:
                     if (nextToken.getType() != TokenTypes.RCURLY && !hasEmptyLineAfter(ast)) {
                         log(nextToken.getLineNo(), MSG_SHOULD_BE_SEPARATED, nextToken.getText());
                     }
-                    if (!allowMultipleEmptyLines && isPrePreviousLineEmpty(ast)) {
+                    if (hasNotAllowedTwoEmptyLinesBefore(ast)) {
                         log(ast.getLineNo(), MSG_MULTIPLE_LINES, ast.getText());
                     }
             }
         }
+    }
+
+    /**
+     * Checks if a token has empty two previous lines and multiple empty lines is not allowed
+     * @param token DetailAST token
+     * @return true, if token has empty two lines before and allowMultipleEmptyLines is false
+     */
+    private boolean hasNotAllowedTwoEmptyLinesBefore(DetailAST token)
+    {
+        return !allowMultipleEmptyLines && hasEmptyLineBefore(token)
+                && isPrePreviousLineEmpty(token);
     }
 
     /**
@@ -318,6 +328,9 @@ public class EmptyLineSeparatorCheck extends Check
     private boolean hasEmptyLineBefore(DetailAST token)
     {
         final int lineNo = token.getLineNo();
+        if (lineNo == 1) {
+            return false;
+        }
         //  [lineNo - 2] is the number of the previous line because the numbering starts from zero.
         final String lineBefore = getLines()[lineNo - 2];
         return lineBefore.trim().isEmpty();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -110,4 +110,15 @@ public class EmptyLineSeparatorCheckTest
         verify(checkConfig, getPath("whitespace/InputEmptyLineSeparatorMultipleFieldsInClass.java"), expected);
     }
 
+    @Test
+    public void testAllowMultipleImportSeparatedFromPackage() throws Exception
+    {
+        DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
+        final String[] expected = {
+
+        };
+        verify(checkConfig, getPath("whitespace/InputEmptyLineSeparatorMultipleImportEmptyClass.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/whitespace/InputEmptyLineSeparatorMultipleImportEmptyClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/whitespace/InputEmptyLineSeparatorMultipleImportEmptyClass.java
@@ -1,0 +1,8 @@
+package com.puppycrawl.tools.checkstyle.whitespace;
+
+import java.util.Calendar;
+import java.util.Date;
+
+public class InputEmptyLineSeparatorMultipleImportEmptyClass
+{
+}


### PR DESCRIPTION
Problem was checking for pre previous line with imports instead of checking for two previous lines. As suggested in previous PR i introduce method hasNotAllowedFewLinesBeforeEmpty which checks if last two lines is empty and multiple empty lines are empty. I changed every checking "!allowMultipleEmptyLines && isPrePreviousLineEmpty(ast)" to hasNotAllowedFewLinesBeforeEmpty. In previous PR @romani suggested putting more light hasEmptyLineBefore function before isPrePreviousLineEmpty, i did not do this because hasEmptyLineBefore function does not check if previous line exist. I certainly can put that guard in hasEmptyLineBefore and put it before isPrePreviousLineEmpty in condition, but in this situation hasEmptyLineBefore would not be any lighter than isPrePreviousLineEmpty but im open to further suggestions. 