### PR TITLE
Fix bug at RightCurlyCheck: Curly brace '}' should be on line by itself not reported for method with annotation, #1014 

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -268,7 +268,7 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
                     //SLIST could be absent if method is abstract, and code like "while(true);"
                     rcurly = lcurly.getLastChild();
                 }
-                nextToken = ast;
+                nextToken = lcurly;
                 break;
             default:
                 throw new RuntimeException("Unexpected token type ("

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -143,4 +143,15 @@ public class RightCurlyCheckTest extends BaseCheckTestSupport {
         };
         verify(checkConfig, getPath("InputRightCurlyEmptyAbstractMethod.java"), expected);
     }
+
+    @Test
+    public void testWithAnnotations() throws Exception {
+        checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT");
+        final String[] expected = {
+            "9:57: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "16:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+        };
+        verify(checkConfig, getPath("InputRightCurlyAnnotations.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputRightCurlyAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputRightCurlyAnnotations.java
@@ -1,0 +1,25 @@
+package com.puppycrawl.tools.checkstyle;
+
+@TestClassAnnotation
+class InputRightCurlyAnnotations
+{
+    private static final int X = 10;
+    @Deprecated
+    @Override
+    public boolean equals(Object other) { return false; }
+
+    @Override
+    public String toString() {
+        return "InputRightCurlyAnnotations{}";
+    }
+
+    public String foo() { return "foo"; }
+
+    @Override
+    @SuppressWarnings("unused")
+    public int hashCode()
+    {
+        int a = 10;
+        return 1;
+    }
+}


### PR DESCRIPTION
@romani 
Fixed issue #1014 and provided additional UTs.
How many (and what) projects should I use to generate report after my changes with checkstyle-tester?