### PR TITLE
UT coverage for RedundantImport check. #1128

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -821,7 +821,6 @@
           <regex><pattern>.*.checks.imports.ImportControlLoader</pattern><branchRate>72</branchRate><lineRate>88</lineRate></regex>
           <regex><pattern>.*.checks.imports.ImportOrderCheck</pattern><branchRate>91</branchRate><lineRate>99</lineRate></regex>
           <regex><pattern>.*.checks.imports.PkgControl</pattern><branchRate>80</branchRate><lineRate>100</lineRate></regex>
-          <regex><pattern>.*.checks.imports.RedundantImportCheck</pattern><branchRate>81</branchRate><lineRate>97</lineRate></regex>
           <regex><pattern>.*.checks.imports.UnusedImportsCheck</pattern><branchRate>95</branchRate><lineRate>100</lineRate></regex>
 
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
@@ -113,7 +113,9 @@ public class RedundantImportCheck
                 log(ast.getLineNo(), ast.getColumnNo(), MSG_LANG,
                     imp.getText());
             }
-            else if (fromPackage(imp.getText(), pkgName)) {
+            // imports from unnamed package are not allowed,
+            // so we are checking SAME rule only for named packages
+            else if (pkgName != null && fromPackage(imp.getText(), pkgName)) {
                 log(ast.getLineNo(), ast.getColumnNo(), MSG_SAME,
                     imp.getText());
             }
@@ -152,17 +154,12 @@ public class RedundantImportCheck
      */
     private static boolean fromPackage(String importName, String pkg) {
         boolean retVal = false;
-        if (pkg == null) {
-            // If not package, then check for no package in the import.
-            retVal = importName.indexOf('.') == -1;
-        }
-        else {
-            final int index = importName.lastIndexOf('.');
-            if (index != -1) {
-                final String front = importName.substring(0, index);
-                retVal = front.equals(pkg);
-            }
-        }
+        // imports from unnamed package are not allowed:
+        // http://docs.oracle.com/javase/specs/jls/se7/html/jls-7.html#jls-7.5
+        // So '.' must be present in member name and we are not checking for it
+        final int index = importName.lastIndexOf('.');
+        final String front = importName.substring(0, index);
+        retVal = front.equals(pkg);
         return retVal;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckTest.java
@@ -50,6 +50,18 @@ public class RedundantImportCheckTest
     }
 
     @Test
+    public void testUnnamedPackage()
+        throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(RedundantImportCheck.class);
+        final String[] expected = {
+            "2:1: " + getCheckMessage(MSG_DUPLICATE, 1, "java.util.List"),
+            "4:1: " + getCheckMessage(MSG_LANG, "java.lang.String"),
+        };
+        verify(checkConfig, getPath("imports" + File.separator + "InputRedundantImportCheck_UnnamedPackage.java"), expected);
+    }
+
+    @Test
     public void testGetAcceptableTokens() {
         RedundantImportCheck testCheckObject =
                 new RedundantImportCheck();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputRedundantImportCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputRedundantImportCheck.java
@@ -45,6 +45,9 @@ import com.puppycrawl.tools.checkstyle.PackageNamesLoader;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DefaultLogger;
 
+import static java.lang.Math.PI;
+import static com.puppycrawl.tools.checkstyle.checks.imports.RedundantImportCheck.MSG_SAME;
+
 /**
  * Test case for imports
  * Here's an import used only by javadoc: {@link Date}.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputRedundantImportCheck_UnnamedPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputRedundantImportCheck_UnnamedPackage.java
@@ -1,0 +1,11 @@
+import java.util.List;
+import java.util.List;
+import java.util.Arrays;
+import java.lang.String;
+import static java.lang.Math.PI;
+
+public class InputRedundantImportCheck_UnnamedPackage
+{
+    public static double pi=PI;
+    public List myList;
+}


### PR DESCRIPTION
Small changes were introduced to improve code coverage due to the fact that imports from unnamed package are not allowed: http://docs.oracle.com/javase/specs/jls/se7/html/jls-7.html#jls-7.5
Based on this some part of previous code was not possible to cover with UT (unrealistic scenario).

Reports to show that changes are most likely didn't affect most code:
[before](http://ivanov-alex.github.io/target_Redundant_BEFORE/site/checkstyle.html) changes
[after](http://ivanov-alex.github.io/target_Redundant_AFTER/site/checkstyle.html) changes
Reports are identical