### PR TITLE
Use EqualsVerifier to test SuppressWithNearbyCommentFilter. #1088

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,12 @@
       <version>1.9.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>1.7.2</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 
@@ -893,7 +899,7 @@
           <regex><pattern>.*.filters.SuppressionFilter</pattern><branchRate>0</branchRate><lineRate>0</lineRate></regex>
           <regex><pattern>.*.filters.SuppressionsLoader</pattern><branchRate>68</branchRate><lineRate>77</lineRate></regex>
           <regex><pattern>.*.filters.SuppressWithNearbyCommentFilter</pattern><branchRate>76</branchRate><lineRate>89</lineRate></regex>
-          <regex><pattern>.*.filters.SuppressWithNearbyCommentFilter\$.*</pattern><branchRate>47</branchRate><lineRate>63</lineRate></regex>
+          <regex><pattern>.*.filters.SuppressWithNearbyCommentFilter\$Tag</pattern><branchRate>88</branchRate><lineRate>78</lineRate></regex>
 
          </regexes>
         </check>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -85,16 +85,16 @@ public class SuppressWithNearbyCommentFilter
         private final String text;
 
         /** The first line where warnings may be suppressed. */
-        private int firstLine;
+        private final int firstLine;
 
         /** The last line where warnings may be suppressed. */
-        private int lastLine;
+        private final int lastLine;
 
         /** The parsed check regexp, expanded for the text of this tag. */
-        private Pattern tagCheckRegexp;
+        private final Pattern tagCheckRegexp;
 
         /** The parsed message regexp, expanded for the text of this tag. */
-        private Pattern tagMessageRegexp;
+        private final Pattern tagMessageRegexp;
 
         /**
          * Constructs a tag.
@@ -108,7 +108,6 @@ public class SuppressWithNearbyCommentFilter
             throws ConversionException {
             this.text = text;
 
-            tagCheckRegexp = filter.checkRegexp;
             //Expand regexp for check and message
             //Does not intern Patterns with Utils.getPattern()
             String format = "";
@@ -119,6 +118,9 @@ public class SuppressWithNearbyCommentFilter
                     format = expandFrocomment(
                          text, filter.messageFormat, filter.commentRegexp);
                     tagMessageRegexp = Pattern.compile(format);
+                }
+                else {
+                    tagMessageRegexp = null;
                 }
                 int influence = 0;
                 if (filter.influenceFormat != null) {
@@ -289,9 +291,6 @@ public class SuppressWithNearbyCommentFilter
     /** The comment pattern that triggers suppression. */
     private String checkFormat;
 
-    /** The parsed check regexp. */
-    private Pattern checkRegexp;
-
     /** The message format to suppress. */
     private String messageFormat;
 
@@ -355,9 +354,7 @@ public class SuppressWithNearbyCommentFilter
      * @param format a <code>String</code> value
      * @throws ConversionException if unable to create Pattern object
      */
-    public void setCheckFormat(String format)
-        throws ConversionException {
-        checkRegexp = Utils.createPattern(format);
+    public void setCheckFormat(String format) throws ConversionException {
         checkFormat = format;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -35,6 +35,8 @@ import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 public class SuppressWithNearbyCommentFilterTest
@@ -172,6 +174,10 @@ public class SuppressWithNearbyCommentFilterTest
         verifySuppressed(filterConfig, suppressed);
     }
 
+    @Test
+    public void testEqualsAndHashCodeOfTagClass() {
+        EqualsVerifier.forClass(SuppressWithNearbyCommentFilter.Tag.class).usingGetClass().verify();
+    }
 
     public static DefaultConfiguration createFilterConfig(Class<?> classObj) {
         return new DefaultConfiguration(classObj.getName());


### PR DESCRIPTION
In order to pass the test `equals` method must reference only final fields. Otherwise, if the value of this field changes, the same object may not be equal to itself at two different points in time.