### PR TITLE
Update maven-assembly-plugin to 2.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1199,7 +1199,7 @@
           <!-- Creates the binary and source distributions -->
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>2.5.4</version>
+            <version>2.5.5</version>
             <configuration>
               <descriptors>
                 <descriptor>config/assembly-bin.xml</descriptor>


### PR DESCRIPTION
Release Notes - Maven Assembly Plugin - Version 2.5.5

* Bug
   * [MASSEMBLY-767] - Schema missing from the web site
    * [MASSEMBLY-768] - JarInputStream unable to find  manifest
created by version 2.5.4
    * [MASSEMBLY-769] - ZIP fileMode permissions not properly set with
dependencySet and unpackOptions