### PR TITLE
Remove unwritten field, issue #778

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -117,9 +117,6 @@ public final class TreeWalker
     private static final Log LOG =
         LogFactory.getLog("com.puppycrawl.tools.checkstyle.TreeWalker");
 
-    /** the file extensions that are accepted */
-    private String[] fileExtensions;
-
     /**
      * Creates a new <code>TreeWalker</code> instance.
      */
@@ -197,7 +194,7 @@ public final class TreeWalker
         final String fileName = file.getPath();
         final long timestamp = file.lastModified();
         if (cache.alreadyChecked(fileName, timestamp)
-                 || !fileExtensionMatches(file, fileExtensions))
+                 || !fileExtensionMatches(file, getFileExtensions()))
         {
             return;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -106,6 +106,15 @@ public abstract class AbstractFileSetCheck
     }
 
     /**
+     * @return file extensions that identify the files that pass the
+     * filter of this FileSetCheck.
+     */
+    public String[] getFileExtensions()
+    {
+        return fileExtensions;
+    }
+
+    /**
      * Sets the file extensions that identify the files that pass the
      * filter of this FileSetCheck.
      * @param extensions the set of file extensions. A missing


### PR DESCRIPTION
All violations of Findbugs rule [UwF: Unwritten field](http://findbugs.sourceforge.net/bugDescriptions.html#UWF_UNWRITTEN_FIELD) are fixed.

Field `fileExtensions` was never written and had it default `null` value. Looks like we had a real bug in code introduced not long time ago. We need to resolve all Findbugs problems ASAP and enforce no further violations.