### PR TITLE
Added support of logging severity for all audit events, issue #67

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/CheckStyleTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/CheckStyleTask.java
@@ -453,7 +453,7 @@ public class CheckStyleTask extends Task
             final OutputStream debug = new LogOutputStream(this,
                     Project.MSG_DEBUG);
             final OutputStream err = new LogOutputStream(this, Project.MSG_ERR);
-            listeners[0] = new DefaultLogger(debug, true, err, true);
+            listeners[0] = new DefaultLogger(debug, true, err, true, true);
         }
         else {
             for (int i = 0; i < formatterCount; i++) {
@@ -584,9 +584,9 @@ public class CheckStyleTask extends Task
             if (toFile == null || !useFile) {
                 return new DefaultLogger(
                     new LogOutputStream(task, Project.MSG_DEBUG),
-                    true, new LogOutputStream(task, Project.MSG_ERR), true);
+                    true, new LogOutputStream(task, Project.MSG_ERR), true, true);
             }
-            return new DefaultLogger(new FileOutputStream(toFile), true);
+            return new DefaultLogger(new FileOutputStream(toFile), true, true);
         }
 
         /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
@@ -53,15 +53,19 @@ public class DefaultLogger
     /** close error stream after use */
     private final boolean closeError;
 
+    /** print severity level. */
+    private boolean printSeverity = true;
+
     /**
      * Creates a new <code>DefaultLogger</code> instance.
      * @param os where to log infos and errors
      * @param closeStreamsAfterUse if oS should be closed in auditFinished()
+     * @param printSeverity if severity level should be printed
      */
-    public DefaultLogger(OutputStream os, boolean closeStreamsAfterUse)
+    public DefaultLogger(OutputStream os, boolean closeStreamsAfterUse, boolean printSeverity)
     {
         // no need to close oS twice
-        this(os, closeStreamsAfterUse, os, false);
+        this(os, closeStreamsAfterUse, os, false, printSeverity);
     }
 
     /**
@@ -71,11 +75,13 @@ public class DefaultLogger
      * @param closeInfoAfterUse auditFinished should close infoStream
      * @param errorStream the <code>OutputStream</code> for error messages
      * @param closeErrorAfterUse auditFinished should close errorStream
+     * @param printSeverity if severity level should be printed
      */
     public DefaultLogger(OutputStream infoStream,
                          boolean closeInfoAfterUse,
                          OutputStream errorStream,
-                         boolean closeErrorAfterUse)
+                         boolean closeErrorAfterUse,
+                         boolean printSeverity)
     {
         closeInfo = closeInfoAfterUse;
         closeError = closeErrorAfterUse;
@@ -83,6 +89,7 @@ public class DefaultLogger
         errorWriter = infoStream == errorStream
             ? infoWriter
             : new PrintWriter(errorStream);
+        this.printSeverity = printSeverity;
     }
 
     /**
@@ -110,8 +117,8 @@ public class DefaultLogger
             if (evt.getColumn() > 0) {
                 sb.append(':').append(evt.getColumn());
             }
-            if (SeverityLevel.WARNING == severityLevel) {
-                sb.append(": warning");
+            if (printSeverity) {
+                sb.append(": ").append(severityLevel.getName());
             }
             sb.append(": ").append(message);
             errorWriter.println(sb.toString());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -200,7 +200,7 @@ public final class Main
             listener = new XMLLogger(out, closeOut);
         }
         else if ("plain".equals(format)) {
-            listener = new DefaultLogger(out, closeOut);
+            listener = new DefaultLogger(out, closeOut, true);
         }
         else {
             System.out.println("Invalid format: (" + format

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -26,7 +26,11 @@ public abstract class BaseCheckTestSupport {
     protected static class BriefLogger
             extends DefaultLogger {
         public BriefLogger(OutputStream out) {
-            super(out, true);
+            super(out, true, false);
+        }
+
+        public BriefLogger(OutputStream out, boolean printSeverity) {
+            super(out, true, printSeverity);
         }
 
         @Override
@@ -67,6 +71,21 @@ public abstract class BaseCheckTestSupport {
         return c;
     }
 
+    protected Checker createChecker(Configuration checkConfig, boolean printSeverity)
+            throws Exception {
+        final DefaultConfiguration dc = createCheckerConfig(checkConfig);
+        final Checker c = new Checker();
+        // make sure the tests always run with english error messages
+        // so the tests don't fail in supported locales like german
+        final Locale locale = Locale.ENGLISH;
+        c.setLocaleCountry(locale.getCountry());
+        c.setLocaleLanguage(locale.getLanguage());
+        c.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        c.configure(dc);
+        c.addListener(new BriefLogger(stream, printSeverity));
+        return c;
+    }
+
     protected DefaultConfiguration createCheckerConfig(Configuration config) {
         final DefaultConfiguration dc =
                 new DefaultConfiguration("configuration");
@@ -86,6 +105,11 @@ public abstract class BaseCheckTestSupport {
     protected static String getSrcPath(String filename) throws IOException {
 
         return new File("src/test/java/com/puppycrawl/tools/checkstyle/" + filename).getCanonicalPath();
+    }
+
+    protected void verify(Configuration aConfig, boolean printSeverity, String fileName,
+            String[] expected) throws Exception {
+        verify(createChecker(aConfig, printSeverity), fileName, fileName, expected);
     }
 
     protected void verify(Configuration aConfig, String fileName, String[] expected)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -85,6 +85,7 @@ public class WriteTagCheckTest extends BaseCheckTestSupport
     @Test
     public void testTagSeverity() throws Exception
     {
+        final boolean printSeverity = true;
         checkConfig.addAttribute("tag", "@incomplete");
         checkConfig.addAttribute("tagFormat", "\\S");
         checkConfig.addAttribute("tagSeverity", "warning");
@@ -92,7 +93,7 @@ public class WriteTagCheckTest extends BaseCheckTestSupport
         {
             "11: " + getCheckMessage(WRITE_TAG, "warning: @incomplete", "This class needs more code..."),
         };
-        verify(checkConfig, getPath("InputWriteTag.java"), expected);
+        verify(checkConfig, printSeverity, getPath("InputWriteTag.java"), expected);
     }
 
     @Test


### PR DESCRIPTION
According to #67 

Added support of logging severity for all audit events via introducing new option to <b>DefaultLogger</b>

Option's default value is <b>true</b>
In UTs it's used with value <b>false</b> to not breaking most of them.

Updated WriteTagTest as it depends from severity level.