### PR TITLE
Final Local Variable Check, extended acceptable tokens

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -112,7 +112,15 @@ public class FinalLocalVariableCheck extends Check
     public int[] getAcceptableTokens()
     {
         return new int[] {
+            TokenTypes.IDENT,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
             TokenTypes.VARIABLE_DEF,
+            TokenTypes.INSTANCE_INIT,
+            TokenTypes.STATIC_INIT,
+            TokenTypes.LITERAL_FOR,
+            TokenTypes.SLIST,
+            TokenTypes.OBJBLOCK,
             TokenTypes.PARAMETER_DEF,
         };
     }


### PR DESCRIPTION
Extended acceptable tokens array as there was a bug which let user set only variables or/and parameters.
Now all supported tokens are acceptable and won't lead to error.