### PR TITLE
CustomImportOrder checks import sorting according to ASCII order, fixes #847

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -119,17 +119,25 @@ import com.puppycrawl.tools.checkstyle.Utils;
  * </code>
  * </pre>
  * <p>
- * By the option it is possible to force alphabetically sorting.
+ * It is possible to enforce <a href="http://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>
+ * of imports in groups using the following configuration:
  * </p>
- *
  * <pre>
- * <code>
- * &lt;module name=&quot;CustomImportOrder&quot;&gt;
+ * <code>&lt;module name=&quot;CustomImportOrder&quot;&gt;
  *    &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
  * </code>
  * </pre>
- *
+ * <p>
+ * Example of ASCII order:
+ * </p>
+ * <pre>
+ * <code>import java.awt.Dialog;
+ * import java.awt.Window;
+ * import java.awt.color.ColorSpace;
+ * import java.awt.Frame; // violation here - in ASCII order 'F' should go before 'c',
+ *                        // as all uppercase come before lowercase letters</code>
+ * </pre>
  * <p>
  * To force checking imports sequence such as:
  * </p>
@@ -223,7 +231,7 @@ public class CustomImportOrderCheck extends Check
     /** Force empty line separator between import groups */
     private boolean separateLineBetweenGroups = true;
 
-    /** Force grouping alphabetically */
+    /** Force grouping alphabetically, in ASCII order */
     private boolean sortImportsInGroupAlphabetically;
 
     /** List of order declaration customizing by user */
@@ -605,7 +613,7 @@ public class CustomImportOrderCheck extends Check
             }
             final String import1Token = import1Tokens[i];
             final String import2Token = import2Tokens[i];
-            result = import1Token.compareToIgnoreCase(import2Token);
+            result = import1Token.compareTo(import2Token);
             if (result != 0) {
                 break;
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -46,7 +46,6 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
             "4: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT"),
-            "7: " + getCheckMessage(MSG_ORDER, "STANDARD_JAVA_PACKAGE"),
             "8: " + getCheckMessage(MSG_ORDER, "STANDARD_JAVA_PACKAGE"),
             "9: " + getCheckMessage(MSG_ORDER, "STANDARD_JAVA_PACKAGE"),
             "10: " + getCheckMessage(MSG_ORDER, "STANDARD_JAVA_PACKAGE"),
@@ -56,6 +55,8 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport
             "14: " + getCheckMessage(MSG_ORDER, "STANDARD_JAVA_PACKAGE"),
             "15: " + getCheckMessage(MSG_ORDER, "STANDARD_JAVA_PACKAGE"),
             "16: " + getCheckMessage(MSG_ORDER, "STANDARD_JAVA_PACKAGE"),
+            "17: " + getCheckMessage(MSG_ORDER, "STANDARD_JAVA_PACKAGE"),
+            "18: " + getCheckMessage(MSG_ORDER, "STANDARD_JAVA_PACKAGE"),
         };
 
         verify(checkConfig, getPath("imports" + File.separator
@@ -78,10 +79,9 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
             "4: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT"),
-            "9: " + getCheckMessage(MSG_LEX, "java.awt.Dialog"),
-            "13: " + getCheckMessage(MSG_LEX, "java.io.File"),
-            "15: " + getCheckMessage(MSG_LEX, "java.io.InputStream"),
-            "20: " + getCheckMessage(MSG_LEX, "com.google.common.collect.*"),
+            "10: " + getCheckMessage(MSG_LEX, "java.awt.Dialog"),
+            "15: " + getCheckMessage(MSG_LEX, "java.io.File"),
+            "22: " + getCheckMessage(MSG_LEX, "com.google.common.collect.*"),
         };
 
         verify(checkConfig, getPath("imports" + File.separator
@@ -104,12 +104,11 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
             "4: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT"),
-            "9: " + getCheckMessage(MSG_LEX, "java.awt.Dialog"),
-            "13: " + getCheckMessage(MSG_LEX, "java.io.File"),
-            "15: " + getCheckMessage(MSG_LEX, "java.io.InputStream"),
-            "18: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-            "20: " + getCheckMessage(MSG_NONGROUP_IMPORT),
-            "21: " + getCheckMessage(MSG_LINE_SEPARATOR, "org.junit.*"),
+            "10: " + getCheckMessage(MSG_LEX, "java.awt.Dialog"),
+            "15: " + getCheckMessage(MSG_LEX, "java.io.File"),
+            "20: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "22: " + getCheckMessage(MSG_NONGROUP_IMPORT),
+            "23: " + getCheckMessage(MSG_LINE_SEPARATOR, "org.junit.*"),
         };
 
         verify(checkConfig, getPath("imports" + File.separator

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder.java
@@ -2,11 +2,13 @@ package com.puppycrawl.tools.checkstyle.imports;
 
 import static java.io.File.createTempFile;
 import static java.awt.Button.ABORT;
+import static java.awt.print.Paper.*;
 import static javax.swing.WindowConstants.*;
 
 import java.awt.Button;
 import java.awt.Frame;
 import java.awt.Dialog;
+import java.awt.color.ColorSpace;
 import java.awt.event.ActionEvent;
 import javax.swing.JComponent;
 import javax.swing.JTable;

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -698,7 +698,7 @@ public class SomeClass { ... }
           </tr>
           <tr>
             <td>sortImportsInGroupAlphabetically</td>
-            <td>Force grouping alphabetically.</td>
+            <td>Force grouping alphabetically, in <a href="http://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>.</td>
             <td><a href="property_types.html#boolean">boolean</a></td>
             <td><code>false</code></td>
           </tr>
@@ -728,12 +728,23 @@ public class SomeClass { ... }
 &lt;/module&gt;
         </source>
         <p>
-          By the option it is possible to force alphabetically sorting.
+          It is possible to enforce <a href="http://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>
+          of imports in groups using the following configuration:
         </p>
        <source>
 &lt;module name=&quot;CustomImportOrder&quot;&gt;
     &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
+       </source>
+       <p>
+         Example of ASCII order:
+       </p>
+       <source>
+import java.awt.Dialog;
+import java.awt.Window;
+import java.awt.color.ColorSpace;
+import java.awt.Frame; // violation here - in ASCII order 'F' should go before 'c',
+                       // as all uppercase come before lowercase letters
        </source>
        <p>
          To force checking imports sequence such as:


### PR DESCRIPTION
Previously used 'ignoreCase' order is different than required ASCII order.

Rendered Javadoc:
![image](https://cloud.githubusercontent.com/assets/5467276/6814362/44703a84-d27e-11e4-8a4b-3b3f4ee48adc.png)

Properties:
![image](https://cloud.githubusercontent.com/assets/5467276/6814400/8e415e2c-d27e-11e4-89d8-9cef096a6988.png)

Documentation:
![image](https://cloud.githubusercontent.com/assets/5467276/6814421/accfe8ea-d27e-11e4-98b9-503ea028d914.png)
