### PR TITLE
Make message-based checks invariant to Locale

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -57,9 +57,9 @@ public abstract class BaseCheckTestSupport {
             throws Exception {
         final DefaultConfiguration dc = createCheckerConfig(checkConfig);
         final Checker c = new Checker();
-        // make sure the tests always run with english error messages
-        // so the tests don't fail in supported locales like german
-        final Locale locale = Locale.ENGLISH;
+        // make sure the tests always run with default error messages (language-invariant)
+        // so the tests don't fail in supported locales like German
+        final Locale locale = Locale.ROOT;
         c.setLocaleCountry(locale.getCountry());
         c.setLocaleLanguage(locale.getLanguage());
         c.setModuleClassLoader(Thread.currentThread().getContextClassLoader());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/FileSetCheckLifecycleTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/FileSetCheckLifecycleTest.java
@@ -102,7 +102,7 @@ public class FileSetCheckLifecycleTest
         twConf.addChild(new DefaultConfiguration(AvoidStarImportCheck.class.getName()));
 
         final Checker checker = new Checker();
-        final Locale locale = Locale.ENGLISH;
+        final Locale locale = Locale.ROOT;
         checker.setLocaleCountry(locale.getCountry());
         checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -114,7 +114,7 @@ public class SuppressWarningsFilterTest
             checkerConfig.addChild(filterConfig);
         }
         final Checker checker = new Checker();
-        final Locale locale = Locale.ENGLISH;
+        final Locale locale = Locale.ROOT;
         checker.setLocaleCountry(locale.getCountry());
         checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -212,7 +212,7 @@ public class SuppressWithNearbyCommentFilterTest
             checkerConfig.addChild(filterConfig);
         }
         final Checker checker = new Checker();
-        final Locale locale = Locale.ENGLISH;
+        final Locale locale = Locale.ROOT;
         checker.setLocaleCountry(locale.getCountry());
         checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -218,7 +218,7 @@ public class SuppressionCommentFilterTest
             checkerConfig.addChild(aFilterConfig);
         }
         final Checker checker = new Checker();
-        final Locale locale = Locale.ENGLISH;
+        final Locale locale = Locale.ROOT;
         checker.setLocaleCountry(locale.getCountry());
         checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());


### PR DESCRIPTION
This PR uses the `ROOT` locale for tests, rather than `ENGLISH` to fix compatibility issues on non-English systems.

The problem with `ENGLISH` is that Java searches for the file `messages_en.properties`, which does not exist. Instead of falling back to `messages.properties`, it tries to load the one for the current locale first. I'm not sure why it does that.

In any case, the correct way is to use `ROOT`, which explicitly uses the "default" and language-invariant file without language specifier.

**How to reproduce:** Set the default locale to some other language: 

    Locale.setDefault(Locale.GERMAN);

in a unit test that compares text messages and it will fail.

**Note**: A few checks (about 25) are based on comparing Exception messages. They are not affected by this and thus still do not work on non-English Locales.