### PR TITLE
Remove element name from selector in CSS

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -14,7 +14,7 @@ h4 {
   text-transform: capitalize;
 }
 
-div.tip {
+.tip {
   margin-left : 5%;
   margin-right : 5%;
   padding-left: 2%;


### PR DESCRIPTION
Fix according to CSSLint [Disallow overqualified elements](https://github.com/CSSLint/csslint/wiki/Disallow-overqualified-elements) rule.