### PR TITLE
Use SVG badge for coveralls.io.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ directory.
 [sonar img]:https://dev.eclipse.org/sonar/images/sonarqube-24x100.png
 
 [coverage]:https://coveralls.io/r/checkstyle/checkstyle
-[coverage img]:https://coveralls.io/repos/checkstyle/checkstyle/badge.png
+[coverage img]:https://coveralls.io/repos/checkstyle/checkstyle/badge.svg
 
 [license]:LICENSE
 [license img]:https://img.shields.io/badge/license-GNU%20LGPL%20v2.1-blue.svg


### PR DESCRIPTION
Now the coveralls.io badge will have a consistent flat look like the other badges.

**Before:**
![before](https://cloud.githubusercontent.com/assets/3539501/6916187/c0800c92-d7b7-11e4-8f85-93c9c04de848.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/3539501/6916189/c94fe0e0-d7b7-11e4-8f4a-baf7a88b30ac.png)

