### PR TITLE
Fix command used to invoke Coveralls, issue #806

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,4 @@ install: mvn clean verify site -Dlinkcheck.skip=true -Dmaven.javadoc.skip=true
              -Dpmd.skip=true -Dfindbugs.skip=true
 
 after_success:
-  - mvn -Ptravis surefire-report:report jacoco:report coveralls:jacoco
-
+  - mvn -Ptravis clean test jacoco:report coveralls:report


### PR DESCRIPTION
Command taken from https://github.com/trautonen/coveralls-maven-plugin#jacoco.

As the next step, probably we can simplify `travis` profile. I'm not sure why we have there `surefire-report` plugin.