### PR TITLE
Remove empty if statements to fix PMD violations, issue #744

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -304,45 +304,44 @@ public class LeftCurlyCheck
             : Utils.lengthMinusTrailingWhitespace(getLine(brace.getLineNo() - 2));
 
         // Check for being told to ignore, or have '{}' which is a special case
-        if (braceLine.length() > brace.getColumnNo() + 1
-            && braceLine.charAt(brace.getColumnNo() + 1) == '}')
+        if (braceLine.length() <= brace.getColumnNo() + 1
+                || braceLine.charAt(brace.getColumnNo() + 1) != '}')
         {
-            // ignore
-        }
-        else if (getAbstractOption() == LeftCurlyOption.NL) {
-            if (!Utils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
-                log(brace.getLineNo(), brace.getColumnNo(),
-                    MSG_KEY_LINE_NEW, "{");
-            }
-        }
-        else if (getAbstractOption() == LeftCurlyOption.EOL) {
-            if (Utils.whitespaceBefore(brace.getColumnNo(), braceLine)
-                && prevLineLen + 2 <= maxLineLength)
-            {
-                log(brace.getLineNo(), brace.getColumnNo(),
-                    MSG_KEY_LINE_PREVIOUS, "{");
-            }
-            if (!hasLineBreakAfter(brace)) {
-                log(brace.getLineNo(), brace.getColumnNo(), MSG_KEY_LINE_BREAK_AFTER);
-            }
-        }
-        else if (getAbstractOption() == LeftCurlyOption.NLOW) {
-            if (startToken.getLineNo() == brace.getLineNo()) {
-                // all ok as on the same line
-            }
-            else if (startToken.getLineNo() + 1 == brace.getLineNo()) {
+            if (getAbstractOption() == LeftCurlyOption.NL) {
                 if (!Utils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
                     log(brace.getLineNo(), brace.getColumnNo(),
                         MSG_KEY_LINE_NEW, "{");
                 }
-                else if (prevLineLen + 2 <= maxLineLength) {
+            }
+            else if (getAbstractOption() == LeftCurlyOption.EOL) {
+                if (Utils.whitespaceBefore(brace.getColumnNo(), braceLine)
+                    && prevLineLen + 2 <= maxLineLength)
+                {
                     log(brace.getLineNo(), brace.getColumnNo(),
                         MSG_KEY_LINE_PREVIOUS, "{");
                 }
+                if (!hasLineBreakAfter(brace)) {
+                    log(brace.getLineNo(), brace.getColumnNo(), MSG_KEY_LINE_BREAK_AFTER);
+                }
             }
-            else if (!Utils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
-                log(brace.getLineNo(), brace.getColumnNo(),
-                    MSG_KEY_LINE_NEW, "{");
+            else if (getAbstractOption() == LeftCurlyOption.NLOW
+                    && startToken.getLineNo() != brace.getLineNo())
+            {
+                // not on the same line
+                if (startToken.getLineNo() + 1 == brace.getLineNo()) {
+                    if (!Utils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
+                        log(brace.getLineNo(), brace.getColumnNo(),
+                                MSG_KEY_LINE_NEW, "{");
+                    }
+                    else if (prevLineLen + 2 <= maxLineLength) {
+                        log(brace.getLineNo(), brace.getColumnNo(),
+                                MSG_KEY_LINE_PREVIOUS, "{");
+                    }
+                }
+                else if (!Utils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
+                    log(brace.getLineNo(), brace.getColumnNo(),
+                            MSG_KEY_LINE_NEW, "{");
+                }
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -264,12 +264,9 @@ public class VariableDeclarationUsageDistanceCheck extends Check
         final int parentType = ast.getParent().getType();
         final DetailAST modifiers = ast.getFirstChild();
 
-        if (ignoreFinal && modifiers.branchContains(TokenTypes.FINAL)
-                || parentType == TokenTypes.OBJBLOCK)
+        if (!(ignoreFinal && modifiers.branchContains(TokenTypes.FINAL)
+                || parentType == TokenTypes.OBJBLOCK))
         {
-            // no code
-        }
-        else {
             final DetailAST variable = ast.findFirstToken(TokenTypes.IDENT);
 
             if (!isVariableMatchesIgnorePattern(variable.getText())) {
@@ -590,12 +587,9 @@ public class VariableDeclarationUsageDistanceCheck extends Check
                 if (currentNodeType == TokenTypes.SLIST) {
                     firstNodeInsideBlock = currentNode.getFirstChild();
                 }
-                else if (currentNodeType == TokenTypes.VARIABLE_DEF
-                        || currentNodeType == TokenTypes.EXPR)
+                else if (currentNodeType != TokenTypes.VARIABLE_DEF
+                        && currentNodeType != TokenTypes.EXPR)
                 {
-                    // no code
-                }
-                else {
                     firstNodeInsideBlock = currentNode;
                 }
             }


### PR DESCRIPTION
Violations of PMD rule [EmptyIfStmt](http://pmd.sourceforge.net/pmd-5.2.3/pmd-java/rules/java/empty.html#EmptyIfStmt) are fixed. All transformations were done by IDE automatically.