### PR TITLE
ThrowCountCheck should have option to skip private methods, #1136

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
@@ -45,7 +45,7 @@ public class ThrowsCountCheckTest extends BaseCheckTestSupport {
             "14:20: " + getCheckMessage(MSG_KEY, 2, 1),
             "18:20: " + getCheckMessage(MSG_KEY, 2, 1),
             "22:20: " + getCheckMessage(MSG_KEY, 3, 1),
-            "45:43: " + getCheckMessage(MSG_KEY, 2, 1),
+            "48:43: " + getCheckMessage(MSG_KEY, 2, 1),
         };
 
         verify(checkConfig, getPath("design" + File.separator + "InputThrowsCount.java"), expected);
@@ -89,5 +89,19 @@ public class ThrowsCountCheckTest extends BaseCheckTestSupport {
         catch (IllegalStateException e) {
             assertEquals(ast.toString(), e.getMessage());
         }
+    }
+
+    @Test
+    public void testNotIgnorePrivateMethod() throws Exception {
+        DefaultConfiguration checkConfig = createCheckConfig(ThrowsCountCheck.class);
+        checkConfig.addAttribute("ignorePrivateMethods", "false");
+        String[] expected = {
+            "14:20: " + getCheckMessage(MSG_KEY, 2, 1),
+            "18:20: " + getCheckMessage(MSG_KEY, 2, 1),
+            "22:20: " + getCheckMessage(MSG_KEY, 3, 1),
+            "29:28: " + getCheckMessage(MSG_KEY, 3, 1),
+            "48:43: " + getCheckMessage(MSG_KEY, 2, 1),
+        };
+        verify(checkConfig, getPath("design" + File.separator + "InputThrowsCount.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/design/InputThrowsCount.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/design/InputThrowsCount.java
@@ -25,6 +25,9 @@ public class InputThrowsCount {
 
     void method6() {
     }
+    
+    private void method7() throws Exception, AWTException, Throwable {
+    }
 }
 
 class SubClass extends InputThrowsCount {

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -591,6 +591,11 @@ public class StringUtils // not final to allow subclassing
           type of exception need be checked for by a caller but any
           subclasses can be caught specifically if necessary.
         </p>
+
+        <p>
+          <b>ignorePrivateMethods</b> - allows to skip private methods as they do
+          not cause problems for other classes.
+        </p>
       </subsection>
 
       <subsection name="Properties">
@@ -607,6 +612,12 @@ public class StringUtils // not final to allow subclassing
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>1</code></td>
           </tr>
+          <tr>
+            <td>ignorePrivateMethods</td>
+            <td>whether private methods must be ignored</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>true</code></td>
+          </tr>
         </table>
       </subsection>
 
@@ -618,6 +629,15 @@ public class StringUtils // not final to allow subclassing
         <source>
 &lt;module name=&quot;ThrowsCount&quot;&gt;
     &lt;property name=&quot;max&quot; value=&quot;2&quot;/&gt;
+&lt;/module&gt;
+        </source>
+
+        <p>
+          To configure the check so that it doesn't skip private methods:
+        </p>
+        <source>
+&lt;module name=&quot;ThrowsCount&quot;&gt;
+    &lt;property name=&quot;ignorePrivateMethods&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
       </subsection>


### PR DESCRIPTION
Report: http://vladlis.github.io/
The option has suppressed 283 violations while running the Check on openjdk7 and spring.framework with default properties (from 3733 to 3450).