### PR TITLE
Replace all occurrences of FastStack with ArrayDeque, issue #86

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -18,6 +18,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.puppycrawl.tools.checkstyle.checks;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,7 +28,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FastStack;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -55,8 +57,7 @@ public abstract class AbstractTypeAwareCheck extends Check
     private ClassResolver classResolver;
 
     /** Stack of maps for type params. */
-    private final FastStack<Map<String, ClassInfo>> typeParams =
-        FastStack.newInstance();
+    private final Deque<Map<String, ClassInfo>> typeParams = new ArrayDeque<>();
 
     /**
      * Whether to log class loading errors to the checkstyle report
@@ -407,8 +408,9 @@ public abstract class AbstractTypeAwareCheck extends Check
     protected final ClassInfo findClassAlias(final String name)
     {
         ClassInfo ci = null;
-        for (int i = typeParams.size() - 1; i >= 0; i--) {
-            final Map<String, ClassInfo> paramMap = typeParams.peek(i);
+        final Iterator<Map<String, ClassInfo>> iterator = typeParams.descendingIterator();
+        while (iterator.hasNext()) {
+            final Map<String, ClassInfo> paramMap = iterator.next();
             ci = paramMap.get(name);
             if (ci != null) {
                 break;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -20,10 +20,13 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FastStack;
 import com.puppycrawl.tools.checkstyle.api.ScopeUtils;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -77,8 +80,7 @@ public class FinalLocalVariableCheck extends Check
     public static final String MSG_KEY = "final.variable";
 
     /** Scope Stack */
-    private final FastStack<Map<String, DetailAST>> scopeStack =
-        FastStack.newInstance();
+    private final Deque<Map<String, DetailAST>> scopeStack = new ArrayDeque<>();
 
     /** Controls whether to check enhanced for-loop variable. */
     private boolean validateEnhancedForLoopVariable;
@@ -275,8 +277,9 @@ public class FinalLocalVariableCheck extends Check
      */
     private void removeVariable(DetailAST ast)
     {
-        for (int i = scopeStack.size() - 1; i >= 0; i--) {
-            final Map<String, DetailAST> state = scopeStack.peek(i);
+        final Iterator<Map<String, DetailAST>> iterator = scopeStack.descendingIterator();
+        while (iterator.hasNext()) {
+            final Map<String, DetailAST> state = iterator.next();
             final Object obj = state.remove(ast.getText());
             if (obj != null) {
                 break;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
@@ -20,9 +20,11 @@ package com.puppycrawl.tools.checkstyle.checks.metrics;
 
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FastStack;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.CheckUtils;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 /**
  * Restricts nested boolean operators (&amp;&amp;, ||, &amp;, | and ^) to
@@ -47,11 +49,11 @@ public final class BooleanExpressionComplexityCheck extends Check
     private static final int DEFAULT_MAX = 3;
 
     /** Stack of contexts. */
-    private final FastStack<Context> contextStack = FastStack.newInstance();
+    private final Deque<Context> contextStack = new ArrayDeque<>();
     /** Maximum allowed complexity. */
     private int max;
     /** Current context. */
-    private Context context;
+    private Context context = new Context(false);
 
     /** Creates new instance of the check. */
     public BooleanExpressionComplexityCheck()


### PR DESCRIPTION
This commit removes all remaining usages of `FastStack`. Removal is scheduled in #989.