### PR TITLE
Add logging to empty catch blocks to fix PMD violations, issue #744

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -587,9 +587,9 @@
           <regex><pattern>.*.PackageNamesLoader</pattern><branchRate>78</branchRate><lineRate>72</lineRate></regex>
           <regex><pattern>.*.PackageObjectFactory</pattern><branchRate>75</branchRate><lineRate>75</lineRate></regex>
           <regex><pattern>.*.PropertiesExpander</pattern><branchRate>50</branchRate><lineRate>83</lineRate></regex>
-          <regex><pattern>.*.PropertyCacheFile</pattern><branchRate>22</branchRate><lineRate>18</lineRate></regex>
+          <regex><pattern>.*.PropertyCacheFile</pattern><branchRate>22</branchRate><lineRate>19</lineRate></regex>
           <regex><pattern>.*.TreeWalker</pattern><branchRate>90</branchRate><lineRate>90</lineRate></regex>
-          <regex><pattern>com.puppycrawl.tools.checkstyle.Utils</pattern><branchRate>78</branchRate><lineRate>71</lineRate></regex>
+          <regex><pattern>com.puppycrawl.tools.checkstyle.Utils</pattern><branchRate>77</branchRate><lineRate>70</lineRate></regex>
           <regex><pattern>.*.XMLLogger</pattern><branchRate>86</branchRate><lineRate>97</lineRate></regex>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -589,7 +589,7 @@
           <regex><pattern>.*.PropertiesExpander</pattern><branchRate>50</branchRate><lineRate>83</lineRate></regex>
           <regex><pattern>.*.PropertyCacheFile</pattern><branchRate>22</branchRate><lineRate>19</lineRate></regex>
           <regex><pattern>.*.TreeWalker</pattern><branchRate>90</branchRate><lineRate>90</lineRate></regex>
-          <regex><pattern>com.puppycrawl.tools.checkstyle.Utils</pattern><branchRate>77</branchRate><lineRate>70</lineRate></regex>
+          <regex><pattern>com.puppycrawl.tools.checkstyle.Utils</pattern><branchRate>77</branchRate><lineRate>71</lineRate></regex>
           <regex><pattern>.*.XMLLogger</pattern><branchRate>86</branchRate><lineRate>97</lineRate></regex>
 
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/CheckStyleTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/CheckStyleTask.java
@@ -19,6 +19,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import com.google.common.collect.Lists;
+import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
@@ -406,7 +407,7 @@ public class CheckStyleTask extends Task
                         + propertiesFile + "'", e, getLocation());
             }
             finally {
-                Utils.closeQuietly(inStream);
+                Closeables.closeQuietly(inStream);
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -24,6 +24,8 @@ import com.puppycrawl.tools.checkstyle.api.AbstractLoader;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -51,6 +53,9 @@ import java.util.Map;
  */
 public final class ConfigurationLoader
 {
+    /** Logger for ConfigurationLoader. */
+    private static final Log LOG = LogFactory.getLog(ConfigurationLoader.class);
+
     /** the public ID for version 1_0 of the configuration dtd */
     private static final String DTD_PUBLIC_ID_1_0 =
         "-//Puppy Crawl//DTD Check Configuration 1.0//EN";
@@ -193,7 +198,7 @@ public final class ConfigurationLoader
                     level = SeverityLevel.getInstance(severity);
                 }
                 catch (final CheckstyleException e) {
-                    //severity not set -> ignore
+                    LOG.debug("Severity not set, ignoring exception", e);
                 }
 
                 // omit this module if these should be omitted and the module

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -19,6 +19,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import com.google.common.collect.Sets;
+import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.api.AbstractLoader;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import java.io.BufferedInputStream;
@@ -171,7 +172,7 @@ public final class PackageNamesLoader
                         "unable to open " + packageFile, e);
             }
             finally {
-                Utils.closeQuietly(stream);
+                Closeables.closeQuietly(stream);
             }
         }
         return namesLoader.getPackageNames();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -20,6 +20,9 @@ package com.puppycrawl.tools.checkstyle;
 
 import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import java.util.Set;
 
 /**
@@ -29,6 +32,9 @@ import java.util.Set;
  */
 class PackageObjectFactory implements ModuleFactory
 {
+    /** Logger for PackageObjectFactory. */
+    private static final Log LOG = LogFactory.getLog(PackageObjectFactory.class);
+
     /** a list of package names to prepend to class names */
     private final Set<String> packages;
 
@@ -80,7 +86,7 @@ class PackageObjectFactory implements ModuleFactory
             return createObject(name);
         }
         catch (final CheckstyleException ex) {
-            // keep looking
+            LOG.debug("Keep looking, ignoring exception", ex);
         }
 
         //now try packages
@@ -91,7 +97,7 @@ class PackageObjectFactory implements ModuleFactory
                 return createObject(className);
             }
             catch (final CheckstyleException ex) {
-                // keep looking
+                LOG.debug("Keep looking, ignoring exception", ex);
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -30,6 +30,8 @@ import java.util.Properties;
 import java.security.MessageDigest;
 
 
+import com.google.common.io.Closeables;
+import com.google.common.io.Flushables;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 /**
@@ -98,7 +100,7 @@ final class PropertyCacheFile
                     .debug("Unable to open cache file, ignoring.", e);
             }
             finally {
-                Utils.closeQuietly(inStream);
+                Closeables.closeQuietly(inStream);
             }
         }
         detailsFile = setInActive ? null : fileName;
@@ -129,17 +131,13 @@ final class PropertyCacheFile
      */
     private void flushAndCloseOutStream(OutputStream stream)
     {
-        if (stream != null) {
-            try {
-                stream.flush();
-            }
-            catch (final IOException ex) {
-                Utils.getExceptionLogger()
-                    .debug("Unable to flush output stream.", ex);
-            }
-            finally {
-                Utils.closeQuietly(stream);
-            }
+        try {
+            Flushables.flush(stream, false);
+            Closeables.close(stream, false);
+        }
+        catch (final IOException ex) {
+            Utils.getExceptionLogger()
+                    .debug("Unable to flush and close output stream.", ex);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
@@ -18,7 +18,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.puppycrawl.tools.checkstyle;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -30,6 +29,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import com.google.common.io.Closeables;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -270,7 +270,7 @@ public final class Utils
             }
         }
         finally {
-            Utils.closeQuietly(lnr);
+            Closeables.closeQuietly(lnr);
         }
         return lines.toArray(new String[lines.size()]);
     }
@@ -324,23 +324,5 @@ public final class Utils
             stripped = fileName.substring(basedir.length() + skipSep);
         }
         return stripped;
-    }
-
-    /**
-     * Closes the supplied {@link Closeable} object ignoring an
-     * {@link IOException} if it is thrown. Honestly, what are you going to
-     * do if you cannot close a file.
-     * @param shutting the object to be closed.
-     */
-    public static void closeQuietly(Closeable shutting)
-    {
-        if (null != shutting) {
-            try {
-                shutting.close();
-            }
-            catch (IOException e) {
-                // ignore
-            }
-        }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.Utils;
 
 /**
@@ -146,7 +147,7 @@ public final class FileText extends AbstractList<String>
             }
         }
         finally {
-            Utils.closeQuietly(reader);
+            Closeables.closeQuietly(reader);
         }
         // buf.trimToSize(); // could be used instead of toString().
         fullText = buf.toString();
@@ -267,7 +268,7 @@ public final class FileText extends AbstractList<String>
             return ByteBuffer.wrap(bytes, 0, fill).asReadOnlyBuffer();
         }
         finally {
-            Utils.closeQuietly(stream);
+            Closeables.closeQuietly(stream);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
@@ -18,8 +18,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.puppycrawl.tools.checkstyle.checks;
 
+import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
-import com.puppycrawl.tools.checkstyle.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -80,15 +80,19 @@ public class NewlineAtEndOfFileCheck
         RandomAccessFile randomAccessFile = null;
         try {
             randomAccessFile = new RandomAccessFile(file, "r");
-            if (!endsWithNewline(randomAccessFile)) {
-                log(0, MSG_KEY_NO_NEWLINE_EOF, file.getPath());
+            boolean threw = true;
+            try {
+                if (!endsWithNewline(randomAccessFile)) {
+                    log(0, MSG_KEY_NO_NEWLINE_EOF, file.getPath());
+                }
+                threw = false;
+            }
+            finally {
+                Closeables.close(randomAccessFile, threw);
             }
         }
         catch (final IOException e) {
             log(0, MSG_KEY_UNABLE_OPEN, file.getPath());
-        }
-        finally {
-            Utils.closeQuietly(randomAccessFile);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.Defn;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
@@ -200,7 +201,7 @@ public class TranslationCheck
             logIOException(e, file);
         }
         finally {
-            Utils.closeQuietly(inStream);
+            Closeables.closeQuietly(inStream);
         }
         return keys;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -34,13 +34,13 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.List;
 
+import com.google.common.io.Closeables;
 import org.apache.commons.beanutils.ConversionException;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
-import com.puppycrawl.tools.checkstyle.Utils;
 
 /**
  * Abstract super class for header checks.
@@ -115,7 +115,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
                     "unable to load header file " + filename, ex);
         }
         finally {
-            Utils.closeQuietly(headerReader);
+            Closeables.closeQuietly(headerReader);
         }
     }
 
@@ -199,7 +199,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
             throw new ConversionException("unable to load header", ex);
         }
         finally {
-            Utils.closeQuietly(headerReader);
+            Closeables.closeQuietly(headerReader);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
@@ -19,6 +19,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.puppycrawl.tools.checkstyle.TestUtils.assertUtilsClassHasPrivateConstructor;
+import static com.puppycrawl.tools.checkstyle.Utils.baseClassname;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -77,6 +78,18 @@ public class UtilsTest
         assertTrue(fileExtensionMatches(file, null));
         file = new File("file.java");
         assertTrue(fileExtensionMatches(file, fileExtensions));
+    }
+
+    @Test
+    public void testBaseClassnameForCanonicalName()
+    {
+        assertEquals("List", baseClassname("java.util.List"));
+    }
+
+    @Test
+    public void testBaseClassnameForSimpleName()
+    {
+        assertEquals("Set", baseClassname("Set"));
     }
 
     @Test


### PR DESCRIPTION
#### Use Guava Closeables to manage closing exceptions 

>While it's not safe in the general case to ignore exceptions that are thrown when closing an I/O resource, it should generally be safe in the case of a resource that's being used only for reading, such as a Reader. Unlike with writable resources, there's no chance that a failure that occurs when closing the reader indicates a meaningful problem such as a failure to flush all bytes to the underlying resource.

`Reader` and `InputStream` instances are closed using `Closeables.closeQuietly()`, while `RandomAccessFile` is closed with `Closeables.close()` that throws `IOException` and needs to be handled.

From Javadoc:
>```java
public static void close(@Nullable
         Closeable closeable,
         boolean swallowIOException)
                  throws IOException
```
>Closes a Closeable, with control over whether an IOException may be thrown. This is primarily useful in a finally block, where a thrown exception needs to be logged but not propagated (otherwise the original exception will be lost).
If swallowIOException is true then we never throw IOException but merely log it.

>Example:
```java
   public void useStreamNicely() throws IOException {
     SomeStream stream = new SomeStream("foo");
     boolean threw = true;
     try {
       // ... code which does something with the stream ...
       threw = false;
     } finally {
       // If an exception occurs, rethrow it only if threw==false:
       Closeables.close(stream, threw);
     }
   }
```

Moreover, `Closeables.close()` and  `Flushables.flush()` are used to flush and close `OutputStream`.

#### Add logging to empty catch blocks to fix PMD violations, issue #744 

All violations of PMD rule [EmptyCatchBlock](http://pmd.sourceforge.net/pmd-5.2.3/pmd-java/rules/java/empty.html#EmptyCatchBlock) are fixed by logging exceptions.

#### Add unit tests for class base name util to improve coverage

Just to bump up coverage in `Utils` that was reduced by removing code.

#### General information

After this pull request will be merged, PMD report on Checkstyle's site won't generate anymore, as all violations are fixed. Then I'm going to bind PMD to `verify` or earlier phase to get fast feedback.