### PR TITLE
Fix non-compiling input for CustomImportOrder check

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -81,7 +81,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport
             "9: " + getCheckMessage(MSG_LEX, "java.awt.Dialog"),
             "13: " + getCheckMessage(MSG_LEX, "java.io.File"),
             "15: " + getCheckMessage(MSG_LEX, "java.io.InputStream"),
-            "20: " + getCheckMessage(MSG_LEX, "com.google.common.*"),
+            "20: " + getCheckMessage(MSG_LEX, "com.google.common.collect.*"),
         };
 
         verify(checkConfig, getPath("imports" + File.separator

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder.java
@@ -17,7 +17,7 @@ import java.io.Reader;
 
 import com.puppycrawl.tools.*;
 
-import com.google.common.*;
+import com.google.common.collect.*;
 import org.junit.*;
 
 public class InputCustomImportOrder {


### PR DESCRIPTION
There are no classes directly under `com.google.common` package - such import was illegal.