### PR TITLE
Fix AvoidStaticImport check violations in codebase, issue #979

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -229,6 +229,7 @@
     <module name="AvoidNestedBlocks">
       <property name="allowInSwitchCase" value="true"/>
     </module>
+    <module name="AvoidStaticImport"/>
 
 <!--
     <module name="AbbreviationAsWordInName"/>
@@ -239,7 +240,6 @@
     <module name="AtclauseOrder"/>
     <module name="AvoidEscapedUnicodeCharacters"/>
     <module name="AvoidInlineConditionals"/>
-    <module name="AvoidStaticImport"/>
     <module name="BooleanExpressionComplexity"/>
     <module name="ClassDataAbstractionCoupling"/>
     <module name="ClassFanOutComplexity"/>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -35,6 +35,7 @@
     <suppress checks="ImportControl" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="Javadoc" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="MagicNumber" files=".*[\\/]src[\\/]test[\\/]"/>
+    <suppress checks="AvoidStaticImport" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="MethodCount" files="[\\/]IndentationCheckTest.java$"/>
     <suppress checks="EqualsAvoidNull" files="[\\/]Int.*FilterTest.java$"/>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -47,8 +47,6 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.SortedSet;
 
-import static com.puppycrawl.tools.checkstyle.Utils.fileExtensionMatches;
-
 /**
  * This class provides the functionality to check a set of files.
  * @author Oliver Burn
@@ -259,7 +257,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher
 
         // Process each file
         for (final File f : files) {
-            if (!fileExtensionMatches(f, fileExtensions)) {
+            if (!Utils.fileExtensionMatches(f, fileExtensions)) {
                 continue;
             }
             final String fileName = f.getAbsolutePath();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -54,8 +54,6 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaLexer;
 import com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaRecognizer;
 
-import static com.puppycrawl.tools.checkstyle.Utils.fileExtensionMatches;
-
 /**
  * Responsible for walking an abstract syntax tree and notifying interested
  * checks at each each node.
@@ -189,7 +187,7 @@ public final class TreeWalker
         final String fileName = file.getPath();
         final long timestamp = file.lastModified();
         if (cache.alreadyChecked(fileName, timestamp)
-                 || !fileExtensionMatches(file, getFileExtensions()))
+                 || !Utils.fileExtensionMatches(file, getFileExtensions()))
         {
             return;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
@@ -21,8 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.AbstractOptionCheck;
-
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Checks for empty blocks. The policy to verify is specified using the {@link
@@ -177,7 +176,7 @@ public class EmptyBlockCheck
                 // Handle braces on the same line
                 final String txt = lines[slistLineNo - 1]
                     .substring(slistColNo + 1, rcurlyColNo);
-                if (isNotBlank(txt)) {
+                if (StringUtils.isNotBlank(txt)) {
                     retVal = true;
                 }
             }


### PR DESCRIPTION
Dozens of tests import statically from the class being tested, so I decided to skip this check for test code.