### PR TITLE
Use entrySet iterator to fix FindBugs violations, issue #778

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
@@ -136,12 +136,10 @@ public class EqualsHashCodeCheck
     @Override
     public void finishTree(DetailAST rootAST)
     {
-        final Set<DetailAST> equalsDefs = objBlockEquals.keySet();
-        for (DetailAST objBlock : equalsDefs) {
-            if (!objBlockWithHashCode.contains(objBlock)) {
-                final DetailAST equalsAST = objBlockEquals.get(objBlock);
-                log(equalsAST.getLineNo(), equalsAST.getColumnNo(),
-                        MSG_KEY);
+        for (Map.Entry<DetailAST, DetailAST> detailASTDetailASTEntry : objBlockEquals.entrySet()) {
+            if (!objBlockWithHashCode.contains(detailASTDetailASTEntry.getKey())) {
+                final DetailAST equalsAST = detailASTDetailASTEntry.getValue();
+                log(equalsAST.getLineNo(), equalsAST.getColumnNo(), MSG_KEY);
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -27,7 +27,6 @@ import com.puppycrawl.tools.checkstyle.Utils;
 import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 
@@ -182,14 +181,13 @@ public class MultipleStringLiteralsCheck extends Check
     @Override
     public void finishTree(DetailAST rootAST)
     {
-        final Set<String> keys = stringMap.keySet();
-        for (String key : keys) {
-            final List<StringInfo> hits = stringMap.get(key);
+        for (Map.Entry<String, List<StringInfo>> stringListEntry : stringMap.entrySet()) {
+            final List<StringInfo> hits = stringListEntry.getValue();
             if (hits.size() > allowedDuplicates) {
                 final StringInfo firstFinding = hits.get(0);
                 final int line = firstFinding.getLine();
                 final int col = firstFinding.getCol();
-                log(line, col, MSG_KEY, key, hits.size());
+                log(line, col, MSG_KEY, stringListEntry.getKey(), hits.size());
             }
         }
     }


### PR DESCRIPTION
These methods accessed the value of a `Map` entry, using a key that was retrieved from a `keySet` iterator. It is more efficient to use an iterator on the `entrySet` of the map, to avoid the `Map.get(key)` lookup.

All violations of FindBugs rule [WMI: Inefficient use of keySet iterator instead of entrySet iterator](http://findbugs.sourceforge.net/bugDescriptions.html#WMI_WRONG_MAP_ITERATOR) are fixed.