### PR TITLE
 100% test coverage for com.puppycrawl.tools.checkstyle.checks.sizes,

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -854,8 +854,6 @@
           <regex><pattern>.*.checks.regexp.RegexpSinglelineCheck</pattern><branchRate>100</branchRate><lineRate>76</lineRate></regex>
           <regex><pattern>.*.checks.regexp.SinglelineDetector</pattern><branchRate>93</branchRate><lineRate>96</lineRate></regex>
 
-          <regex><pattern>.*.checks.sizes.MethodCountCheck</pattern><branchRate>95</branchRate><lineRate>100</lineRate></regex>
-
           <regex><pattern>.*.checks.whitespace.AbstractParenPadCheck</pattern><branchRate>88</branchRate><lineRate>100</lineRate></regex>
           <regex><pattern>.*.checks.whitespace.EmptyForInitializerPadCheck</pattern><branchRate>91</branchRate><lineRate>93</lineRate></regex>
           <regex><pattern>.*.checks.whitespace.EmptyForIteratorPadCheck</pattern><branchRate>100</branchRate><lineRate>92</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
@@ -158,15 +158,12 @@ public final class MethodCountCheck extends Check {
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (TokenTypes.CLASS_DEF == ast.getType()
-            || TokenTypes.INTERFACE_DEF == ast.getType()
-            || TokenTypes.ENUM_CONSTANT_DEF == ast.getType()
-            || TokenTypes.ENUM_DEF == ast.getType()) {
+        if (TokenTypes.METHOD_DEF == ast.getType()) {
+            raiseCounter(ast);
+        }
+        else {
             final boolean inInterface = TokenTypes.INTERFACE_DEF == ast.getType();
             counters.push(new MethodCounter(inInterface));
-        }
-        else if (TokenTypes.METHOD_DEF == ast.getType()) {
-            raiseCounter(ast);
         }
     }
 


### PR DESCRIPTION
 100% test coverage for com.puppycrawl.tools.checkstyle.checks.sizes, issue #1024.

I made some fixes in visitToken() according to my assumptions https://github.com/checkstyle/checkstyle/issues/1167#issuecomment-109049527
and also I refactored the method.

cobertura report 
http://mezk.github.io/cobertura/

checkstyle-tester report befor changes in MethodCountCheck (method visitToken() )
http://mezk.github.io/site_before/index.html

checkstyle-tester report after changes in MethodCountCheck (method visitToken() )
http://mezk.github.io/site_after/index.html

git diff shows that reports before and after changes are equal.

