### PR TITLE
added validation for header in setHeader in RegexpHeaderCheck.java

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -145,4 +145,25 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck
         }
     }
 
+    /**
+     * Validates the {@code header} by compiling it with
+     * {@link Pattern#compile(java.lang.String) } and throws
+     * {@link PatternSyntaxException} if {@code header} isn't a valid pattern.
+     * @param header the header value to validate and set (in that order)
+     */
+    @Override
+    public void setHeader(String header)
+    {
+        if (header == null || header.trim().length() == 0) {
+            return;
+        }
+        try {
+            Pattern.compile(header);
+        }
+        catch (PatternSyntaxException exception) {
+            throw exception;
+        }
+        super.setHeader(header);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
@@ -1,0 +1,66 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.header;
+
+import java.util.regex.PatternSyntaxException;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author richter
+ */
+public class RegexpHeaderCheckTest
+{
+
+    public RegexpHeaderCheckTest()
+    {
+    }
+
+    /**
+     * Test of setHeader method, of class RegexpHeaderCheck.
+     */
+    @Test
+    public void testSetHeader()
+    {
+        // check null passes
+        RegexpHeaderCheck instance = new RegexpHeaderCheck(); // recreate for
+            // each test because multiple invokations fail
+        String header = null;
+        instance.setHeader(header);
+        // check empty string passes
+        instance = new RegexpHeaderCheck();
+        header = "";
+        instance.setHeader(header);
+        // check valid header passes
+        instance = new RegexpHeaderCheck();
+        header = "abc.*";
+        instance.setHeader(header);
+        // check invalid header passes
+        instance = new RegexpHeaderCheck();
+        header = "^/**\\n * Licensed to the Apache Software Foundation (ASF)";
+        try {
+            instance.setHeader(header);
+            Assert.fail(String.format("%s should have been thrown", PatternSyntaxException.class));
+        }
+        catch (PatternSyntaxException ex) {
+        }
+    }
+
+}


### PR DESCRIPTION
to provide better feedback when an invalid Pattern is specified (was InvocationTargetException only before)

problem is described at http://stackoverflow.com/questions/29272034/whats-the-reason-for-header-specification-is-not-a-regular-expression-invocat

copy-paste from stackoverflow post:
I'm running the maven-checkstyle-plugin 2.15 with the following specification of a header check
```
<module name="RegexpHeader">
    <property
        name="header"
        value="^&lt;!--\n    Licensed to the Apache Software Foundation (ASF) under one or more\n   contributor license agreements.  See the NOTICE file distributed with\n   this work for additional information regarding copyright ownership.\n   The ASF licenses this file to You under the Apache License, Version 2.0\n   (the &quot;License&quot;); you may not use this file except in compliance with\n   the License.  You may obtain a copy of the License at\n\n        http://www.apache.org/licenses/LICENSE-2.0\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License.--&gt;.*"/>
    <property name="fileExtensions" value="xml"/>
</module>
<module name="RegexpHeader">
    <property
        name="header"
        value="^/**\n * Licensed to the Apache Software Foundation (ASF) under one or more\n * contributor license agreements.  See the NOTICE file distributed with\n * this work for additional information regarding copyright ownership.\n * The ASF licenses this file to You under the Apache License, Version 2.0\n * (the &quot;License&quot;); you may not use this file except in compliance with\n * the License.  You may obtain a copy of the License at\n *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required by applicable law or agreed to in writing, software\n * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,\n * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n * See the License for the specific language governing permissions and\n * limitations under the License.\n */"/>
    <property name="fileExtensions" value="java"/>
</module>
```

What could cause the error line 1 in header specification is not a regular expression: InvocationTargetException? There's nothing to try because the plugin doesn't tell what's actually wrong (could return parser error details or anything helpful).

The complete error is
```
Failed during checkstyle configuration: cannot initialize module RegexpHeader - Cannot set property 'header' in module RegexpHeader to '^/**\n * Licensed to the Apache Software Foundation (ASF) under one or more\n * contributor license agreements.  See the NOTICE file distributed with\n * this work for additional information regarding copyright ownership.\n * The ASF licenses this file to You under the Apache License, Version 2.0\n * (the "License"); you may not use this file except in compliance with\n * the License.  You may obtain a copy of the License at\n *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required by applicable law or agreed to in writing, software\n * distributed under the License is distributed on an "AS IS" BASIS,\n * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n * See the License for the specific language governing permissions and\n * limitations under the License.\n */.*': line 1 in header specification is not a regular expression: InvocationTargetException -> [Help 1]
```
