### PR TITLE
Introduce new handler SynchronizedHandler for checking identation. Fixes #580

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -751,7 +751,8 @@
           <regex><pattern>.*.checks.indentation.PrimordialHandler</pattern><branchRate>100</branchRate><lineRate>60</lineRate></regex>
           <regex><pattern>.*.checks.indentation.SlistHandler</pattern><branchRate>100</branchRate><lineRate>94</lineRate></regex>
 
-
+          <regex><pattern>.*.checks.indentation.SynchronizedHandler</pattern><branchRate>100</branchRate><lineRate>100</lineRate></regex>
+             
           <regex><pattern>.*.checks.javadoc.AbstractJavadocCheck</pattern><branchRate>90</branchRate><lineRate>93</lineRate></regex>
           <regex><pattern>.*.checks.javadoc.AbstractJavadocCheck\$.*</pattern><branchRate>50</branchRate><lineRate>68</lineRate></regex>
           <regex><pattern>.*.checks.javadoc.AtclauseOrderCheck</pattern><branchRate>88</branchRate><lineRate>88</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
@@ -104,6 +104,7 @@ public class HandlerFactory
         register(TokenTypes.VARIABLE_DEF, MemberDefHandler.class);
         register(TokenTypes.LITERAL_NEW, NewHandler.class);
         register(TokenTypes.INDEX_OP, IndexHandler.class);
+        register(TokenTypes.LITERAL_SYNCHRONIZED, SynchronizedHandler.class);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
@@ -117,7 +117,8 @@ public class SlistHandler extends BlockParentHandler
             || parentType == TokenTypes.LITERAL_FINALLY
             || parentType == TokenTypes.CTOR_DEF
             || parentType == TokenTypes.METHOD_DEF
-            || parentType == TokenTypes.STATIC_INIT;
+            || parentType == TokenTypes.STATIC_INIT
+            || parentType == TokenTypes.LITERAL_SYNCHRONIZED;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SynchronizedHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SynchronizedHandler.java
@@ -1,0 +1,96 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.indentation;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * Handler for synchronized statements.
+ *
+ * @author liscju piotr.listkiewicz@gmail.com
+ */
+public class SynchronizedHandler extends BlockParentHandler
+{
+
+    /**
+     * Determine that "synchronized" token used as modifier of method
+     */
+    private boolean isMethodModifier;
+
+    /**
+     * Construct an instance of this handler with the given indentation check,
+     * name, abstract syntax tree, and parent handler.
+     *
+     * @param indentCheck the indentation check
+     * @param ast         the abstract syntax tree
+     * @param parent      the parent handler
+     */
+    public SynchronizedHandler(IndentationCheck indentCheck, DetailAST ast,
+                               ExpressionHandler parent)
+    {
+        super(indentCheck, "synchronized", ast, parent);
+        isMethodModifier = isMethodModifier(ast);
+    }
+
+    @Override
+    public void checkIndentation()
+    {
+        if (!isMethodModifier) {
+            super.checkIndentation();
+            checkSynchronizedExpr();
+            final LineWrappingHandler lineWrap =
+                    new LineWrappingHandler(getIndentCheck(), getMainAst(),
+                            getSynchronizedStatementRightParen(getMainAst()));
+            lineWrap.checkIndentation();
+        }
+    }
+
+    /**
+     * Check identation of expression we synchronized on
+     */
+    private void checkSynchronizedExpr()
+    {
+        final DetailAST syncAst = getMainAst().findFirstToken(TokenTypes.LPAREN)
+                .getNextSibling();
+        final IndentLevel expected =
+                new IndentLevel(getLevel(), getBasicOffset());
+        checkExpressionSubtree(syncAst, expected, false, false);
+    }
+
+    /**
+     * Checks if given synchronized is modifier of method*
+     * @param ast synchronized(TokenTypes.LITERAL_SYNCHRONIZED) to check
+     * @return true if synchronized only modifies method
+     */
+    private static boolean isMethodModifier(DetailAST ast)
+    {
+        return ast.getParent().getType() == TokenTypes.MODIFIERS;
+    }
+
+    /**
+     * Returns right parenthesis of synchronized statement.
+     * @param syncStatementAST ast node(TokenTypes.LITERAL_SYNCHRONIZED)
+     * @return right parenthesis of synchronized statement.
+     */
+    private static DetailAST getSynchronizedStatementRightParen(DetailAST syncStatementAST)
+    {
+        return syncStatementAST.findFirstToken(TokenTypes.RPAREN);
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1492,4 +1492,38 @@ public class IndentationCheckTest extends BaseCheckTestSupport
         verifyWarns(checkConfig, getPath("indentation/InputSwitchCustom.java"),
                expected);
     }
+
+    @Test
+    public void testSynchronizedStatement() throws Exception
+    {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+        checkConfig.addAttribute("arrayInitIndent", "4");
+        checkConfig.addAttribute("basicOffset", "4");
+        checkConfig.addAttribute("braceAdjustment", "0");
+        checkConfig.addAttribute("caseIndent", "4");
+        checkConfig.addAttribute("forceStrictCondition", "false");
+        checkConfig.addAttribute("lineWrappingIndentation", "8");
+        checkConfig.addAttribute("tabWidth", "4");
+        checkConfig.addAttribute("throwsIndent", "8");
+        final String[] expected = {
+        };
+        verifyWarns(checkConfig, getPath("indentation/InputSynchronizedStatement.java"), expected);
+    }
+
+    @Test
+    public void testSynchronizedMethod() throws Exception
+    {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+        checkConfig.addAttribute("arrayInitIndent", "4");
+        checkConfig.addAttribute("basicOffset", "4");
+        checkConfig.addAttribute("braceAdjustment", "0");
+        checkConfig.addAttribute("caseIndent", "4");
+        checkConfig.addAttribute("forceStrictCondition", "false");
+        checkConfig.addAttribute("lineWrappingIndentation", "8");
+        checkConfig.addAttribute("tabWidth", "4");
+        checkConfig.addAttribute("throwsIndent", "8");
+        final String[] expected = {
+        };
+        verifyWarns(checkConfig, getPath("indentation/InputSynchronizedMethod.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputSynchronizedMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputSynchronizedMethod.java
@@ -1,0 +1,21 @@
+package com.puppycrawl.tools.checkstyle.indentation;//indent:0 exp:0
+
+/**                                                                           //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:   //indent:1 exp:1
+ *                                                                            //indent:1 exp:1
+ * arrayInitIndent = 4                                                        //indent:1 exp:1
+ * basicOffset = 4                                                            //indent:1 exp:1
+ * braceAdjustment = 0                                                        //indent:1 exp:1
+ * caseIndent = 4                                                             //indent:1 exp:1
+ * forceStrictCondition = false                                               //indent:1 exp:1
+ * lineWrappingIndentation = 8                                                //indent:1 exp:1
+ * tabWidth = 4                                                               //indent:1 exp:1
+ * throwsIndent = 8                                                           //indent:1 exp:1
+ *                                                                            //indent:1 exp:1
+ *                                                                            //indent:1 exp:1
+ */                                                                           //indent:1 exp:1
+public class InputSynchronizedMethod {//indent:0 exp:0
+    public synchronized InputSynchronizedMethod calculate() {//indent:4 exp:4
+        return null;//indent:8 exp:8
+    }//indent:4 exp:4
+}//indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputSynchronizedStatement.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputSynchronizedStatement.java
@@ -1,0 +1,28 @@
+package com.puppycrawl.tools.checkstyle.indentation; //indent:0 exp:0
+
+
+/**                                                                           //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:   //indent:1 exp:1
+ *                                                                            //indent:1 exp:1
+ * arrayInitIndent = 4                                                        //indent:1 exp:1
+ * basicOffset = 4                                                            //indent:1 exp:1
+ * braceAdjustment = 0                                                        //indent:1 exp:1
+ * caseIndent = 4                                                             //indent:1 exp:1
+ * forceStrictCondition = false                                               //indent:1 exp:1
+ * lineWrappingIndentation = 8                                                //indent:1 exp:1
+ * tabWidth = 4                                                               //indent:1 exp:1
+ * throwsIndent = 8                                                           //indent:1 exp:1
+ *                                                                            //indent:1 exp:1
+ *                                                                            //indent:1 exp:1
+ */                                                                           //indent:1 exp:1                                                                   //indent:1 exp:1
+public class InputSynchronizedStatement { //indent:0 exp:0
+    private static InputSynchronizedStatement instance;//indent:4 exp:4
+    public static InputSynchronizedStatement getInstance() {//indent:4 exp:4
+        if (instance == null) //indent:8 exp:8
+            synchronized (InputSynchronizedStatement.class) {//indent:12 exp:12
+                if (instance == null)//indent:16 exp:16
+                    instance = new InputSynchronizedStatement();//indent:20 exp:20
+            }//indent:12 exp:12
+        return instance;//indent:8 exp:8
+    }//indent:4 exp:4
+} //indent:0 exp:0


### PR DESCRIPTION
Discussion what bad was going on is in discussion for issue #580. It introduces new SynchronizedHandler for synchronized expressions. To distinguish between synchronized method and synchronized block it has  isOnlyMethodModifier field which is determined by isMethodModifier method.