### PR TITLE
Make inner classes static when possible, issue #778

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -714,7 +714,7 @@ public class CustomImportOrderCheck extends Check
      * group.
      * @author max
      */
-    class ImportDetails
+    static class ImportDetails
     {
         /** Import full path */
         private String importFullPath;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -561,7 +561,7 @@ public abstract class AbstractJavadocCheck extends Check
     /**
      * Custom error listener for JavadocParser that prints user readable errors.
      */
-    class DescriptiveErrorListener extends BaseErrorListener
+    static class DescriptiveErrorListener extends BaseErrorListener
     {
         /**
          * Parse error while token recognition.


### PR DESCRIPTION
All violations of Fildbugs rule [SIC: Should be a static inner class](http://findbugs.sourceforge.net/bugDescriptions.html#SIC_INNER_SHOULD_BE_STATIC) are fixed.