### PR TITLE
Remove useless parentheses to fix PMD violations, issue #744

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/CheckStyleTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/CheckStyleTask.java
@@ -284,7 +284,7 @@ public class CheckStyleTask extends Task
         log("compiled on " + compileTimestamp, Project.MSG_VERBOSE);
 
         // Check for no arguments
-        if ((fileName == null) && fileSets.isEmpty()) {
+        if (fileName == null && fileSets.isEmpty()) {
             throw new BuildException(
                     "Must specify at least one of 'file' or nested 'fileset'.",
                     getLocation());
@@ -320,8 +320,8 @@ public class CheckStyleTask extends Task
             log("To process the files took " + (endTime - startTime) + " ms.",
                 Project.MSG_VERBOSE);
             final int numWarnings = warningCounter.getCount();
-            final boolean ok = (numErrs <= maxErrors)
-                    && (numWarnings <= maxWarnings);
+            final boolean ok = numErrs <= maxErrors
+                    && numWarnings <= maxWarnings;
 
             // Handle the return status
             if (!ok) {
@@ -565,7 +565,7 @@ public class CheckStyleTask extends Task
          */
         public AuditListener createListener(Task task) throws IOException
         {
-            if ((formatterType != null)
+            if (formatterType != null
                     && E_XML.equals(formatterType.getValue()))
             {
                 return createXMLLogger(task);
@@ -581,7 +581,7 @@ public class CheckStyleTask extends Task
         private AuditListener createDefaultLogger(Task task)
             throws IOException
         {
-            if ((toFile == null) || !useFile) {
+            if (toFile == null || !useFile) {
                 return new DefaultLogger(
                     new LogOutputStream(task, Project.MSG_DEBUG),
                     true, new LogOutputStream(task, Project.MSG_ERR), true);
@@ -596,7 +596,7 @@ public class CheckStyleTask extends Task
          */
         private AuditListener createXMLLogger(Task task) throws IOException
         {
-            if ((toFile == null) || !useFile) {
+            if (toFile == null || !useFile) {
                 return new XMLLogger(new LogOutputStream(task,
                         Project.MSG_INFO), true);
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -347,7 +347,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher
 
         final String osName = System.getProperty("os.name").toLowerCase(
                 Locale.US);
-        final boolean onNetWare = (osName.indexOf("netware") > -1);
+        final boolean onNetWare = osName.indexOf("netware") > -1;
 
         String path = normalizingPath.replace('/', File.separatorChar).replace('\\',
             File.separatorChar);
@@ -357,15 +357,15 @@ public class Checker extends AutomaticBean implements MessageDispatcher
 
         if (!onNetWare) {
             if (!path.startsWith(File.separator)
-                && !((path.length() >= 2)
-                     && Character.isLetter(path.charAt(0)) && (colon == 1)))
+                && !(path.length() >= 2
+                     && Character.isLetter(path.charAt(0)) && colon == 1))
             {
                 final String msg = path + " is not an absolute path";
                 throw new IllegalArgumentException(msg);
             }
         }
         else {
-            if (!path.startsWith(File.separator) && (colon == -1)) {
+            if (!path.startsWith(File.separator) && colon == -1) {
                 final String msg = path + " is not an absolute path";
                 throw new IllegalArgumentException(msg);
             }
@@ -374,9 +374,9 @@ public class Checker extends AutomaticBean implements MessageDispatcher
         boolean dosWithDrive = false;
         String root = null;
         // Eliminate consecutive slashes after the drive spec
-        if ((!onNetWare && (path.length() >= 2)
-             && Character.isLetter(path.charAt(0)) && (path.charAt(1) == ':'))
-            || (onNetWare && (colon > -1)))
+        if (!onNetWare && path.length() >= 2
+             && Character.isLetter(path.charAt(0)) && path.charAt(1) == ':'
+            || onNetWare && colon > -1)
         {
 
             dosWithDrive = true;
@@ -395,8 +395,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher
             // Eliminate consecutive slashes after the drive spec
             final StringBuilder sbPath = new StringBuilder();
             for (int i = colon + 1; i < ca.length; i++) {
-                if ((ca[i] != '\\') || ((ca[i] == '\\') && (ca[i - 1] != '\\')))
-                {
+                if (ca[i] != '\\' || ca[i] == '\\' && ca[i - 1] != '\\') {
                     sbPath.append(ca[i]);
                 }
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -519,7 +519,7 @@ public final class ConfigurationLoader
             }
             //if we are at the end of the string, we tack on a $
             //then move past it
-            if (pos == (value.length() - 1)) {
+            if (pos == value.length() - 1) {
                 fragments.add("$");
                 prev = pos + 1;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
@@ -80,7 +80,7 @@ public class DefaultLogger
         closeInfo = closeInfoAfterUse;
         closeError = closeErrorAfterUse;
         infoWriter = new PrintWriter(infoStream);
-        errorWriter = (infoStream == errorStream)
+        errorWriter = infoStream == errorStream
             ? infoWriter
             : new PrintWriter(errorStream);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -154,7 +154,7 @@ public final class PackageNamesLoader
         //being created anew for each file
         final PackageNamesLoader namesLoader = newPackageNamesLoader();
 
-        while ((null != packageFiles) && packageFiles.hasMoreElements()) {
+        while (null != packageFiles && packageFiles.hasMoreElements()) {
             final URL packageFile = packageFiles.nextElement();
             InputStream stream = null;
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -80,7 +80,7 @@ final class PropertyCacheFile
                 final String cachedConfigHash =
                     details.getProperty(CONFIG_HASH_KEY);
                 setInActive = false;
-                if ((cachedConfigHash == null)
+                if (cachedConfigHash == null
                     || !cachedConfigHash.equals(currentConfigHash))
                 {
                     // Detected configuration change - clear cache
@@ -102,7 +102,7 @@ final class PropertyCacheFile
                 Utils.closeQuietly(inStream);
             }
         }
-        detailsFile = (setInActive) ? null : fileName;
+        detailsFile = setInActive ? null : fileName;
     }
 
     /** Cleans up the object and updates the cache file. **/
@@ -152,8 +152,8 @@ final class PropertyCacheFile
     boolean alreadyChecked(String fileName, long timestamp)
     {
         final String lastChecked = details.getProperty(fileName);
-        return (lastChecked != null)
-            && (lastChecked.equals(Long.toString(timestamp)));
+        return lastChecked != null
+            && lastChecked.equals(Long.toString(timestamp));
     }
 
     /**
@@ -225,7 +225,7 @@ final class PropertyCacheFile
         final StringBuilder buf = new StringBuilder(2 * byteArray.length);
         for (final byte b : byteArray) {
             final int low = b & MASK_0X0F;
-            final int high = (b >> SHIFT_4) & MASK_0X0F;
+            final int high = b >> SHIFT_4 & MASK_0X0F;
             buf.append(HEX_CHARS[high]);
             buf.append(HEX_CHARS[low]);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -549,7 +549,7 @@ public final class TreeWalker
         while (curNode != null) {
             notifyVisit(curNode, astState);
             DetailAST toVisit = curNode.getFirstChild();
-            while ((curNode != null) && (toVisit == null)) {
+            while (curNode != null && toVisit == null) {
                 notifyLeave(curNode, astState);
                 toVisit = curNode.getNextSibling();
                 if (toVisit == null) {
@@ -596,7 +596,7 @@ public final class TreeWalker
             }
 
             DetailAST toVisit = curNode.getFirstChild();
-            while ((curNode != null) && (toVisit == null)) {
+            while (curNode != null && toVisit == null) {
                 toVisit = curNode.getNextSibling();
                 if (toVisit == null) {
                     curNode = curNode.getParent();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
@@ -43,7 +43,7 @@ public final class Utils
     public static boolean fileExtensionMatches(File file, String[] fileExtensions)
     {
         boolean result = false;
-        if ((fileExtensions == null) || (fileExtensions.length == 0)) {
+        if (fileExtensions == null || fileExtensions.length == 0) {
             result = true;
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -188,7 +188,7 @@ public class XMLLogger
                     break;
                 case '&':
                     final int nextSemi = value.indexOf(";", i);
-                    if ((nextSemi < 0)
+                    if (nextSemi < 0
                         || !isReference(value.substring(i, nextSemi + 1)))
                     {
                         sb.append("&amp;");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AuditEvent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AuditEvent.java
@@ -118,7 +118,7 @@ public final class AuditEvent
     /** @return the audit event severity level **/
     public SeverityLevel getSeverityLevel()
     {
-        return (message == null)
+        return message == null
             ? SeverityLevel.INFO
             : message.getSeverityLevel();
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -139,7 +139,7 @@ public class AutomaticBean
                 // figure out if the bean property really exists.
                 final PropertyDescriptor pd =
                     PropertyUtils.getPropertyDescriptor(this, key);
-                if ((pd == null) || (pd.getWriteMethod() == null)) {
+                if (pd == null || pd.getWriteMethod() == null) {
                     throw new CheckstyleException(
                         "Property '" + key + "' in module "
                         + configuration.getName()

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Comment.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Comment.java
@@ -106,7 +106,7 @@ public class Comment implements TextBlock
         final long inStart = startLineNo * multiplier + startColNo;
         final long inEnd = endLineNo * multiplier + endColNo;
 
-        return !((thisEnd < inStart) || (inEnd < thisStart));
+        return !(thisEnd < inStart || inEnd < thisStart);
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -95,7 +95,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens
     public void setNextSibling(AST ast)
     {
         super.setNextSibling(ast);
-        if ((ast != null) && (parent != null)) {
+        if (ast != null && parent != null) {
             ((DetailAST) ast).setParent(parent);
         }
         if (ast != null) {
@@ -163,7 +163,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens
         super.addChild(ast);
         if (ast != null) {
             ((DetailAST) ast).setParent(this);
-            (getFirstChild()).setParent(this);
+            getFirstChild().setParent(this);
         }
     }
 
@@ -300,7 +300,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens
     public DetailAST getLastChild()
     {
         DetailAST ast = getFirstChild();
-        while ((ast != null) && (ast.getNextSibling() != null)) {
+        while (ast != null && ast.getNextSibling() != null) {
             ast = ast.getNextSibling();
         }
         return ast;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FastStack.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FastStack.java
@@ -95,7 +95,7 @@ public class FastStack<E> implements Iterable<E>
      */
     public E peek(int index)
     {
-        if ((index < 0) || (index >= entries.size())) {
+        if (index < 0 || index >= entries.size()) {
             throw new IllegalArgumentException("index out of range.");
         }
         return entries.get(index);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -215,7 +215,7 @@ public final class FileContents implements CommentListener
         int lineNo = lineNoBefore - 2;
 
         // skip blank lines
-        while ((lineNo > 0) && (lineIsBlank(lineNo) || lineIsComment(lineNo))) {
+        while (lineNo > 0 && (lineIsBlank(lineNo) || lineIsComment(lineNo))) {
             lineNo--;
         }
 
@@ -316,7 +316,7 @@ public final class FileContents implements CommentListener
              lineNumber++)
         {
             final TextBlock comment = cppComments.get(lineNumber);
-            if ((comment != null)
+            if (comment != null
                     && comment.intersects(startLineNo, startColNo,
                             endLineNo, endColNo))
             {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -205,7 +205,7 @@ public final class FileText extends AbstractList<String>
      */
     public static FileText fromLines(File file, List<String> lines)
     {
-        return (lines instanceof FileText)
+        return lines instanceof FileText
             ? (FileText) lines
             : new FileText(file, lines);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
@@ -94,8 +94,8 @@ public enum JavadocTagInfo
                 || type == TokenTypes.ANNOTATION_DEF
                 || type == TokenTypes.METHOD_DEF
                 || type == TokenTypes.CTOR_DEF
-                || (type == TokenTypes.VARIABLE_DEF
-                && !ScopeUtils.isLocalVariableDef(ast));
+                || type == TokenTypes.VARIABLE_DEF
+                && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
 
@@ -115,8 +115,8 @@ public enum JavadocTagInfo
                 || type == TokenTypes.ENUM_DEF
                 || type == TokenTypes.ANNOTATION_DEF
                 || type == TokenTypes.METHOD_DEF || type == TokenTypes.CTOR_DEF
-                || (type == TokenTypes.VARIABLE_DEF
-                && !ScopeUtils.isLocalVariableDef(ast));
+                || type == TokenTypes.VARIABLE_DEF
+                && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
 
@@ -138,8 +138,8 @@ public enum JavadocTagInfo
                 || type == TokenTypes.CTOR_DEF
                 || type == TokenTypes.ENUM_CONSTANT_DEF
                 || type == TokenTypes.ANNOTATION_FIELD_DEF
-                || (type == TokenTypes.VARIABLE_DEF
-                && !ScopeUtils.isLocalVariableDef(ast));
+                || type == TokenTypes.VARIABLE_DEF
+                && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
 
@@ -191,8 +191,8 @@ public enum JavadocTagInfo
                 || type == TokenTypes.ENUM_DEF
                 || type == TokenTypes.ANNOTATION_DEF
                 || type == TokenTypes.METHOD_DEF || type == TokenTypes.CTOR_DEF
-                || (type == TokenTypes.VARIABLE_DEF
-                && !ScopeUtils.isLocalVariableDef(ast));
+                || type == TokenTypes.VARIABLE_DEF
+                && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
 
@@ -212,8 +212,8 @@ public enum JavadocTagInfo
                 || type == TokenTypes.ENUM_DEF
                 || type == TokenTypes.ANNOTATION_DEF
                 || type == TokenTypes.METHOD_DEF || type == TokenTypes.CTOR_DEF
-                || (type == TokenTypes.VARIABLE_DEF
-                && !ScopeUtils.isLocalVariableDef(ast));
+                || type == TokenTypes.VARIABLE_DEF
+                && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
 
@@ -233,8 +233,8 @@ public enum JavadocTagInfo
                 || type == TokenTypes.ENUM_DEF
                 || type == TokenTypes.ANNOTATION_DEF
                 || type == TokenTypes.METHOD_DEF || type == TokenTypes.CTOR_DEF
-                || (type == TokenTypes.VARIABLE_DEF
-                && !ScopeUtils.isLocalVariableDef(ast));
+                || type == TokenTypes.VARIABLE_DEF
+                && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
 
@@ -291,8 +291,8 @@ public enum JavadocTagInfo
                 || type == TokenTypes.ANNOTATION_DEF
                 || type == TokenTypes.METHOD_DEF
                 || type == TokenTypes.CTOR_DEF
-                || (type == TokenTypes.VARIABLE_DEF
-                && !ScopeUtils.isLocalVariableDef(ast));
+                || type == TokenTypes.VARIABLE_DEF
+                && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
 
@@ -373,8 +373,8 @@ public enum JavadocTagInfo
                 || type == TokenTypes.ANNOTATION_DEF
                 || type == TokenTypes.METHOD_DEF
                 || type == TokenTypes.CTOR_DEF
-                || (type == TokenTypes.VARIABLE_DEF
-                && !ScopeUtils.isLocalVariableDef(ast));
+                || type == TokenTypes.VARIABLE_DEF
+                && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
 
@@ -410,8 +410,8 @@ public enum JavadocTagInfo
                 || type == TokenTypes.ANNOTATION_DEF
                 || type == TokenTypes.METHOD_DEF
                 || type == TokenTypes.CTOR_DEF
-                || (type == TokenTypes.VARIABLE_DEF
-                && !ScopeUtils.isLocalVariableDef(ast));
+                || type == TokenTypes.VARIABLE_DEF
+                && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
@@ -59,7 +59,7 @@ public class LineColumn implements Comparable<LineColumn>
     @Override
     public int compareTo(LineColumn lineColumn)
     {
-        return (this.getLine() != lineColumn.getLine())
+        return this.getLine() != lineColumn.getLine()
             ? this.getLine() - lineColumn.getLine()
             : this.getColumn() - lineColumn.getColumn();
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -164,7 +164,7 @@ public final class LocalizedMessage
         this.lineNo = lineNo;
         this.colNo = colNo;
         this.key = key;
-        this.args = (null == args) ? null : args.clone();
+        this.args = null == args ? null : args.clone();
         this.bundle = bundle;
         this.severityLevel = severityLevel;
         this.moduleId = moduleId;
@@ -383,10 +383,10 @@ public final class LocalizedMessage
             if (getColumnNo() == other.getColumnNo()) {
                 return getMessage().compareTo(other.getMessage());
             }
-            return (getColumnNo() < other.getColumnNo()) ? -1 : 1;
+            return getColumnNo() < other.getColumnNo() ? -1 : 1;
         }
 
-        return (getLineNo() < other.getLineNo()) ? -1 : 1;
+        return getLineNo() < other.getLineNo() ? -1 : 1;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Scope.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Scope.java
@@ -62,7 +62,7 @@ public enum Scope
      */
     public boolean isIn(Scope scope)
     {
-        return (compareTo(scope) <= 0);
+        return compareTo(scope) <= 0;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/ScopeUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/ScopeUtils.java
@@ -76,15 +76,15 @@ public final class ScopeUtils
              token = token.getParent())
         {
             final int type = token.getType();
-            if ((type == TokenTypes.CLASS_DEF)
-                || (type == TokenTypes.INTERFACE_DEF)
-                || (type == TokenTypes.ANNOTATION_DEF)
-                || (type == TokenTypes.ENUM_DEF))
+            if (type == TokenTypes.CLASS_DEF
+                || type == TokenTypes.INTERFACE_DEF
+                || type == TokenTypes.ANNOTATION_DEF
+                || type == TokenTypes.ENUM_DEF)
             {
                 final DetailAST mods =
                     token.findFirstToken(TokenTypes.MODIFIERS);
                 final Scope modScope = ScopeUtils.getScopeFromMods(mods);
-                if ((retVal == null) || (retVal.isIn(modScope))) {
+                if (retVal == null || retVal.isIn(modScope)) {
                     retVal = modScope;
                 }
             }
@@ -114,9 +114,9 @@ public final class ScopeUtils
              token = token.getParent())
         {
             final int type = token.getType();
-            if ((type == TokenTypes.CLASS_DEF)
-                || (type == TokenTypes.ENUM_DEF)
-                || (type == TokenTypes.ANNOTATION_DEF))
+            if (type == TokenTypes.CLASS_DEF
+                || type == TokenTypes.ENUM_DEF
+                || type == TokenTypes.ANNOTATION_DEF)
             {
                 break; // in a class, enum or annotation
             }
@@ -149,9 +149,9 @@ public final class ScopeUtils
              token = token.getParent())
         {
             final int type = token.getType();
-            if ((type == TokenTypes.CLASS_DEF)
-                || (type == TokenTypes.ENUM_DEF)
-                || (type == TokenTypes.INTERFACE_DEF))
+            if (type == TokenTypes.CLASS_DEF
+                || type == TokenTypes.ENUM_DEF
+                || type == TokenTypes.INTERFACE_DEF)
             {
                 break; // in a class, enum or interface
             }
@@ -197,9 +197,9 @@ public final class ScopeUtils
              token = token.getParent())
         {
             final int type = token.getType();
-            if ((type == TokenTypes.INTERFACE_DEF)
-                || (type == TokenTypes.ANNOTATION_DEF)
-                || (type == TokenTypes.CLASS_DEF))
+            if (type == TokenTypes.INTERFACE_DEF
+                || type == TokenTypes.ANNOTATION_DEF
+                || type == TokenTypes.CLASS_DEF)
             {
                 break; // in an interface, annotation or class
             }
@@ -232,10 +232,10 @@ public final class ScopeUtils
              token = token.getParent())
         {
             final int type = token.getType();
-            if ((type == TokenTypes.METHOD_DEF)
-                || (type == TokenTypes.CTOR_DEF)
-                || (type == TokenTypes.INSTANCE_INIT)
-                || (type == TokenTypes.STATIC_INIT))
+            if (type == TokenTypes.METHOD_DEF
+                || type == TokenTypes.CTOR_DEF
+                || type == TokenTypes.INSTANCE_INIT
+                || type == TokenTypes.STATIC_INIT)
             {
                 retVal = true;
                 break;
@@ -258,10 +258,10 @@ public final class ScopeUtils
              parent != null;
              parent = parent.getParent())
         {
-            if ((parent.getType() == TokenTypes.CLASS_DEF)
-                || (parent.getType() == TokenTypes.INTERFACE_DEF)
-                || (parent.getType() == TokenTypes.ANNOTATION_DEF)
-                || (parent.getType() == TokenTypes.ENUM_DEF))
+            if (parent.getType() == TokenTypes.CLASS_DEF
+                || parent.getType() == TokenTypes.INTERFACE_DEF
+                || parent.getType() == TokenTypes.ANNOTATION_DEF
+                || parent.getType() == TokenTypes.ENUM_DEF)
             {
                 retVal = false;
                 break;
@@ -285,16 +285,16 @@ public final class ScopeUtils
             final DetailAST parent = aAST.getParent();
             if (parent != null) {
                 final int type = parent.getType();
-                return (type == TokenTypes.SLIST)
-                    || (type == TokenTypes.FOR_INIT)
-                    || (type == TokenTypes.FOR_EACH_CLAUSE);
+                return type == TokenTypes.SLIST
+                    || type == TokenTypes.FOR_INIT
+                    || type == TokenTypes.FOR_EACH_CLAUSE;
             }
         }
         // catch parameter?
         else if (aAST.getType() == TokenTypes.PARAMETER_DEF) {
             final DetailAST parent = aAST.getParent();
             if (parent != null) {
-                return (parent.getType() == TokenTypes.LITERAL_CATCH);
+                return parent.getType() == TokenTypes.LITERAL_CATCH;
             }
         }
         return false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Utils.java
@@ -247,7 +247,7 @@ public final class Utils
     public static String baseClassname(String type)
     {
         final int i = type.lastIndexOf(".");
-        return (i == -1) ? type : type.substring(i + 1);
+        return i == -1 ? type : type.substring(i + 1);
     }
 
     /**
@@ -260,7 +260,7 @@ public final class Utils
             final String basedir, final String fileName)
     {
         final String stripped;
-        if ((basedir == null) || !fileName.startsWith(basedir)) {
+        if (basedir == null || !fileName.startsWith(basedir)) {
             stripped = fileName;
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -139,9 +139,9 @@ public abstract class AbstractTypeAwareCheck extends Check
         else if (ast.getType() == TokenTypes.IMPORT) {
             processImport(ast);
         }
-        else if ((ast.getType() == TokenTypes.CLASS_DEF)
-                 || (ast.getType() == TokenTypes.INTERFACE_DEF)
-                 || (ast.getType() == TokenTypes.ENUM_DEF))
+        else if (ast.getType() == TokenTypes.CLASS_DEF
+                 || ast.getType() == TokenTypes.INTERFACE_DEF
+                 || ast.getType() == TokenTypes.ENUM_DEF)
         {
             processClass(ast);
         }
@@ -156,8 +156,8 @@ public abstract class AbstractTypeAwareCheck extends Check
     @Override
     public final void leaveToken(DetailAST ast)
     {
-        if ((ast.getType() == TokenTypes.CLASS_DEF)
-            || (ast.getType() == TokenTypes.ENUM_DEF))
+        if (ast.getType() == TokenTypes.CLASS_DEF
+            || ast.getType() == TokenTypes.ENUM_DEF)
         {
             // perhaps it was inner class
             int dotIdx = currentClass.lastIndexOf("$");
@@ -177,8 +177,8 @@ public abstract class AbstractTypeAwareCheck extends Check
         else if (ast.getType() == TokenTypes.METHOD_DEF) {
             typeParams.pop();
         }
-        else if ((ast.getType() != TokenTypes.PACKAGE_DEF)
-                 && (ast.getType() != TokenTypes.IMPORT))
+        else if (ast.getType() != TokenTypes.PACKAGE_DEF
+                 && ast.getType() != TokenTypes.IMPORT)
         {
             leaveAST(ast);
         }
@@ -220,7 +220,7 @@ public abstract class AbstractTypeAwareCheck extends Check
      */
     protected boolean isSubclass(Class<?> child, Class<?> parent)
     {
-        return (parent != null) && (child != null)
+        return parent != null && child != null
             &&  parent.isAssignableFrom(child);
     }
 
@@ -485,7 +485,7 @@ public abstract class AbstractTypeAwareCheck extends Check
         @Override
         public Class<?> getClazz()
         {
-            if (isLoadable() && (classObj == null)) {
+            if (isLoadable() && classObj == null) {
                 setClazz(check.tryLoadClass(getName(), surroundingClass));
             }
             return classObj;
@@ -498,7 +498,7 @@ public abstract class AbstractTypeAwareCheck extends Check
         private void setClazz(Class<?> classObj)
         {
             this.classObj = classObj;
-            isLoadable = (classObj != null);
+            isLoadable = classObj != null;
         }
 
         @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheck.java
@@ -64,8 +64,8 @@ public class ArrayTypeStyleCheck extends Check
         final DetailAST variableAST = typeAST.getNextSibling();
         if (variableAST != null) {
             final boolean isJavaStyle =
-                (variableAST.getLineNo() > ast.getLineNo())
-                || (variableAST.getColumnNo() > ast.getColumnNo());
+                variableAST.getLineNo() > ast.getLineNo()
+                || variableAST.getColumnNo() > ast.getColumnNo();
 
             if (isJavaStyle != javaStyle) {
                 log(ast.getLineNo(), ast.getColumnNo(), "array.type.style");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -217,10 +217,10 @@ public class AvoidEscapedUnicodeCharactersCheck
         if (hasUnicodeChar(literal)) {
             if (!(allowByTailComment && haastrailComment(ast)
                     || isAllCharactersEscaped(literal)
-                    || (allowEscapesForControlCharacters
-                            && isOnlyUnicodeValidChars(literal, sUnicodeControl))
-                    || (allowNonPrintableEscapes
-                            && isOnlyUnicodeValidChars(literal, sNonPrintableChars))))
+                    || allowEscapesForControlCharacters
+                            && isOnlyUnicodeValidChars(literal, sUnicodeControl)
+                    || allowNonPrintableEscapes
+                            && isOnlyUnicodeValidChars(literal, sNonPrintableChars)))
             {
                 log(ast.getLineNo(), "forbid.escaped.unicode.char");
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/CheckUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/CheckUtils.java
@@ -69,7 +69,7 @@ public final class CheckUtils
 
         // one parameter?
         final DetailAST paramsNode = ast.findFirstToken(TokenTypes.PARAMETERS);
-        return (paramsNode.getChildCount() == 1);
+        return paramsNode.getChildCount() == 1;
     }
 
     /**
@@ -81,7 +81,7 @@ public final class CheckUtils
     {
         final DetailAST parentAST = ast.getParent();
 
-        return (ast.getType() == TokenTypes.LITERAL_IF)
+        return ast.getType() == TokenTypes.LITERAL_IF
             && (isElse(parentAST) || isElseWithCurlyBraces(parentAST));
     }
 
@@ -103,8 +103,8 @@ public final class CheckUtils
      */
     private static boolean isElseWithCurlyBraces(DetailAST ast)
     {
-        return (ast.getType() == TokenTypes.SLIST)
-            && (ast.getChildCount() == 2)
+        return ast.getType() == TokenTypes.SLIST
+            && ast.getChildCount() == 2
             && isElse(ast.getParent());
     }
 
@@ -169,7 +169,7 @@ public final class CheckUtils
                     radix = BASE_8;
                     txt = txt.substring(1);
                 }
-                if ((txt.endsWith("L")) || (txt.endsWith("l"))) {
+                if (txt.endsWith("L") || txt.endsWith("l")) {
                     txt = txt.substring(0, txt.length() - 1);
                 }
                 if (txt.length() > 0) {
@@ -257,9 +257,9 @@ public final class CheckUtils
         DetailAST child = node.getFirstChild();
         while (child != null) {
             final DetailAST newNode = getFirstNode(child);
-            if ((newNode.getLineNo() < currentNode.getLineNo())
-                || ((newNode.getLineNo() == currentNode.getLineNo())
-                    && (newNode.getColumnNo() < currentNode.getColumnNo())))
+            if (newNode.getLineNo() < currentNode.getLineNo()
+                || newNode.getLineNo() == currentNode.getLineNo()
+                    && newNode.getColumnNo() < currentNode.getColumnNo())
             {
                 currentNode = newNode;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
@@ -97,7 +97,7 @@ public class ClassResolver
 
         //inner class of this class???
         if (!"".equals(currentClass)) {
-            final String innerClass = (!"".equals(pkg) ? (pkg + ".") : "")
+            final String innerClass = (!"".equals(pkg) ? pkg + "." : "")
                 + currentClass + "$" + name;
             if (isLoadable(innerClass)) {
                 return safeLoad(innerClass);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/DeclarationCollector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/DeclarationCollector.java
@@ -192,7 +192,7 @@ public abstract class DeclarationCollector extends Check
     protected final boolean isClassField(String name)
     {
         final LexicalFrame frame = findFrame(name);
-        return (frame instanceof ClassFrame)
+        return frame instanceof ClassFrame
                 && ((ClassFrame) frame).hasInstanceMember(name);
     }
 
@@ -204,7 +204,7 @@ public abstract class DeclarationCollector extends Check
     protected final boolean isClassMethod(String name)
     {
         final LexicalFrame frame = findFrame(name);
-        return (frame instanceof ClassFrame)
+        return frame instanceof ClassFrame
                 && ((ClassFrame) frame).hasInstanceMethod(name);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
@@ -235,14 +235,14 @@ public class DescendantTokenCheck extends Check
             }
             if (total < minimumNumber) {
                 log(ast.getLineNo(), ast.getColumnNo(),
-                        (null == minimumMessage) ? MSG_KEY_SUM_MIN
+                        null == minimumMessage ? MSG_KEY_SUM_MIN
                                 : minimumMessage,
                         String.valueOf(total),
                         String.valueOf(minimumNumber), name);
             }
             if (total > maximumNumber) {
                 log(ast.getLineNo(), ast.getColumnNo(),
-                        (null == maximumMessage) ? MSG_KEY_SUM_MAX
+                        null == maximumMessage ? MSG_KEY_SUM_MAX
                                 : maximumMessage,
                         String.valueOf(total),
                         String.valueOf(maximumNumber),
@@ -256,7 +256,7 @@ public class DescendantTokenCheck extends Check
                     final String descendantName = TokenTypes
                             .getTokenName(element);
                     log(ast.getLineNo(), ast.getColumnNo(),
-                            (null == minimumMessage) ? MSG_KEY_MIN
+                            null == minimumMessage ? MSG_KEY_MIN
                                     : minimumMessage,
                             String.valueOf(tokenCount),
                             String.valueOf(minimumNumber),
@@ -267,7 +267,7 @@ public class DescendantTokenCheck extends Check
                     final String descendantName = TokenTypes
                             .getTokenName(element);
                     log(ast.getLineNo(), ast.getColumnNo(),
-                            (null == maximumMessage) ? MSG_KEY_MAX
+                            null == maximumMessage ? MSG_KEY_MAX
                                     : maximumMessage,
                             String.valueOf(tokenCount),
                             String.valueOf(maximumNumber),

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/RegexpCheck.java
@@ -123,7 +123,7 @@ public class RegexpCheck extends AbstractFormatCheck
      */
     public void setMessage(String message)
     {
-        this.message = (message == null) ? "" : message;
+        this.message = message == null ? "" : message;
     }
 
     /**
@@ -173,7 +173,7 @@ public class RegexpCheck extends AbstractFormatCheck
     public void setDuplicateLimit(int duplicateLimit)
     {
         this.duplicateLimit = duplicateLimit;
-        checkForDuplicates = (duplicateLimit > DEFAULT_DUPLICATE_LIMIT);
+        checkForDuplicates = duplicateLimit > DEFAULT_DUPLICATE_LIMIT;
     }
 
     @Override
@@ -203,7 +203,7 @@ public class RegexpCheck extends AbstractFormatCheck
         boolean ignore = false;
 
         foundMatch = matcher.find();
-        if (!foundMatch && !illegalPattern && (matchCount == 0)) {
+        if (!foundMatch && !illegalPattern && matchCount == 0) {
             logMessage(0);
         }
         else if (foundMatch) {
@@ -221,14 +221,14 @@ public class RegexpCheck extends AbstractFormatCheck
             }
             if (!ignore) {
                 matchCount++;
-                if (illegalPattern || (checkForDuplicates
-                        && ((matchCount - 1) > duplicateLimit)))
+                if (illegalPattern || checkForDuplicates
+                        && matchCount - 1 > duplicateLimit)
                 {
                     errorCount++;
                     logMessage(startLine);
                 }
             }
-            if ((errorCount < errorLimit)
+            if (errorCount < errorLimit
                     && (ignore || illegalPattern || checkForDuplicates))
             {
                 findMatch();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -207,12 +207,12 @@ public class SuppressWarningsHolder
             for (Entry entry : entries) {
                 final boolean afterStart =
                     entry.getFirstLine() < line
-                        || (entry.getFirstLine() == line && entry
-                            .getFirstColumn() <= column);
+                        || entry.getFirstLine() == line && entry
+                            .getFirstColumn() <= column;
                 final boolean beforeEnd =
                     entry.getLastLine() > line
-                        || (entry.getLastLine() == line && entry
-                            .getLastColumn() >= column);
+                        || entry.getLastLine() == line && entry
+                            .getLastColumn() >= column;
                 final boolean nameMatches =
                     entry.getCheckName().equals(checkAlias);
                 if (afterStart && beforeEnd && nameMatches) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -181,7 +181,7 @@ public class TrailingCommentCheck extends AbstractFormatCheck
                     }
                 }
             }
-            if ((comment != null)
+            if (comment != null
                 && !blankLinePattern.matcher(lineBefore).find()
                 && !isLegalComment(comment))
             {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -132,7 +132,7 @@ public class TranslationCheck
         final int underscoreIdx = filePath.indexOf(basenameSeparator,
             baseNameStart);
         final int dotIdx = filePath.indexOf('.', baseNameStart);
-        final int cutoffIdx = (underscoreIdx != -1) ? underscoreIdx : dotIdx;
+        final int cutoffIdx = underscoreIdx != -1 ? underscoreIdx : dotIdx;
         return filePath.substring(0, cutoffIdx);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -249,7 +249,7 @@ public class UncommentedMainCheck
         if (params.getChildCount() != 1) {
             return false;
         }
-        final DetailAST paratype = (params.getFirstChild())
+        final DetailAST paratype = params.getFirstChild()
             .findFirstToken(TokenTypes.TYPE);
         final DetailAST arrayDecl =
             paratype.findFirstToken(TokenTypes.ARRAY_DECLARATOR);
@@ -259,12 +259,12 @@ public class UncommentedMainCheck
 
         final DetailAST arrayType = arrayDecl.getFirstChild();
 
-        if ((arrayType.getType() == TokenTypes.IDENT)
-            || (arrayType.getType() == TokenTypes.DOT))
+        if (arrayType.getType() == TokenTypes.IDENT
+            || arrayType.getType() == TokenTypes.DOT)
         {
             final FullIdent type = FullIdent.createFullIdent(arrayType);
-            return ("String".equals(type.getText())
-                    || "java.lang.String".equals(type.getText()));
+            return "String".equals(type.getText())
+                    || "java.lang.String".equals(type.getText());
         }
 
         return false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
@@ -172,8 +172,8 @@ public final class MissingOverrideCheck extends Check
         }
 
         if (containastag
-            && (!AnnotationUtility.containsAnnotation(ast, OVERRIDE)
-            && !AnnotationUtility.containsAnnotation(ast, FQ_OVERRIDE)))
+            && !AnnotationUtility.containsAnnotation(ast, OVERRIDE)
+            && !AnnotationUtility.containsAnnotation(ast, FQ_OVERRIDE))
         {
             this.log(ast.getLineNo(), MSG_KEY_ANNOTATION_MISSING_OVERRIDE);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -204,7 +204,7 @@ public class SuppressWarningsCheck extends AbstractFormatCheck
         final DetailAST annotation = AnnotationUtility.getAnnotation(
             ast, SuppressWarningsCheck.SUPPRESS_WARNINGS);
 
-        return (annotation != null) ? annotation
+        return annotation != null ? annotation
             : AnnotationUtility.getAnnotation(
                 ast, SuppressWarningsCheck.FQ_SUPPRESS_WARNINGS);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheck.java
@@ -116,8 +116,8 @@ public class AvoidNestedBlocksCheck extends Check
         final DetailAST parent = ast.getParent();
         if (parent.getType() == TokenTypes.SLIST) {
             if (allowInSwitchCase
-                    && (parent.getParent().getType() == TokenTypes.CASE_GROUP)
-                    && (parent.getNumberOfChildren() == 1))
+                    && parent.getParent().getType() == TokenTypes.CASE_GROUP
+                    && parent.getNumberOfChildren() == 1)
             {
                 return;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
@@ -181,16 +181,16 @@ public class EmptyBlockCheck
             }
             else {
                 // check only whitespace of first & last lines
-                if ((lines[slistLineNo - 1]
-                     .substring(slistColNo + 1).trim().length() != 0)
-                    || (lines[rcurlyLineNo - 1]
-                        .substring(0, rcurlyColNo).trim().length() != 0))
+                if (lines[slistLineNo - 1]
+                     .substring(slistColNo + 1).trim().length() != 0
+                    || lines[rcurlyLineNo - 1]
+                        .substring(0, rcurlyColNo).trim().length() != 0)
                 {
                     retVal = true;
                 }
                 else {
                     // check if all lines are also only whitespace
-                    for (int i = slistLineNo; i < (rcurlyLineNo - 1); i++) {
+                    for (int i = slistLineNo; i < rcurlyLineNo - 1; i++) {
                         if (lines[i].trim().length() > 0) {
                             retVal = true;
                             break;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -190,7 +190,7 @@ public class LeftCurlyCheck
             case TokenTypes.ENUM_CONSTANT_DEF :
                 startToken = skipAnnotationOnlyLines(ast);
                 final DetailAST objBlock = ast.findFirstToken(TokenTypes.OBJBLOCK);
-                brace = (objBlock == null)
+                brace = objBlock == null
                     ? null
                     : objBlock.getFirstChild();
                 break;
@@ -211,7 +211,7 @@ public class LeftCurlyCheck
                 startToken = ast;
                 final DetailAST candidate = ast.getFirstChild();
                 brace =
-                    (candidate.getType() == TokenTypes.SLIST)
+                    candidate.getType() == TokenTypes.SLIST
                     ? candidate
                     : null; // silently ignore
                 break;
@@ -226,7 +226,7 @@ public class LeftCurlyCheck
                 brace = null;
         }
 
-        if ((brace != null) && (startToken != null)) {
+        if (brace != null && startToken != null) {
             verifyBrace(brace, startToken);
         }
     }
@@ -260,8 +260,8 @@ public class LeftCurlyCheck
         }
         final int lastAnnotLineNumber = lastAnnot.getLineNo();
         while (lastAnnot.getPreviousSibling() != null
-               && (lastAnnot.getPreviousSibling().getLineNo()
-                    == lastAnnotLineNumber))
+               && lastAnnot.getPreviousSibling().getLineNo()
+                    == lastAnnotLineNumber)
         {
             lastAnnot = lastAnnot.getPreviousSibling();
         }
@@ -299,13 +299,13 @@ public class LeftCurlyCheck
         // calculate the previous line length without trailing whitespace. Need
         // to handle the case where there is no previous line, cause the line
         // being check is the first line in the file.
-        final int prevLineLen = (brace.getLineNo() == 1)
+        final int prevLineLen = brace.getLineNo() == 1
             ? maxLineLength
             : Utils.lengthMinusTrailingWhitespace(getLine(brace.getLineNo() - 2));
 
         // Check for being told to ignore, or have '{}' which is a special case
-        if ((braceLine.length() > (brace.getColumnNo() + 1))
-            && (braceLine.charAt(brace.getColumnNo() + 1) == '}'))
+        if (braceLine.length() > brace.getColumnNo() + 1
+            && braceLine.charAt(brace.getColumnNo() + 1) == '}')
         {
             ; // ignore
         }
@@ -317,7 +317,7 @@ public class LeftCurlyCheck
         }
         else if (getAbstractOption() == LeftCurlyOption.EOL) {
             if (Utils.whitespaceBefore(brace.getColumnNo(), braceLine)
-                && ((prevLineLen + 2) <= maxLineLength))
+                && prevLineLen + 2 <= maxLineLength)
             {
                 log(brace.getLineNo(), brace.getColumnNo(),
                     MSG_KEY_LINE_PREVIOUS, "{");
@@ -330,12 +330,12 @@ public class LeftCurlyCheck
             if (startToken.getLineNo() == brace.getLineNo()) {
                 ; // all ok as on the same line
             }
-            else if ((startToken.getLineNo() + 1) == brace.getLineNo()) {
+            else if (startToken.getLineNo() + 1 == brace.getLineNo()) {
                 if (!Utils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
                     log(brace.getLineNo(), brace.getColumnNo(),
                         MSG_KEY_LINE_NEW, "{");
                 }
-                else if ((prevLineLen + 2) <= maxLineLength) {
+                else if (prevLineLen + 2 <= maxLineLength) {
                     log(brace.getLineNo(), brace.getColumnNo(),
                         MSG_KEY_LINE_PREVIOUS, "{");
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -155,15 +155,15 @@ public class NeedBracesCheck extends Check
     {
         final DetailAST slistAST = ast.findFirstToken(TokenTypes.SLIST);
         boolean isElseIf = false;
-        if ((ast.getType() == TokenTypes.LITERAL_ELSE)
-            && (ast.findFirstToken(TokenTypes.LITERAL_IF) != null))
+        if (ast.getType() == TokenTypes.LITERAL_ELSE
+            && ast.findFirstToken(TokenTypes.LITERAL_IF) != null)
         {
             isElseIf = true;
         }
 
         final boolean skipStatement = isSkipStatement(ast);
 
-        if ((slistAST == null) && !isElseIf && !skipStatement) {
+        if (slistAST == null && !isElseIf && !skipStatement) {
             log(ast.getLineNo(), MSG_KEY_NEED_BRACES, ast.getText());
         }
     }
@@ -363,7 +363,7 @@ public class NeedBracesCheck extends Check
             final DetailAST caseBreak = slist.findFirstToken(TokenTypes.LITERAL_BREAK);
             final boolean atOneLine = literalCase.getLineNo() == block.getLineNo();
             if (caseBreak != null) {
-                result = atOneLine && (block.getLineNo() == caseBreak.getLineNo());
+                result = atOneLine && block.getLineNo() == caseBreak.getLineNo();
             }
         }
         return result;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -226,7 +226,7 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption>
                     + TokenTypes.getTokenName(ast.getType()) + ")");
         }
 
-        if ((rcurly == null) || (rcurly.getType() != TokenTypes.RCURLY)) {
+        if (rcurly == null || rcurly.getType() != TokenTypes.RCURLY) {
             // we need to have both tokens to perform the check
             return;
         }
@@ -240,13 +240,13 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption>
                 log(rcurly, MSG_KEY_LINE_ALONE, "}");
             }
         }
-        else if ((getAbstractOption() == RightCurlyOption.SAME)
-                && (rcurly.getLineNo() != nextToken.getLineNo()))
+        else if (getAbstractOption() == RightCurlyOption.SAME
+                && rcurly.getLineNo() != nextToken.getLineNo())
         {
             log(rcurly, MSG_KEY_LINE_SAME, "}");
         }
-        else if ((getAbstractOption() == RightCurlyOption.ALONE)
-                && (rcurly.getLineNo() == nextToken.getLineNo())
+        else if (getAbstractOption() == RightCurlyOption.ALONE
+                && rcurly.getLineNo() == nextToken.getLineNo()
                 && !isEmptyBody(lcurly))
         {
             log(rcurly, MSG_KEY_LINE_ALONE, "}");
@@ -259,7 +259,7 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption>
                 Utils.whitespaceBefore(rcurly.getColumnNo(),
                         getLines()[rcurly.getLineNo() - 1]);
 
-        if (!startsLine && (lcurly.getLineNo() != rcurly.getLineNo())) {
+        if (!startsLine && lcurly.getLineNo() != rcurly.getLineNo()) {
             log(rcurly, MSG_KEY_LINE_NEW, "}");
         }
     }
@@ -292,7 +292,7 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption>
     {
         DetailAST next = null;
         DetailAST parent = ast;
-        while ((parent != null) && (next == null)) {
+        while (parent != null && next == null) {
             next = parent.getNextSibling();
             parent = parent.getParent();
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalCheck.java
@@ -66,7 +66,7 @@ public abstract class AbstractIllegalCheck extends Check
         for (final String name : classNames) {
             illegalClassNames.add(name);
             final int lastDot = name.lastIndexOf(".");
-            if ((lastDot > 0) && (lastDot < (name.length() - 1))) {
+            if (lastDot > 0 && lastDot < name.length() - 1) {
                 final String shortName = name
                         .substring(name.lastIndexOf(".") + 1);
                 illegalClassNames.add(shortName);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -155,19 +155,19 @@ public abstract class AbstractSuperCheck
         }
         // dot operator?
         DetailAST parent = ast.getParent();
-        if ((parent == null) || (parent.getType() != TokenTypes.DOT)) {
+        if (parent == null || parent.getType() != TokenTypes.DOT) {
             return false;
         }
 
         // same name of method
         AST sibling = ast.getNextSibling();
         // ignore type parameters
-        if ((sibling != null)
-            && (sibling.getType() == TokenTypes.TYPE_ARGUMENTS))
+        if (sibling != null
+            && sibling.getType() == TokenTypes.TYPE_ARGUMENTS)
         {
             sibling = sibling.getNextSibling();
         }
-        if ((sibling == null) || (sibling.getType() != TokenTypes.IDENT)) {
+        if (sibling == null || sibling.getType() != TokenTypes.IDENT) {
             return false;
         }
         final String name = sibling.getText();
@@ -177,7 +177,7 @@ public abstract class AbstractSuperCheck
 
         // 0 parameters?
         final DetailAST args = parent.getNextSibling();
-        if ((args == null) || (args.getType() != TokenTypes.ELIST)) {
+        if (args == null || args.getType() != TokenTypes.ELIST) {
             return false;
         }
         if (args.getChildCount() != 0) {
@@ -189,8 +189,8 @@ public abstract class AbstractSuperCheck
             if (parent.getType() == TokenTypes.METHOD_DEF) {
                 return isOverridingMethod(parent);
             }
-            else if ((parent.getType() == TokenTypes.CTOR_DEF)
-                || (parent.getType() == TokenTypes.INSTANCE_INIT))
+            else if (parent.getType() == TokenTypes.CTOR_DEF
+                || parent.getType() == TokenTypes.INSTANCE_INIT)
             {
                 return false;
             }
@@ -223,7 +223,7 @@ public abstract class AbstractSuperCheck
      */
     private boolean isOverridingMethod(DetailAST ast)
     {
-        if ((ast.getType() != TokenTypes.METHOD_DEF)
+        if (ast.getType() != TokenTypes.METHOD_DEF
             || ScopeUtils.inInterfaceOrAnnotationBlock(ast))
         {
             return false;
@@ -234,6 +234,6 @@ public abstract class AbstractSuperCheck
             return false;
         }
         final DetailAST params = ast.findFirstToken(TokenTypes.PARAMETERS);
-        return (params.getChildCount() == 0);
+        return params.getChildCount() == 0;
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
@@ -66,8 +66,8 @@ public class ArrayTrailingCommaCheck extends Check
 
         // if curlys are on the same line
         // or array is empty then check nothing
-        if ((arrayInit.getLineNo() == rcurly.getLineNo())
-            || (arrayInit.getChildCount() == 1))
+        if (arrayInit.getLineNo() == rcurly.getLineNo()
+            || arrayInit.getChildCount() == 1)
         {
             return;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheck.java
@@ -127,6 +127,6 @@ public class CovariantEqualsCheck extends Check
         final DetailAST typeNode = paramNode.findFirstToken(TokenTypes.TYPE);
         final FullIdent fullIdent = FullIdent.createFullIdentBelow(typeNode);
         final String name = fullIdent.getText();
-        return ("Object".equals(name) || "java.lang.Object".equals(name));
+        return "Object".equals(name) || "java.lang.Object".equals(name);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -190,9 +190,9 @@ public class DeclarationOrderCheck extends Check
                 break;
 
             case TokenTypes.MODIFIERS:
-                if ((parentType != TokenTypes.VARIABLE_DEF)
-                    || (ast.getParent().getParent().getType()
-                        != TokenTypes.OBJBLOCK))
+                if (parentType != TokenTypes.VARIABLE_DEF
+                    || ast.getParent().getParent().getType()
+                        != TokenTypes.OBJBLOCK)
                 {
                     return;
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java
@@ -82,9 +82,9 @@ public class DefaultComesLastCheck extends Check
             final DetailAST lastGroupAST =
                 switchAST.getLastChild().getPreviousSibling();
 
-            if ((defaultGroupAST.getLineNo() != lastGroupAST.getLineNo())
-                || (defaultGroupAST.getColumnNo()
-                    != lastGroupAST.getColumnNo()))
+            if (defaultGroupAST.getLineNo() != lastGroupAST.getLineNo()
+                || defaultGroupAST.getColumnNo()
+                    != lastGroupAST.getColumnNo())
             {
                 log(ast, MSG_KEY);
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -131,9 +131,9 @@ public class EqualsAvoidNullCheck extends Check
         //Also, checks if calling using strange inner class
         //syntax outter.inner.equals(otherObj) by looking
         //for the dot operator which cannot be improved
-        if ((objCalledOn.getType() == TokenTypes.STRING_LITERAL)
-                || (objCalledOn.getType() == TokenTypes.LITERAL_NEW)
-                || (objCalledOn.getType() == TokenTypes.DOT))
+        if (objCalledOn.getType() == TokenTypes.STRING_LITERAL
+                || objCalledOn.getType() == TokenTypes.LITERAL_NEW
+                || objCalledOn.getType() == TokenTypes.DOT)
         {
             return;
         }
@@ -166,7 +166,7 @@ public class EqualsAvoidNullCheck extends Check
      */
     private boolean containsNoArgs(final AST expr)
     {
-        return (expr == null);
+        return expr == null;
     }
 
     /**
@@ -179,7 +179,7 @@ public class EqualsAvoidNullCheck extends Check
     private boolean containsMultiArgs(final AST expr)
     {
         final AST comma = expr.getNextSibling();
-        return (comma != null) && (comma.getType() == TokenTypes.COMMA);
+        return comma != null && comma.getType() == TokenTypes.COMMA;
     }
 
     /**
@@ -226,8 +226,8 @@ public class EqualsAvoidNullCheck extends Check
         //(s += "SweetString").equals(s); //true
         //arg = skipVariablePlusAssign(arg);
 
-        if ((arg).branchContains(TokenTypes.PLUS_ASSIGN)
-                || (arg).branchContains(TokenTypes.IDENT))
+        if (arg.branchContains(TokenTypes.PLUS_ASSIGN)
+                || arg.branchContains(TokenTypes.IDENT))
         {
             return false;
         }
@@ -243,8 +243,8 @@ public class EqualsAvoidNullCheck extends Check
      */
     private DetailAST skipVariableAssign(final DetailAST currentAST)
     {
-        if ((currentAST.getType() == TokenTypes.ASSIGN)
-                && (currentAST.getFirstChild().getType() == TokenTypes.IDENT))
+        if (currentAST.getType() == TokenTypes.ASSIGN
+                && currentAST.getFirstChild().getType() == TokenTypes.IDENT)
         {
             return currentAST.getFirstChild().getNextSibling();
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
@@ -91,19 +91,19 @@ public class EqualsHashCodeCheck
         final AST methodName = ast.findFirstToken(TokenTypes.IDENT);
         final DetailAST parameters = ast.findFirstToken(TokenTypes.PARAMETERS);
 
-        if ((type.getFirstChild().getType() == TokenTypes.LITERAL_BOOLEAN)
+        if (type.getFirstChild().getType() == TokenTypes.LITERAL_BOOLEAN
                 && "equals".equals(methodName.getText())
                 && modifiers.branchContains(TokenTypes.LITERAL_PUBLIC)
-                && (parameters.getChildCount() == 1)
+                && parameters.getChildCount() == 1
                 && isObjectParam(parameters.getFirstChild())
             )
         {
             objBlockEquals.put(ast.getParent(), ast);
         }
-        else if ((type.getFirstChild().getType() == TokenTypes.LITERAL_INT)
+        else if (type.getFirstChild().getType() == TokenTypes.LITERAL_INT
                 && "hashCode".equals(methodName.getText())
                 && modifiers.branchContains(TokenTypes.LITERAL_PUBLIC)
-                && (parameters.getFirstChild() == null)) // no params
+                && parameters.getFirstChild() == null) // no params
         {
             objBlockWithHashCode.add(ast.getParent());
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -93,7 +93,7 @@ public class ExplicitInitializationCheck extends Check
         }
 
         final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
-        if ((modifiers != null)
+        if (modifiers != null
             && modifiers.branchContains(TokenTypes.FINAL))
         {
             // do not check final variables
@@ -105,24 +105,24 @@ public class ExplicitInitializationCheck extends Check
         final DetailAST exprStart =
             assign.getFirstChild().getFirstChild();
         if (isObjectType(type)
-            && (exprStart.getType() == TokenTypes.LITERAL_NULL))
+            && exprStart.getType() == TokenTypes.LITERAL_NULL)
         {
             log(ident, MSG_KEY, ident.getText(), "null");
         }
 
         final int primitiveType = type.getFirstChild().getType();
-        if ((primitiveType == TokenTypes.LITERAL_BOOLEAN)
-            && (exprStart.getType() == TokenTypes.LITERAL_FALSE))
+        if (primitiveType == TokenTypes.LITERAL_BOOLEAN
+            && exprStart.getType() == TokenTypes.LITERAL_FALSE)
         {
             log(ident, MSG_KEY, ident.getText(), "false");
         }
         if (isNumericType(primitiveType) && isZero(exprStart)) {
             log(ident, MSG_KEY, ident.getText(), "0");
         }
-        if ((primitiveType == TokenTypes.LITERAL_CHAR)
+        if (primitiveType == TokenTypes.LITERAL_CHAR
             && (isZero(exprStart)
-                || ((exprStart.getType() == TokenTypes.CHAR_LITERAL)
-                && "'\\0'".equals(exprStart.getText()))))
+                || exprStart.getType() == TokenTypes.CHAR_LITERAL
+                && "'\\0'".equals(exprStart.getText())))
         {
             log(ident, MSG_KEY, ident.getText(), "\\0");
         }
@@ -136,8 +136,8 @@ public class ExplicitInitializationCheck extends Check
     private boolean isObjectType(DetailAST type)
     {
         final int objectType = type.getFirstChild().getType();
-        return ((objectType == TokenTypes.IDENT) || (objectType == TokenTypes.DOT)
-                || (objectType == TokenTypes.ARRAY_DECLARATOR));
+        return objectType == TokenTypes.IDENT || objectType == TokenTypes.DOT
+                || objectType == TokenTypes.ARRAY_DECLARATOR;
     }
 
     /**
@@ -148,12 +148,12 @@ public class ExplicitInitializationCheck extends Check
      */
     private boolean isNumericType(int type)
     {
-        return ((type == TokenTypes.LITERAL_BYTE)
-                || (type == TokenTypes.LITERAL_SHORT)
-                || (type == TokenTypes.LITERAL_INT)
-                || (type == TokenTypes.LITERAL_FLOAT)
-                || (type == TokenTypes.LITERAL_LONG)
-                || (type == TokenTypes.LITERAL_DOUBLE));
+        return type == TokenTypes.LITERAL_BYTE
+                || type == TokenTypes.LITERAL_SHORT
+                || type == TokenTypes.LITERAL_INT
+                || type == TokenTypes.LITERAL_FLOAT
+                || type == TokenTypes.LITERAL_LONG
+                || type == TokenTypes.LITERAL_DOUBLE;
     }
 
     /**
@@ -169,7 +169,7 @@ public class ExplicitInitializationCheck extends Check
             case TokenTypes.NUM_INT:
             case TokenTypes.NUM_LONG:
                 final String text = expr.getText();
-                return (0 == CheckUtils.parseFloat(text, type));
+                return 0 == CheckUtils.parseFloat(text, type);
             default:
                 return false;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -143,8 +143,8 @@ public class FallThroughCheck extends Check
     {
         final DetailAST nextGroup = ast.getNextSibling();
         final boolean isLastGroup =
-            ((nextGroup == null)
-             || (nextGroup.getType() != TokenTypes.CASE_GROUP));
+                nextGroup == null
+                 || nextGroup.getType() != TokenTypes.CASE_GROUP;
         if (isLastGroup && !checkLastGroup) {
             // we do not need to check last group
             return;
@@ -222,7 +222,7 @@ public class FallThroughCheck extends Check
             lastStmt = lastStmt.getPreviousSibling();
         }
 
-        return (lastStmt != null)
+        return lastStmt != null
             && isTerminated(lastStmt, useBreak, useContinue);
     }
 
@@ -242,7 +242,7 @@ public class FallThroughCheck extends Check
         final DetailAST elseStmt = thenStmt.getNextSibling();
         boolean isTerminated = isTerminated(thenStmt, useBreak, useContinue);
 
-        if (isTerminated && (elseStmt != null)) {
+        if (isTerminated && elseStmt != null) {
             isTerminated = isTerminated(elseStmt.getFirstChild(),
                                         useBreak, useContinue);
         }
@@ -290,7 +290,7 @@ public class FallThroughCheck extends Check
                                             useBreak, useContinue);
 
         DetailAST catchStmt = ast.findFirstToken(TokenTypes.LITERAL_CATCH);
-        while ((catchStmt != null) && isTerminated) {
+        while (catchStmt != null && isTerminated) {
             final DetailAST catchBody =
                 catchStmt.findFirstToken(TokenTypes.SLIST);
             isTerminated &= isTerminated(catchBody, useBreak, useContinue);
@@ -309,9 +309,9 @@ public class FallThroughCheck extends Check
     private boolean checkSwitch(final DetailAST ast, boolean useContinue)
     {
         DetailAST caseGroup = ast.findFirstToken(TokenTypes.CASE_GROUP);
-        boolean isTerminated = (caseGroup != null);
-        while (isTerminated && (caseGroup != null)
-               && (caseGroup.getType() != TokenTypes.RCURLY))
+        boolean isTerminated = caseGroup != null;
+        while (isTerminated && caseGroup != null
+               && caseGroup.getType() != TokenTypes.RCURLY)
         {
             final DetailAST caseBody =
                 caseGroup.findFirstToken(TokenTypes.SLIST);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -153,7 +153,7 @@ public class FinalLocalVariableCheck extends Check
                     break;
                 }
             case TokenTypes.VARIABLE_DEF:
-                if ((ast.getParent().getType() != TokenTypes.OBJBLOCK)
+                if (ast.getParent().getType() != TokenTypes.OBJBLOCK
                     && shouldCheckEnhancedForLoopVariable(ast)
                     && isVariableInForInit(ast))
                 {
@@ -163,22 +163,22 @@ public class FinalLocalVariableCheck extends Check
 
             case TokenTypes.IDENT:
                 final int parentType = ast.getParent().getType();
-                if ((TokenTypes.POST_DEC        == parentType)
-                    || (TokenTypes.DEC          == parentType)
-                    || (TokenTypes.POST_INC     == parentType)
-                    || (TokenTypes.INC          == parentType)
-                    || (TokenTypes.ASSIGN       == parentType)
-                    || (TokenTypes.PLUS_ASSIGN  == parentType)
-                    || (TokenTypes.MINUS_ASSIGN == parentType)
-                    || (TokenTypes.DIV_ASSIGN   == parentType)
-                    || (TokenTypes.STAR_ASSIGN  == parentType)
-                    || (TokenTypes.MOD_ASSIGN   == parentType)
-                    || (TokenTypes.SR_ASSIGN    == parentType)
-                    || (TokenTypes.BSR_ASSIGN   == parentType)
-                    || (TokenTypes.SL_ASSIGN    == parentType)
-                    || (TokenTypes.BXOR_ASSIGN  == parentType)
-                    || (TokenTypes.BOR_ASSIGN   == parentType)
-                    || (TokenTypes.BAND_ASSIGN  == parentType))
+                if (TokenTypes.POST_DEC        == parentType
+                    || TokenTypes.DEC          == parentType
+                    || TokenTypes.POST_INC     == parentType
+                    || TokenTypes.INC          == parentType
+                    || TokenTypes.ASSIGN       == parentType
+                    || TokenTypes.PLUS_ASSIGN  == parentType
+                    || TokenTypes.MINUS_ASSIGN == parentType
+                    || TokenTypes.DIV_ASSIGN   == parentType
+                    || TokenTypes.STAR_ASSIGN  == parentType
+                    || TokenTypes.MOD_ASSIGN   == parentType
+                    || TokenTypes.SR_ASSIGN    == parentType
+                    || TokenTypes.BSR_ASSIGN   == parentType
+                    || TokenTypes.SL_ASSIGN    == parentType
+                    || TokenTypes.BXOR_ASSIGN  == parentType
+                    || TokenTypes.BOR_ASSIGN   == parentType
+                    || TokenTypes.BAND_ASSIGN  == parentType)
                 {
                     // TODO: is there better way to check is ast
                     // in left part of assignment?

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -230,12 +230,12 @@ public class HiddenFieldCheck
         //check.
         final DetailAST typeMods = ast.findFirstToken(TokenTypes.MODIFIERS);
         final boolean isStaticInnerType =
-                (typeMods != null)
+                typeMods != null
                         && typeMods.branchContains(TokenTypes.LITERAL_STATIC);
 
         final FieldFrame frame =
             new FieldFrame(currentFrame, isStaticInnerType, type,
-                (type == TokenTypes.CLASS_DEF || type == TokenTypes.ENUM_DEF)
+                type == TokenTypes.CLASS_DEF || type == TokenTypes.ENUM_DEF
                     ? ast.findFirstToken(TokenTypes.IDENT).getText()
                     : null
             );
@@ -268,9 +268,9 @@ public class HiddenFieldCheck
     @Override
     public void leaveToken(DetailAST ast)
     {
-        if ((ast.getType() == TokenTypes.CLASS_DEF)
-            || (ast.getType() == TokenTypes.ENUM_DEF)
-            || (ast.getType() == TokenTypes.ENUM_CONSTANT_DEF))
+        if (ast.getType() == TokenTypes.CLASS_DEF
+            || ast.getType() == TokenTypes.ENUM_DEF
+            || ast.getType() == TokenTypes.ENUM_CONSTANT_DEF)
         {
             //pop
             currentFrame = currentFrame.getParent();
@@ -287,15 +287,15 @@ public class HiddenFieldCheck
     {
         if (!ScopeUtils.inInterfaceOrAnnotationBlock(ast)
             && (ScopeUtils.isLocalVariableDef(ast)
-                || (ast.getType() == TokenTypes.PARAMETER_DEF)))
+                || ast.getType() == TokenTypes.PARAMETER_DEF))
         {
             // local variable or parameter. Does it shadow a field?
             final DetailAST nameAST = ast.findFirstToken(TokenTypes.IDENT);
             final String name = nameAST.getText();
 
             if ((currentFrame.containsStaticField(name)
-                || (!inStatic(ast) && currentFrame.containsInstanceField(name)))
-                && ((regexp == null) || (!getRegexp().matcher(name).find()))
+                || !inStatic(ast) && currentFrame.containsInstanceField(name))
+                && (regexp == null || !getRegexp().matcher(name).find())
                 && !isIgnoredSetterParam(ast, name)
                 && !isIgnoredConstructorParam(ast)
                 && !isIgnoredParamOfAbstractMethod(ast))
@@ -380,7 +380,7 @@ public class HiddenFieldCheck
             final DetailAST typeAST = aMethodAST.findFirstToken(TokenTypes.TYPE);
             final String returnType = typeAST.getFirstChild().getText();
             if (typeAST.branchContains(TokenTypes.LITERAL_VOID)
-                || (setterCanReturnItsClass && currentFrame.embeddedIn(returnType)))
+                || setterCanReturnItsClass && currentFrame.embeddedIn(returnType))
             {
                 // this method has signature
                 //
@@ -413,7 +413,7 @@ public class HiddenFieldCheck
         // one is a capital one, since according to JavBeans spec
         // setXYzz() is a setter for XYzz property, not for xYzz one.
         if (name != null && (name.length() == 1
-                || (name.length() > 1 && !Character.isUpperCase(name.charAt(1)))))
+                || name.length() > 1 && !Character.isUpperCase(name.charAt(1))))
         {
             setterName = name.substring(0, 1).toUpperCase() + name.substring(1);
         }
@@ -430,12 +430,12 @@ public class HiddenFieldCheck
     private boolean isIgnoredConstructorParam(DetailAST ast)
     {
         boolean result = false;
-        if ((ast.getType() == TokenTypes.PARAMETER_DEF)
+        if (ast.getType() == TokenTypes.PARAMETER_DEF
             && ignoreConstructorParameter)
         {
             final DetailAST parametersAST = ast.getParent();
             final DetailAST constructorAST = parametersAST.getParent();
-            result = (constructorAST.getType() == TokenTypes.CTOR_DEF);
+            result = constructorAST.getType() == TokenTypes.CTOR_DEF;
         }
         return result;
     }
@@ -451,13 +451,13 @@ public class HiddenFieldCheck
     private boolean isIgnoredParamOfAbstractMethod(DetailAST ast)
     {
         boolean result = false;
-        if ((ast.getType() == TokenTypes.PARAMETER_DEF)
+        if (ast.getType() == TokenTypes.PARAMETER_DEF
             && ignoreAbstractMethods)
         {
             final DetailAST method = ast.getParent().getParent();
             if (method.getType() == TokenTypes.METHOD_DEF) {
                 final DetailAST mods = method.findFirstToken(TokenTypes.MODIFIERS);
-                result = ((mods != null) && mods.branchContains(TokenTypes.ABSTRACT));
+                result = mods != null && mods.branchContains(TokenTypes.ABSTRACT);
             }
         }
         return result;
@@ -612,7 +612,7 @@ public class HiddenFieldCheck
         {
             return instanceFields.contains(field)
                     || !isStaticType()
-                    && (parent != null)
+                    && parent != null
                     && parent.containsInstanceField(field);
 
         }
@@ -625,7 +625,7 @@ public class HiddenFieldCheck
         public boolean containsStaticField(String field)
         {
             return staticFields.contains(field)
-                    || (parent != null)
+                    || parent != null
                     && parent.containsStaticField(field);
 
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -212,8 +212,8 @@ public class IllegalInstantiationCheck
     {
         final DetailAST typeNameAST = ast.getFirstChild();
         final AST nameSibling = typeNameAST.getNextSibling();
-        if ((nameSibling != null)
-                && (nameSibling.getType() == TokenTypes.ARRAY_DECLARATOR))
+        if (nameSibling != null
+                && nameSibling.getType() == TokenTypes.ARRAY_DECLARATOR)
         {
             // ast == "new Boolean[]"
             return;
@@ -244,13 +244,13 @@ public class IllegalInstantiationCheck
         }
 
         final int clsNameLen = className.length();
-        final int pkgNameLen = (pkgName == null) ? 0 : pkgName.length();
+        final int pkgNameLen = pkgName == null ? 0 : pkgName.length();
 
         for (String illegal : illegalClasses) {
             final int illegalLen = illegal.length();
 
             // class from java.lang
-            if (((illegalLen - javlang.length()) == clsNameLen)
+            if (illegalLen - javlang.length() == clsNameLen
                 && illegal.endsWith(className)
                 && illegal.startsWith(javlang))
             {
@@ -289,9 +289,9 @@ public class IllegalInstantiationCheck
 
             // the test is the "no garbage" version of
             // illegal.equals(pkgName + "." + className)
-            if ((pkgName != null)
-                && (clsNameLen == illegalLen - pkgNameLen - 1)
-                && (illegal.charAt(pkgNameLen) == '.')
+            if (pkgName != null
+                && clsNameLen == illegalLen - pkgNameLen - 1
+                && illegal.charAt(pkgNameLen) == '.'
                 && illegal.endsWith(className)
                 && illegal.startsWith(pkgName))
             {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -122,7 +122,7 @@ public class IllegalTokenTextCheck
      */
     public void setMessage(String message)
     {
-        this.message = (null == message) ? "" : message;
+        this.message = null == message ? "" : message;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -236,7 +236,7 @@ public final class IllegalTypeCheck extends AbstractFormatCheck
     {
         final DetailAST grandParentAST = paradef.getParent().getParent();
 
-        if ((grandParentAST.getType() == TokenTypes.METHOD_DEF)
+        if (grandParentAST.getType() == TokenTypes.METHOD_DEF
             && isCheckedMethod(grandParentAST))
         {
             checkClassName(paradef);
@@ -313,10 +313,10 @@ public final class IllegalTypeCheck extends AbstractFormatCheck
     private boolean isMatchingClassName(String className)
     {
         final String shortName = className.substring(className.lastIndexOf(".") + 1);
-        return (illegalClassNames.contains(className)
-                || illegalClassNames.contains(shortName))
-            || (!legalAbstractClassNames.contains(className)
-                && getRegexp().matcher(className).find());
+        return illegalClassNames.contains(className)
+                || illegalClassNames.contains(shortName)
+                || !legalAbstractClassNames.contains(className)
+                    && getRegexp().matcher(className).find();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
@@ -197,7 +197,7 @@ public class InnerAssignmentCheck
         }
         final DetailAST expr = ast.getParent();
         final AST exprNext = expr.getNextSibling();
-        return (exprNext != null) && (exprNext.getType() == TokenTypes.SEMI);
+        return exprNext != null && exprNext.getType() == TokenTypes.SEMI;
     }
 
     /**
@@ -231,7 +231,7 @@ public class InnerAssignmentCheck
     private static boolean isComparison(DetailAST ast)
     {
         final int astType = ast.getType();
-        return (Arrays.binarySearch(COMPARISON_TYPES, astType) >= 0);
+        return Arrays.binarySearch(COMPARISON_TYPES, astType) >= 0;
     }
 
     /**
@@ -252,7 +252,7 @@ public class InnerAssignmentCheck
             for (int j = 0; j < len; j++) {
                 current = current.getParent();
                 final int expectedType = element[j];
-                if ((current == null) || (current.getType() != expectedType)) {
+                if (current == null || current.getType() != expectedType) {
                     break;
                 }
                 if (j == len - 1) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -110,7 +110,7 @@ public class MagicNumberCheck extends Check
         }
 
         if (inIgnoreList(ast)
-            || (ignoreHashCodeMethod && isInHashCodeMethod(ast)))
+            || ignoreHashCodeMethod && isInHashCodeMethod(ast))
         {
             return;
         }
@@ -143,9 +143,9 @@ public class MagicNumberCheck extends Check
     private DetailAST findContainingConstantDef(DetailAST ast)
     {
         DetailAST varDefAST = ast;
-        while ((varDefAST != null)
-                && (varDefAST.getType() != TokenTypes.VARIABLE_DEF)
-                && (varDefAST.getType() != TokenTypes.ENUM_CONSTANT_DEF))
+        while (varDefAST != null
+                && varDefAST.getType() != TokenTypes.VARIABLE_DEF
+                && varDefAST.getType() != TokenTypes.ENUM_CONSTANT_DEF)
         {
             varDefAST = varDefAST.getParent();
         }
@@ -157,7 +157,7 @@ public class MagicNumberCheck extends Check
 
         // implicit constant?
         if (ScopeUtils.inInterfaceOrAnnotationBlock(varDefAST)
-            || (varDefAST.getType() == TokenTypes.ENUM_CONSTANT_DEF))
+            || varDefAST.getType() == TokenTypes.ENUM_CONSTANT_DEF)
         {
             return varDefAST;
         }
@@ -215,8 +215,8 @@ public class MagicNumberCheck extends Check
 
         // find the method definition AST
         DetailAST methodDefAST = ast.getParent();
-        while ((null != methodDefAST)
-                && (TokenTypes.METHOD_DEF != methodDefAST.getType()))
+        while (null != methodDefAST
+                && TokenTypes.METHOD_DEF != methodDefAST.getType())
         {
             methodDefAST = methodDefAST.getParent();
         }
@@ -258,7 +258,7 @@ public class MagicNumberCheck extends Check
         if (parent.getType() == TokenTypes.UNARY_MINUS) {
             value = -1 * value;
         }
-        return (Arrays.binarySearch(ignoreNumbers, value) >= 0);
+        return Arrays.binarySearch(ignoreNumbers, value) >= 0;
     }
 
     /**
@@ -268,7 +268,7 @@ public class MagicNumberCheck extends Check
      */
     public void setIgnoreNumbers(double[] list)
     {
-        if ((list == null) || (list.length == 0)) {
+        if (list == null || list.length == 0) {
             ignoreNumbers = new double[0];
         }
         else {
@@ -307,14 +307,14 @@ public class MagicNumberCheck extends Check
      */
     private boolean isInAnnotation(DetailAST ast)
     {
-        if ((null == ast.getParent())
-                || (null == ast.getParent().getParent()))
+        if (null == ast.getParent()
+                || null == ast.getParent().getParent())
         {
             return false;
         }
 
-        return (TokenTypes.ANNOTATION == ast.getParent().getParent().getType())
-                || (TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR
-                        == ast.getParent().getParent().getType());
+        return TokenTypes.ANNOTATION == ast.getParent().getParent().getType()
+                || TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR
+                        == ast.getParent().getParent().getType();
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheck.java
@@ -73,7 +73,7 @@ public class MissingCtorCheck extends DescendantTokenCheck
     public void visitToken(DetailAST ast)
     {
         final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
-        if ((modifiers != null)
+        if (modifiers != null
             && modifiers.branchContains(TokenTypes.ABSTRACT))
         {
             // should apply the check to abstract class

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -208,11 +208,11 @@ public final class ModifiedControlVariableCheck extends Check
      */
     private void checkIdent(DetailAST ast)
     {
-        if ((currentVariables != null) && !currentVariables.isEmpty()) {
+        if (currentVariables != null && !currentVariables.isEmpty()) {
             final DetailAST identAST = ast.getFirstChild();
 
-            if ((identAST != null)
-                && (identAST.getType() == TokenTypes.IDENT)
+            if (identAST != null
+                && identAST.getType() == TokenTypes.IDENT
                 && currentVariables.contains(identAST.getText()))
             {
                 log(ast.getLineNo(), ast.getColumnNo(),

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -92,8 +92,8 @@ public class MultipleStringLiteralsCheck extends Check
      */
     public void setIgnoreStringsRegexp(String ignoreStringsRegexp)
     {
-        if ((ignoreStringsRegexp != null)
-            && (ignoreStringsRegexp.length() > 0))
+        if (ignoreStringsRegexp != null
+            && ignoreStringsRegexp.length() > 0)
         {
             pattern = Utils.getPattern(ignoreStringsRegexp);
         }
@@ -134,7 +134,7 @@ public class MultipleStringLiteralsCheck extends Check
             return;
         }
         final String currentString = ast.getText();
-        if ((pattern == null) || !pattern.matcher(currentString).find()) {
+        if (pattern == null || !pattern.matcher(currentString).find()) {
             List<StringInfo> hitList = stringMap.get(currentString);
             if (hitList == null) {
                 hitList = Lists.newArrayList();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleVariableDeclarationsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleVariableDeclarationsCheck.java
@@ -79,21 +79,21 @@ public class MultipleVariableDeclarationsCheck extends Check
     {
         DetailAST nextNode = ast.getNextSibling();
         final boolean isCommaSeparated =
-            ((nextNode != null) && (nextNode.getType() == TokenTypes.COMMA));
+                nextNode != null && nextNode.getType() == TokenTypes.COMMA;
 
         if (nextNode == null) {
             // no next statement - no check
             return;
         }
 
-        if ((nextNode.getType() == TokenTypes.COMMA)
-            || (nextNode.getType() == TokenTypes.SEMI))
+        if (nextNode.getType() == TokenTypes.COMMA
+            || nextNode.getType() == TokenTypes.SEMI)
         {
             nextNode = nextNode.getNextSibling();
         }
 
-        if ((nextNode != null)
-            && (nextNode.getType() == TokenTypes.VARIABLE_DEF))
+        if (nextNode != null
+            && nextNode.getType() == TokenTypes.VARIABLE_DEF)
         {
             final DetailAST firstNode = CheckUtils.getFirstNode(ast);
             if (isCommaSeparated) {
@@ -130,9 +130,9 @@ public class MultipleVariableDeclarationsCheck extends Check
         DetailAST child = node.getFirstChild();
         while (child != null) {
             final DetailAST newNode = getLastNode(child);
-            if ((newNode.getLineNo() > currentNode.getLineNo())
-                || ((newNode.getLineNo() == currentNode.getLineNo())
-                    && (newNode.getColumnNo() > currentNode.getColumnNo())))
+            if (newNode.getLineNo() > currentNode.getLineNo()
+                || newNode.getLineNo() == currentNode.getLineNo()
+                    && newNode.getColumnNo() > currentNode.getColumnNo())
             {
                 currentNode = newNode;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
@@ -117,7 +117,7 @@ public final class OneStatementPerLineCheck extends Check
         exprDepth++;
         if (exprDepth == 1
                 && !inForHeader
-                && (lastStatementEnd == ast.getLineNo()))
+                && lastStatementEnd == ast.getLineNo())
         {
             log(ast, MSG_KEY);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
@@ -206,11 +206,11 @@ public final class ParameterAssignmentCheck extends Check
      */
     private void checkIdent(DetailAST ast)
     {
-        if ((parameterNames != null) && !parameterNames.isEmpty()) {
+        if (parameterNames != null && !parameterNames.isEmpty()) {
             final DetailAST identAST = ast.getFirstChild();
 
-            if ((identAST != null)
-                && (identAST.getType() == TokenTypes.IDENT)
+            if (identAST != null
+                && identAST.getType() == TokenTypes.IDENT
                 && parameterNames.contains(identAST.getText()))
             {
                 log(ast.getLineNo(), ast.getColumnNo(),

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -188,26 +188,26 @@ public class RequireThisCheck extends DeclarationCollector
             return;
         }
 
-        if ((parentType == TokenTypes.DOT)
-            && (ast.getPreviousSibling() != null))
+        if (parentType == TokenTypes.DOT
+            && ast.getPreviousSibling() != null)
         {
             // it's the method name in a method call; no problem
             return;
         }
-        if ((parentType == TokenTypes.TYPE)
-            || (parentType == TokenTypes.LITERAL_NEW))
+        if (parentType == TokenTypes.TYPE
+            || parentType == TokenTypes.LITERAL_NEW)
         {
             // it's a type name; no problem
             return;
         }
-        if ((parentType == TokenTypes.VARIABLE_DEF)
-            || (parentType == TokenTypes.CTOR_DEF)
-            || (parentType == TokenTypes.METHOD_DEF)
-            || (parentType == TokenTypes.CLASS_DEF)
-            || (parentType == TokenTypes.ENUM_DEF)
-            || (parentType == TokenTypes.INTERFACE_DEF)
-            || (parentType == TokenTypes.PARAMETER_DEF)
-            || (parentType == TokenTypes.TYPE_ARGUMENT))
+        if (parentType == TokenTypes.VARIABLE_DEF
+            || parentType == TokenTypes.CTOR_DEF
+            || parentType == TokenTypes.METHOD_DEF
+            || parentType == TokenTypes.CLASS_DEF
+            || parentType == TokenTypes.ENUM_DEF
+            || parentType == TokenTypes.INTERFACE_DEF
+            || parentType == TokenTypes.PARAMETER_DEF
+            || parentType == TokenTypes.TYPE_ARGUMENT)
         {
             // it's being declared; no problem
             return;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
@@ -205,7 +205,7 @@ public final class ReturnCountCheck extends AbstractFormatCheck
          */
         public void checkCount(DetailAST ast)
         {
-            if (checking && (count > getMax())) {
+            if (checking && count > getMax()) {
                 log(ast.getLineNo(), ast.getColumnNo(), MSG_KEY,
                     count, getMax());
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
@@ -134,13 +134,13 @@ public class SimplifyBooleanReturnCheck
      */
     private static boolean isBooleanLiteralReturnStatement(AST ast)
     {
-        if ((ast == null) || (ast.getType() != TokenTypes.LITERAL_RETURN)) {
+        if (ast == null || ast.getType() != TokenTypes.LITERAL_RETURN) {
             return false;
         }
 
         final AST expr = ast.getFirstChild();
 
-        if ((expr == null) || (expr.getType() == TokenTypes.SEMI)) {
+        if (expr == null || expr.getType() == TokenTypes.SEMI) {
             return false;
         }
 
@@ -155,8 +155,8 @@ public class SimplifyBooleanReturnCheck
      */
     private static boolean isBooleanLiteralType(final int tokenType)
     {
-        final boolean iastrue = (tokenType == TokenTypes.LITERAL_TRUE);
-        final boolean isFalse = (tokenType == TokenTypes.LITERAL_FALSE);
+        final boolean iastrue = tokenType == TokenTypes.LITERAL_TRUE;
+        final boolean isFalse = tokenType == TokenTypes.LITERAL_FALSE;
         return iastrue || isFalse;
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -63,8 +63,8 @@ public class StringLiteralEqualityCheck extends Check
         final AST firstChild = ast.getFirstChild();
         final AST secondChild = firstChild.getNextSibling();
 
-        if ((firstChild.getType() == TokenTypes.STRING_LITERAL)
-                || (secondChild.getType() == TokenTypes.STRING_LITERAL))
+        if (firstChild.getType() == TokenTypes.STRING_LITERAL
+                || secondChild.getType() == TokenTypes.STRING_LITERAL)
         {
             log(ast.getLineNo(), ast.getColumnNo(),
                     MSG_KEY, ast.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -196,15 +196,15 @@ public class UnnecessaryParenthesesCheck extends Check
         final boolean surrounded = isSurrounded(ast);
         final DetailAST parent = ast.getParent();
 
-        if ((type == TokenTypes.ASSIGN)
-            && (parent.getType() == TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR))
+        if (type == TokenTypes.ASSIGN
+            && parent.getType() == TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR)
         {
             // shouldn't process assign in annotation pairs
             return;
         }
 
         // An identifier surrounded by parentheses.
-        if (surrounded && (type == TokenTypes.IDENT)) {
+        if (surrounded && type == TokenTypes.IDENT) {
             parentToSkip = ast.getParent();
             log(ast, MSG_IDENT, ast.getText());
             return;
@@ -239,8 +239,8 @@ public class UnnecessaryParenthesesCheck extends Check
         final int type = ast.getType();
         final DetailAST parent = ast.getParent();
 
-        if ((type == TokenTypes.ASSIGN)
-            && (parent.getType() == TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR))
+        if (type == TokenTypes.ASSIGN
+            && parent.getType() == TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR)
         {
             // shouldn't process assign in annotation pairs
             return;
@@ -253,7 +253,7 @@ public class UnnecessaryParenthesesCheck extends Check
             // warning about an immediate child node in visitToken, so we don't
             // need to log another one here.
 
-            if ((parentToSkip != ast) && exprSurrounded(ast)) {
+            if (parentToSkip != ast && exprSurrounded(ast)) {
                 if (assignDepth >= 1) {
                     log(ast, MSG_ASSIGN);
                 }
@@ -291,8 +291,8 @@ public class UnnecessaryParenthesesCheck extends Check
         final DetailAST prev = ast.getPreviousSibling();
         final DetailAST next = ast.getNextSibling();
 
-        return (prev != null) && (prev.getType() == TokenTypes.LPAREN)
-            && (next != null) && (next.getType() == TokenTypes.RPAREN);
+        return prev != null && prev.getType() == TokenTypes.LPAREN
+            && next != null && next.getType() == TokenTypes.RPAREN;
     }
 
     /**
@@ -314,8 +314,8 @@ public class UnnecessaryParenthesesCheck extends Check
             final AST n1 = ast.getFirstChild();
             final AST nn = ast.getLastChild();
 
-            surrounded = (n1.getType() == TokenTypes.LPAREN)
-                && (nn.getType() == TokenTypes.RPAREN);
+            surrounded = n1.getType() == TokenTypes.LPAREN
+                && nn.getType() == TokenTypes.RPAREN;
         }
         return surrounded;
     }
@@ -334,7 +334,7 @@ public class UnnecessaryParenthesesCheck extends Check
         //       HashMap to do the searches.
 
         boolean found = false;
-        for (int i = 0; (i < tokens.length) && !found; i++) {
+        for (int i = 0; i < tokens.length && !found; i++) {
             found = tokens[i] == type;
         }
         return found;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -264,7 +264,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check
         final int parentType = ast.getParent().getType();
         final DetailAST modifiers = ast.getFirstChild();
 
-        if ((ignoreFinal && modifiers.branchContains(TokenTypes.FINAL))
+        if (ignoreFinal && modifiers.branchContains(TokenTypes.FINAL)
                 || parentType == TokenTypes.OBJBLOCK)
         {
             ;// no code

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -104,8 +104,8 @@ public class DesignForExtensionCheck extends Check
         // Note: native methods don't have impl in java code, so
         // implementation can be null even if method not abstract
         final DetailAST implementation = ast.findFirstToken(TokenTypes.SLIST);
-        if ((implementation != null)
-            && (implementation.getFirstChild().getType() == TokenTypes.RCURLY))
+        if (implementation != null
+            && implementation.getFirstChild().getType() == TokenTypes.RCURLY)
         {
             return;
         }
@@ -114,7 +114,7 @@ public class DesignForExtensionCheck extends Check
         final DetailAST classDef = findContainingClass(ast);
         final DetailAST classMods =
             classDef.findFirstToken(TokenTypes.MODIFIERS);
-        if ((classDef.getType() == TokenTypes.ENUM_DEF)
+        if (classDef.getType() == TokenTypes.ENUM_DEF
             || classMods.branchContains(TokenTypes.FINAL))
         {
             return;
@@ -160,8 +160,8 @@ public class DesignForExtensionCheck extends Check
     private DetailAST findContainingClass(DetailAST ast)
     {
         DetailAST searchAST = ast;
-        while ((searchAST.getType() != TokenTypes.CLASS_DEF)
-               && (searchAST.getType() != TokenTypes.ENUM_DEF))
+        while (searchAST.getType() != TokenTypes.CLASS_DEF
+               && searchAST.getType() != TokenTypes.ENUM_DEF)
         {
             searchAST = searchAST.getParent();
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -68,15 +68,15 @@ public class FinalClassCheck
         final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
 
         if (ast.getType() == TokenTypes.CLASS_DEF) {
-            final boolean isFinal = (modifiers != null)
+            final boolean isFinal = modifiers != null
                     && modifiers.branchContains(TokenTypes.FINAL);
-            final boolean isAbstract = (modifiers != null)
+            final boolean isAbstract = modifiers != null
                     && modifiers.branchContains(TokenTypes.ABSTRACT);
             classes.push(new ClassDesc(isFinal, isAbstract));
         }
         else if (!ScopeUtils.inEnumBlock(ast)) { //ctors in enums don't matter
             final ClassDesc desc = classes.peek();
-            if ((modifiers != null)
+            if (modifiers != null
                 && modifiers.branchContains(TokenTypes.LITERAL_PRIVATE))
             {
                 desc.reportPrivateCtor();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -106,7 +106,7 @@ public class HideUtilityClassConstructorCheck extends Check
             child = child.getNextSibling();
         }
 
-        final boolean hasAccessibleCtor = (hasDefaultCtor || hasPublicCtor);
+        final boolean hasAccessibleCtor = hasDefaultCtor || hasPublicCtor;
 
         // figure out if class extends java.lang.object directly
         // keep it simple for now and get a 99% solution
@@ -118,7 +118,7 @@ public class HideUtilityClassConstructorCheck extends Check
         final boolean isUtilClass = extendsJLO && hasMethodOrField
             && !hasNonStaticMethodOrField && hasNonPrivateStaticMethodOrField;
 
-        if (isUtilClass && (hasAccessibleCtor && !hasStaticModifier)) {
+        if (isUtilClass && hasAccessibleCtor && !hasStaticModifier) {
             log(ast.getLineNo(), ast.getColumnNo(), MSG_KEY);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheck.java
@@ -81,9 +81,9 @@ public final class InterfaceIsTypeCheck
         final DetailAST variableDef =
                 objBlock.findFirstToken(TokenTypes.VARIABLE_DEF);
         final boolean methodRequired =
-                !allowMarkerInterfaces || (variableDef != null);
+                !allowMarkerInterfaces || variableDef != null;
 
-        if ((methodDef == null) && methodRequired) {
+        if (methodDef == null && methodRequired) {
             log(ast.getLineNo(), MSG_KEY);
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
@@ -137,7 +137,7 @@ public final class MutableExceptionCheck extends AbstractFormatCheck
      */
     private void visitVariableDef(DetailAST ast)
     {
-        if (checking && (ast.getParent().getType() == TokenTypes.OBJBLOCK)) {
+        if (checking && ast.getParent().getType() == TokenTypes.OBJBLOCK) {
             final DetailAST modifiersAST =
                 ast.findFirstToken(TokenTypes.MODIFIERS);
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -552,13 +552,13 @@ public class VisibilityModifierCheck
             final Set<String> classModifiers = getModifiers(classDef);
 
             result =
-                (mods.contains("static") && mods.contains("final"))
-                || (isPackageAllowed() && "package".equals(variableScope))
-                || (isProtectedAllowed() && "protected".equals(variableScope))
-                || ("public".equals(variableScope)
+                mods.contains("static") && mods.contains("final")
+                || isPackageAllowed() && "package".equals(variableScope)
+                || isProtectedAllowed() && "protected".equals(variableScope)
+                || "public".equals(variableScope)
                    && getPublicMemberRegexp().matcher(variableName).find()
-                   || (allowPublicImmutableFields
-                      && classModifiers.contains("final") && isImmutableField(variableDef)));
+                   || allowPublicImmutableFields
+                      && classModifiers.contains("final") && isImmutableField(variableDef);
         }
 
         return result;
@@ -641,9 +641,9 @@ public class VisibilityModifierCheck
             final boolean isCanonicalName = type.getFirstChild().getType() == TokenTypes.DOT;
             final String typeName = getTypeName(type, isCanonicalName);
 
-            result = (!isCanonicalName && isPrimitive(type))
+            result = !isCanonicalName && isPrimitive(type)
                      || immutableClassShortNames.contains(typeName)
-                     || (isCanonicalName && immutableClassCanonicalNames.contains(typeName));
+                     || isCanonicalName && immutableClassCanonicalNames.contains(typeName);
         }
         return result;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -89,7 +89,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
     public void setHeaderFile(String fileName)
     {
         // Handle empty param
-        if ((fileName == null) || (fileName.trim().length() == 0)) {
+        if (fileName == null || fileName.trim().length() == 0) {
             return;
         }
 
@@ -183,7 +183,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
      */
     public void setHeader(String header)
     {
-        if ((header == null) || (header.trim().length() == 0)) {
+        if (header == null || header.trim().length() == 0) {
             return;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
@@ -54,7 +54,7 @@ public class HeaderCheck extends AbstractHeaderCheck
      */
     private boolean isIgnoreLine(int lineNo)
     {
-        return (Arrays.binarySearch(ignoreLines, lineNo) >= 0);
+        return Arrays.binarySearch(ignoreLines, lineNo) >= 0;
     }
 
     /**
@@ -76,7 +76,7 @@ public class HeaderCheck extends AbstractHeaderCheck
      */
     public void setIgnoreLines(int[] list)
     {
-        if ((list == null) || (list.length == 0)) {
+        if (list == null || list.length == 0) {
             ignoreLines = EMPTY_INT_ARRAY;
             return;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -56,7 +56,7 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck
      */
     public void setMultiLines(int[] list)
     {
-        if ((list == null) || (list.length == 0)) {
+        if (list == null || list.length == 0) {
             multiLines = EMPTY_INT_ARRAY;
             return;
         }
@@ -78,12 +78,12 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck
         else {
             int headerLineNo = 0;
             int i;
-            for (i = 0; (headerLineNo < headerSize) && (i < fileSize); i++) {
+            for (i = 0; headerLineNo < headerSize && i < fileSize; i++) {
                 final String line = lines.get(i);
                 boolean isMatch = isMatch(line, headerLineNo);
                 while (!isMatch && isMultiLine(headerLineNo)) {
                     headerLineNo++;
-                    isMatch = (headerLineNo == headerSize)
+                    isMatch = headerLineNo == headerSize
                             || isMatch(line, headerLineNo);
                 }
                 if (!isMatch) {
@@ -125,7 +125,7 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck
      */
     private boolean isMultiLine(int lineNo)
     {
-        return (Arrays.binarySearch(multiLines, lineNo + 1) >= 0);
+        return Arrays.binarySearch(multiLines, lineNo + 1) >= 0;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
@@ -127,12 +127,12 @@ public class AvoidStarImportCheck
     @Override
     public void visitToken(final DetailAST ast)
     {
-        if (!allowClassImports && (TokenTypes.IMPORT == ast.getType())) {
+        if (!allowClassImports && TokenTypes.IMPORT == ast.getType()) {
             final DetailAST startingDot = ast.getFirstChild();
             logsStarredImportViolation(startingDot);
         }
         else if (!allowStaticMemberImports
-            && (TokenTypes.STATIC_IMPORT == ast.getType()))
+            && TokenTypes.STATIC_IMPORT == ast.getType())
         {
             // must navigate past the static keyword
             final DetailAST startingDot = ast.getFirstChild().getNextSibling();
@@ -160,6 +160,6 @@ public class AvoidStarImportCheck
      */
     private boolean isStaredImport(FullIdent importIdent)
     {
-        return (null != importIdent) && importIdent.getText().endsWith(".*");
+        return null != importIdent && importIdent.getText().endsWith(".*");
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
@@ -103,7 +103,7 @@ public class AvoidStaticImportCheck
             ast.getFirstChild().getNextSibling();
         final FullIdent name = FullIdent.createFullIdent(startingDot);
 
-        if ((null != name) && !isExempt(name.getText())) {
+        if (null != name && !isExempt(name.getText())) {
             log(startingDot.getLineNo(), MSG_KEY, name.getText());
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/Guard.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/Guard.java
@@ -113,8 +113,8 @@ class Guard
         else {
             pkgMatch = forImport.startsWith(pkgName + ".");
             if (pkgMatch && exactMatch) {
-                pkgMatch = (forImport.indexOf('.',
-                    (pkgName.length() + 1)) == -1);
+                pkgMatch = forImport.indexOf('.',
+                        pkgName.length() + 1) == -1;
             }
         }
         return calculateResult(pkgMatch);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -137,7 +137,7 @@ public class ImportControlCheck extends Check
     public void setUrl(final String url)
     {
         // Handle empty param
-        if ((url == null) || (url.trim().length() == 0)) {
+        if (url == null || url.trim().length() == 0) {
             return;
         }
         final URI uri;
@@ -164,7 +164,7 @@ public class ImportControlCheck extends Check
     public void setFile(final String name)
     {
         // Handle empty param
-        if ((name == null) || (name.trim().length() == 0)) {
+        if (name == null || name.trim().length() == 0) {
             return;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -98,13 +98,13 @@ final class ImportControlLoader extends AbstractLoader
             // May have "exact-match" for "pkg"
             // May have "local-only"
             final boolean isAllow = "allow".equals(qName);
-            final boolean isLocalOnly = (atts.getValue("local-only") != null);
+            final boolean isLocalOnly = atts.getValue("local-only") != null;
             final String pkg = atts.getValue("pkg");
-            final boolean regex = (atts.getValue("regex") != null);
+            final boolean regex = atts.getValue("regex") != null;
             final Guard g;
             if (pkg != null) {
                 final boolean exactMatch =
-                    (atts.getValue("exact-match") != null);
+                        atts.getValue("exact-match") != null;
                 g = new Guard(isAllow, isLocalOnly, pkg, exactMatch, regex);
             }
             else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -257,7 +257,7 @@ public class ImportOrderCheck
 
             case ABOVE:
                 // previous non-static but current is static
-                doVisitToken(ident, isStatic, (!lastImportStatic && isStatic));
+                doVisitToken(ident, isStatic, !lastImportStatic && isStatic);
                 break;
 
             case INFLOW:
@@ -274,7 +274,7 @@ public class ImportOrderCheck
 
             case UNDER:
                 // previous static but current is non-static
-                doVisitToken(ident, isStatic, (lastImportStatic && !isStatic));
+                doVisitToken(ident, isStatic, lastImportStatic && !isStatic);
                 break;
 
             default:
@@ -306,7 +306,7 @@ public class ImportOrderCheck
                 if (!beforeFirstImport && separated) {
                     // This check should be made more robust to handle
                     // comments and imports that span more than one line.
-                    if ((line - lastImportLine) < 2) {
+                    if (line - lastImportLine < 2) {
                         log(line, MSG_SEPARATION, name);
                     }
                 }
@@ -349,10 +349,10 @@ public class ImportOrderCheck
             final boolean shouldFireError =
                 // current and previous static or current and
                 // previous non-static
-                (!(lastImportStatic ^ isStatic)
+                !(lastImportStatic ^ isStatic)
                 &&
                 // and out of lexicographic order
-                (compare(lastImport, name, caseSensitive) > 0))
+                        compare(lastImport, name, caseSensitive) > 0
                 ||
                 // previous non-static but current is static (above)
                 // or
@@ -383,8 +383,8 @@ public class ImportOrderCheck
             final Matcher matcher = groups[i].matcher(name);
             while (matcher.find()) {
                 final int length = matcher.end() - matcher.start();
-                if ((length > bestLength)
-                    || ((length == bestLength) && (matcher.start() < bestPos)))
+                if (length > bestLength
+                    || length == bestLength && matcher.start() < bestPos)
                 {
                     bestIndex = i;
                     bestLength = length;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
@@ -160,7 +160,7 @@ public class RedundantImportCheck
         boolean retVal = false;
         if (pkg == null) {
             // If not package, then check for no package in the import.
-            retVal = (importName.indexOf('.') == -1);
+            retVal = importName.indexOf('.') == -1;
         }
         else {
             final int index = importName.lastIndexOf('.');

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -189,10 +189,10 @@ public class UnusedImportsCheck extends Check
     {
         final DetailAST parent = ast.getParent();
         final int parentType = parent.getType();
-        if (((parentType != TokenTypes.DOT)
-            && (parentType != TokenTypes.METHOD_DEF))
-            || ((parentType == TokenTypes.DOT)
-                && (ast.getNextSibling() != null)))
+        if (parentType != TokenTypes.DOT
+            && parentType != TokenTypes.METHOD_DEF
+            || parentType == TokenTypes.DOT
+                && ast.getNextSibling() != null)
         {
             referenced.add(ast.getText());
         }
@@ -205,7 +205,7 @@ public class UnusedImportsCheck extends Check
     private void processImport(DetailAST ast)
     {
         final FullIdent name = FullIdent.createFullIdentBelow(ast);
-        if ((name != null) && !name.getText().endsWith(".*")) {
+        if (name != null && !name.getText().endsWith(".*")) {
             imports.add(name);
         }
     }
@@ -219,7 +219,7 @@ public class UnusedImportsCheck extends Check
         final FullIdent name =
             FullIdent.createFullIdent(
                 ast.getFirstChild().getNextSibling());
-        if ((name != null) && !name.getText().endsWith(".*")) {
+        if (name != null && !name.getText().endsWith(".*")) {
             imports.add(name);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
@@ -47,7 +47,7 @@ public class ArrayInitHandler extends BlockParentHandler
     {
         final DetailAST parentAST = getMainAst().getParent();
         final int type = parentAST.getType();
-        if ((type == TokenTypes.LITERAL_NEW) || (type == TokenTypes.ASSIGN)) {
+        if (type == TokenTypes.LITERAL_NEW || type == TokenTypes.ASSIGN) {
             // note: assumes new or assignment is line to align with
             return new IndentLevel(getLineStart(parentAST));
         }
@@ -111,7 +111,7 @@ public class ArrayInitHandler extends BlockParentHandler
                     getIndentCheck().getLineWrappingIndentation());
 
         final int firstLine = getFirstLine(Integer.MAX_VALUE, getListChild());
-        if (hasCurlys() && (firstLine == getLCurly().getLineNo())) {
+        if (hasCurlys() && firstLine == getLCurly().getLineNo()) {
             final int lcurlyPos = expandedTabsColumnNo(getLCurly());
             final int firstChildPos =
                 getNextFirstNonblankOnLineAfter(firstLine, lcurlyPos);
@@ -136,13 +136,13 @@ public class ArrayInitHandler extends BlockParentHandler
         int realColumnNo = columnNo + 1;
         final String line = getIndentCheck().getLines()[lineNo - 1];
         final int lineLength = line.length();
-        while ((realColumnNo < lineLength)
+        while (realColumnNo < lineLength
                && Character.isWhitespace(line.charAt(realColumnNo)))
         {
             realColumnNo++;
         }
 
-        return (realColumnNo == lineLength) ? -1 : realColumnNo;
+        return realColumnNo == lineLength ? -1 : realColumnNo;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -96,7 +96,7 @@ public class BlockParentHandler extends ExpressionHandler
     {
         final DetailAST toplevel = getToplevelAST();
 
-        if ((toplevel == null)
+        if (toplevel == null
             || getLevel().accept(expandedTabsColumnNo(toplevel)) || hasLabelBefore())
         {
             return;
@@ -135,7 +135,7 @@ public class BlockParentHandler extends ExpressionHandler
      */
     protected boolean hasCurlys()
     {
-        return (getLCurly() != null) && (getRCurly() != null);
+        return getLCurly() != null && getRCurly() != null;
     }
 
     /**
@@ -173,7 +173,7 @@ public class BlockParentHandler extends ExpressionHandler
         final DetailAST lcurly = getLCurly();
         final int lcurlyPos = expandedTabsColumnNo(lcurly);
 
-        if ((lcurly == null)
+        if (lcurly == null
             || curlyLevel().accept(lcurlyPos)
             || !startsLine(lcurly))
         {
@@ -224,9 +224,9 @@ public class BlockParentHandler extends ExpressionHandler
         final DetailAST rcurly = getRCurly();
         final int rcurlyPos = expandedTabsColumnNo(rcurly);
 
-        if ((rcurly == null)
+        if (rcurly == null
             || curlyLevel().accept(rcurlyPos)
-            || (!rcurlyMustStart() && !startsLine(rcurly))
+            || !rcurlyMustStart() && !startsLine(rcurly)
             || areOnSameLine(rcurly, lcurly))
         {
             return;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java
@@ -41,9 +41,9 @@ public class ClassDefHandler extends BlockParentHandler
                            ExpressionHandler parent)
     {
         super(indentCheck,
-              (ast.getType() == TokenTypes.CLASS_DEF)
-              ? "class def" : ((ast.getType() == TokenTypes.ENUM_DEF)
-                  ? "enum def" : "interface def"),
+              ast.getType() == TokenTypes.CLASS_DEF
+              ? "class def" : ast.getType() == TokenTypes.ENUM_DEF
+                  ? "enum def" : "interface def",
               ast, parent);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ElseHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ElseHandler.java
@@ -54,8 +54,8 @@ public class ElseHandler extends BlockParentHandler
             final DetailAST slist = ifAST.findFirstToken(TokenTypes.SLIST);
             if (slist != null) {
                 final DetailAST lcurly = slist.getLastChild();
-                if ((lcurly != null)
-                    && (lcurly.getLineNo() == getMainAst().getLineNo()))
+                if (lcurly != null
+                    && lcurly.getLineNo() == getMainAst().getLineNo())
                 {
                     // indentation checked as part of LITERAL IF check
                     return;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ExpressionHandler.java
@@ -155,7 +155,7 @@ public abstract class ExpressionHandler
                                   int actualLevel, IndentLevel expectedLevel)
     {
         final String typeStr =
-            ("".equals(subtypeName) ? "" : (" " + subtypeName));
+                "".equals(subtypeName) ? "" : " " + subtypeName;
         String messageKey = MSG_ERROR;
         if (expectedLevel.isMultiLevel()) {
             messageKey = MSG_ERROR_MULTI;
@@ -205,8 +205,8 @@ public abstract class ExpressionHandler
      */
     static boolean areOnSameLine(DetailAST ast1, DetailAST ast2)
     {
-        return (ast1 != null) && (ast2 != null)
-            && (ast1.getLineNo() == ast2.getLineNo());
+        return ast1 != null && ast2 != null
+            && ast1.getLineNo() == ast2.getLineNo();
     }
 
     /**
@@ -222,9 +222,9 @@ public abstract class ExpressionHandler
 
         while (child != null) {
             final DetailAST toTest = getFirstToken(child);
-            if ((toTest.getLineNo() < first.getLineNo())
-                || ((toTest.getLineNo() == first.getLineNo())
-                    && (toTest.getColumnNo() < first.getColumnNo())))
+            if (toTest.getLineNo() < first.getLineNo()
+                || toTest.getLineNo() == first.getLineNo()
+                    && toTest.getColumnNo() < first.getColumnNo())
             {
                 first = toTest;
             }
@@ -317,7 +317,7 @@ public abstract class ExpressionHandler
 
         IndentLevel theLevel = indentLevel;
         if (firstLineMatches
-            || ((firstLine > mainAst.getLineNo()) && shouldIncreaseIndent()))
+            || firstLine > mainAst.getLineNo() && shouldIncreaseIndent())
         {
             theLevel = new IndentLevel(indentLevel, getBasicOffset());
         }
@@ -369,7 +369,7 @@ public abstract class ExpressionHandler
         // error if this statement starts the line and it is less than
         // the correct indentation level
         if (mustMatch ? !indentLevel.accept(start)
-            : (colNum == start) && indentLevel.gt(start))
+            : colNum == start && indentLevel.gt(start))
         {
             logChildError(lineNum, start, indentLevel);
         }
@@ -504,7 +504,7 @@ public abstract class ExpressionHandler
         boolean allowNesting)
     {
         if (getIndentCheck().getHandlerFactory().isHandledType(tree.getType())
-            || (tree.getLineNo() < 0))
+            || tree.getLineNo() < 0)
         {
             return;
         }
@@ -513,7 +513,7 @@ public abstract class ExpressionHandler
         final Integer colNum = lines.getStartColumn(lineNum);
 
         final int thisLineColumn = expandedTabsColumnNo(tree);
-        if ((colNum == null) || (thisLineColumn < colNum.intValue())) {
+        if (colNum == null || thisLineColumn < colNum.intValue()) {
             lines.addLineAndCol(lineNum, thisLineColumn);
         }
 
@@ -621,7 +621,7 @@ public abstract class ExpressionHandler
 
         // or has <lparen level> + 1 indentation
         final int lparenLevel = expandedTabsColumnNo(lparen);
-        if (rparenLevel == (lparenLevel + 1)) {
+        if (rparenLevel == lparenLevel + 1) {
             return;
         }
 
@@ -636,7 +636,7 @@ public abstract class ExpressionHandler
     {
         // the rcurly can either be at the correct indentation, or on the
         // same line as the lcurly
-        if ((lparen == null)
+        if (lparen == null
             || getLevel().accept(expandedTabsColumnNo(lparen))
             || !startsLine(lparen))
         {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
@@ -206,10 +206,10 @@ public class HandlerFactory
     {
         ExpressionHandler theParent = parent;
         DetailAST astNode = ast.getFirstChild();
-        while ((astNode != null) && (astNode.getType() == TokenTypes.DOT)) {
+        while (astNode != null && astNode.getType() == TokenTypes.DOT) {
             astNode = astNode.getFirstChild();
         }
-        if ((astNode != null) && isHandledType(astNode.getType())) {
+        if (astNode != null && isHandledType(astNode.getType())) {
             theParent = getHandler(indentCheck, astNode, theParent);
             createdHandlers.put(astNode, theParent);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IfHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IfHandler.java
@@ -70,8 +70,8 @@ public class IfHandler extends BlockParentHandler
     {
         // check if there is an 'else' and an 'if' on the same line
         final DetailAST parent = getMainAst().getParent();
-        return (parent.getType() == TokenTypes.LITERAL_ELSE)
-            && (parent.getLineNo() == getMainAst().getLineNo());
+        return parent.getType() == TokenTypes.LITERAL_ELSE
+            && parent.getLineNo() == getMainAst().getLineNo();
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineSet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineSet.java
@@ -53,7 +53,7 @@ public class LineSet
     public int firstLineCol()
     {
         final Object firstLineKey = lines.firstKey();
-        return (lines.get(firstLineKey)).intValue();
+        return lines.get(firstLineKey).intValue();
     }
 
     /**
@@ -63,7 +63,7 @@ public class LineSet
      */
     public int firstLine()
     {
-        return (lines.firstKey()).intValue();
+        return lines.firstKey().intValue();
     }
 
     /**
@@ -73,7 +73,7 @@ public class LineSet
      */
     public int lastLine()
     {
-        return (lines.lastKey()).intValue();
+        return lines.lastKey().intValue();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -221,7 +221,7 @@ public class LineWrappingHandler
         DetailAST nodeToVisit = curNode.getFirstChild();
         DetailAST currentNode = curNode;
 
-        while ((currentNode != null) && (nodeToVisit == null)) {
+        while (currentNode != null && nodeToVisit == null) {
             nodeToVisit = currentNode.getNextSibling();
             if (nodeToVisit == null) {
                 currentNode = currentNode.getParent();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -53,7 +53,7 @@ public class MethodCallHandler extends ExpressionHandler
         // an expression, so get the previous line's start
         if (getParent() instanceof MethodCallHandler) {
             final MethodCallHandler container =
-                ((MethodCallHandler) getParent());
+                    (MethodCallHandler) getParent();
             if (container != null) {
                 if (areOnSameLine(container.getMainAst(), getMainAst())) {
                     return container.getLevel();
@@ -65,14 +65,14 @@ public class MethodCallHandler extends ExpressionHandler
                 final DetailAST dot = main.getFirstChild();
                 final DetailAST target = dot.getFirstChild();
 
-                if ((dot.getType() == TokenTypes.DOT)
-                    && (target.getType() == TokenTypes.METHOD_CALL))
+                if (dot.getType() == TokenTypes.DOT
+                    && target.getType() == TokenTypes.METHOD_CALL)
                 {
                     final DetailAST dot1 = target.getFirstChild();
                     final DetailAST target1 = dot1.getFirstChild();
 
-                    if ((dot1.getType() == TokenTypes.DOT)
-                        && (target1.getType() == TokenTypes.METHOD_CALL))
+                    if (dot1.getType() == TokenTypes.DOT
+                        && target1.getType() == TokenTypes.METHOD_CALL)
                     {
                         return container.getLevel();
                     }
@@ -117,7 +117,7 @@ public class MethodCallHandler extends ExpressionHandler
         // call name
 
         DetailAST astNode = ast.getFirstChild();
-        while ((astNode != null) && (astNode.getType() == TokenTypes.DOT)) {
+        while (astNode != null && astNode.getType() == TokenTypes.DOT) {
             astNode = astNode.getFirstChild();
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
@@ -40,7 +40,7 @@ public class MethodDefHandler extends BlockParentHandler
     public MethodDefHandler(IndentationCheck indentCheck,
         DetailAST ast, ExpressionHandler parent)
     {
-        super(indentCheck, (ast.getType() == TokenTypes.CTOR_DEF)
+        super(indentCheck, ast.getType() == TokenTypes.CTOR_DEF
             ? "ctor def" : "method def", ast, parent);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
@@ -55,8 +55,8 @@ public class NewHandler extends ExpressionHandler
         final DetailAST rparen = getMainAst().findFirstToken(TokenTypes.RPAREN);
         checkLParen(lparen);
 
-        if ((rparen == null) || (lparen == null)
-            || (rparen.getLineNo() == lparen.getLineNo()))
+        if (rparen == null || lparen == null
+            || rparen.getLineNo() == lparen.getLineNo())
         {
             return;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
@@ -110,7 +110,7 @@ public class ObjectBlockHandler extends BlockParentHandler
         final IndentLevel level = curlyLevel();
         level.addAcceptedIndent(level.getFirstIndentLevel() + getLineWrappingIndent());
 
-        if ((rcurly != null) && !level.accept(rcurlyPos)
+        if (rcurly != null && !level.accept(rcurlyPos)
             && (rcurlyMustStart() || startsLine(rcurly))
                 && !areOnSameLine(rcurly, lcurly))
         {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
@@ -55,10 +55,10 @@ public class SlistHandler extends BlockParentHandler
         //  preceded by a switch
 
         // if our parent is a block handler we want to be transparent
-        if (((getParent() instanceof BlockParentHandler)
-                && !(getParent() instanceof SlistHandler))
-            || ((getParent() instanceof CaseHandler)
-                && (child instanceof SlistHandler)))
+        if (getParent() instanceof BlockParentHandler
+                && !(getParent() instanceof SlistHandler)
+            || getParent() instanceof CaseHandler
+                && child instanceof SlistHandler)
         {
             return getParent().suggestedChildLevel(child);
         }
@@ -107,17 +107,17 @@ public class SlistHandler extends BlockParentHandler
     private boolean hasBlockParent()
     {
         final int parentType = getMainAst().getParent().getType();
-        return (parentType == TokenTypes.LITERAL_IF)
-            || (parentType == TokenTypes.LITERAL_FOR)
-            || (parentType == TokenTypes.LITERAL_WHILE)
-            || (parentType == TokenTypes.LITERAL_DO)
-            || (parentType == TokenTypes.LITERAL_ELSE)
-            || (parentType == TokenTypes.LITERAL_TRY)
-            || (parentType == TokenTypes.LITERAL_CATCH)
-            || (parentType == TokenTypes.LITERAL_FINALLY)
-            || (parentType == TokenTypes.CTOR_DEF)
-            || (parentType == TokenTypes.METHOD_DEF)
-            || (parentType == TokenTypes.STATIC_INIT);
+        return parentType == TokenTypes.LITERAL_IF
+            || parentType == TokenTypes.LITERAL_FOR
+            || parentType == TokenTypes.LITERAL_WHILE
+            || parentType == TokenTypes.LITERAL_DO
+            || parentType == TokenTypes.LITERAL_ELSE
+            || parentType == TokenTypes.LITERAL_TRY
+            || parentType == TokenTypes.LITERAL_CATCH
+            || parentType == TokenTypes.LITERAL_FINALLY
+            || parentType == TokenTypes.CTOR_DEF
+            || parentType == TokenTypes.METHOD_DEF
+            || parentType == TokenTypes.STATIC_INIT;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler.java
@@ -44,8 +44,8 @@ public class TryHandler extends BlockParentHandler
     @Override
     public IndentLevel suggestedChildLevel(ExpressionHandler child)
     {
-        if ((child instanceof CatchHandler)
-            || (child instanceof FinallyHandler))
+        if (child instanceof CatchHandler
+            || child instanceof FinallyHandler)
         {
             return getLevel();
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -543,7 +543,7 @@ public abstract class AbstractJavadocCheck extends Check
                 visitJavadocToken(curNode);
             }
             DetailNode toVisit = JavadocUtils.getFirstChild(curNode);
-            while ((curNode != null) && (toVisit == null)) {
+            while (curNode != null && toVisit == null) {
 
                 if (waitsFor) {
                     leaveJavadocToken(curNode);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java
@@ -58,7 +58,7 @@ class HtmlTag
     HtmlTag(String id, int lineNo, int position, boolean closedTag,
             boolean incomplete, String text)
     {
-        this.id = (!"".equals(id) && (id.charAt(0) == '/'))
+        this.id = !"".equals(id) && id.charAt(0) == '/'
             ? id.substring(1) : id;
         this.lineNo = lineNo;
         this.position = position;
@@ -82,10 +82,10 @@ class HtmlTag
      */
     public boolean isCloseTag()
     {
-        if (position == (text.length() - 1)) {
+        if (position == text.length() - 1) {
             return false;
         }
-        return (text.charAt(position + 1) == '/');
+        return text.charAt(position + 1) == '/';
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -367,7 +367,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
     protected final void processAST(DetailAST ast)
     {
         if ((ast.getType() == TokenTypes.METHOD_DEF || ast.getType() == TokenTypes.CTOR_DEF)
-            && (getMethodsNumberOfLine(ast) <= minLineCount)
+            && getMethodsNumberOfLine(ast) <= minLineCount
             || hasAllowedAnnotations(ast))
         {
             return;
@@ -453,8 +453,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
     protected boolean isMissingJavadocAllowed(final DetailAST ast)
     {
         return allowMissingJavadoc
-            || (allowMissingPropertyJavadoc
-                && (isSetterMethod(ast) || isGetterMethod(ast)))
+            || allowMissingPropertyJavadoc
+                && (isSetterMethod(ast) || isGetterMethod(ast))
             || matchesSkipRegex(ast);
     }
 
@@ -491,7 +491,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
 
         return scope.isIn(this.scope)
                 && surroundingScope.isIn(this.scope)
-                && ((excludeScope == null) || !scope.isIn(excludeScope)
+                && (excludeScope == null || !scope.isIn(excludeScope)
                     || !surroundingScope.isIn(excludeScope));
     }
 
@@ -514,7 +514,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
             // Check for inheritDoc
             boolean hasInheritDocTag = false;
             while (it.hasNext() && !hasInheritDocTag) {
-                hasInheritDocTag |= (it.next()).isInheritDocTag();
+                hasInheritDocTag |= it.next().isInheritDocTag();
             }
 
             checkParamTags(tags, ast, !hasInheritDocTag);
@@ -546,8 +546,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
             final List<JavadocTag> tags)
     {
         // Check if it contains {@inheritDoc} tag
-        if ((tags.size() != 1)
-                || !(tags.get(0)).isInheritDocTag())
+        if (tags.size() != 1
+                || !tags.get(0).isInheritDocTag())
         {
             return false;
         }
@@ -721,8 +721,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
         if (throwsAST != null) {
             DetailAST child = throwsAST.getFirstChild();
             while (child != null) {
-                if ((child.getType() == TokenTypes.IDENT)
-                        || (child.getType() == TokenTypes.DOT))
+                if (child.getType() == TokenTypes.IDENT
+                        || child.getType() == TokenTypes.DOT)
                 {
                     final FullIdent fi = FullIdent.createFullIdent(child);
                     final ExceptionInfo ei = new ExceptionInfo(new Token(fi),
@@ -827,8 +827,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
         boolean retVal = false;
         if (ast.getType() == TokenTypes.METHOD_DEF) {
             final DetailAST typeAST = ast.findFirstToken(TokenTypes.TYPE);
-            if ((typeAST != null)
-                && (typeAST.findFirstToken(TokenTypes.LITERAL_VOID) == null))
+            if (typeAST != null
+                && typeAST.findFirstToken(TokenTypes.LITERAL_VOID) == null)
             {
                 retVal = true;
             }
@@ -973,8 +973,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
         // Check have a method with exactly 7 children which are all that
         // is allowed in a proper setter method which does not throw any
         // exceptions.
-        if ((ast.getType() != TokenTypes.METHOD_DEF)
-                || (ast.getChildCount() != MAX_CHILDREN))
+        if (ast.getType() != TokenTypes.METHOD_DEF
+                || ast.getChildCount() != MAX_CHILDREN)
         {
             return false;
         }
@@ -995,8 +995,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
 
         // Check that is had only one parameter
         final DetailAST params = ast.findFirstToken(TokenTypes.PARAMETERS);
-        if ((params == null)
-                || (params.getChildCount(TokenTypes.PARAMETER_DEF) != 1))
+        if (params == null
+                || params.getChildCount(TokenTypes.PARAMETER_DEF) != 1)
         {
             return false;
         }
@@ -1006,13 +1006,13 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
         // SEMI
         // RCURLY
         final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
-        if ((slist == null) || (slist.getChildCount() != BODY_SIZE)) {
+        if (slist == null || slist.getChildCount() != BODY_SIZE) {
             return false;
         }
 
         final AST expr = slist.getFirstChild();
-        if ((expr.getType() != TokenTypes.EXPR)
-                || (expr.getFirstChild().getType() != TokenTypes.ASSIGN))
+        if (expr.getType() != TokenTypes.EXPR
+                || expr.getFirstChild().getType() != TokenTypes.ASSIGN)
         {
             return false;
         }
@@ -1030,8 +1030,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
         // Check have a method with exactly 7 children which are all that
         // is allowed in a proper getter method which does not throw any
         // exceptions.
-        if ((ast.getType() != TokenTypes.METHOD_DEF)
-                || (ast.getChildCount() != MAX_CHILDREN))
+        if (ast.getType() != TokenTypes.METHOD_DEF
+                || ast.getChildCount() != MAX_CHILDREN)
         {
             return false;
         }
@@ -1051,8 +1051,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
 
         // Check that is had only one parameter
         final DetailAST params = ast.findFirstToken(TokenTypes.PARAMETERS);
-        if ((params == null)
-                || (params.getChildCount(TokenTypes.PARAMETER_DEF) > 0))
+        if (params == null
+                || params.getChildCount(TokenTypes.PARAMETER_DEF) > 0)
         {
             return false;
         }
@@ -1061,13 +1061,13 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck
         // SLIST -> RETURN
         // RCURLY
         final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
-        if ((slist == null) || (slist.getChildCount() != 2)) {
+        if (slist == null || slist.getChildCount() != 2) {
             return false;
         }
 
         final AST expr = slist.getFirstChild();
-        if ((expr.getType() != TokenTypes.LITERAL_RETURN)
-                || (expr.getFirstChild().getType() != TokenTypes.EXPR))
+        if (expr.getType() != TokenTypes.LITERAL_RETURN
+                || expr.getFirstChild().getType() != TokenTypes.EXPR)
         {
             return false;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -186,11 +186,11 @@ public class JavadocStyleCheck
         final Scope surroundingScope = ScopeUtils.getSurroundingScope(ast);
 
         return scope.isIn(this.scope)
-            && ((surroundingScope == null) || surroundingScope.isIn(this.scope))
-            && ((excludeScope == null)
+            && (surroundingScope == null || surroundingScope.isIn(this.scope))
+            && (excludeScope == null
                 || !scope.isIn(excludeScope)
-                || ((surroundingScope != null)
-                && !surroundingScope.isIn(excludeScope)));
+                || surroundingScope != null
+                && !surroundingScope.isIn(excludeScope));
     }
 
     /**
@@ -242,7 +242,7 @@ public class JavadocStyleCheck
     {
         final String commentText = getCommentText(comment.getText());
 
-        if ((commentText.length() != 0)
+        if (commentText.length() != 0
             && !getEndOfSentencePattern().matcher(commentText).find()
             && !("{@inheritDoc}".equals(commentText)
             && JavadocTagInfo.INHERIT_DOC.isValidOn(ast)))
@@ -328,9 +328,9 @@ public class JavadocStyleCheck
             if (Character.isWhitespace(buffer.charAt(i))) {
                 buffer.deleteCharAt(i);
             }
-            else if ((i > 0)
-                     && (buffer.charAt(i - 1) == '*')
-                     && (buffer.charAt(i) == '/'))
+            else if (i > 0
+                     && buffer.charAt(i - 1) == '*'
+                     && buffer.charAt(i) == '/')
             {
                 buffer.deleteCharAt(i);
                 buffer.deleteCharAt(i - 1);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java
@@ -113,14 +113,14 @@ public class JavadocTag
     /** @return whether the tag is an 'throws' or 'exception' tag **/
     public boolean isThrowsTag()
     {
-        return (JavadocTagInfo.THROWS == tagInfo
-            || JavadocTagInfo.EXCEPTION == tagInfo);
+        return JavadocTagInfo.THROWS == tagInfo
+            || JavadocTagInfo.EXCEPTION == tagInfo;
     }
 
     /** @return whether the tag is a 'see' or 'inheritDoc' tag **/
     public boolean isSeeOrInheritDocTag()
     {
-        return (JavadocTagInfo.SEE == tagInfo || isInheritDocTag());
+        return JavadocTagInfo.SEE == tagInfo || isInheritDocTag();
     }
 
     /** @return whether the tag is a 'inheritDoc' tag **/
@@ -132,11 +132,11 @@ public class JavadocTag
     /** @return whether the tag can contain references to imported classes **/
     public boolean canReferenceImports()
     {
-        return (JavadocTagInfo.SEE == tagInfo
+        return JavadocTagInfo.SEE == tagInfo
                 || JavadocTagInfo.LINK == tagInfo
                 || JavadocTagInfo.LINKPLAIN == tagInfo
                 || JavadocTagInfo.THROWS == tagInfo
-                || JavadocTagInfo.EXCEPTION == tagInfo);
+                || JavadocTagInfo.EXCEPTION == tagInfo;
     }
 }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -244,11 +244,11 @@ public class JavadocTypeCheck
         final Scope surroundingScope = ScopeUtils.getSurroundingScope(ast);
 
         return scope.isIn(this.scope)
-            && ((surroundingScope == null) || surroundingScope.isIn(this.scope))
-            && ((excludeScope == null)
+            && (surroundingScope == null || surroundingScope.isIn(this.scope))
+            && (excludeScope == null
                 || !scope.isIn(excludeScope)
-                || ((surroundingScope != null)
-                && !surroundingScope.isIn(excludeScope)));
+                || surroundingScope != null
+                && !surroundingScope.isIn(excludeScope));
     }
 
     /**
@@ -313,8 +313,8 @@ public class JavadocTypeCheck
         for (int i = tags.size() - 1; i >= 0; i--) {
             final JavadocTag tag = tags.get(i);
             if (tag.isParamTag()
-                && (tag.getArg1() != null)
-                && (tag.getArg1().indexOf("<" + typeParamName + ">") == 0))
+                && tag.getArg1() != null
+                && tag.getArg1().indexOf("<" + typeParamName + ">") == 0)
             {
                 found = true;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
@@ -162,7 +162,7 @@ public final class JavadocUtils
                         final String tagName = tagMatcher.group(1);
                         final String tagValue = tagMatcher.group(2).trim();
                         final int line = cmt.getStartLineNo() + i;
-                        int col = commentOffset + (tagMatcher.start(1) - 1);
+                        int col = commentOffset + tagMatcher.start(1) - 1;
                         if (i == 0) {
                             col += cmt.getStartColNo();
                         }
@@ -302,7 +302,7 @@ public final class JavadocUtils
             }
 
             DetailNode toVisit = getFirstChild(curNode);
-            while ((curNode != null) && (toVisit == null)) {
+            while (curNode != null && toVisit == null) {
                 toVisit = getNextSibling(curNode);
                 if (toVisit == null) {
                     curNode = curNode.getParent();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -167,7 +167,7 @@ public class JavadocVariableCheck
         final Scope surroundingScope = ScopeUtils.getSurroundingScope(ast);
 
         return scope.isIn(this.scope) && surroundingScope.isIn(this.scope)
-            && ((excludeScope == null)
+            && (excludeScope == null
                 || !scope.isIn(excludeScope)
                 || !surroundingScope.isIn(excludeScope));
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
@@ -111,15 +111,15 @@ class TagParser
             else {
                 // find end of tag
                 final Point endTag = findChar(text, '>', position);
-                final boolean incompleteTag = (endTag.getLineNo() >= nLines);
+                final boolean incompleteTag = endTag.getLineNo() >= nLines;
                 // get tag id (one word)
                 final String tagId =
-                    (incompleteTag ? "" : getTagId(text, position));
+                        incompleteTag ? "" : getTagId(text, position);
                 // is this closed tag
                 final boolean closedTag =
-                    ((endTag.getLineNo() < nLines) && (endTag.getColumnNo() > 0)
-                     && (text[endTag.getLineNo()]
-                     .charAt(endTag.getColumnNo() - 1) == '/'));
+                        endTag.getLineNo() < nLines && endTag.getColumnNo() > 0
+                         && text[endTag.getLineNo()]
+                         .charAt(endTag.getColumnNo() - 1) == '/';
                 // add new tag
                 add(new HtmlTag(tagId,
                                 position.getLineNo() + lineNo,
@@ -146,11 +146,11 @@ class TagParser
 
         //Character.isJavidentifier... may not be a valid HTML
         //identifier but is valid for generics
-        return ((column < text.length())
+        return column < text.length()
                 && (Character.isJavaIdentifierStart(text.charAt(column))
                     || Character.isJavaIdentifierPart(text.charAt(column))
                     || text.charAt(column) == '/')
-                || (column >= text.length()));
+                || column >= text.length();
     }
 
     /**
@@ -208,7 +208,7 @@ class TagParser
     {
         Point to = from;
         to = findChar(text, '>', to);
-        while ((to.getLineNo() < text.length)
+        while (to.getLineNo() < text.length
                && !text[to.getLineNo()]
                .substring(0, to.getColumnNo() + 1).endsWith("-->"))
         {
@@ -227,8 +227,8 @@ class TagParser
     private Point findChar(String[] text, char character, Point from)
     {
         Point curr = new Point(from.getLineNo(), from.getColumnNo());
-        while ((curr.getLineNo() < text.length)
-               && (text[curr.getLineNo()].charAt(curr.getColumnNo()) != character))
+        while (curr.getLineNo() < text.length
+               && text[curr.getLineNo()].charAt(curr.getColumnNo()) != character)
         {
             curr = getNextCharPos(text, curr);
         }
@@ -247,21 +247,21 @@ class TagParser
     {
         int line = from.getLineNo();
         int column = from.getColumnNo() + 1;
-        while ((line < text.length) && (column >= text[line].length())) {
+        while (line < text.length && column >= text[line].length()) {
             // go to the next line
             line++;
             column = 0;
             if (line < text.length) {
                 //skip beginning spaces and stars
                 final String currentLine = text[line];
-                while ((column < currentLine.length())
+                while (column < currentLine.length()
                        && (Character.isWhitespace(currentLine.charAt(column))
-                           || (currentLine.charAt(column) == '*')))
+                           || currentLine.charAt(column) == '*'))
                 {
                     column++;
-                    if ((column < currentLine.length())
-                        && (currentLine.charAt(column - 1) == '*')
-                        && (currentLine.charAt(column) == '/'))
+                    if (column < currentLine.length()
+                        && currentLine.charAt(column - 1) == '*'
+                        && currentLine.charAt(column) == '/')
                     {
                         // this is end of comment
                         column = currentLine.length();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
@@ -212,7 +212,7 @@ public class WriteTagCheck
                 tagCount += 1;
                 final int contentStart = matcher.start(1);
                 final String content = s.substring(contentStart);
-                if ((formatRE != null) && !formatRE.matcher(content).find()) {
+                if (formatRE != null && !formatRE.matcher(content).find()) {
                     log(lineNo + i - comment.length, TAG_FORMAT, tag,
                         format);
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -304,7 +304,7 @@ public abstract class AbstractClassCouplingCheck extends Check
          */
         private boolean isSignificant(String className)
         {
-            return (className.length() > 0)
+            return className.length() > 0
                     && !excludedClasses.contains(className)
                     && !className.startsWith("java.lang.");
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
@@ -208,7 +208,7 @@ public final class BooleanExpressionComplexityCheck extends Check
     private void visitExpr()
     {
         contextStack.push(context);
-        context = new Context((context == null) || context.isChecking());
+        context = new Context(context == null || context.isChecking());
     }
 
     /**
@@ -268,7 +268,7 @@ public final class BooleanExpressionComplexityCheck extends Check
          */
         public void checkCount(DetailAST ast)
         {
-            if (checking && (count > getMax())) {
+            if (checking && count > getMax()) {
                 final DetailAST parentAST = ast.getParent();
 
                 log(parentAST.getLineNo(), parentAST.getColumnNo(),

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -196,11 +196,11 @@ public class JavaNCSSCheck extends Check
     {
         final int tokenType = ast.getType();
 
-        if ((TokenTypes.CLASS_DEF == tokenType)
-            || (TokenTypes.METHOD_DEF == tokenType)
-            || (TokenTypes.CTOR_DEF == tokenType)
-            || (TokenTypes.STATIC_INIT == tokenType)
-            || (TokenTypes.INSTANCE_INIT == tokenType))
+        if (TokenTypes.CLASS_DEF == tokenType
+            || TokenTypes.METHOD_DEF == tokenType
+            || TokenTypes.CTOR_DEF == tokenType
+            || TokenTypes.STATIC_INIT == tokenType
+            || TokenTypes.INSTANCE_INIT == tokenType)
         {
             //add a counter for this class/method
             counters.push(new Counter());
@@ -219,10 +219,10 @@ public class JavaNCSSCheck extends Check
     public void leaveToken(DetailAST ast)
     {
         final int tokenType = ast.getType();
-        if ((TokenTypes.METHOD_DEF == tokenType)
-            || (TokenTypes.CTOR_DEF == tokenType)
-            || (TokenTypes.STATIC_INIT == tokenType)
-            || (TokenTypes.INSTANCE_INIT == tokenType))
+        if (TokenTypes.METHOD_DEF == tokenType
+            || TokenTypes.CTOR_DEF == tokenType
+            || TokenTypes.STATIC_INIT == tokenType
+            || TokenTypes.INSTANCE_INIT == tokenType)
         {
             //pop counter from the stack
             final Counter counter = counters.pop();
@@ -329,8 +329,8 @@ public class JavaNCSSCheck extends Check
         // object block
         final int parentType = ast.getParent().getType();
 
-        if ((TokenTypes.SLIST == parentType)
-            || (TokenTypes.OBJBLOCK == parentType))
+        if (TokenTypes.SLIST == parentType
+            || TokenTypes.OBJBLOCK == parentType)
         {
             final DetailAST prevSibling = ast.getPreviousSibling();
 
@@ -338,8 +338,8 @@ public class JavaNCSSCheck extends Check
             //the sibling is no COMMA.
             //This is done because multiple assignment on one line are countes
             // as 1
-            countable = (prevSibling == null)
-                    || (TokenTypes.COMMA != prevSibling.getType());
+            countable = prevSibling == null
+                    || TokenTypes.COMMA != prevSibling.getType();
         }
 
         return countable;
@@ -369,8 +369,8 @@ public class JavaNCSSCheck extends Check
             case TokenTypes.LITERAL_ELSE :
                 //don't count if or loop conditions
                 final DetailAST prevSibling = ast.getPreviousSibling();
-                countable = (prevSibling == null)
-                    || (TokenTypes.LPAREN != prevSibling.getType());
+                countable = prevSibling == null
+                    || TokenTypes.LPAREN != prevSibling.getType();
                 break;
             default :
                 countable = false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
@@ -151,7 +151,7 @@ public class ModifierOrderCheck
         do {
             modifier = it.next();
         }
-        while (it.hasNext() && (modifier.getType() == TokenTypes.ANNOTATION));
+        while (it.hasNext() && modifier.getType() == TokenTypes.ANNOTATION);
 
         //All modifiers are annotations, no problem
         if (modifier.getType() == TokenTypes.ANNOTATION) {
@@ -164,7 +164,7 @@ public class ModifierOrderCheck
                 return modifier;
             }
 
-            while ((i < JLS_ORDER.length)
+            while (i < JLS_ORDER.length
                    && !JLS_ORDER[i].equals(modifier.getText()))
             {
                 i++;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
@@ -99,11 +99,11 @@ public class RedundantModifierCheck
                 // is not a method or annotation field
 
                 final int type = modifier.getType();
-                if ((type == TokenTypes.LITERAL_PUBLIC)
-                    || ((type == TokenTypes.LITERAL_STATIC)
-                            && ast.getType() != TokenTypes.METHOD_DEF)
-                    || (type == TokenTypes.ABSTRACT)
-                    || (type == TokenTypes.FINAL))
+                if (type == TokenTypes.LITERAL_PUBLIC
+                    || type == TokenTypes.LITERAL_STATIC
+                            && ast.getType() != TokenTypes.METHOD_DEF
+                    || type == TokenTypes.ABSTRACT
+                    || type == TokenTypes.FINAL)
                 {
                     log(modifier.getLineNo(), modifier.getColumnNo(),
                             MSG_KEY, modifier.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -233,10 +233,10 @@ public class AbbreviationAsWordInNameCheck extends Check
                 result = true;
             }
             else {
-                result = (ignoreFinal
-                          && modifiers.branchContains(TokenTypes.FINAL))
-                    || (ignoreStatic
-                        && modifiers.branchContains(TokenTypes.LITERAL_STATIC));
+                result = ignoreFinal
+                          && modifiers.branchContains(TokenTypes.FINAL)
+                    || ignoreStatic
+                        && modifiers.branchContains(TokenTypes.LITERAL_STATIC);
             }
         }
         else if (ast.getType() == TokenTypes.METHOD_DEF) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractAccessControlNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractAccessControlNameCheck.java
@@ -98,10 +98,10 @@ public abstract class AbstractAccessControlNameCheck
                 .branchContains(TokenTypes.LITERAL_PRIVATE);
         final boolean isPackage = !(isPublic || isProtected || isPrivate);
 
-        return (applyToPublic && isPublic)
-                || (applyToProtected && isProtected)
-                || (applyToPackage && isPackage)
-                || (applyToPrivate && isPrivate);
+        return applyToPublic && isPublic
+                || applyToProtected && isProtected
+                || applyToPackage && isPackage
+                || applyToPrivate && isPrivate;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.java
@@ -67,9 +67,9 @@ public abstract class AbstractTypeParameterNameCheck
     {
         this.location = getLocation();
 
-        assert (this.location == TokenTypes.CLASS_DEF)
-            || (this.location == TokenTypes.METHOD_DEF)
-            || (this.location == TokenTypes.INTERFACE_DEF);
+        assert this.location == TokenTypes.CLASS_DEF
+            || this.location == TokenTypes.METHOD_DEF
+            || this.location == TokenTypes.INTERFACE_DEF;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
@@ -81,22 +81,22 @@ public class ConstantNameCheck
 
         final DetailAST modifiersAST =
             ast.findFirstToken(TokenTypes.MODIFIERS);
-        final boolean isStatic = (modifiersAST != null)
+        final boolean isStatic = modifiersAST != null
             && modifiersAST.branchContains(TokenTypes.LITERAL_STATIC);
-        final boolean isFinal = (modifiersAST != null)
+        final boolean isFinal = modifiersAST != null
             && modifiersAST.branchContains(TokenTypes.FINAL);
 
-        if ((isStatic  && isFinal && shouldCheckInScope(modifiersAST))
+        if (isStatic  && isFinal && shouldCheckInScope(modifiersAST)
                 || ScopeUtils.inAnnotationBlock(ast)
-                || (ScopeUtils.inInterfaceOrAnnotationBlock(ast)
-                        && !ScopeUtils.inCodeBlock(ast)))
+                || ScopeUtils.inInterfaceOrAnnotationBlock(ast)
+                        && !ScopeUtils.inCodeBlock(ast))
         {
             // Handle the serialVersionUID and serialPersistentFields constants
             // which are used for Serialization. Cannot enforce rules on it. :-)
             final DetailAST nameAST = ast.findFirstToken(TokenTypes.IDENT);
-            if ((nameAST != null)
-                && !("serialVersionUID".equals(nameAST.getText()))
-                && !("serialPersistentFields".equals(nameAST.getText())))
+            if (nameAST != null
+                && !"serialVersionUID".equals(nameAST.getText())
+                && !"serialPersistentFields".equals(nameAST.getText()))
             {
                 retVal = true;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheck.java
@@ -80,8 +80,8 @@ public class LocalFinalVariableNameCheck
     {
         final DetailAST modifiersAST =
             ast.findFirstToken(TokenTypes.MODIFIERS);
-        final boolean isFinal = (modifiersAST != null)
+        final boolean isFinal = modifiersAST != null
             && modifiersAST.branchContains(TokenTypes.FINAL);
-        return (isFinal && ScopeUtils.isLocalVariableDef(ast));
+        return isFinal && ScopeUtils.isLocalVariableDef(ast);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheck.java
@@ -116,14 +116,14 @@ public class LocalVariableNameCheck
     {
         final DetailAST modifiersAST =
             ast.findFirstToken(TokenTypes.MODIFIERS);
-        final boolean isFinal = (modifiersAST != null)
+        final boolean isFinal = modifiersAST != null
             && modifiersAST.branchContains(TokenTypes.FINAL);
         if (allowOneCharVarInForLoop && isForLoopVariable(ast)) {
             final String variableName =
                     ast.findFirstToken(TokenTypes.IDENT).getText();
             return !sSingleChar.matcher(variableName).find();
         }
-        return (!isFinal && ScopeUtils.isLocalVariableDef(ast));
+        return !isFinal && ScopeUtils.isLocalVariableDef(ast);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheck.java
@@ -74,11 +74,11 @@ public class MemberNameCheck
     {
         final DetailAST modifiersAST =
             ast.findFirstToken(TokenTypes.MODIFIERS);
-        final boolean isStatic = (modifiersAST != null)
+        final boolean isStatic = modifiersAST != null
             && modifiersAST.branchContains(TokenTypes.LITERAL_STATIC);
 
-        return (!isStatic && !ScopeUtils.inInterfaceOrAnnotationBlock(ast)
-            && !ScopeUtils.isLocalVariableDef(ast))
-            && shouldCheckInScope(modifiersAST);
+        return !isStatic && !ScopeUtils.inInterfaceOrAnnotationBlock(ast)
+            && !ScopeUtils.isLocalVariableDef(ast)
+                && shouldCheckInScope(modifiersAST);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
@@ -135,7 +135,7 @@ public class MethodNameCheck
             // new Outclass.InnerInterface(x) { ... }
             // Such a rare case, will not have the logic to handle parsing
             // down the tree looking for the first ident.
-            if ((null != classIdent)
+            if (null != classIdent
                 && method.getText().equals(classIdent.getText()))
             {
                 log(method.getLineNo(), method.getColumnNo(),

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -74,7 +74,7 @@ public class ParameterNameCheck
     protected boolean mustCheckName(DetailAST ast)
     {
         return !(
-            (ast.getParent() != null)
-                && (ast.getParent().getType() == TokenTypes.LITERAL_CATCH));
+            ast.getParent() != null
+                && ast.getParent().getType() == TokenTypes.LITERAL_CATCH);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheck.java
@@ -72,14 +72,14 @@ public class StaticVariableNameCheck
     {
         final DetailAST modifiersAST =
             ast.findFirstToken(TokenTypes.MODIFIERS);
-        final boolean isStatic = (modifiersAST != null)
+        final boolean isStatic = modifiersAST != null
             && modifiersAST.branchContains(TokenTypes.LITERAL_STATIC);
-        final boolean isFinal = (modifiersAST != null)
+        final boolean isFinal = modifiersAST != null
             && modifiersAST.branchContains(TokenTypes.FINAL);
 
-        return (isStatic
+        return isStatic
                 && !isFinal
                 && shouldCheckInScope(modifiersAST)
-                && !ScopeUtils.inInterfaceOrAnnotationBlock(ast));
+                && !ScopeUtils.inInterfaceOrAnnotationBlock(ast);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/CommentSuppressor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/CommentSuppressor.java
@@ -34,7 +34,7 @@ class CommentSuppressor implements MatchSuppressor
     public boolean shouldSuppress(int startLineNo, int startColNo,
             int endLineNo, int endColNo)
     {
-        return (null != currentContents)
+        return null != currentContents
                 && currentContents.hasIntersectionWithComment(startLineNo,
                         startColNo, endLineNo, endColNo);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
@@ -195,7 +195,7 @@ class DetectorOptions
      */
     public Pattern getPattern()
     {
-        final int options = (ignoreCase) ? compileFlags
+        final int options = ignoreCase ? compileFlags
                 | Pattern.CASE_INSENSITIVE : compileFlags;
         return Utils.getPattern(format, options);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
@@ -185,10 +185,10 @@ public final class ExecutableStatementCountCheck
             DetailAST parent = ast.getParent();
             while (parent != null) {
                 final int type = parent.getType();
-                if ((type == TokenTypes.CTOR_DEF)
-                    || (type == TokenTypes.METHOD_DEF)
-                    || (type == TokenTypes.INSTANCE_INIT)
-                    || (type == TokenTypes.STATIC_INIT))
+                if (type == TokenTypes.CTOR_DEF
+                    || type == TokenTypes.METHOD_DEF
+                    || type == TokenTypes.INSTANCE_INIT
+                    || type == TokenTypes.STATIC_INIT)
                 {
                     if (parent == contextAST) {
                         context.addCount(ast.getChildCount() / 2);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
@@ -117,7 +117,7 @@ public class LineLengthCheck extends Check
                 line, line.length(), getTabWidth());
 
 
-            if ((realLength > max)
+            if (realLength > max
                 && !ignorePattern.matcher(line).find())
             {
                 log(i + 1, MSG_KEY, max, realLength);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
@@ -111,7 +111,7 @@ public final class MethodCountCheck extends Check
         int value(Scope scope)
         {
             final Integer value = counts.get(scope);
-            return (null == value) ? 0 : value;
+            return null == value ? 0 : value;
         }
 
         /** @return the total number of methods. */
@@ -164,10 +164,10 @@ public final class MethodCountCheck extends Check
     @Override
     public void visitToken(DetailAST ast)
     {
-        if ((TokenTypes.CLASS_DEF == ast.getType())
-            || (TokenTypes.INTERFACE_DEF == ast.getType())
-            || (TokenTypes.ENUM_CONSTANT_DEF == ast.getType())
-            || (TokenTypes.ENUM_DEF == ast.getType()))
+        if (TokenTypes.CLASS_DEF == ast.getType()
+            || TokenTypes.INTERFACE_DEF == ast.getType()
+            || TokenTypes.ENUM_CONSTANT_DEF == ast.getType()
+            || TokenTypes.ENUM_DEF == ast.getType())
         {
             counters.push(new MethodCounter(
                 TokenTypes.INTERFACE_DEF == ast.getType()));
@@ -180,10 +180,10 @@ public final class MethodCountCheck extends Check
     @Override
     public void leaveToken(DetailAST ast)
     {
-        if ((TokenTypes.CLASS_DEF == ast.getType())
-            || (TokenTypes.INTERFACE_DEF == ast.getType())
-            || (TokenTypes.ENUM_CONSTANT_DEF == ast.getType())
-            || (TokenTypes.ENUM_DEF == ast.getType()))
+        if (TokenTypes.CLASS_DEF == ast.getType()
+            || TokenTypes.INTERFACE_DEF == ast.getType()
+            || TokenTypes.ENUM_CONSTANT_DEF == ast.getType()
+            || TokenTypes.ENUM_DEF == ast.getType())
         {
             final MethodCounter counter = counters.pop();
             checkCounters(counter, ast);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/AbstractParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/AbstractParenPadCheck.java
@@ -74,14 +74,14 @@ abstract class AbstractParenPadCheck
         final String line = getLines()[ast.getLineNo() - 1];
         final int after = ast.getColumnNo() + 1;
         if (after < line.length()) {
-            if ((PadOption.NOSPACE == getAbstractOption())
-                && (Character.isWhitespace(line.charAt(after))))
+            if (PadOption.NOSPACE == getAbstractOption()
+                && Character.isWhitespace(line.charAt(after)))
             {
                 log(ast.getLineNo(), after, WS_FOLLOWED, "(");
             }
-            else if ((PadOption.SPACE == getAbstractOption())
+            else if (PadOption.SPACE == getAbstractOption()
                      && !Character.isWhitespace(line.charAt(after))
-                     && (line.charAt(after) != ')'))
+                     && line.charAt(after) != ')')
             {
                 log(ast.getLineNo(), after, WS_NOT_FOLLOWED, "(");
             }
@@ -97,15 +97,15 @@ abstract class AbstractParenPadCheck
         final String line = getLines()[ast.getLineNo() - 1];
         final int before = ast.getColumnNo() - 1;
         if (before >= 0) {
-            if ((PadOption.NOSPACE == getAbstractOption())
+            if (PadOption.NOSPACE == getAbstractOption()
                 && Character.isWhitespace(line.charAt(before))
                 && !Utils.whitespaceBefore(before, line))
             {
                 log(ast.getLineNo(), before, WS_PRECEDED, ")");
             }
-            else if ((PadOption.SPACE == getAbstractOption())
+            else if (PadOption.SPACE == getAbstractOption()
                 && !Character.isWhitespace(line.charAt(before))
-                && (line.charAt(before) != '('))
+                && line.charAt(before) != '(')
             {
                 log(ast.getLineNo(), ast.getColumnNo(),
                     WS_NOT_PRECEDED, ")");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
@@ -96,12 +96,12 @@ public class EmptyForInitializerPadCheck
             //don't check if semi at beginning of line
             if (!Utils.whitespaceBefore(before, line)) {
                 final PadOption option = getAbstractOption();
-                if ((PadOption.NOSPACE == option)
-                    && (Character.isWhitespace(line.charAt(before))))
+                if (PadOption.NOSPACE == option
+                    && Character.isWhitespace(line.charAt(before)))
                 {
                     log(semi.getLineNo(), before, MSG_PRECEDED, ";");
                 }
-                else if ((PadOption.SPACE == option)
+                else if (PadOption.SPACE == option
                          && !Character.isWhitespace(line.charAt(before)))
                 {
                     log(semi.getLineNo(), before, MSG_NOT_PRECEDED, ";");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
@@ -94,12 +94,12 @@ public class EmptyForIteratorPadCheck
             final int after = semi.getColumnNo() + 1;
             //don't check if at end of line
             if (after < line.length()) {
-                if ((PadOption.NOSPACE == getAbstractOption())
-                    && (Character.isWhitespace(line.charAt(after))))
+                if (PadOption.NOSPACE == getAbstractOption()
+                    && Character.isWhitespace(line.charAt(after)))
                 {
                     log(semi.getLineNo(), after, WS_FOLLOWED, ";");
                 }
-                else if ((PadOption.SPACE == getAbstractOption())
+                else if (PadOption.SPACE == getAbstractOption()
                          && !Character.isWhitespace(line.charAt(after)))
                 {
                     log(semi.getLineNo(), after, WS_NOT_FOLLOWED, ";");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -250,8 +250,8 @@ public class EmptyLineSeparatorCheck extends Check
                     break;
                 case TokenTypes.IMPORT:
                     if (astType != nextToken.getType() && !hasEmptyLineAfter(ast)
-                        || (ast.getLineNo() > 1 && !hasEmptyLineBefore(ast)
-                            && ast.getPreviousSibling() == null))
+                        || ast.getLineNo() > 1 && !hasEmptyLineBefore(ast)
+                            && ast.getPreviousSibling() == null)
                     {
                         log(nextToken.getLineNo(), MSG_SHOULD_BE_SEPARATED, nextToken.getText());
                     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -139,7 +139,7 @@ public class GenericWhitespaceCheck extends Check
         final int before = ast.getColumnNo() - 1;
         final int after = ast.getColumnNo() + 1;
 
-        if ((0 <= before) && Character.isWhitespace(line.charAt(before))
+        if (0 <= before && Character.isWhitespace(line.charAt(before))
                 && !Utils.whitespaceBefore(before, line))
         {
             log(ast.getLineNo(), before, WS_PRECEDED, ">");
@@ -156,21 +156,21 @@ public class GenericWhitespaceCheck extends Check
                 //    Collections.<Object>emptySet();
                 //                        ^
                 //                        +--- whitespace not allowed
-                if ((ast.getParent().getType() == TokenTypes.TYPE_ARGUMENTS)
-                        && ((ast.getParent().getParent().getType()
-                            == TokenTypes.DOT)
-                        && (ast.getParent().getParent().getParent().getType()
-                            == TokenTypes.METHOD_CALL))
-                    || isAfterMethodReference(ast))
+                if (ast.getParent().getType() == TokenTypes.TYPE_ARGUMENTS
+                        && ast.getParent().getParent().getType()
+                            == TokenTypes.DOT
+                        && ast.getParent().getParent().getParent().getType()
+                            == TokenTypes.METHOD_CALL
+                        || isAfterMethodReference(ast))
                 {
                     if (Character.isWhitespace(charAfter)) {
                         log(ast.getLineNo(), after, WS_FOLLOWED, ">");
                     }
                 }
                 else if (!Character.isWhitespace(charAfter)
-                    && ('(' != charAfter) && (')' != charAfter)
-                    && (',' != charAfter) && ('[' != charAfter)
-                    && ('.' != charAfter) && (':' != charAfter)
+                    && '(' != charAfter && ')' != charAfter
+                    && ',' != charAfter && '[' != charAfter
+                    && '.' != charAfter && ':' != charAfter
                     && !isAfterMethodReference(ast))
                 {
                     log(ast.getLineNo(), after, WS_ILLEGAL_FOLLOW, ">");
@@ -186,7 +186,7 @@ public class GenericWhitespaceCheck extends Check
                 //   should be whitespace if followed by & -+
                 //
                 final int indexOfAmp = line.indexOf('&', after);
-                if ((indexOfAmp != -1)
+                if (indexOfAmp != -1
                     && whitespaceBetween(after, indexOfAmp, line))
                 {
                     if (indexOfAmp - after == 0) {
@@ -234,9 +234,9 @@ public class GenericWhitespaceCheck extends Check
             // Detect if the first case
             final DetailAST parent = ast.getParent();
             final DetailAST grandparent = parent.getParent();
-            if ((TokenTypes.TYPE_PARAMETERS == parent.getType())
-                && ((TokenTypes.CTOR_DEF == grandparent.getType())
-                    || (TokenTypes.METHOD_DEF == grandparent.getType())))
+            if (TokenTypes.TYPE_PARAMETERS == parent.getType()
+                && (TokenTypes.CTOR_DEF == grandparent.getType()
+                    || TokenTypes.METHOD_DEF == grandparent.getType()))
             {
                 // Require whitespace
                 if (!Character.isWhitespace(line.charAt(before))) {
@@ -251,7 +251,7 @@ public class GenericWhitespaceCheck extends Check
             }
         }
 
-        if ((after < line.length())
+        if (after < line.length()
                 && Character.isWhitespace(line.charAt(after)))
         {
             log(ast.getLineNo(), after, WS_FOLLOWED, "<");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
@@ -123,7 +123,7 @@ public class MethodParamPadCheck
     public void visitToken(DetailAST ast)
     {
         final DetailAST parenAST;
-        if ((ast.getType() == TokenTypes.METHOD_CALL)) {
+        if (ast.getType() == TokenTypes.METHOD_CALL) {
             parenAST = ast;
         }
         else {
@@ -142,12 +142,12 @@ public class MethodParamPadCheck
         }
         else {
             final int before = parenAST.getColumnNo() - 1;
-            if ((PadOption.NOSPACE == getAbstractOption())
-                && (Character.isWhitespace(line.charAt(before))))
+            if (PadOption.NOSPACE == getAbstractOption()
+                && Character.isWhitespace(line.charAt(before)))
             {
                 log(parenAST , WS_PRECEDED, parenAST.getText());
             }
-            else if ((PadOption.SPACE == getAbstractOption())
+            else if (PadOption.SPACE == getAbstractOption()
                      && !Character.isWhitespace(line.charAt(before)))
             {
                 log(parenAST, WS_NOT_PRECEDED, parenAST.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -316,7 +316,7 @@ public class NoWhitespaceAfterCheck extends Check
     private boolean hasRedundantWhitespace(String line, int after)
     {
         boolean result = !allowLineBreaks;
-        for (int i = after + 1; !result && (i < line.length()); i++) {
+        for (int i = after + 1; !result && i < line.length(); i++) {
             if (!Character.isWhitespace(line.charAt(i))) {
                 result = true;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
@@ -97,14 +97,14 @@ public class NoWhitespaceBeforeCheck
         final String line = getLine(ast.getLineNo() - 1);
         final int before = ast.getColumnNo() - 1;
 
-        if ((before < 0) || Character.isWhitespace(line.charAt(before))) {
+        if (before < 0 || Character.isWhitespace(line.charAt(before))) {
 
             // empty FOR initializer?
             if (ast.getType() == TokenTypes.SEMI) {
                 final DetailAST sibling = ast.getPreviousSibling();
-                if ((sibling != null)
-                        && (sibling.getType() == TokenTypes.FOR_INIT)
-                        && (sibling.getChildCount() == 0))
+                if (sibling != null
+                        && sibling.getType() == TokenTypes.FOR_INIT
+                        && sibling.getChildCount() == 0)
                 {
                     return;
                 }
@@ -112,7 +112,7 @@ public class NoWhitespaceBeforeCheck
 
             boolean flag = !allowLineBreaks;
             // verify all characters before '.' are whitespace
-            for (int i = 0; !flag && (i < before); i++) {
+            for (int i = 0; !flag && i < before; i++) {
                 if (!Character.isWhitespace(line.charAt(i))) {
                     flag = true;
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
@@ -188,8 +188,8 @@ public class OperatorWrapCheck
     {
         if (ast.getType() == TokenTypes.COLON) {
             final DetailAST parent = ast.getParent();
-            if ((parent.getType() == TokenTypes.LITERAL_DEFAULT)
-                || (parent.getType() == TokenTypes.LITERAL_CASE))
+            if (parent.getType() == TokenTypes.LITERAL_DEFAULT
+                || parent.getType() == TokenTypes.LITERAL_CASE)
             {
                 //we do not want to check colon for cases and defaults
                 return;
@@ -206,14 +206,14 @@ public class OperatorWrapCheck
         // Check if rest of line is whitespace, and not just the operator
         // by itself. This last bit is to handle the operator on a line by
         // itself.
-        if ((wOp == WrapOption.NL)
+        if (wOp == WrapOption.NL
             && !text.equals(currentLine.trim())
-            && (currentLine.substring(colNo + text.length())
-                .trim().length() == 0))
+            && currentLine.substring(colNo + text.length())
+                .trim().length() == 0)
         {
             log(lineNo, colNo, LINE_NEW, text);
         }
-        else if ((wOp == WrapOption.EOL)
+        else if (wOp == WrapOption.EOL
                   && Utils.whitespaceBefore(colNo - 1, currentLine))
         {
             log(lineNo, colNo, LINE_PREVIOUS, text);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
@@ -92,8 +92,8 @@ public class ParenPadCheck extends AbstractParenPadCheck
         // Strange logic in this method to guard against checking RPAREN tokens
         // that are associated with a TYPECAST token.
         if (theAst.getType() != TokenTypes.RPAREN) {
-            if ((theAst.getType() == TokenTypes.CTOR_CALL)
-                || (theAst.getType() == TokenTypes.SUPER_CTOR_CALL))
+            if (theAst.getType() == TokenTypes.CTOR_CALL
+                || theAst.getType() == TokenTypes.SUPER_CTOR_CALL)
             {
                 theAst = theAst.getFirstChild();
             }
@@ -101,10 +101,10 @@ public class ParenPadCheck extends AbstractParenPadCheck
                 processLeft(theAst);
             }
         }
-        else if (((theAst.getParent() == null)
-                 || (theAst.getParent().getType() != TokenTypes.TYPECAST)
-                 || (theAst.getParent().findFirstToken(TokenTypes.RPAREN)
-                     != theAst))
+        else if ((theAst.getParent() == null
+                 || theAst.getParent().getType() != TokenTypes.TYPECAST
+                 || theAst.getParent().findFirstToken(TokenTypes.RPAREN)
+                     != theAst)
                  && !isFollowsEmptyForIterator(theAst))
         {
             processRight(theAst);
@@ -120,14 +120,14 @@ public class ParenPadCheck extends AbstractParenPadCheck
         boolean followsEmptyForIterator = false;
         final DetailAST parent = ast.getParent();
         //Only traditional for statements are examined, not for-each statements
-        if ((parent != null)
-            && (parent.getType() == TokenTypes.LITERAL_FOR)
-            && (parent.findFirstToken(TokenTypes.FOR_EACH_CLAUSE) == null))
+        if (parent != null
+            && parent.getType() == TokenTypes.LITERAL_FOR
+            && parent.findFirstToken(TokenTypes.FOR_EACH_CLAUSE) == null)
         {
             final DetailAST forIterator =
                 parent.findFirstToken(TokenTypes.FOR_ITERATOR);
-            followsEmptyForIterator = (forIterator.getChildCount() == 0)
-                && (ast == forIterator.getNextSibling());
+            followsEmptyForIterator = forIterator.getChildCount() == 0
+                && ast == forIterator.getNextSibling();
         }
         return followsEmptyForIterator;
     }
@@ -141,14 +141,14 @@ public class ParenPadCheck extends AbstractParenPadCheck
         boolean preceedsEmptyForInintializer = false;
         final DetailAST parent = ast.getParent();
         //Only traditional for statements are examined, not for-each statements
-        if ((parent != null)
-            && (parent.getType() == TokenTypes.LITERAL_FOR)
-            && (parent.findFirstToken(TokenTypes.FOR_EACH_CLAUSE) == null))
+        if (parent != null
+            && parent.getType() == TokenTypes.LITERAL_FOR
+            && parent.findFirstToken(TokenTypes.FOR_EACH_CLAUSE) == null)
         {
             final DetailAST forIterator =
                     parent.findFirstToken(TokenTypes.FOR_INIT);
-            preceedsEmptyForInintializer = (forIterator.getChildCount() == 0)
-                    && (ast == forIterator.getPreviousSibling());
+            preceedsEmptyForInintializer = forIterator.getChildCount() == 0
+                    && ast == forIterator.getPreviousSibling();
         }
         return preceedsEmptyForInintializer;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
@@ -142,7 +142,7 @@ public class SeparatorWrapCheck
         final WrapOption wSp = getAbstractOption();
 
         if (wSp == WrapOption.EOL
-                && (substringBeforeToken.length() == 0))
+                && substringBeforeToken.length() == 0)
         {
             log(lineNo, colNo, LINE_PREVIOUS, text);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheck.java
@@ -75,10 +75,10 @@ public class TypecastParenPadCheck extends AbstractParenPadCheck
         if (ast.getType() == TokenTypes.TYPECAST) {
             processLeft(ast);
         }
-        else if ((ast.getParent() != null)
-                 && (ast.getParent().getType() == TokenTypes.TYPECAST)
-                 && (ast.getParent().findFirstToken(TokenTypes.RPAREN)
-                     == ast))
+        else if (ast.getParent() != null
+                 && ast.getParent().getType() == TokenTypes.TYPECAST
+                 && ast.getParent().findFirstToken(TokenTypes.RPAREN)
+                     == ast)
         {
             processRight(ast);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java
@@ -102,8 +102,8 @@ public class WhitespaceAfterCheck
         if (after < line.length()) {
 
             final char charAfter = line.charAt(after);
-            if ((targetAST.getType() == TokenTypes.SEMI)
-                && ((charAfter == ';') || (charAfter == ')')))
+            if (targetAST.getType() == TokenTypes.SEMI
+                && (charAfter == ';' || charAfter == ')'))
             {
                 return;
             }
@@ -112,9 +112,9 @@ public class WhitespaceAfterCheck
                 if (targetAST.getType() == TokenTypes.SEMI) {
                     final DetailAST sibling =
                         targetAST.getNextSibling();
-                    if ((sibling != null)
-                        && (sibling.getType() == TokenTypes.FOR_ITERATOR)
-                        && (sibling.getChildCount() == 0))
+                    if (sibling != null
+                        && sibling.getType() == TokenTypes.FOR_ITERATOR
+                        && sibling.getChildCount() == 0)
                     {
                         return;
                     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -347,29 +347,29 @@ public class WhitespaceAroundCheck extends Check
         final int parentType = ast.getParent().getType();
 
         // Check for CURLY in array initializer
-        if (((currentType == TokenTypes.RCURLY)
-                || (currentType == TokenTypes.LCURLY))
-            && ((parentType == TokenTypes.ARRAY_INIT)
-                || (parentType == TokenTypes.ANNOTATION_ARRAY_INIT)))
+        if ((currentType == TokenTypes.RCURLY
+                || currentType == TokenTypes.LCURLY)
+            && (parentType == TokenTypes.ARRAY_INIT
+                || parentType == TokenTypes.ANNOTATION_ARRAY_INIT))
         {
             return;
         }
 
         // Check for import pkg.name.*;
-        if ((currentType == TokenTypes.STAR)
-            && (parentType == TokenTypes.DOT))
+        if (currentType == TokenTypes.STAR
+            && parentType == TokenTypes.DOT)
         {
             return;
         }
 
         // Check for an SLIST that has a parent CASE_GROUP. It is not a '{'.
-        if ((currentType == TokenTypes.SLIST)
-            && (parentType == TokenTypes.CASE_GROUP))
+        if (currentType == TokenTypes.SLIST
+            && parentType == TokenTypes.CASE_GROUP)
         {
             return;
         }
 
-        if ((currentType == TokenTypes.COLON)) {
+        if (currentType == TokenTypes.COLON) {
             //we do not want to check colon for cases and defaults
             if (parentType == TokenTypes.LITERAL_DEFAULT
                 || parentType == TokenTypes.LITERAL_CASE)
@@ -392,7 +392,7 @@ public class WhitespaceAroundCheck extends Check
         }
 
         // Checks if empty classes, interfaces or enums are allowed
-        if (allowEmptyTypes && (isEmptyType(ast, parentType))) {
+        if (allowEmptyTypes && isEmptyType(ast, parentType)) {
             return;
         }
 
@@ -400,7 +400,7 @@ public class WhitespaceAroundCheck extends Check
         final int before = ast.getColumnNo() - 1;
         final int after = ast.getColumnNo() + ast.getText().length();
 
-        if ((before >= 0) && !Character.isWhitespace(line.charAt(before))) {
+        if (before >= 0 && !Character.isWhitespace(line.charAt(before))) {
             log(ast.getLineNo(), ast.getColumnNo(),
                     WS_NOT_PRECEDED, ast.getText());
         }
@@ -412,14 +412,14 @@ public class WhitespaceAroundCheck extends Check
         final char nextChar = line.charAt(after);
         if (!Character.isWhitespace(nextChar)
             // Check for "return;"
-            && !((currentType == TokenTypes.LITERAL_RETURN)
-                && (ast.getFirstChild().getType() == TokenTypes.SEMI))
+            && !(currentType == TokenTypes.LITERAL_RETURN
+                && ast.getFirstChild().getType() == TokenTypes.SEMI)
             // Check for "})" or "};" or "},". Happens with anon-inners
-            && !((currentType == TokenTypes.RCURLY)
-                && ((nextChar == ')')
-                    || (nextChar == ';')
-                    || (nextChar == ',')
-                    || (nextChar == '.'))))
+            && !(currentType == TokenTypes.RCURLY
+                && (nextChar == ')'
+                    || nextChar == ';'
+                    || nextChar == ','
+                    || nextChar == '.')))
         {
             log(ast.getLineNo(), ast.getColumnNo() + ast.getText().length(),
                     WS_NOT_FOLLOWED, ast.getText());
@@ -524,12 +524,12 @@ public class WhitespaceAroundCheck extends Check
         final int type = ast.getType();
         if (type == TokenTypes.RCURLY) {
             final DetailAST grandParent = ast.getParent().getParent();
-            return (parentType == TokenTypes.SLIST)
-                && (grandParent.getType() == match);
+            return parentType == TokenTypes.SLIST
+                && grandParent.getType() == match;
         }
 
-        return (type == TokenTypes.SLIST)
-            && (parentType == match)
-            && (ast.getFirstChild().getType() == TokenTypes.RCURLY);
+        return type == TokenTypes.SLIST
+            && parentType == match
+            && ast.getFirstChild().getType() == TokenTypes.RCURLY;
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/doclets/CheckDocsDoclet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/doclets/CheckDocsDoclet.java
@@ -88,7 +88,7 @@ public final class CheckDocsDoclet
     {
         final String openTag = "<p>";
         final int tagLen = openTag.length();
-        if ((text.length() > tagLen)
+        if (text.length() > tagLen
                 && text.substring(0, tagLen).equals(openTag))
         {
             text.delete(0, tagLen);
@@ -185,7 +185,7 @@ public final class CheckDocsDoclet
                 // allow checks to override pageName when
                 // java package hierarchy is not reflected in doc structure
                 final Tag[] docPageTags = classDoc.tags("checkstyle-docpage");
-                if ((docPageTags != null) && (docPageTags.length > 0)) {
+                if (docPageTags != null && docPageTags.length > 0) {
                     pageName = docPageTags[0].text();
                 }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
@@ -61,7 +61,7 @@ public final class TokenTypesDoclet
         try {
             ps = new PrintStream(fos);
             final ClassDoc[] classes = root.classes();
-            if ((classes.length != 1)
+            if (classes.length != 1
                 || !"TokenTypes".equals(classes[0].name()))
             {
                 final String message =
@@ -72,7 +72,7 @@ public final class TokenTypesDoclet
             final FieldDoc[] fields = classes[0].fields();
             for (final FieldDoc field : fields) {
                 if (field.isStatic() && field.isPublic() && field.isFinal()
-                    && "int".equals((field.type().qualifiedTypeName())))
+                    && "int".equals(field.type().qualifiedTypeName()))
                 {
                     if (field.firstSentenceTags().length != 1) {
                         final String message = "Should be only one tag.";

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilter.java
@@ -49,8 +49,8 @@ class IntRangeFilter implements IntFilter
     @Override
     public boolean accept(int intValue)
     {
-        return ((lowerBound.compareTo(intValue) <= 0)
-            && (upperBound.compareTo(intValue) >= 0));
+        return lowerBound.compareTo(intValue) <= 0
+            && upperBound.compareTo(intValue) >= 0;
     }
 
     @Override
@@ -64,8 +64,8 @@ class IntRangeFilter implements IntFilter
     {
         if (object instanceof IntRangeFilter) {
             final IntRangeFilter other = (IntRangeFilter) object;
-            return (this.lowerBound.equals(other.lowerBound)
-                && this.upperBound.equals(other.upperBound));
+            return this.lowerBound.equals(other.lowerBound)
+                && this.upperBound.equals(other.upperBound);
         }
         return false;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressElement.java
@@ -139,19 +139,19 @@ public class SuppressElement
     public boolean accept(AuditEvent event)
     {
         // file and check match?
-        if ((event.getFileName() == null)
+        if (event.getFileName() == null
                 || !fileRegexp.matcher(event.getFileName()).find()
-                || (event.getLocalizedMessage() == null)
-                || ((moduleId != null) && !moduleId.equals(event
-                        .getModuleId()))
-                || ((checkRegexp != null) && !checkRegexp.matcher(
-                        event.getSourceName()).find()))
+                || event.getLocalizedMessage() == null
+                || moduleId != null && !moduleId.equals(event
+                        .getModuleId())
+                || checkRegexp != null && !checkRegexp.matcher(
+                        event.getSourceName()).find())
         {
             return true;
         }
 
         // reject if no line/column matching
-        if ((lineFilter == null) && (columnFilter == null)) {
+        if (lineFilter == null && columnFilter == null) {
             return false;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -186,7 +186,7 @@ public class SuppressWithNearbyCommentFilter
                 return lastLine - other.lastLine;
             }
 
-            return (firstLine - other.firstLine);
+            return firstLine - other.firstLine;
         }
 
         /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -190,7 +190,7 @@ public class SuppressionCommentFilter
                 return column - object.column;
             }
 
-            return (line - object.line);
+            return line - object.line;
         }
 
         /**
@@ -426,7 +426,7 @@ public class SuppressionCommentFilter
             tagSuppressions();
         }
         final Tag matchTag = findNearestMatch(event);
-        if ((matchTag != null) && !matchTag.isOn()) {
+        if (matchTag != null && !matchTag.isOn()) {
             return false;
         }
         return true;
@@ -444,9 +444,9 @@ public class SuppressionCommentFilter
         // TODO: try binary search if sequential search becomes a performance
         // problem.
         for (Tag tag : tags) {
-            if ((tag.getLine() > event.getLine())
-                || ((tag.getLine() == event.getLine())
-                    && (tag.getColumn() > event.getColumn())))
+            if (tag.getLine() > event.getLine()
+                || tag.getLine() == event.getLine()
+                    && tag.getColumn() > event.getColumn())
             {
                 break;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -100,7 +100,7 @@ public final class SuppressionsLoader
             }
             final String checks = atts.getValue("checks");
             final String modId = atts.getValue("id");
-            if ((checks == null) && (modId == null)) {
+            if (checks == null && modId == null) {
                 throw new SAXException("missing checks and id attribute");
             }
             final SuppressElement suppress;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
@@ -161,7 +161,7 @@ class FileDrop
             new DropTarget(c, dropListener);
         }
 
-        if (recursive && (c instanceof Container)) {
+        if (recursive && c instanceof Container) {
             final Container cont = (Container) c;
             final Component[] comps = cont.getComponents();
             for (Component element : comps)
@@ -178,7 +178,7 @@ class FileDrop
 
         // See if any of the flavors are a file list
         int i = 0;
-        while (!ok && (i < flavors.length)) {   // Is the flavor a file list?
+        while (!ok && i < flavors.length) {   // Is the flavor a file list?
             if (flavors[i].equals(DataFlavor.javaFileListFlavor))
                 ok = true;
             i++;
@@ -216,7 +216,7 @@ class FileDrop
     static void remove(Component c, boolean recursive)
     {
         c.setDropTarget(null);
-        if (recursive && (c instanceof Container)) {
+        if (recursive && c instanceof Container) {
             final Component[] comps = ((Container) c).getComponents();
             for (Component element : comps) {
                 remove(element, recursive);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
@@ -197,7 +197,7 @@ public class JTreeTable extends JTable
     public int getEditingRow()
     {
         final Class<?> editingClass = getColumnClass(editingColumn);
-        return (editingClass == TreeTableModel.class) ? -1 : editingRow;
+        return editingClass == TreeTableModel.class ? -1 : editingRow;
     }
 
     /**
@@ -207,7 +207,7 @@ public class JTreeTable extends JTable
     public void setRowHeight(int newRowHeight)
     {
         super.setRowHeight(newRowHeight);
-        if ((tree != null) && (tree.getRowHeight() != newRowHeight)) {
+        if (tree != null && tree.getRowHeight() != newRowHeight) {
             tree.setRowHeight(getRowHeight());
         }
     }
@@ -251,7 +251,7 @@ public class JTreeTable extends JTable
             // colors.
             final TreeCellRenderer tcr = getCellRenderer();
             if (tcr instanceof DefaultTreeCellRenderer) {
-                final DefaultTreeCellRenderer dtcr = ((DefaultTreeCellRenderer) tcr);
+                final DefaultTreeCellRenderer dtcr = (DefaultTreeCellRenderer) tcr;
                 // For 1.1 uncomment this, 1.2 has a bug that will cause an
                 // exception to be thrown if the border selection color is
                 // null.
@@ -272,8 +272,8 @@ public class JTreeTable extends JTable
         {
             if (newRowHeight > 0) {
                 super.setRowHeight(newRowHeight);
-                if ((JTreeTable.this != null) &&
-                    (JTreeTable.this.getRowHeight() != newRowHeight))
+                if (JTreeTable.this != null &&
+                        JTreeTable.this.getRowHeight() != newRowHeight)
                 {
                     JTreeTable.this.setRowHeight(getRowHeight());
                 }
@@ -464,7 +464,7 @@ public class JTreeTable extends JTable
                     final int max = listSelectionModel.getMaxSelectionIndex();
 
                     clearSelection();
-                    if ((min != -1) && (max != -1)) {
+                    if (min != -1 && max != -1) {
                         for (int counter = min; counter <= max; counter++) {
                             if (listSelectionModel.isSelectedIndex(counter)) {
                                 final TreePath selPath = tree.getPathForRow

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -163,7 +163,7 @@ public class ParseTreeInfoPanel extends JPanel
         @Override
         public void filesDropped(File[] files)
         {
-            if ((files != null) && (files.length > 0))
+            if (files != null && files.length > 0)
             {
                 final File file = files[0];
                 openFile(file, mSp);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -64,7 +64,7 @@ public class HeaderCheckTest extends BaseFileSetCheckTestSupport
     {
         final DefaultConfiguration checkConfig =
             createCheckConfig(RegexpHeaderCheck.class);
-        URI uri = (new File(getPath("regexp.header"))).toURI();
+        URI uri = new File(getPath("regexp.header")).toURI();
         checkConfig.addAttribute("headerFile", uri.toString());
         final String[] expected = {
             "3: " + getCheckMessage(MSG_MISMATCH, "// Created: 2002"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -146,16 +146,16 @@ public class IndentationCheckTest extends BaseCheckTestSupport
         if (match.matches()) {
             final int expectedLevel = Integer.parseInt(match.group(1));
 
-            return (expectedLevel == indentInComment) && !isWarnComment
-                    || (expectedLevel != indentInComment) && isWarnComment;
+            return expectedLevel == indentInComment && !isWarnComment
+                    || expectedLevel != indentInComment && isWarnComment;
         }
 
         match = NONSTRICT_LEVEL_COMMENT_REGEX.matcher(comment);
         if (match.matches()) {
             final int expectedMinimalIndent = Integer.parseInt(match.group(1));
 
-            return (indentInComment >= expectedMinimalIndent) && !isWarnComment
-                    || (indentInComment < expectedMinimalIndent) && isWarnComment;
+            return indentInComment >= expectedMinimalIndent && !isWarnComment
+                    || indentInComment < expectedMinimalIndent && isWarnComment;
         }
 
         throw new IllegalArgumentException();


### PR DESCRIPTION
All [UselessParentheses](http://pmd.sourceforge.net/pmd-5.2.3/pmd-java/rules/java/unnecessary.html#UselessParentheses) violations are fixed.

Parentheses are considered unnecessary if the evaluation order of an expression remains unchanged if the parentheses are removed.

After these changes number of PMD violations decrease from 736 to 17.