### PR TITLE
Remove units for zero values in CSS

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -34,5 +34,5 @@ div.tip {
 
 #banner {
   border-bottom: 1px solid #fff;
-  background: url("../images/banner.jpg") repeat scroll 0% 0% transparent;
+  background: url("../images/banner.jpg") repeat scroll 0 0 transparent;
 }


### PR DESCRIPTION
Even if CSS allows you to put units in the value 0 you should not. The value is always the same, with or without units, and without those units your will shrink the file size and speedup your page load time.

Fix according to CSSLint [Disallow units for zero values](https://github.com/CSSLint/csslint/wiki/Disallow-units-for-zero-values) rule.