### PR TITLE
Replace calls to equals() on enums with identity comparison

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -199,7 +199,7 @@ public final class ConfigurationLoader
                 // omit this module if these should be omitted and the module
                 // has the severity 'ignore'
                 final boolean omitModule = omitIgnoredModules
-                    && SeverityLevel.IGNORE.equals(level);
+                    && SeverityLevel.IGNORE == level;
 
                 if (omitModule && !configStack.isEmpty()) {
                     final DefaultConfiguration parentModule =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
@@ -95,7 +95,7 @@ public class DefaultLogger
     public void addError(AuditEvent evt)
     {
         final SeverityLevel severityLevel = evt.getSeverityLevel();
-        if (!SeverityLevel.IGNORE.equals(severityLevel)) {
+        if (SeverityLevel.IGNORE != severityLevel) {
 
             final String fileName = evt.getFileName();
             final String message = evt.getMessage();
@@ -110,7 +110,7 @@ public class DefaultLogger
             if (evt.getColumn() > 0) {
                 sb.append(':').append(evt.getColumn());
             }
-            if (SeverityLevel.WARNING.equals(severityLevel)) {
+            if (SeverityLevel.WARNING == severityLevel) {
                 sb.append(": warning");
             }
             sb.append(": ").append(message);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -131,7 +131,7 @@ public class XMLLogger
     @Override
     public void addError(AuditEvent evt)
     {
-        if (!SeverityLevel.IGNORE.equals(evt.getSeverityLevel())) {
+        if (SeverityLevel.IGNORE != evt.getSeverityLevel()) {
             writer.print("<error" + " line=\"" + evt.getLine() + "\"");
             if (evt.getColumn() > 0) {
                 writer.print(" column=\"" + evt.getColumn() + "\"");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounter.java
@@ -48,7 +48,7 @@ public final class SeverityLevelCounter implements AuditListener
     @Override
     public void addError(AuditEvent evt)
     {
-        if (level.equals(evt.getSeverityLevel())) {
+        if (level == evt.getSeverityLevel()) {
             count++;
         }
     }
@@ -57,7 +57,7 @@ public final class SeverityLevelCounter implements AuditListener
     @Override
     public void addException(AuditEvent evt, Throwable throwable)
     {
-        if (SeverityLevel.ERROR.equals(level)) {
+        if (SeverityLevel.ERROR == level) {
             count++;
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -265,19 +265,19 @@ public final class AnnotationUseStyleCheck extends Check
      */
     private void checkStyleType(final DetailAST annotation)
     {
-        if (ElementStyle.IGNORE.equals(this.style)
+        if (ElementStyle.IGNORE == this.style
             || this.style == null)
         {
             return;
         }
 
-        if (ElementStyle.COMPACT_NO_ARRAY.equals(this.style)) {
+        if (ElementStyle.COMPACT_NO_ARRAY == this.style) {
             this.checkCompactNoArrayStyle(annotation);
         }
-        else if (ElementStyle.COMPACT.equals(this.style)) {
+        else if (ElementStyle.COMPACT == this.style) {
             this.checkCompactStyle(annotation);
         }
-        else if (ElementStyle.EXPANDED.equals(this.style)) {
+        else if (ElementStyle.EXPANDED == this.style) {
             this.checkExpandedStyle(annotation);
         }
     }
@@ -372,7 +372,7 @@ public final class AnnotationUseStyleCheck extends Check
      */
     private void checkTrailingComma(final DetailAST annotation)
     {
-        if (TrailingArrayComma.IGNORE.equals(this.comma)
+        if (TrailingArrayComma.IGNORE == this.comma
             || this.comma == null)
         {
             return;
@@ -413,13 +413,13 @@ public final class AnnotationUseStyleCheck extends Check
         //comma can be null if array is empty
         final DetailAST comma = rCurly.getPreviousSibling();
 
-        if (TrailingArrayComma.ALWAYS.equals(this.comma)
+        if (TrailingArrayComma.ALWAYS == this.comma
             && (comma == null || comma.getType() != TokenTypes.COMMA))
         {
             this.log(rCurly.getLineNo(),
                 rCurly.getColumnNo(), MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING);
         }
-        else if (TrailingArrayComma.NEVER.equals(this.comma)
+        else if (TrailingArrayComma.NEVER == this.comma
             && comma != null && comma.getType() == TokenTypes.COMMA)
         {
             this.log(comma.getLineNo(),
@@ -435,7 +435,7 @@ public final class AnnotationUseStyleCheck extends Check
      */
     private void checkCheckClosingParens(final DetailAST ast)
     {
-        if (ClosingParens.IGNORE.equals(this.parens)
+        if (ClosingParens.IGNORE == this.parens
             || this.parens == null)
         {
             return;
@@ -444,12 +444,12 @@ public final class AnnotationUseStyleCheck extends Check
         final DetailAST paren = ast.getLastChild();
         final boolean parenExists = paren.getType() == TokenTypes.RPAREN;
 
-        if (ClosingParens.ALWAYS.equals(this.parens)
+        if (ClosingParens.ALWAYS == this.parens
             && !parenExists)
         {
             this.log(ast.getLineNo(), MSG_KEY_ANNOTATION_PARENS_MISSING);
         }
-        else if (ClosingParens.NEVER.equals(this.parens)
+        else if (ClosingParens.NEVER == this.parens
             && !ast.branchContains(TokenTypes.EXPR)
             && !ast.branchContains(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR)
             && !ast.branchContains(TokenTypes.ANNOTATION_ARRAY_INIT)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -122,7 +122,7 @@ public class ImportControlCheck extends Check
             }
             final AccessResult access = currentLeaf.checkAccess(imp.getText(),
                     inPkg);
-            if (!AccessResult.ALLOWED.equals(access)) {
+            if (AccessResult.ALLOWED != access) {
                 log(ast, MSG_DISALLOWED, imp.getText());
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -339,7 +339,7 @@ public class ImportOrderCheck
             return;
         }
 
-        if (getAbstractOption().equals(ImportOrderOption.INFLOW)) {
+        if (getAbstractOption() == ImportOrderOption.INFLOW) {
             // out of lexicographic order
             if (compare(lastImport, name, caseSensitive) > 0) {
                 log(line, MSG_ORDERING, name);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java
@@ -95,48 +95,48 @@ public class JavadocTag
     /** @return whether the tag is an 'author' tag **/
     public boolean isAuthorTag()
     {
-        return JavadocTagInfo.AUTHOR.equals(tagInfo);
+        return JavadocTagInfo.AUTHOR == tagInfo;
     }
 
     /** @return whether the tag is an 'return' tag **/
     public boolean isReturnTag()
     {
-        return JavadocTagInfo.RETURN.equals(tagInfo);
+        return JavadocTagInfo.RETURN == tagInfo;
     }
 
     /** @return whether the tag is an 'param' tag **/
     public boolean isParamTag()
     {
-        return JavadocTagInfo.PARAM.equals(tagInfo);
+        return JavadocTagInfo.PARAM == tagInfo;
     }
 
     /** @return whether the tag is an 'throws' or 'exception' tag **/
     public boolean isThrowsTag()
     {
-        return (JavadocTagInfo.THROWS.equals(tagInfo)
-            || JavadocTagInfo.EXCEPTION.equals(tagInfo));
+        return (JavadocTagInfo.THROWS == tagInfo
+            || JavadocTagInfo.EXCEPTION == tagInfo);
     }
 
     /** @return whether the tag is a 'see' or 'inheritDoc' tag **/
     public boolean isSeeOrInheritDocTag()
     {
-        return (JavadocTagInfo.SEE.equals(tagInfo) || isInheritDocTag());
+        return (JavadocTagInfo.SEE == tagInfo || isInheritDocTag());
     }
 
     /** @return whether the tag is a 'inheritDoc' tag **/
     public boolean isInheritDocTag()
     {
-        return JavadocTagInfo.INHERIT_DOC.equals(tagInfo);
+        return JavadocTagInfo.INHERIT_DOC == tagInfo;
     }
 
     /** @return whether the tag can contain references to imported classes **/
     public boolean canReferenceImports()
     {
-        return (JavadocTagInfo.SEE.equals(tagInfo)
-                || JavadocTagInfo.LINK.equals(tagInfo)
-                || JavadocTagInfo.LINKPLAIN.equals(tagInfo)
-                || JavadocTagInfo.THROWS.equals(tagInfo)
-                || JavadocTagInfo.EXCEPTION.equals(tagInfo));
+        return (JavadocTagInfo.SEE == tagInfo
+                || JavadocTagInfo.LINK == tagInfo
+                || JavadocTagInfo.LINKPLAIN == tagInfo
+                || JavadocTagInfo.THROWS == tagInfo
+                || JavadocTagInfo.EXCEPTION == tagInfo);
     }
 }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
@@ -116,8 +116,8 @@ public final class JavadocUtils
         for (int i = 0; i < text.length; i++) {
             final String s = text[i];
             final Matcher blockTagMatcher = blockTagPattern.matcher(s);
-            if ((tagType.equals(JavadocTagType.ALL) || tagType
-                    .equals(JavadocTagType.BLOCK)) && blockTagMatcher.find())
+            if ((tagType == JavadocTagType.ALL || tagType == JavadocTagType.BLOCK)
+                    && blockTagMatcher.find())
             {
                 final String tagName = blockTagMatcher.group(1);
                 String content = s.substring(blockTagMatcher.end(1));
@@ -138,8 +138,7 @@ public final class JavadocUtils
                 }
             }
             // No block tag, so look for inline validTags
-            else if (tagType.equals(JavadocTagType.ALL)
-                    || tagType.equals(JavadocTagType.INLINE))
+            else if (tagType == JavadocTagType.ALL || tagType == JavadocTagType.INLINE)
             {
                 // Match Javadoc text after comment characters
                 final Pattern commentPattern =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
@@ -65,7 +65,7 @@ public class SeverityMatchFilter
     @Override
     public boolean accept(AuditEvent event)
     {
-        final boolean result = severityLevel.equals(event.getSeverityLevel());
+        final boolean result = severityLevel == event.getSeverityLevel();
         if (acceptOnMatch) {
             return result;
         }


### PR DESCRIPTION
This replacement is safe because two enum constants are equal only when they have the same identity.