### PR TITLE
Use value of putIfAbsent to fix Findbugs violation, issue #778

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
@@ -37,6 +37,8 @@ import org.apache.commons.logging.LogFactory;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 /**
  * Contains utility methods.
  *
@@ -211,8 +213,9 @@ public final class Utils
         final String key = pattern + ":flags-" + compileFlags;
         Pattern retVal = CREATED_RES.get(key);
         if (retVal == null) {
-            retVal = Pattern.compile(pattern, compileFlags);
-            CREATED_RES.putIfAbsent(key, retVal);
+            final Pattern compiledPattern = Pattern.compile(pattern, compileFlags);
+            retVal = CREATED_RES.putIfAbsent(key, compiledPattern);
+            retVal = firstNonNull(retVal, compiledPattern);
         }
         return retVal;
     }


### PR DESCRIPTION
Previously there was slight risk that returned value is not the one that is associated with the key in the map. This could happen if another thread inserted value to map between calls to `get` and `putIfAbsent`.

All violations of Findbugs rule [RV: Return value of putIfAbsent ignored, value passed to putIfAbsent reused](http://findbugs.sourceforge.net/bugDescriptions.html#RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED) are fixed.