### PR TITLE
Update Maven JAR Plugin to 2.6, issue #644

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
+        <version>2.6</version>
         <configuration>
           <archive>
             <manifest>


### PR DESCRIPTION
### Release Notes (2015-03-09)

Bugs:
 * [MJAR-135] - encoding problem with folder-names
 * [MJAR-151] - Error assembling JAR on OS X
 * [MJAR-179] - Adding empty files to jar failed with a ZipException : bad CRC checksum
 * [MJAR-185] - Update version of plexus-archiver to 2.7.1
 * [MJAR-188] - maven-jar-plugin is very slow on machines with slow Unix group lookups
 * [MJAR-189] - Upgrade plexus-archiver dependency to v2.9

Improvements:
 * [MJAR-178] - Change information on site
 * [MJAR-180] - Upgrade to Maven 2.2.1 compatiblity
 * [MJAR-181] - MavenProject/MavenSession Injection as a paremeter instead as a component.
 * [MJAR-182] - Update version of plexus-archiver to 2.6.3
 * [MJAR-184] - Update version of plexus-archiver to 2.7
 * [MJAR-186] - Upgrade maven-plugins-testing-harness from 1.2 to 1.3
 * [MJAR-187] - Upgrade maven-archiver to 2.6
 * [MJAR-190] - Upgrade to maven-plugins version 25 to 26
 * [MJAR-191] - Upgrade to maven-plugins parent version 27