### PR TITLE
Remove null checks on previously dereferenced values, issue #778

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -173,10 +173,7 @@ public class BlockParentHandler extends ExpressionHandler
         final DetailAST lcurly = getLCurly();
         final int lcurlyPos = expandedTabsColumnNo(lcurly);
 
-        if (lcurly == null
-            || curlyLevel().accept(lcurlyPos)
-            || !startsLine(lcurly))
-        {
+        if (curlyLevel().accept(lcurlyPos) || !startsLine(lcurly)) {
             return;
         }
 
@@ -224,8 +221,7 @@ public class BlockParentHandler extends ExpressionHandler
         final DetailAST rcurly = getRCurly();
         final int rcurlyPos = expandedTabsColumnNo(rcurly);
 
-        if (rcurly == null
-            || curlyLevel().accept(rcurlyPos)
+        if (curlyLevel().accept(rcurlyPos)
             || !rcurlyMustStart() && !startsLine(rcurly)
             || areOnSameLine(rcurly, lcurly))
         {


### PR DESCRIPTION
Violations of Findbugs rule [RCN: Nullcheck of value previously dereferenced](http://findbugs.sourceforge.net/bugDescriptions.html#RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE) in class `BlockParentHandler` are fixed.