### PR TITLE
Disable additional invocation of site plugin, issue #821

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -998,6 +998,9 @@
         <artifactId>maven-linkcheck-plugin</artifactId>
         <version>1.2</version>
         <configuration>
+          <httpMethod>GET</httpMethod>
+          <timeout>3000</timeout>
+          <httpFollowRedirect>false</httpFollowRedirect>
           <excludedPages>
             <excludedPage>dependencies.html</excludedPage>
             <excludedPage>cobertura/**</excludedPage>
@@ -1028,18 +1031,6 @@
           <excludedHttpStatusErrors>
             <excludedHttpStatusError>401</excludedHttpStatusError>
           </excludedHttpStatusErrors>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <!-- validate all @link via mvn linkcheck:linkcheck -->
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-linkcheck-plugin</artifactId>
-        <version>1.2</version>
-        <configuration>
-          <httpMethod>GET</httpMethod>
-          <timeout>3000</timeout>
-          <httpFollowRedirect>false</httpFollowRedirect>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1001,6 +1001,7 @@
           <httpMethod>GET</httpMethod>
           <timeout>3000</timeout>
           <httpFollowRedirect>false</httpFollowRedirect>
+          <forceSite>false</forceSite>
           <excludedPages>
             <excludedPage>dependencies.html</excludedPage>
             <excludedPage>cobertura/**</excludedPage>


### PR DESCRIPTION
1. Remove duplicated Linkcheck plugin declaration, issue #751.
2. Disable additional invocation of site plugin, issue #821. 
By default property [forceSite](https://maven.apache.org/plugins/maven-linkcheck-plugin/linkcheck-mojo.html#forceSite) is `true` and Linkcheck plugin unnecessarily tries to invoke `mvn site` to freshly generate all resources needed for link checking. Not all plugins are ready to support such invocation in different context, e.g. tidy-maven-plugin. Without this additional invocation everything works fine and site generation is faster.