### PR TITLE
Fix equals and hashCode in LocalizedMessage. #1088

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -669,7 +669,7 @@
           <regex><pattern>.*.api.JavadocTagInfo</pattern><branchRate>25</branchRate><lineRate>77</lineRate></regex>
           <regex><pattern>.*.api.JavadocTagInfo\$.*</pattern><branchRate>0</branchRate><lineRate>8</lineRate></regex>
           <regex><pattern>.*.api.JavadocTokenTypes</pattern><branchRate>100</branchRate><lineRate>0</lineRate></regex>
-          <regex><pattern>.*.api.LocalizedMessage</pattern><branchRate>53</branchRate><lineRate>67</lineRate></regex>
+          <regex><pattern>.*.api.LocalizedMessage</pattern><branchRate>66</branchRate><lineRate>81</lineRate></regex>
           <regex><pattern>.*.api.LocalizedMessage\$.*</pattern><branchRate>41</branchRate><lineRate>66</lineRate></regex>
           <regex><pattern>.*.api.ScopeUtils</pattern><branchRate>0</branchRate><lineRate>0</lineRate></regex>
           <regex><pattern>.*.api.SeverityLevelCounter</pattern><branchRate>50</branchRate><lineRate>76</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Objects;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 import java.util.ResourceBundle.Control;
@@ -50,9 +51,6 @@ public final class LocalizedMessage
     implements Comparable<LocalizedMessage>, Serializable {
     /** Required for serialization. */
     private static final long serialVersionUID = 5675176836184862150L;
-
-    /** hash function multiplicand */
-    private static final int HASH_MULT = 29;
 
     /** the locale to localise messages to **/
     private static Locale sLocale = Locale.getDefault();
@@ -210,42 +208,25 @@ public final class LocalizedMessage
         if (this == object) {
             return true;
         }
-        if (!(object instanceof LocalizedMessage)) {
+        if (object == null || getClass() != object.getClass()) {
             return false;
         }
-
-        final LocalizedMessage localizedMessage = (LocalizedMessage) object;
-
-        if (colNo != localizedMessage.colNo) {
-            return false;
-        }
-        if (lineNo != localizedMessage.lineNo) {
-            return false;
-        }
-        if (!key.equals(localizedMessage.key)) {
-            return false;
-        }
-
-        if (!Arrays.equals(args, localizedMessage.args)) {
-            return false;
-        }
-        // ignoring bundle for perf reasons.
-
-        // we currently never load the same error from different bundles.
-
-        return true;
+        final LocalizedMessage that = (LocalizedMessage) object;
+        return Objects.equals(lineNo, that.lineNo)
+                && Objects.equals(colNo, that.colNo)
+                && Objects.equals(severityLevel, that.severityLevel)
+                && Objects.equals(moduleId, that.moduleId)
+                && Objects.equals(key, that.key)
+                && Objects.equals(bundle, that.bundle)
+                && Objects.equals(sourceClass, that.sourceClass)
+                && Objects.equals(customMessage, that.customMessage)
+                && Arrays.equals(args, that.args);
     }
 
     @Override
     public int hashCode() {
-        int result;
-        result = lineNo;
-        result = HASH_MULT * result + colNo;
-        result = HASH_MULT * result + key.hashCode();
-        for (final Object element : args) {
-            result = HASH_MULT * result + element.hashCode();
-        }
-        return result;
+        return Objects.hash(lineNo, colNo, severityLevel, moduleId, key, bundle, sourceClass,
+                customMessage, Arrays.hashCode(args));
     }
 
     /** Clears the cache. */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
@@ -1,0 +1,30 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.api;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public class LocalizedMessageTest {
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(LocalizedMessage.class).usingGetClass().verify();
+    }
+}


### PR DESCRIPTION
The current `equals` and `hashCode` are clearly wrong and they do not follow contracts and standards. 

Here are open questions:
* Can we fix these methods (API breaking changes, but kind of bug fix)?
* How much performance sensitive this code is? Maybe the author intentionally sacrificed correctness and contracts for performance reasons?
* Should we include all the fields in `equals` and `hashCode` or only the ones that are currently used? Should we mark some fields as `transient` to indicate that they are "derived"?
