### PR TITLE
Disable Findbugs for 'grammars' package, issue  #778

### DIFF
--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Package name="~com\.puppycrawl\.tools\.checkstyle\.grammars.*" />
+    </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -1056,6 +1056,9 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
         <version>3.0.1</version>
+        <configuration>
+          <excludeFilterFile>config/findbugs-exclude.xml</excludeFilterFile>
+        </configuration>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Package `com.puppycrawl.tools.checkstyle.grammars` contains only autogenerated code, so it should be excluded from Findbugs analysis.