### PR TITLE
Fix PMD violations from UseVarargs rule, issue #999

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -125,8 +125,6 @@
     <exclude name="EmptyMethodInAbstractClassShouldBeAbstract"/>
     <!-- till #998 -->
     <exclude name="TooFewBranchesForASwitchStatement"/>
-    <!-- till #999 -->
-    <exclude name="UseVarargs"/>
     <!-- we will use our own declaration order logic -->
     <exclude name="FieldDeclarationsShouldBeAtStartOfClass"/>
     <!-- too much alarms of Checks, we will never move logic out of Check, each Check is independed logic contianer -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -385,7 +385,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher
      * @param extensions the set of file extensions. A missing
      * initial '.' character of an extension is automatically added.
      */
-    public final void setFileExtensions(String[] extensions)
+    public final void setFileExtensions(String... extensions)
     {
         if (extensions == null) {
             fileExtensions = null;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -52,7 +52,7 @@ public final class Main
      * @param args the command line arguments
      * @exception UnsupportedEncodingException if there is a problem to use UTF-8
      **/
-    public static void main(String[] args) throws UnsupportedEncodingException
+    public static void main(String... args) throws UnsupportedEncodingException
     {
         boolean parseResult = false;
         try {
@@ -85,7 +85,7 @@ public final class Main
      *         when passed arguments are not valid
      * @exception CheckstyleException when provided parameters are not supported
      */
-    private static CommandLine parseCli(String[] args)
+    private static CommandLine parseCli(String... args)
             throws ParseException
     {
         // parse the parameters
@@ -198,7 +198,7 @@ public final class Main
      * @throws CheckstyleException
      *         when there is no file to process
      */
-    private static List<File> getFilesToProcess(String[] filesToProcess)
+    private static List<File> getFilesToProcess(String... filesToProcess)
             throws CheckstyleException
     {
         final List<File> files = Lists.newLinkedList();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -220,7 +220,7 @@ final class PropertyCacheFile
      * @param byteArray the byte array
      * @return hex encoding of <code>byteArray</code>
      */
-    private static String hexEncode(byte[] byteArray)
+    private static String hexEncode(byte... byteArray)
     {
         final StringBuilder buf = new StringBuilder(2 * byteArray.length);
         for (final byte b : byteArray) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -119,7 +119,7 @@ public final class TreeWalker
      */
     public TreeWalker()
     {
-        setFileExtensions(new String[]{"java"});
+        setFileExtensions("java");
     }
 
     /** @param tabWidth the distance between tab stops */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
@@ -46,7 +46,7 @@ public final class Utils
      * @param fileExtensions files extensions, empty property in config makes it matches to all.
      * @return whether there is a match.
      */
-    public static boolean fileExtensionMatches(File file, String[] fileExtensions)
+    public static boolean fileExtensionMatches(File file, String... fileExtensions)
     {
         boolean result = false;
         if (fileExtensions == null || fileExtensions.length == 0) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -121,7 +121,7 @@ public abstract class AbstractFileSetCheck
      * @param extensions the set of file extensions. A missing
      * initial '.' character of an extension is automatically added.
      */
-    public final void setFileExtensions(String[] extensions)
+    public final void setFileExtensions(String... extensions)
     {
         if (extensions == null) {
             fileExtensions = null;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
@@ -98,7 +98,7 @@ public abstract class Check extends AbstractViolationReporter
      * Adds a set of tokens the check is interested in.
      * @param strRep the string representation of the tokens interested in
      */
-    public final void setTokens(String[] strRep)
+    public final void setTokens(String... strRep)
     {
         Collections.addAll(tokens, strRep);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -74,7 +74,7 @@ public final class FileContents implements CommentListener
      * @deprecated Use {@link #FileContents(FileText)} instead
      *   in order to preserve the original line breaks where possible.
      */
-    @Deprecated public FileContents(String filename, String[] lines)
+    @Deprecated public FileContents(String filename, String... lines)
     {
         this.fileName = filename;
         text = FileText.fromLines(new File(filename), Arrays.asList(lines));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
@@ -319,7 +319,7 @@ public class DescendantTokenCheck extends Check
      * Sets the tokens which occurance as descendant is limited.
      * @param limitedTokensParam - list of tokens to ignore.
      */
-    public void setLimitedTokens(String[] limitedTokensParam)
+    public void setLimitedTokens(String... limitedTokensParam)
     {
         limitedTokens = new int[limitedTokensParam.length];
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/LineSeparatorOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/LineSeparatorOption.java
@@ -55,7 +55,7 @@ public enum LineSeparatorOption
      * @return if bytes is equal to the byte representation
      * of this line separator
      */
-    public boolean matches(byte[] bytes)
+    public boolean matches(byte... bytes)
     {
         final String s = new String(bytes);
         return s.equals(lineSeparator);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -94,7 +94,7 @@ public class TranslationCheck
      */
     public TranslationCheck()
     {
-        setFileExtensions(new String[]{"properties"});
+        setFileExtensions("properties");
         setBasenameSeparator("_");
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -54,8 +54,7 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck
      */
     public UniquePropertiesCheck()
     {
-        super.setFileExtensions(new String[]
-        {"properties"});
+        super.setFileExtensions("properties");
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalCheck.java
@@ -35,7 +35,7 @@ public abstract class AbstractIllegalCheck extends Check
      * Constructs an object.
      * @param initialNames the initial class names to treat as illegal
      */
-    protected AbstractIllegalCheck(final String[] initialNames)
+    protected AbstractIllegalCheck(final String... initialNames)
     {
         assert initialNames != null;
         setIllegalClassNames(initialNames);
@@ -59,7 +59,7 @@ public abstract class AbstractIllegalCheck extends Check
      * @param classNames
      *            array of illegal exception classes
      */
-    public final void setIllegalClassNames(final String[] classNames)
+    public final void setIllegalClassNames(final String... classNames)
     {
         assert classNames != null;
         illegalClassNames.clear();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -43,13 +43,8 @@ public final class IllegalCatchCheck extends AbstractIllegalCheck
     /** Creates new instance of the check. */
     public IllegalCatchCheck()
     {
-        super(new String[] {"Exception", "Error",
-                            "RuntimeException", "Throwable",
-                            "java.lang.Error",
-                            "java.lang.Exception",
-                            "java.lang.RuntimeException",
-                            "java.lang.Throwable",
-        });
+        super("Exception", "Error", "RuntimeException", "Throwable", "java.lang.Error",
+                "java.lang.Exception", "java.lang.RuntimeException", "java.lang.Throwable");
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
@@ -71,12 +71,8 @@ public final class IllegalThrowsCheck extends AbstractIllegalCheck
     /** Creates new instance of the check. */
     public IllegalThrowsCheck()
     {
-        super(new String[] {"Error",
-                            "RuntimeException", "Throwable",
-                            "java.lang.Error",
-                            "java.lang.RuntimeException",
-                            "java.lang.Throwable",
-        });
+        super("Error", "RuntimeException", "Throwable", "java.lang.Error",
+                "java.lang.RuntimeException", "java.lang.Throwable");
         setIgnoredMethodNames(DEFAULT_IGNORED_METHOD_NAMES);
     }
 
@@ -144,7 +140,7 @@ public final class IllegalThrowsCheck extends AbstractIllegalCheck
      * Set the list of ignore method names.
      * @param methodNames array of ignored method names
      */
-    public void setIgnoredMethodNames(String[] methodNames)
+    public void setIgnoredMethodNames(String... methodNames)
     {
         ignoredMethodNames.clear();
         Collections.addAll(ignoredMethodNames, methodNames);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -402,7 +402,7 @@ public final class IllegalTypeCheck extends AbstractFormatCheck
      * Set the list of illegal variable types.
      * @param classNames array of illegal variable types
      */
-    public void setIllegalClassNames(String[] classNames)
+    public void setIllegalClassNames(String... classNames)
     {
         illegalClassNames.clear();
         Collections.addAll(illegalClassNames, classNames);
@@ -422,7 +422,7 @@ public final class IllegalTypeCheck extends AbstractFormatCheck
      * Set the list of ignore method names.
      * @param methodNames array of ignored method names
      */
-    public void setIgnoredMethodNames(String[] methodNames)
+    public void setIgnoredMethodNames(String... methodNames)
     {
         ignoredMethodNames.clear();
         Collections.addAll(ignoredMethodNames, methodNames);
@@ -442,7 +442,7 @@ public final class IllegalTypeCheck extends AbstractFormatCheck
      * Set the list of legal abstract class names.
      * @param classNames array of legal abstract class names
      */
-    public void setLegalAbstractClassNames(String[] classNames)
+    public void setLegalAbstractClassNames(String... classNames)
     {
         legalAbstractClassNames.clear();
         Collections.addAll(legalAbstractClassNames, classNames);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
@@ -244,7 +244,7 @@ public class InnerAssignmentCheck
      * @return whether the parents nodes of ast match
      * one of the allowed type paths
      */
-    private static boolean isInContext(DetailAST ast, int[][] contextSet)
+    private static boolean isInContext(DetailAST ast, int[]... contextSet)
     {
         for (int[] element : contextSet) {
             DetailAST current = ast;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -346,7 +346,7 @@ public class MagicNumberCheck extends Check
      * BeanUtils converts numeric token list to double array automatically.
      * @param list list of numbers to ignore.
      */
-    public void setIgnoreNumbers(double[] list)
+    public void setIgnoreNumbers(double... list)
     {
         if (list.length == 0) {
             ignoreNumbers = new double[0];

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheck.java
@@ -49,9 +49,7 @@ public class MissingCtorCheck extends DescendantTokenCheck
     /** Creates new instance of the check. */
     public MissingCtorCheck()
     {
-        setLimitedTokens(new String[] {
-            TokenTypes.getTokenName(TokenTypes.CTOR_DEF),
-        });
+        setLimitedTokens(TokenTypes.getTokenName(TokenTypes.CTOR_DEF));
         setMinimumNumber(1);
         setMaximumDepth(2);
         setMinimumMessage(MSG_KEY);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
@@ -54,9 +54,7 @@ public class MissingSwitchDefaultCheck extends DescendantTokenCheck
     /** Creates new instance of the check. */
     public MissingSwitchDefaultCheck()
     {
-        setLimitedTokens(new String[] {
-            TokenTypes.getTokenName(TokenTypes.LITERAL_DEFAULT),
-        });
+        setLimitedTokens(TokenTypes.getTokenName(TokenTypes.LITERAL_DEFAULT));
         setMinimumNumber(1);
         setMaximumDepth(2);
         setMinimumMessage(MSG_KEY);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -109,7 +109,7 @@ public class MultipleStringLiteralsCheck extends Check
      * Adds a set of tokens the check is interested in.
      * @param strRep the string representation of the tokens interested in
      */
-    public final void setIgnoreOccurrenceContext(String[] strRep)
+    public final void setIgnoreOccurrenceContext(String... strRep)
     {
         ignoreOccurrenceContext.clear();
         for (final String s : strRep) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -327,7 +327,7 @@ public class UnnecessaryParenthesesCheck extends Check
      * @return <code>true</code> if <code>type</code> was found in <code>
      *         tokens</code>.
      */
-    private boolean inTokenList(int type, int[] tokens)
+    private boolean inTokenList(int type, int... tokens)
     {
         // NOTE: Given the small size of the two arrays searched, I'm not sure
         //       it's worth bothering with doing a binary search or using a

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -316,7 +316,7 @@ public class VisibilityModifierCheck
      * Set the list of ignore annotations.
      * @param annotationNames array of ignore annotations canonical names.
      */
-    public void setIgnoreAnnotationCanonicalNames(String[] annotationNames)
+    public void setIgnoreAnnotationCanonicalNames(String... annotationNames)
     {
         ignoreAnnotationCanonicalNames = Arrays.asList(annotationNames);
     }
@@ -379,7 +379,7 @@ public class VisibilityModifierCheck
      * Set the list of immutable classes types names.
      * @param classNames array of immutable types canonical names.
      */
-    public void setImmutableClassCanonicalNames(String[] classNames)
+    public void setImmutableClassCanonicalNames(String... classNames)
     {
         immutableClassCanonicalNames = Arrays.asList(classNames);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
@@ -74,7 +74,7 @@ public class HeaderCheck extends AbstractHeaderCheck
      * Set the lines numbers to ignore in the header check.
      * @param list comma separated list of line numbers to ignore in header.
      */
-    public void setIgnoreLines(int[] list)
+    public void setIgnoreLines(int... list)
     {
         if (list == null || list.length == 0) {
             ignoreLines = EMPTY_INT_ARRAY;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -55,7 +55,7 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck
      * Set the lines numbers to repeat in the header check.
      * @param list comma separated list of line numbers to repeat in header.
      */
-    public void setMultiLines(int[] list)
+    public void setMultiLines(int... list)
     {
         if (list == null || list.length == 0) {
             multiLines = EMPTY_INT_ARRAY;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
@@ -98,7 +98,7 @@ public class AvoidStarImportCheck
      * @param excludesParam a list of package names/fully-qualifies class names
      * where star imports are ok
      */
-    public void setExcludes(String[] excludesParam)
+    public void setExcludes(String... excludesParam)
     {
         excludes.clear();
         for (final String exclude : excludesParam) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
@@ -91,7 +91,7 @@ public class AvoidStaticImportCheck
      * @param excludes a list of fully-qualified class names/specific
      * static members where static imports are ok
      */
-    public void setExcludes(String[] excludes)
+    public void setExcludes(String... excludes)
     {
         this.excludes = excludes.clone();
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
@@ -75,14 +75,14 @@ public class IllegalImportCheck
      */
     public IllegalImportCheck()
     {
-        setIllegalPkgs(new String[] {"sun"});
+        setIllegalPkgs("sun");
     }
 
     /**
      * Set the list of illegal packages.
      * @param from array of illegal packages
      */
-    public void setIllegalPkgs(String[] from)
+    public void setIllegalPkgs(String... from)
     {
         illegalPkgs = from.clone();
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -170,7 +170,7 @@ public class ImportOrderCheck
      *
      * @param packageGroups a comma-separated list of package names/prefixes.
      */
-    public void setGroups(String[] packageGroups)
+    public void setGroups(String... packageGroups)
     {
         groups = new Pattern[packageGroups.length];
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
@@ -133,7 +133,7 @@ public class JavadocNodeImpl implements DetailNode
         this.columnNumber = columnNumber;
     }
 
-    public void setChildren(DetailNode[] children)
+    public void setChildren(DetailNode... children)
     {
         this.children = Arrays.copyOf(children, children.length);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
@@ -56,7 +56,7 @@ public class JavadocPackageCheck extends AbstractFileSetCheck
     {
         // java, not html!
         // The rule is: Every JAVA file should have a package.html sibling
-        setFileExtensions(new String[]{"java"});
+        setFileExtensions("java");
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -273,7 +273,7 @@ public class JavadocStyleCheck
      * @param comments the lines of Javadoc.
      * @return a comment text String.
      */
-    private String getCommentText(String[] comments)
+    private String getCommentText(String... comments)
     {
         final StringBuffer buffer = new StringBuffer();
         for (final String line : comments) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -106,7 +106,7 @@ public abstract class AbstractClassCouplingCheck extends Check
      * Sets user-excluded classes to ignore.
      * @param excludedClasses the list of classes to ignore.
      */
-    public final void setExcludedClasses(String[] excludedClasses)
+    public final void setExcludedClasses(String... excludedClasses)
     {
         this.excludedClasses = ImmutableSet.copyOf(excludedClasses);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
@@ -44,7 +44,7 @@ public final class ClassDataAbstractionCouplingCheck
     public ClassDataAbstractionCouplingCheck()
     {
         super(DEFAULT_MAX);
-        setTokens(new String[] {"LITERAL_NEW"});
+        setTokens("LITERAL_NEW");
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/doclets/CheckDocsDoclet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/doclets/CheckDocsDoclet.java
@@ -235,7 +235,7 @@ public final class CheckDocsDoclet
      * @param options Javadoc commandline options
      * @return the dest dir specified on the command line (or ant task)
      */
-    public static String getDestDir(String[][] options)
+    public static String getDestDir(String[]... options)
     {
         for (final String[] opt : options) {
             if (DEST_DIR_OPT.equalsIgnoreCase(opt[0])) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
@@ -141,7 +141,7 @@ public final class TokenTypesDoclet
      * @param options all specified options.
      * @return destination file name
      */
-    private static String getDestFileName(String[][] options)
+    private static String getDestFileName(String[]... options)
     {
         String fileName = null;
         for (final String[] opt : options) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/AbstractTreeTableModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/AbstractTreeTableModel.java
@@ -136,7 +136,7 @@ public abstract class AbstractTreeTableModel implements TreeTableModel
      */
     protected void fireTreeNodesChanged(Object source, Object[] path,
             int[] childIndices,
-            Object[] children)
+            Object... children)
     {
         // Guaranteed to return a non-null array
         final Object[] listeners = listenerList.getListenerList();
@@ -164,7 +164,7 @@ public abstract class AbstractTreeTableModel implements TreeTableModel
      */
     protected void fireTreeNodesInserted(Object source, Object[] path,
             int[] childIndices,
-            Object[] children)
+            Object... children)
     {
         // Guaranteed to return a non-null array
         final Object[] listeners = listenerList.getListenerList();
@@ -192,7 +192,7 @@ public abstract class AbstractTreeTableModel implements TreeTableModel
      */
     protected void fireTreeNodesRemoved(Object source, Object[] path,
             int[] childIndices,
-            Object[] children)
+            Object... children)
     {
         // Guaranteed to return a non-null array
         final Object[] listeners = listenerList.getListenerList();
@@ -220,7 +220,7 @@ public abstract class AbstractTreeTableModel implements TreeTableModel
      */
     protected void fireTreeStructureChanged(Object source, Object[] path,
             int[] childIndices,
-            Object[] children)
+            Object... children)
     {
         // Guaranteed to return a non-null array
         final Object[] listeners = listenerList.getListenerList();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
@@ -246,7 +246,7 @@ class FileDrop
          * @param files An array of <tt>File</tt>s that were dropped.
          * @since 1.0
          */
-        void filesDropped(File[] files);
+        void filesDropped(File... files);
     }
 
     private class FileDropTargetListener implements DropTargetListener

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
@@ -38,7 +38,7 @@ public class Main
     /**
      * Entry point
      */
-    public static void main(String[] args)
+    public static void main(String... args)
     {
         frame = new JFrame("CheckStyle");
         final ParseTreeInfoPanel panel = new ParseTreeInfoPanel();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -160,7 +160,7 @@ public class ParseTreeInfoPanel extends JPanel
         private final JScrollPane mSp;
 
         @Override
-        public void filesDropped(File[] files)
+        public void filesDropped(File... files)
         {
             if (files != null && files.length > 0)
             {


### PR DESCRIPTION
The changes are fully backward-compatible. Method with vararg can be invoked both using array and list of parameters.