### PR TITLE
Changed Integration Tests to use /src/it/. #1200

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -72,7 +72,7 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 		String rootPath = absoluteRootPath.substring(0,
 				absoluteRootPath.lastIndexOf("src"));
 		for (File file : mFiles) {
-			if (file.toString().contains(aFileName)) {
+			if (file.toString().endsWith(aFileName+".java")) {
 				return rootPath + file.toString();
 			}
 		}

--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule21filename/OuterTypeFilenameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule21filename/OuterTypeFilenameTest.java
@@ -18,7 +18,7 @@ public class OuterTypeFilenameTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule231filetab/FileTabCharacterTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule231filetab/FileTabCharacterTest.java
@@ -19,7 +19,7 @@ public class FileTabCharacterTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
     
     @Override

--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/IllegalTokenTextTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/IllegalTokenTextTest.java
@@ -20,7 +20,7 @@ public class IllegalTokenTextTest extends BaseCheckTestSupport{
     @BeforeClass
     public static void setConfigurationBuilder()
     		throws CheckstyleException, MalformedURLException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule233nonascii/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule233nonascii/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -18,7 +18,7 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java
@@ -18,7 +18,7 @@ public class LineLengthTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/AvoidStarImportTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/AvoidStarImportTest.java
@@ -18,7 +18,7 @@ public class AvoidStarImportTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java
@@ -19,7 +19,7 @@ public class NoLineWrapTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
@@ -24,7 +24,7 @@ public class CustomImportOrderTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/OneTopLevelClassTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/OneTopLevelClassTest.java
@@ -18,7 +18,7 @@ public class OneTopLevelClassTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/OverloadMethodsDeclarationOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/OverloadMethodsDeclarationOrderTest.java
@@ -18,7 +18,7 @@ public class OverloadMethodsDeclarationOrderTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3sourcefile/EmptyLineSeparatorTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3sourcefile/EmptyLineSeparatorTest.java
@@ -18,7 +18,7 @@ public class EmptyLineSeparatorTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule411bracesareused/NeedBracesTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule411bracesareused/NeedBracesTest.java
@@ -18,7 +18,7 @@ public class NeedBracesTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyRightCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyRightCurlyTest.java
@@ -21,7 +21,7 @@ public class LeftCurlyRightCurlyTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyBlockTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyBlockTest.java
@@ -18,7 +18,7 @@ public class EmptyBlockTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyCatchBlockTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyCatchBlockTest.java
@@ -20,7 +20,7 @@ public class EmptyCatchBlockTest extends BaseCheckTestSupport
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException
     {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineTest.java
@@ -18,7 +18,7 @@ public class OneStatementPerLineTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule44cloumunlimit/LineLengthTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule44cloumunlimit/LineLengthTest.java
@@ -18,7 +18,7 @@ public class LineLengthTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreack/MethodParamPadTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreack/MethodParamPadTest.java
@@ -18,7 +18,7 @@ public class MethodParamPadTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreack/OperatorWrapTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreack/OperatorWrapTest.java
@@ -22,7 +22,7 @@ public class OperatorWrapTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreack/SeparatorWrapTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreack/SeparatorWrapTest.java
@@ -18,7 +18,7 @@ public class SeparatorWrapTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java
@@ -18,7 +18,7 @@ public class EmptyLineSeparatorTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
@@ -19,7 +19,7 @@ public class WhitespaceAroundTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4821onevariablepreline/MultipleVariableDeclarationsTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4821onevariablepreline/MultipleVariableDeclarationsTest.java
@@ -18,7 +18,7 @@ public class MultipleVariableDeclarationsTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4822variabledistance/VariableDeclarationUsageDistanceTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4822variabledistance/VariableDeclarationUsageDistanceTest.java
@@ -18,7 +18,7 @@ public class VariableDeclarationUsageDistanceTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/ArrayTypeStyleTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/ArrayTypeStyleTest.java
@@ -18,7 +18,7 @@ public class ArrayTypeStyleTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java
@@ -19,7 +19,7 @@ public class IndentationTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new IndentationConfigurationBuilder(new File("src/"));
+        builder = new IndentationConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4842fallthrow/FallThroughTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4842fallthrow/FallThroughTest.java
@@ -18,7 +18,7 @@ public class FallThroughTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4843defaultcasepresent/MissingSwitchDefaultTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4843defaultcasepresent/MissingSwitchDefaultTest.java
@@ -18,7 +18,7 @@ public class MissingSwitchDefaultTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule485annotations/AnnotationLocationTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule485annotations/AnnotationLocationTest.java
@@ -19,7 +19,7 @@ public class AnnotationLocationTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule487modifiers/ModifierOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule487modifiers/ModifierOrderTest.java
@@ -18,7 +18,7 @@ public class ModifierOrderTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule488numericliterals/UpperEllTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule488numericliterals/UpperEllTest.java
@@ -17,7 +17,7 @@ public class UpperEllTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java
@@ -23,7 +23,7 @@ public class PackageNameTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
         checkConfig = builder.getCheckConfig("PackageName");
         format = checkConfig.getAttribute("format");
     }

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule522typenames/TypeNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule522typenames/TypeNameTest.java
@@ -18,7 +18,7 @@ public class TypeNameTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule523methodnames/MethodNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule523methodnames/MethodNameTest.java
@@ -17,7 +17,7 @@ public class MethodNameTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java
@@ -22,7 +22,7 @@ public class MemberNameTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
         checkConfig = builder.getCheckConfig("MemberName");
         format = checkConfig.getAttribute("format");
     }

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java
@@ -22,7 +22,7 @@ public class ParameterNameTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
         checkConfig = builder.getCheckConfig("ParameterName");
         format = checkConfig.getAttribute("format");
     }

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
@@ -22,7 +22,7 @@ public class LocalVariableNameTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
         checkConfig = builder.getCheckConfig("LocalVariableName");
         format = checkConfig.getAttribute("format");
     }

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassMethodTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassMethodTypeParameterNameTest.java
@@ -23,7 +23,7 @@ public class ClassMethodTypeParameterNameTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
         checkConfig = builder.getCheckConfig("ClassTypeParameterName");
         format = checkConfig.getAttribute("format");
     }

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
@@ -21,7 +21,7 @@ public class AbbreviationAsWordInNameTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
         checkConfig = builder.getCheckConfig("AbbreviationAsWordInName");
     }
 

--- a/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule62donotignoreexceptions/EmptyBlockTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule62donotignoreexceptions/EmptyBlockTest.java
@@ -18,7 +18,7 @@ public class EmptyBlockTest extends BaseCheckTestSupport{
     
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule64finalizers/NoFinalizerTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule64finalizers/NoFinalizerTest.java
@@ -18,7 +18,7 @@ public class NoFinalizerTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/SingleLineJavadocTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/SingleLineJavadocTest.java
@@ -18,7 +18,7 @@ public class SingleLineJavadocTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/JavadocParagraphTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/JavadocParagraphTest.java
@@ -18,7 +18,7 @@ public class JavadocParagraphTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/AtclauseOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/AtclauseOrderTest.java
@@ -18,7 +18,7 @@ public class AtclauseOrderTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/JavadocTagContinuationIndentationTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/JavadocTagContinuationIndentationTest.java
@@ -18,7 +18,7 @@ public class JavadocTagContinuationIndentationTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/NonEmptyAtclauseDescriptionTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/NonEmptyAtclauseDescriptionTest.java
@@ -18,7 +18,7 @@ public class NonEmptyAtclauseDescriptionTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/SummaryJavadocTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/SummaryJavadocTest.java
@@ -18,7 +18,7 @@ public class SummaryJavadocTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/JavadocMethodTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/JavadocMethodTest.java
@@ -18,7 +18,7 @@ public class JavadocMethodTest extends BaseCheckTestSupport{
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
-        builder = new ConfigurationBuilder(new File("src/"));
+        builder = new ConfigurationBuilder(new File("src/it/"));
     }
 
     @Test


### PR DESCRIPTION
Problem was caused by the fact that Integration tests were picking-up wrong .java files on input.

* Changed ConfigurationBuilder.java to use `endsWith(aFileName+".java")` instead of `contains(aFileName)`. It still may result in confusion in some cases where files have different prefixes, but works good on current set of files.
* ConfigurationBuilder will search for files in `src/it/` folder. There are different files with the same name in `src/it/resources/` and `src/test/resources/`. Some errors were caused by this.