### PR TITLE
Fix NeedBraces check not requiring braces in multiline statements when using allowSingleLineStatement option. #895

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -299,9 +299,13 @@ public class NeedBracesCheck extends Check {
         boolean result = false;
         final DetailAST ifCondition = literalIf.findFirstToken(TokenTypes.EXPR);
         if (literalIf.getParent().getType() == TokenTypes.SLIST) {
-            DetailAST block = literalIf.getLastChild();
-            if (block.getType() != TokenTypes.LITERAL_RETURN) {
-                block = literalIf.getLastChild().getPreviousSibling();
+            final DetailAST literalIfLastChild = literalIf.getLastChild();
+            final DetailAST block;
+            if (literalIfLastChild.getType() == TokenTypes.LITERAL_ELSE) {
+                block = literalIfLastChild.getPreviousSibling();
+            }
+            else {
+                block = literalIfLastChild;
             }
             result = ifCondition.getLineNo() == block.getLineNo();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheckTest.java
@@ -67,6 +67,8 @@ public class NeedBracesCheckTest extends BaseCheckTestSupport {
             "46: " + getCheckMessage(MSG_KEY_NEED_BRACES, "while"),
             "53: " + getCheckMessage(MSG_KEY_NEED_BRACES, "do"),
             "59: " + getCheckMessage(MSG_KEY_NEED_BRACES, "for"),
+            "88: " + getCheckMessage(MSG_KEY_NEED_BRACES, "if"),
+            "92: " + getCheckMessage(MSG_KEY_NEED_BRACES, "else"),
         };
         verify(checkConfig, getPath("InputBracesSingleLineStatements.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputBracesSingleLineStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputBracesSingleLineStatements.java
@@ -83,4 +83,13 @@ public class InputBracesSingleLineStatements
         else System.out.println("no");
         for (;;);
     }
+
+    private int testMissingWarnings() {
+        if (true)
+            throw new RuntimeException();
+        if (true) {
+            return 1;
+        } else
+            return 2;
+    }
 }


### PR DESCRIPTION
Fix for #895.

Previous implementaion was wrong, as detecting if an `if` statement is single line has nothing to presence of `return` statement.