### PR TITLE
Add virtual machine crash log files to .gitingore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ checkstyle.iml
 
 #Temp files
 *~
+
+#Virtual machine crash logs
+hs_err_pid*
+replay_pid*


### PR DESCRIPTION
http://www.java.com/en/download/help/error_hotspot.xml

These files can safely be ignored, as there is never need to commit crash logs.