### PR TITLE
Add support for canonical class names in MutableException. #1124

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
@@ -151,11 +151,12 @@ public final class MutableExceptionCheck extends AbstractFormatCheck {
     private boolean isExtendedClassNamedAsException(DetailAST ast) {
         final DetailAST extendsClause = ast.findFirstToken(TokenTypes.EXTENDS_CLAUSE);
         if (extendsClause != null) {
-            final DetailAST extendedClass = extendsClause.findFirstToken(TokenTypes.IDENT);
-            if (extendedClass != null) {
-                final String extendedClassName = extendedClass.getText();
-                return extendedClassName.matches(extendedClassNameFormat);
+            DetailAST currentNode = extendsClause;
+            while (currentNode.getType() != TokenTypes.IDENT) {
+                currentNode = currentNode.getLastChild();
             }
+            final String extendedClassName = currentNode.getText();
+            return extendedClassName.matches(extendedClassNameFormat);
         }
         return false;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
@@ -42,6 +42,7 @@ public class MutableExceptionCheckTest extends BaseCheckTestSupport {
         String[] expected = {
             "6:9: " + getCheckMessage(MSG_KEY, "errorCode"),
             "23:9: " + getCheckMessage(MSG_KEY, "errorCode"),
+            "46:9: " + getCheckMessage(MSG_KEY, "errorCode"),
         };
 
         verify(checkConfig, getPath("design" + File.separator + "InputMutableException.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/design/InputMutableException.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/design/InputMutableException.java
@@ -39,6 +39,10 @@ public class InputMutableException {
             } 
         }
     }
-    
+
     class CustomException extends java.lang.Exception {}
+
+    class CustomMutableException extends java.lang.Exception {
+        int errorCode;
+    }
 }


### PR DESCRIPTION
Regression run has been made on extended list of projects (with HBase sources included).

Before fix:
![image](https://cloud.githubusercontent.com/assets/5467276/7802677/46251460-033b-11e5-91e8-24172153cf51.png)
http://mkordas.github.io/mutable-exception-before-fix/checkstyle.html

After fix:
![image](https://cloud.githubusercontent.com/assets/5467276/7802681/589ebdc6-033b-11e5-8724-7d461d3982c5.png)
http://mkordas.github.io/mutable-exception-after-fix/checkstyle.html

Sample new mutable exceptions detected:
https://code.google.com/p/findbugs/source/browse/plugins/jira/src/generated/com/atlassian/jira/rpc/exception/RemoteValidationException.java#10
https://github.com/apache/hbase/blob/master/hbase-client/src/main/java/org/apache/hadoop/hbase/exceptions/UnknownProtocolException.java#L31