### PR TITLE
Remove unnecessary semicolons to fix PMD violations, issue #744

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -57,7 +57,9 @@
 
     <module name="AvoidStarImport"/>
     <module name="ConstantName"/>
-    <module name="EmptyBlock"/>
+    <module name="EmptyBlock">
+      <property name="option" value="text"/>
+    </module>
     <module name="EmptyForIteratorPad"/>
     <module name="EqualsHashCode"/>
     <module name="OneStatementPerLine"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -193,7 +193,6 @@ public final class ConfigurationLoader
                 }
                 catch (final CheckstyleException e) {
                     //severity not set -> ignore
-                    ;
                 }
 
                 // omit this module if these should be omitted and the module

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -80,7 +80,7 @@ class PackageObjectFactory implements ModuleFactory
             return createObject(name);
         }
         catch (final CheckstyleException ex) {
-            ; // keep looking
+            // keep looking
         }
 
         //now try packages
@@ -91,7 +91,7 @@ class PackageObjectFactory implements ModuleFactory
                 return createObject(className);
             }
             catch (final CheckstyleException ex) {
-                ; // keep looking
+                // keep looking
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
@@ -639,6 +639,6 @@ public enum JavadocTagInfo
         BLOCK,
 
         /** inline type. **/
-        INLINE;
+        INLINE
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Utils.java
@@ -284,7 +284,7 @@ public final class Utils
                 shutting.close();
             }
             catch (IOException e) {
-                ; // ignore
+                // ignore
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/BlockOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/BlockOption.java
@@ -46,5 +46,5 @@ public enum BlockOption
      * }
      * </pre>
      */
-    STMT;
+    STMT
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -307,7 +307,7 @@ public class LeftCurlyCheck
         if (braceLine.length() > brace.getColumnNo() + 1
             && braceLine.charAt(brace.getColumnNo() + 1) == '}')
         {
-            ; // ignore
+            // ignore
         }
         else if (getAbstractOption() == LeftCurlyOption.NL) {
             if (!Utils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
@@ -328,7 +328,7 @@ public class LeftCurlyCheck
         }
         else if (getAbstractOption() == LeftCurlyOption.NLOW) {
             if (startToken.getLineNo() == brace.getLineNo()) {
-                ; // all ok as on the same line
+                // all ok as on the same line
             }
             else if (startToken.getLineNo() + 1 == brace.getLineNo()) {
                 if (!Utils.whitespaceBefore(brace.getColumnNo(), braceLine)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyOption.java
@@ -69,5 +69,5 @@ public enum LeftCurlyOption
      *     ...
      * </pre>
      */
-    NL;
+    NL
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java
@@ -48,5 +48,5 @@ public enum RightCurlyOption
      * } finally {
      * </pre>
      **/
-    SAME;
+    SAME
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -267,7 +267,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check
         if (ignoreFinal && modifiers.branchContains(TokenTypes.FINAL)
                 || parentType == TokenTypes.OBJBLOCK)
         {
-            ;// no code
+            // no code
         }
         else {
             final DetailAST variable = ast.findFirstToken(TokenTypes.IDENT);
@@ -593,7 +593,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check
                 else if (currentNodeType == TokenTypes.VARIABLE_DEF
                         || currentNodeType == TokenTypes.EXPR)
                 {
-                    ; // no code
+                    // no code
                 }
                 else {
                     firstNodeInsideBlock = currentNode;
@@ -856,7 +856,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check
                         break;
 
                     default:
-                        ;// no code
+                        // no code
                 }
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderOption.java
@@ -102,5 +102,5 @@ public enum ImportOrderOption
         import static javax.swing.WindowConstants.*;
      * </pre>
      */
-    BOTTOM;
+    BOTTOM
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
@@ -195,7 +195,7 @@ public final class JavadocUtils
         /** inline type. */
         INLINE,
         /** all validTags. */
-        ALL;
+        ALL
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
@@ -119,7 +119,7 @@ public final class MethodCountCheck extends Check
         {
             return total;
         }
-    };
+    }
 
     /** default maximum number of methods */
     private static final int DEFAULT_MAX_METHODS = 100;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/PadOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/PadOption.java
@@ -37,5 +37,5 @@ public enum PadOption
      * Represents mandatory spacing following a left parenthesis
      * and preceeing a right one.
      */
-    SPACE;
+    SPACE
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WrapOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WrapOption.java
@@ -28,5 +28,5 @@ public enum WrapOption
     /** Require that the token is on a new line. */
     NL,
     /** Require that the token is at the end of the line. */
-    EOL;
+    EOL
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -453,7 +453,7 @@ public class SuppressionCommentFilter
             if (tag.isMatch(event)) {
                 result = tag;
             }
-        };
+        }
         return result;
     }
 


### PR DESCRIPTION
All violations of rule [EmptyStatementNotInLoop](http://pmd.sourceforge.net/pmd-5.2.3/pmd-java/rules/java/empty.html#EmptyStatementNotInLoop) are fixed. 

Empty statements sometimes were used to trick Checkstyle to allow empty blocks. While generally empty blocks are bad practice, there are too many of them in Checkstyle code to fix them in scope of this commit. Instead, [EmplyBlock](http://checkstyle.sourceforge.net/config_blocks.html#EmptyBlock) setting was changed to allow empty block when there is comment inside it for Checkstyle codebase.