### PR TITLE
Added new DemandTypesInLambdaCheck, fixes issue #142

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -719,8 +719,8 @@
           <regex><pattern>.*.checks.indentation.PackageDefHandler</pattern><branchRate>50</branchRate><lineRate>85</lineRate></regex>
           <regex><pattern>.*.checks.indentation.PrimordialHandler</pattern><branchRate>100</branchRate><lineRate>60</lineRate></regex>
           <regex><pattern>.*.checks.indentation.SlistHandler</pattern><branchRate>100</branchRate><lineRate>94</lineRate></regex>
-          
-          
+
+
           <regex><pattern>.*.checks.javadoc.AbstractJavadocCheck</pattern><branchRate>90</branchRate><lineRate>93</lineRate></regex>
           <regex><pattern>.*.checks.javadoc.AbstractJavadocCheck\$.*</pattern><branchRate>50</branchRate><lineRate>68</lineRate></regex>
           <regex><pattern>.*.checks.javadoc.AtclauseOrderCheck</pattern><branchRate>88</branchRate><lineRate>88</lineRate></regex>
@@ -738,9 +738,9 @@
           <regex><pattern>.*.checks.javadoc.SummaryJavadocCheck</pattern><branchRate>93</branchRate><lineRate>100</lineRate></regex>
           <regex><pattern>.*.checks.javadoc.TagParser</pattern><branchRate>92</branchRate><lineRate>98</lineRate></regex>
           <regex><pattern>.*.checks.javadoc.WriteTagCheck</pattern><branchRate>100</branchRate><lineRate>91</lineRate></regex>
-          
-          
-          <regex><pattern>.*.checks.metrics.AbstractClassCouplingCheck</pattern><branchRate>87</branchRate><lineRate>97</lineRate></regex>
+
+          <regex><pattern>.*.checks.lambda.DemandTypesInLambdaCheck</pattern><branchRate>85</branchRate><lineRate>100</lineRate></regex>
+
           <regex><pattern>.*.checks.metrics.AbstractClassCouplingCheck\$.*</pattern><branchRate>78</branchRate><lineRate>100</lineRate></regex>
           <regex><pattern>.*.checks.metrics.AbstractComplexityCheck</pattern><branchRate>83</branchRate><lineRate>92</lineRate></regex>
           <regex><pattern>.*.checks.metrics.BooleanExpressionComplexityCheck</pattern><branchRate>74</branchRate><lineRate>80</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/lambda/DemandTypesInLambdaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/lambda/DemandTypesInLambdaCheck.java
@@ -1,0 +1,117 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.lambda;
+
+import com.puppycrawl.tools.checkstyle.api.Check;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * Checks if variables in lambda expression have defined types.
+ *
+ * <p>
+ * Rationale: Lambda expressions are easier to read when types are
+ * explicitly list.
+ * </p>
+ * <p>
+ * An example of how to configure the check is:
+ * </p>
+ * <pre>
+ * &lt;module name="DemandTypesInLambdaCheck"/&gt;
+ * </pre>
+ * @author liscju
+ */
+public class DemandTypesInLambdaCheck extends Check
+{
+
+    /**
+     * A key is pointing to the warning message text in "messages.properties"
+     * file.
+     */
+    public static final String MSG_ERROR_DEMAND_TYPES_IN_LAMBDA = "lambda.demandtypes.error";
+
+    @Override
+    public int[] getDefaultTokens()
+    {
+        return new int[] {TokenTypes.LAMBDA};
+    }
+
+    @Override
+    public void visitToken(DetailAST ast)
+    {
+        final DetailAST lambdaFirstChild = ast.getFirstChild();
+        if (lambdaFirstChild.getType() == TokenTypes.IDENT) {
+            log(lambdaFirstChild.getLineNo(), lambdaFirstChild.getColumnNo(),
+                    MSG_ERROR_DEMAND_TYPES_IN_LAMBDA);
+        }
+        else {
+            //assert lambdaFirstChild.getType() == TokenTypes.LPAREN;
+            final DetailAST lambdaParameters = ast.findFirstToken(TokenTypes.PARAMETERS);
+            checkParameters(lambdaParameters);
+        }
+    }
+
+    /**
+     * Checks if all parameters in given parameters has defined types
+     * @param lambdaParameters parameters(TokenTypes.PARAMETERS)
+     */
+    private void checkParameters(DetailAST lambdaParameters)
+    {
+        //assert lambdaParameters.getType() == TokenTypes.PARAMETERS;
+        DetailAST iteratingParameter = lambdaParameters.getFirstChild();
+        while (iteratingParameter != null) {
+            if (iteratingParameter.getType() == TokenTypes.PARAMETER_DEF) {
+                checkParameter(iteratingParameter);
+            }
+            iteratingParameter = iteratingParameter.getNextSibling();
+        }
+    }
+
+    /**
+     * Check if given lambda parameter has defined type
+     * @param parameter lambda parameter(TokenTypes.PARAMETER_DEF)
+     */
+    private void checkParameter(DetailAST parameter)
+    {
+        //assert parameter.getType() == TokenTypes.PARAMETER_DEF;
+        final DetailAST parameterType = parameter.findFirstToken(TokenTypes.TYPE);
+        if (!isProperType(parameterType)) {
+            log(parameter.getLineNo(), parameter.getColumnNo(), MSG_ERROR_DEMAND_TYPES_IN_LAMBDA);
+        }
+    }
+
+    /**
+     * Checks if type ast is properly defined
+     * @param type DetailAST
+     * @return true,if it is a valid type
+     */
+    private static boolean isProperType(DetailAST type)
+    {
+        return type != null && type.getType() == TokenTypes.TYPE && type.getChildCount() > 0;
+    }
+}
+
+
+
+
+
+
+
+
+

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/lambda/package-info.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/lambda/package-info.java
@@ -1,0 +1,23 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Lambda checks.
+ */
+package com.puppycrawl.tools.checkstyle.checks.lambda;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/lambda/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/lambda/messages.properties
@@ -1,0 +1,1 @@
+lambda.demandtypes.error=Lambda parameter must have defined type

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/lambda/DemandTypesInLambdaCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/lambda/DemandTypesInLambdaCheckTest.java
@@ -1,0 +1,94 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.lambda;
+
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import org.junit.Test;
+import java.io.File;
+
+import static com.puppycrawl.tools.checkstyle.checks.lambda.DemandTypesInLambdaCheck.MSG_ERROR_DEMAND_TYPES_IN_LAMBDA;
+
+public class DemandTypesInLambdaCheckTest extends BaseCheckTestSupport
+{
+
+    private String getJava8Path(String fileName) throws Exception
+    {
+        return new File("src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/" + fileName).getCanonicalPath();
+    }
+
+    @Test
+    public void testNoParameterLambda() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(DemandTypesInLambdaCheck.class);
+        final String[] expected = {
+        };
+        verify(checkConfig, getJava8Path("lambda/InputNoParameterLambda.java"),
+                expected);
+    }
+
+    @Test
+    public void testOneGenericParameterLambda() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(DemandTypesInLambdaCheck.class);
+        final String[] expected = {
+            "9:22: " + getCheckMessage(MSG_ERROR_DEMAND_TYPES_IN_LAMBDA),
+            "11:28: " + getCheckMessage(MSG_ERROR_DEMAND_TYPES_IN_LAMBDA),
+        };
+        verify(checkConfig, getJava8Path("lambda/InputOneGenericParameterLambda.java"),
+                expected);
+    }
+
+    @Test
+    public void testOneTypeParameterLambda() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(DemandTypesInLambdaCheck.class);
+        final String[] expected = {
+        };
+        verify(checkConfig, getJava8Path("lambda/InputOneTypeParameterLambda.java"),
+                expected);
+    }
+
+    @Test
+    public void testFewGenericParameterLambda() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(DemandTypesInLambdaCheck.class);
+        final String[] expected = {
+            "9:31: " + getCheckMessage(MSG_ERROR_DEMAND_TYPES_IN_LAMBDA),
+            "9:33: " + getCheckMessage(MSG_ERROR_DEMAND_TYPES_IN_LAMBDA),
+        };
+        verify(checkConfig, getJava8Path("lambda/InputFewGenericParameterLambda.java"),
+                expected);
+    }
+
+    @Test
+    public void testFewTypeParameterLambda() throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(DemandTypesInLambdaCheck.class);
+        final String[] expected = {
+        };
+        verify(checkConfig, getJava8Path("lambda/InputFewTypeParameterLambda.java"),
+                expected);
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/lambda/InputFewGenericParameterLambda.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/lambda/InputFewGenericParameterLambda.java
@@ -1,0 +1,11 @@
+//Compilable with Java8
+package com.puppycrawl.tools.checkstyle.checks.lambda;
+import java.util.List;
+import java.util.Arrays;
+
+public class InputFewGenericParameterLambda {
+    public static void main(String[] args) {
+        List<Integer> list = Arrays.asList(1, 2, 3, 4, 5, 6, 7);
+        list.stream().reduce((x,y) -> x*y);
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/lambda/InputFewTypeParameterLambda.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/lambda/InputFewTypeParameterLambda.java
@@ -1,0 +1,11 @@
+//Compilable with Java8
+package com.puppycrawl.tools.checkstyle.checks.lambda;
+import java.util.List;
+import java.util.Arrays;
+
+public class InputFewTypeParameterLambda {
+    public static void main(String[] args) {
+        List<Integer> list = Arrays.asList(1, 2, 3, 4, 5, 6, 7);
+        list.stream().reduce((Integer x,Integer y) -> x*y);
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/lambda/InputNoParameterLambda.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/lambda/InputNoParameterLambda.java
@@ -1,0 +1,6 @@
+//Compilable with Java8
+package com.puppycrawl.tools.checkstyle.checks.lambda;
+
+public class InputNoParameterLambda {
+    static Runnable r1 = ()-> System.out.println("Hello world one!");
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/lambda/InputOneGenericParameterLambda.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/lambda/InputOneGenericParameterLambda.java
@@ -1,0 +1,13 @@
+//Compilable with Java8
+package com.puppycrawl.tools.checkstyle.checks.lambda;
+import java.util.List;
+import java.util.Arrays;
+
+public class InputOneGenericParameterLambda {
+    public static void main(String[] args) {
+        List<Integer> list = Arrays.asList(1, 2, 3, 4, 5, 6, 7);
+        list.forEach(n -> System.out.println(n));
+
+        list.stream().map((x) -> x*x)
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/lambda/InputOneTypeParameterLambda.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/lambda/InputOneTypeParameterLambda.java
@@ -1,0 +1,11 @@
+//Compilable with Java8
+package com.puppycrawl.tools.checkstyle.checks.lambda;
+import java.util.List;
+import java.util.Arrays;
+
+public class InputOneGenericParameterLambda {
+    public static void main(String[] args) {
+        List<Integer> list = Arrays.asList(1, 2, 3, 4, 5, 6, 7);
+        int sum = list.stream().map((Integer x) -> x*x);
+    }
+}

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -150,6 +150,10 @@
         </td>
       </tr>
       <tr>
+        <td><a href="config_lambda.html#DemandTypesInLambda">DemandTypesInLambda</a></td>
+        <td>Checks for types in lambda parameters</td>
+      </tr>
+      <tr>
         <td><a href="config_misc.html#DescendantToken">DescendantToken</a></td>
         <td>Checks for restricted tokens beneath other tokens.</td>
       </tr>


### PR DESCRIPTION
Introduce new check DemandTypesInLambdaCheck which checks if all parameters in lambda has explicit types. It checks for all possible lambda parameter types:
a) () -> ... empty parameter list
b) t  -> ... one implicit type
c) (a,b,..) -> ... many implicit types
d) (T a,T b,..) -> ... many explicit types

 I commented out assertions because cubertura checks them and it decreases code coverage(at this moment it looks like cubertura does not have option to skip assertions) but i think they are valuable information in code. I would be grateful for comment what to do about them. 