### PR TITLE
Align method with its return type, and variable with its type

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
@@ -43,17 +43,20 @@ public class MemberDefHandler extends ExpressionHandler {
 
     @Override
     public void checkIndentation() {
-        final DetailAST modifiersNode = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
+        final DetailAST main = getMainAst();
+        final DetailAST modifiersNode = main.findFirstToken(TokenTypes.MODIFIERS);
         if (modifiersNode.getChildCount() != 0) {
             checkModifiers();
         }
         else {
             checkType();
         }
+        final DetailAST assign = main.findFirstToken(TokenTypes.ASSIGN);
+        final DetailAST last = getVarDefStatementSemicolon(main);
+        final DetailAST mid = assign == null ? last : assign.getPreviousSibling();
         final LineWrappingHandler lineWrap =
-            new LineWrappingHandler(getIndentCheck(), getMainAst(),
-                getVarDefStatementSemicolon(getMainAst()));
-        if (lineWrap.getLastNode() != null && !isArrayDeclaration(getMainAst())) {
+            new LineWrappingHandler(getIndentCheck(), main, mid, last);
+        if (lineWrap.getLastNode() != null && !isArrayDeclaration(main)) {
             lineWrap.checkIndentation();
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
@@ -62,9 +62,12 @@ public class MethodDefHandler extends BlockParentHandler {
     public void checkIndentation() {
         checkModifiers();
 
+        final DetailAST main = getMainAst();
+        final DetailAST leftParen = main.findFirstToken(TokenTypes.LPAREN);
+        final DetailAST rightParen = getMethodDefParamRightParen(main);
         final LineWrappingHandler lineWrap =
-            new LineWrappingHandler(getIndentCheck(), getMainAst(),
-                getMethodDefParamRightParen(getMainAst()));
+            new LineWrappingHandler(getIndentCheck(), main, leftParen.getPreviousSibling(),
+                rightParen);
         lineWrap.checkIndentation();
         if (getLCurly() == null) {
             // asbtract method def -- no body

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -113,7 +113,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     private static int getIndentFromComment(String comment) {
         final Matcher match = GET_INDENT_FROM_COMMENT_REGEX.matcher(comment);
-        match.matches();
+        Assert.assertTrue(match.matches());
         return Integer.parseInt(match.group(1));
     }
 
@@ -511,8 +511,8 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("throwsIndent", "4");
         final String fname = getPath("indentation/InputValidMethodIndent.java");
         final String[] expected = {
-            "129: " + getCheckMessage(MSG_ERROR, "void", 4, 8),
-            "130: " + getCheckMessage(MSG_ERROR, "method5", 4, 8),
+            "129: " + getCheckMessage(MSG_ERROR, "void", 2, 4),
+            "130: " + getCheckMessage(MSG_ERROR, "method5", 2, 4),
         };
         verifyWarns(checkConfig, fname, expected);
     }
@@ -539,13 +539,13 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
             "31: " + getCheckMessage(MSG_ERROR, "method def modifier", 2, 4),
             "32: " + getCheckMessage(MSG_ERROR, "method def rcurly", 6, 4),
             "69: " + getCheckMessage(MSG_ERROR, "method def modifier", 5, 4),
-            "70: " + getCheckMessage(MSG_ERROR, "final", 5, 9),
-            "71: " + getCheckMessage(MSG_ERROR, "void", 5, 9),
-            "72: " + getCheckMessage(MSG_ERROR, "method5", 4, 9),
+            "70: " + getCheckMessage(MSG_ERROR, "final", 4, 5),
+            "71: " + getCheckMessage(MSG_ERROR, "void", 4, 5),
+            "72: " + getCheckMessage(MSG_ERROR, "method5", 4, 5),
             "80: " + getCheckMessage(MSG_ERROR, "method def modifier", 3, 4),
-            "81: " + getCheckMessage(MSG_ERROR, "final", 3, 7),
-            "82: " + getCheckMessage(MSG_ERROR, "void", 3, 7),
-            "83: " + getCheckMessage(MSG_ERROR, "method6", 5, 7),
+            "81: " + getCheckMessage(MSG_ERROR, "final", 2, 3),
+            "82: " + getCheckMessage(MSG_ERROR, "void", 2, 3),
+            "83: " + getCheckMessage(MSG_ERROR, "method6", 2, 3),
             "93: " + getCheckMessage(MSG_CHILD_ERROR, "ctor def", 4, 8),
             "93: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 4, 8),
             "98: " + getCheckMessage(MSG_ERROR, "member def type", 6, 8),
@@ -568,8 +568,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
             "158: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 6, 12),
             "170: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 4, 8),
             "175: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 4, 8),
-            "179: " + getCheckMessage(MSG_ERROR, "int", 0, 8),
-            "180: " + getCheckMessage(MSG_ERROR, "method9", 4, 8),
+            "179: " + getCheckMessage(MSG_ERROR, "int", 0, 4),
             "190: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 12, 8),
         };
         verifyWarns(checkConfig, fname, expected, 6);
@@ -826,7 +825,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
             "88: " + getCheckMessage(MSG_ERROR, "class def ident", 6, 4),
             "91: " + getCheckMessage(MSG_ERROR, "class def ident", 2, 4),
             "95: " + getCheckMessage(MSG_ERROR, "member def modifier", 6, 8),
-            "101: " + getCheckMessage(MSG_ERROR, "int", 10, 12),
+            "101: " + getCheckMessage(MSG_ERROR, "int", 6, 8),
             "106: " + getCheckMessage(MSG_ERROR, "member def modifier", 6, 8),
             "111: " + getCheckMessage(MSG_ERROR, "class def rcurly", 6, 4),
             "113: " + getCheckMessage(MSG_ERROR, "class def ident", 6, 4),
@@ -1217,7 +1216,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
         final String fname = getPath("indentation/InputValidClassDefIndent.java");
         final String[] expected = {
             "49: " + getCheckMessage(MSG_ERROR, "class", 0, 4),
-            "71: " + getCheckMessage(MSG_ERROR, "int", 8, 12),
+            "71: " + getCheckMessage(MSG_ERROR, "int", 6, 8),
         };
         verifyWarns(checkConfig, fname, expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputClassesMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputClassesMethods.java
@@ -50,7 +50,23 @@ class IndentationCorrectClassInput  //indent:0 exp:0
 
     };  //indent:4 exp:4
   }  //indent:2 exp:2
-} //indent:0 exp:0
+
+  public static SecondClassWithLongLongLongLongName  //indent:2 exp:2
+  methodWithVeryLongName(int argZero,  //indent:2 exp:2
+      int argOne, int argTwo) {  //indent:6 exp:6
+    return null;  //indent:4 exp:4
+  }  //indent:2 exp:2
+
+  public static final SecondClassWithLongLongLongLongName  //indent:2 exp:2
+  STATIC_MEMBER_WITH_A_LONG_NAME = null;  //indent:2 exp:2
+
+  public static SecondClassWithLongLongLongLongName  //indent:2 exp:2
+  STATIC_MEMBER_WITH_A_LONG_NAME_NOT_INITIALIZED;  //indent:2 exp:2
+
+  public static final SecondClassWithLongLongLongLongName  //indent:2 exp:2
+  STATIC_MEMBER_WITH_A_LONG_NAME_AND_LONG_INITIALIZER =  //indent:2 exp:2
+      Object.class.toString().equals("foo") ? null : null;  //indent:6 exp:6
+}  //indent:0 exp:0
 
 class SecondClassWithLongLongLongLongName  //indent:0 exp:0
     extends  //indent:4 exp:4

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputInvalidClassDefIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputInvalidClassDefIndent.java
@@ -98,7 +98,7 @@ final class InputValidClassDefIndent66 extends java.awt.event.MouseAdapter imple
 
     class foo3b {  //indent:4 exp:4
         public  //indent:8 exp:8
-          int x;  //indent:10 exp:>=12 warn
+      int x;  //indent:6 exp:>=8 warn
     } //indent:4 exp:4
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputInvalidMethodIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputInvalidMethodIndent.java
@@ -67,9 +67,9 @@ public class InputInvalidMethodIndent { //indent:0 exp:0
     } //indent:4 exp:4
 
      public //indent:5 exp:4 warn
-     final //indent:5 exp:9 warn
-     void //indent:5 exp:9 warn
-    method5() //indent:4 exp:9 warn
+    final //indent:4 exp:5 warn
+    void //indent:4 exp:5 warn
+    method5() //indent:4 exp:5 warn
     { //indent:4 exp:4
         boolean test = true; //indent:8 exp:8
         if (test) { //indent:8 exp:8
@@ -78,9 +78,9 @@ public class InputInvalidMethodIndent { //indent:0 exp:0
     } //indent:4 exp:4
 
    public //indent:3 exp:4 warn
-   final //indent:3 exp:7 warn
-   void //indent:3 exp:7 warn
-     method6() //indent:5 exp:7 warn
+  final //indent:2 exp:3 warn
+  void //indent:2 exp:3 warn
+  method6() //indent:2 exp:3 warn
     { //indent:4 exp:4
         boolean test = true; //indent:8 exp:8
         if (test) { //indent:8 exp:8
@@ -176,8 +176,8 @@ public class InputInvalidMethodIndent { //indent:0 exp:0
     } //indent:4 exp:4
 
     public //indent:4 exp:4
-int[] //indent:0 exp:8 warn
-    method9() //indent:4 exp:8 warn
+int[] //indent:0 exp:4 warn
+    method9() //indent:4 exp:4
     { //indent:4 exp:4
         return null; //indent:8 exp:8
     } //indent:4 exp:4

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputValidClassDefIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputValidClassDefIndent.java
@@ -68,7 +68,7 @@ final class InputValidClassDefIndent6 extends java.awt.event.MouseAdapter implem
 
     class foo3 {  //indent:4 exp:4
         public  //indent:8 exp:8
-        int x;  //indent:8 exp:>=12 warn
+      int x;  //indent:6 exp:>=8 warn
     } //indent:4 exp:4
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputValidMethodIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputValidMethodIndent.java
@@ -124,10 +124,10 @@ public class InputValidMethodIndent extends java.awt.event.MouseAdapter implemen
                 4); //indent:16 exp:>=12
     } //indent:4 exp:4
 
-    // strange IMHO, but I suppose this should be allowed //indent:4 exp:4
+    // Since C days, people have aligned methods with their return type //indent:4 exp:4
     public //indent:4 exp:4
-    void //indent:4 exp:8 warn
-    method5() { //indent:4 exp:8 warn
+  void //indent:2 exp:4 warn
+  method5() { //indent:2 exp:4 warn
     } //indent:4 exp:4
 
 
@@ -192,6 +192,11 @@ public class InputValidMethodIndent extends java.awt.event.MouseAdapter implemen
 
     private void indexTest() { //indent:4 exp:4
         getArray()[0] = 2; //indent:8 exp:8
+    } //indent:4 exp:4
+
+    public //indent:4 exp:4
+    void //indent:4 exp:4
+    method5b() { //indent:4 exp:4
     } //indent:4 exp:4
 
 } //indent:0 exp:0


### PR DESCRIPTION
For example,

```java
  public LongParameterizedType<LongClassName, AnotherLongClassName>
  foo(int arg) {
    return null;
  }
```

Also, fix a few typos.