### PR TITLE
Import Order Check, added option allows alphabetical grouping order in s...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -696,7 +696,7 @@
           <regex><pattern>.*.checks.imports.IllegalImportCheck</pattern><branchRate>100</branchRate><lineRate>94</lineRate></regex>
           <regex><pattern>.*.checks.imports.ImportControlCheck</pattern><branchRate>75</branchRate><lineRate>70</lineRate></regex>
           <regex><pattern>.*.checks.imports.ImportControlLoader</pattern><branchRate>72</branchRate><lineRate>88</lineRate></regex>
-          <regex><pattern>.*.checks.imports.ImportOrderCheck</pattern><branchRate>91</branchRate><lineRate>98</lineRate></regex>
+          <regex><pattern>.*.checks.imports.ImportOrderCheck</pattern><branchRate>91</branchRate><lineRate>99</lineRate></regex>
           <regex><pattern>.*.checks.imports.PkgControl</pattern><branchRate>80</branchRate><lineRate>100</lineRate></regex>
           <regex><pattern>.*.checks.imports.RedundantImportCheck</pattern><branchRate>81</branchRate><lineRate>94</lineRate></regex>
           <regex><pattern>.*.checks.imports.UnusedImportsCheck</pattern><branchRate>90</branchRate><lineRate>97</lineRate></regex>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -227,4 +227,139 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport
         final String[] expected = {};
         verify(checkConfig, getPath("imports" + File.separator + "InputImportOrder_NoFailureForRedundantImports.java"), expected);
     }
+
+    @Test
+    public void testStaticGroupsAlphabeticalOrder() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("option", "top");
+        checkConfig.addAttribute("groups", "org, java");
+        checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
+        final String[] expected = {};
+        verify(checkConfig, getPath("imports" + File.separator + "InputImportOrderStaticGroupOrder.java"), expected);
+    }
+
+    @Test
+    public void testStaticGroupsOrder() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("option", "top");
+        checkConfig.addAttribute("groups", "org, java");
+        final String[] expected = {
+            "4: " + getCheckMessage(MSG_ORDERING, "org.abego.treelayout.Configuration.AlignmentInLevel"),
+        };
+        verify(checkConfig, getPath("imports" + File.separator + "InputImportOrderStaticGroupOrder.java"), expected);
+    }
+
+    @Test
+    public void testStaticGroupsAlphabeticalOrderBottom() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("option", "bottom");
+        checkConfig.addAttribute("groups", "org, java");
+        checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
+        final String[] expected = {};
+        verify(checkConfig, getPath("imports" + File.separator + "InputImportOrderStaticGroupOrderBottom.java"), expected);
+    }
+
+    @Test
+    public void testStaticGroupsOrderBottom() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("option", "bottom");
+        checkConfig.addAttribute("groups", "org, java");
+        final String[] expected = {
+            "8: " + getCheckMessage(MSG_ORDERING, "org.abego.treelayout.Configuration.AlignmentInLevel"),
+        };
+        verify(checkConfig, getPath("imports" + File.separator + "InputImportOrderStaticGroupOrderBottom.java"), expected);
+    }
+
+    @Test
+    public void testStaticGroupsOrderAbove() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("option", "above");
+        checkConfig.addAttribute("groups", "org, java");
+        checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
+        final String[] expected = {
+            "7: " + getCheckMessage(MSG_ORDERING, "java.lang.Math.PI"),
+            "8: " + getCheckMessage(MSG_ORDERING, "org.abego.treelayout.Configuration.AlignmentInLevel"),
+        };
+        verify(checkConfig, getPath("imports" + File.separator + "InputImportOrderStaticGroupOrderBottom.java"), expected);
+    }
+
+    @Test
+    public void testStaticOnDemandGroupsOrder() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("option", "top");
+        checkConfig.addAttribute("groups", "org, java");
+        final String[] expected = {
+            "4: " + getCheckMessage(MSG_ORDERING, "org.abego.treelayout.Configuration.*"),
+        };
+        verify(checkConfig, getPath("imports" + File.separator
+                 + "InputImportOrderStaticOnDemandGroupOrder.java"), expected);
+    }
+
+    @Test
+    public void testStaticOnDemandGroupsAlphabeticalOrder() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("option", "top");
+        checkConfig.addAttribute("groups", "org, java");
+        checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
+        final String[] expected = {};
+        verify(checkConfig, getPath("imports" + File.separator
+                 + "InputImportOrderStaticOnDemandGroupOrder.java"), expected);
+    }
+
+    @Test
+    public void testStaticOnDemandGroupsOrderBottom() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("option", "bottom");
+        checkConfig.addAttribute("groups", "org, java");
+        final String[] expected = {
+            "8: " + getCheckMessage(MSG_ORDERING, "org.abego.treelayout.Configuration.*"),
+        };
+        verify(checkConfig, getPath("imports" + File.separator
+                 + "InputImportOrderStaticOnDemandGroupOrderBottom.java"), expected);
+    }
+
+    @Test
+    public void testStaticOnDemandGroupsAlphabeticalOrderBottom() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("option", "bottom");
+        checkConfig.addAttribute("groups", "org, java");
+        checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
+        final String[] expected = {};
+        verify(checkConfig, getPath("imports" + File.separator
+                 + "InputImportOrderStaticOnDemandGroupOrderBottom.java"), expected);
+    }
+
+    @Test
+    public void testStaticOnDemandGroupsOrderAbove() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("option", "above");
+        checkConfig.addAttribute("groups", "org, java");
+        checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
+        final String[] expected = {
+            "7: " + getCheckMessage(MSG_ORDERING, "java.lang.Math.*"),
+            "8: " + getCheckMessage(MSG_ORDERING, "org.abego.treelayout.Configuration.*"),
+        };
+        verify(checkConfig, getPath("imports" + File.separator
+                 + "InputImportOrderStaticOnDemandGroupOrderBottom.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputImportOrderStaticGroupOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputImportOrderStaticGroupOrder.java
@@ -1,0 +1,13 @@
+package com.puppycrawl.tools.checkstyle.imports;
+
+import static java.lang.Math.abs;
+import static org.abego.treelayout.Configuration.AlignmentInLevel;
+
+import org.*;
+
+import java.util.Set;
+
+public class InputImportOrderStaticGroupOrder
+{
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputImportOrderStaticGroupOrderBottom.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputImportOrderStaticGroupOrderBottom.java
@@ -1,0 +1,13 @@
+package com.puppycrawl.tools.checkstyle.imports;
+
+import org.*;
+
+import java.util.Set;
+
+import static java.lang.Math.PI;
+import static org.abego.treelayout.Configuration.AlignmentInLevel;
+
+public class InputImportOrderStaticGroupOrderBottom
+{
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputImportOrderStaticOnDemandGroupOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputImportOrderStaticOnDemandGroupOrder.java
@@ -1,0 +1,13 @@
+package com.puppycrawl.tools.checkstyle.imports;
+
+import static java.lang.Math.*;
+import static org.abego.treelayout.Configuration.*;
+
+import org.*;
+
+import java.util.Set;
+
+public class InputImportOrderStaticOnDemandGroupOrder
+{
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputImportOrderStaticOnDemandGroupOrderBottom.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputImportOrderStaticOnDemandGroupOrderBottom.java
@@ -1,0 +1,13 @@
+package com.puppycrawl.tools.checkstyle.imports;
+
+import org.*;
+
+import java.util.Set;
+
+import static java.lang.Math.*;
+import static org.abego.treelayout.Configuration.*;
+
+public class InputImportOrderStaticOnDemandGroupOrderBottom
+{
+
+}

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -423,6 +423,13 @@ class FooBar {
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>true</td>
           </tr>
+          <tr>
+            <td>sortStaticImportsAlphabetically</td>
+            <td>whether static imports grouped by <b>top</b> or <b>bottom</b> option
+            are sorted alphabetically or not</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td>false</td>
+          </tr>
         </table>
       </subsection>
 
@@ -443,6 +450,30 @@ class FooBar {
     &lt;property name=&quot;option&quot; value=&quot;above&quot;/>
 &lt;/module>
         </source>
+
+        <p>
+          To configure the Check allows static imports grouped to the <b>top</b>
+          being sorted alphabetically:
+        </p>
+
+        <source>
+&lt;module name=&quot;ImportOrder&quot;>
+    &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/>
+    &lt;property name=&quot;option&quot; value=&quot;top&quot;/>
+&lt;/module>
+        </source>
+
+        <source>
+import static java.lang.Math.abs;
+import static org.abego.treelayout.Configuration.AlignmentInLevel; // OK, alphabetical order
+
+import org.abego.*;
+
+import java.util.Set;
+
+public class SomeClass { ... }
+        </source>
+
       </subsection>
 
       <subsection name="Package">


### PR DESCRIPTION
...tatic group, issue #12

According to #12 

Added option which lets to order static group of imports in alphabetical order if this group if grouped by <b>top</b> or <b>bottom</b> options.

Added UTs and inputs, updated docs.