### PR TITLE
Declare comparator class as Serializable to fix Findbugs violation, issue #778

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/doclets/CheckDocsDoclet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/doclets/CheckDocsDoclet.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Comparator;
 import com.sun.javadoc.ClassDoc;
@@ -52,8 +53,11 @@ public final class CheckDocsDoclet
      * by their check name.
      */
     private static class ClassDocByCheckNameComparator implements
-        Comparator<ClassDoc>
+        Comparator<ClassDoc>, Serializable
     {
+        /** Serialization version. */
+        private static final long serialVersionUID = 1731995210294871881L;
+
         /** {@inheritDoc} */
         public int compare(ClassDoc object1, ClassDoc object2)
         {


### PR DESCRIPTION
All violations of Fildbugs rule [Se: Comparator doesn't implement Serializable](http://findbugs.sourceforge.net/bugDescriptions.html#SE_COMPARATOR_SHOULD_BE_SERIALIZABLE) are fixed.