### PR TITLE
Update cobertura-maven-plugin to 2.7, issue #916

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -611,7 +611,7 @@
       <plugin>
        <groupId>org.codehaus.mojo</groupId>
        <artifactId>cobertura-maven-plugin</artifactId>
-       <version>2.6</version>
+       <version>2.7</version>
        <configuration>
         <format>xml</format>
         <check>
@@ -995,7 +995,14 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.6</version>
+        <version>2.7</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>cobertura</report>
+            </reports>
+          </reportSet>
+        </reportSets>
         <configuration>
           <formats>
             <format>xml</format>


### PR DESCRIPTION
In version 2.7 the new `cobertura-integration-test` report is generated by
default.
As Checkstyle doesn't have `integration-test` phase, just `cobertura`
report is enough and this needs to be set explicitly.

More information in #916.