### PR TITLE
Changed SAME_PACKAGE rule for CustomImportOrderCheck #1262

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -42,35 +42,42 @@ import com.puppycrawl.tools.checkstyle.Utils;
  * STATIC group. This group sets the ordering of static imports.
  * </pre>
  *
- * <pre>
+ * <p>
  * SAME_PACKAGE(n) group. This group sets the ordering of the same package imports.
- * 'n' - a number of the first package domains. For example:
- * </pre>
+ * Imports are considered on SAME_PACKAGE group if <b>n</b> first domains in package name
+ * and import name are identical.
+ * </p>
  *
  * <pre>
  * <code>
- * package java.util.concurrent;
+ * package java.util.concurrent.locks;
  *
- * import java.util.regex.Pattern;
- * import java.util.List;
- * import java.util.StringTokenizer;
- * import java.util.regex.Pattern;
- * import java.util.*;
- * import java.util.concurrent.AbstractExecutorService;
- * import java.util.concurrent.*;
- *
- * And we have such configuration: SAME_PACKAGE (3).
- * Same package imports are java.util.*, java.util.concurrent.*,
- * java.util.concurrent.AbstractExecutorService,
- * java.util.List and java.util.StringTokenizer
+ * import java.io.File;
+ * import java.util.*; //#1
+ * import java.util.List; //#2
+ * import java.util.StringTokenizer; //#3
+ * import java.util.concurrent.*; //#4
+ * import java.util.concurrent.AbstractExecutorService; //#5
+ * import java.util.concurrent.locks.LockSupport; //#6
+ * import java.util.regex.Pattern; //#7
+ * import java.util.regex.Matcher; //#8
  * </code>
  * </pre>
  *
- * <pre>
+ * <p>
+ * If we have SAME_PACKAGE(3) on configuration file,
+ * imports #4-6 will be considered as a SAME_PACKAGE group (java.util.concurrent.*,
+ * java.util.concurrent.AbstractExecutorService, java.util.concurrent.locks.LockSupport).
+ * SAME_PACKAGE(2) will include #1-8. SAME_PACKAGE(4) will include only #6.
+ * SAME_PACKAGE(5) will result in no imports assigned to SAME_PACKAGE group because
+ * actual package java.util.concurrent.locks has only 4 domains.
+ * </p>
+ *
+ * <p>
  * THIRD_PARTY_PACKAGE group. This group sets ordering of third party imports.
  * Third party imports are all imports except STATIC,
  * SAME_PACKAGE(n), STANDARD_JAVA_PACKAGE and SPECIAL_IMPORTS.
- * </pre>
+ * </p>
  *
  * <pre>
  * STANDARD_JAVA_PACKAGE group. This group sets ordering of standard java/javax imports.
@@ -82,7 +89,7 @@ import com.puppycrawl.tools.checkstyle.Utils;
  * </pre>
  *
  * <p>
- * NOTICE!
+ * NOTE!
  * </p>
  * <p>
  * Use the separator '###' between rules.
@@ -91,6 +98,27 @@ import com.puppycrawl.tools.checkstyle.Utils;
  * To set RegExps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
  * thirdPartyPackageRegExp and standardPackageRegExp options.
  * </p>
+ *
+ * <pre>
+ * Properties:
+ * </pre>
+ * <table summary="Properties">
+ *     <tr><th>name</th><th>Description</th><th>type</th><th>default value</th></tr>
+ *      <tr><td>customImportOrderRules</td><td>List of order declaration customizing by user.</td>
+ *          <td>string</td><td>null</td></tr>
+ *      <tr><td>standardPackageRegExp</td><td>RegExp for STANDARD_JAVA_PACKAGE group imports.</td>
+ *          <td>regular expression</td><td>^(java|javax)\.</td></tr>
+ *      <tr><td>thirdPartyPackageRegExp</td><td>RegExp for THIRDPARTY_PACKAGE group imports.</td>
+ *          <td>regular expression</td><td>.*</td></tr>
+ *      <tr><td>specialImportsRegExp</td><td>RegExp for SPECIAL_IMPORTS group imports.</td>
+ *          <td>regular expression</td><td>^$</td></tr>
+ *      <tr><td>samePackageMatchingDepth</td><td>Number of first domains for SAME_PACKAGE group.
+ *          </td><td>Integer</td><td>2</td></tr>
+ *      <tr><td>separateLineBetweenGroups</td><td>Force empty line separator between import groups.
+ *          </td><td>boolean</td><td>true</td></tr>
+ *      <tr><td>sortImportsInGroupAlphabetically</td><td>Force grouping alphabetically,
+ *          in ASCII sort order.</td><td>boolean</td><td>false</td></tr>
+ * </table>
  *
  * <pre>
  * For example:
@@ -516,9 +544,10 @@ public class CustomImportOrderCheck extends Check {
      */
     private boolean matchesSamePackageImportGroup(boolean isStatic,
         String importFullPath, String currentGroup) {
-        final String importPath = importFullPath.substring(0, importFullPath.lastIndexOf('.'));
+        final String importPathTrimmedToSamePackageDepth =
+                getFirstNDomainsFromIdent(this.samePackageMatchingDepth, importFullPath);
         return !isStatic && SAME_PACKAGE_RULE_GROUP.equals(currentGroup)
-                && samePackageDomainsRegExp.contains(importPath);
+                && samePackageDomainsRegExp.equals(importPathTrimmedToSamePackageDepth);
     }
 
     /**
@@ -668,8 +697,22 @@ public class CustomImportOrderCheck extends Check {
      */
     private static String createSamePackageRegexp(int firstPackageDomainsCount,
              DetailAST packageNode) {
-        final StringBuilder builder = new StringBuilder();
         final String packageFullPath = getFullImportIdent(packageNode);
+        return getFirstNDomainsFromIdent(firstPackageDomainsCount, packageFullPath);
+    }
+
+    /**
+     * Extracts defined amount of domains from the left side of package/import identifier
+     * @param firstPackageDomainsCount
+     *        number of first package domains.
+     * @param packageFullPath
+     *        full identifier containing path to package or imported object.
+     * @return String with defined amount of domains or full identifier
+     *        (if full identifier had less domain then specified)
+     */
+    private static String getFirstNDomainsFromIdent(
+            final int firstPackageDomainsCount, final String packageFullPath) {
+        final StringBuilder builder = new StringBuilder();
         final StringTokenizer tokens = new StringTokenizer(packageFullPath, ".");
         int count = firstPackageDomainsCount;
 
@@ -677,7 +720,7 @@ public class CustomImportOrderCheck extends Check {
             builder.append(tokens.nextToken()).append('.');
             count--;
         }
-        return builder.append("*").toString();
+        return builder.toString();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -146,8 +146,6 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
                 "STATIC###SAME_PACKAGE(3)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-            "5: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
             "6: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
             "7: " + getCheckMessage(MSG_ORDER, "STATIC"),
             "8: " + getCheckMessage(MSG_ORDER, "STATIC"),
@@ -161,25 +159,6 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testOnlySamePackage() throws Exception {
-        final DefaultConfiguration checkConfig =
-                createCheckConfig(CustomImportOrderCheck.class);
-        checkConfig.addAttribute("customImportOrderRules", "SAME_PACKAGE(3)");
-        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
-        final String[] expected = {
-            "4: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-            "6: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-            "7: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-            "8: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-            "9: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-        };
-
-        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
-                + "checkstyle/imports/"
-                + "InputCustomImportOrderSamePackage2.java").getCanonicalPath(), expected);
-    }
-
-    @Test
     public void testWithoutLineSeparator() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(CustomImportOrderCheck.class);
@@ -189,8 +168,6 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
                 "STATIC###SAME_PACKAGE(3)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-            "5: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
             "6: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
             "7: " + getCheckMessage(MSG_ORDER, "STATIC"),
             "8: " + getCheckMessage(MSG_ORDER, "STATIC"),
@@ -324,6 +301,81 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         };
 
         assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testSamePackageDepth2() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
+        checkConfig.addAttribute("separateLineBetweenGroups", "false");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(2)");
+        final String[] expected = {
+            "7: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "8: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "9: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "10: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "11: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "12: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "13: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "14: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            };
+
+        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/imports/"
+                + "InputCustomImportOrderSamePackageDepth2-5.java").getCanonicalPath(), expected);
+    }
+
+    @Test
+    public void testSamePackageDepth3() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
+        checkConfig.addAttribute("separateLineBetweenGroups", "false");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(3)");
+        final String[] expected = {
+            "10: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "11: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "12: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            };
+
+        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/imports/"
+                + "InputCustomImportOrderSamePackageDepth2-5.java").getCanonicalPath(), expected);
+    }
+
+    @Test
+    public void testSamePackageDepth4() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
+        checkConfig.addAttribute("separateLineBetweenGroups", "false");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(4)");
+        final String[] expected = {
+            "12: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            };
+
+        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/imports/"
+                + "InputCustomImportOrderSamePackageDepth2-5.java").getCanonicalPath(), expected);
+    }
+
+    @Test
+    public void testSamePackageDepthLongerThenActualPackage() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
+        checkConfig.addAttribute("separateLineBetweenGroups", "false");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(5)");
+        final String[] expected = {};
+
+        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/imports/"
+                + "InputCustomImportOrderSamePackageDepth2-5.java").getCanonicalPath(), expected);
     }
 
     @Test(expected = CheckstyleException.class)

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackageDepth2-5.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackageDepth2-5.java
@@ -1,0 +1,17 @@
+package java.util.concurrent.locks;
+// SAME_PACKAGE(2) should include #1-8
+// SAME_PACKAGE(3) should include #4-6
+// SAME_PACKAGE(4) should include only #6
+// SAME_PACKAGE(5) should include no imports because actual package has only 4 domains 
+import java.io.File;
+import java.util.*; //#1
+import java.util.List; //#2
+import java.util.StringTokenizer; //#3
+import java.util.concurrent.*; //#4
+import java.util.concurrent.AbstractExecutorService; //#5
+import java.util.concurrent.locks.LockSupport; //#6
+import java.util.regex.Pattern; //#7
+import java.util.regex.Matcher; //#8
+
+public class InputCustomImportOrderSamePackage2 {
+}

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -628,24 +628,22 @@ public class SomeClass { ... }
         </p>
         <p>
           2) SAME_PACKAGE(n) group. This group sets the ordering of the same package imports.
-          n' - a number of the first package domains. For example:
+          Imports are considered on SAME_PACKAGE group if <b>n</b> first domains in package name and import name are identical. For example:
         </p>
         <source>
- package java.util.concurrent;
-
- import java.util.regex.Pattern;
- import java.util.List;
- import java.util.StringTokenizer;
- import java.util.regex.Pattern;
- import java.util.*;
- import java.util.concurrent.AbstractExecutorService;
- import java.util.concurrent.*;
+package java.util.concurrent.locks;
+import java.io.File;
+import java.util.*; //#1
+import java.util.List; //#2
+import java.util.StringTokenizer; //#3
+import java.util.concurrent.*; //#4
+import java.util.concurrent.AbstractExecutorService; //#5
+import java.util.concurrent.locks.LockSupport; //#6
+import java.util.regex.Pattern; //#7
+import java.util.regex.Matcher; //#8
         </source>
         <p>
-          And we have such configuration: SAME_PACKAGE (3).
-          Same package imports are java.util.*, java.util.concurrent.*,
-          java.util.concurrent.AbstractExecutorService,
-          java.util.List and java.util.StringTokenizer
+          If we have SAME_PACKAGE(3) on configuration file, imports #4-6 will be considered as a SAME_PACKAGE group (java.util.concurrent.*, java.util.concurrent.AbstractExecutorService, java.util.concurrent.locks.LockSupport). SAME_PACKAGE(2) will include #1-8. SAME_PACKAGE(4) will include only #6. SAME_PACKAGE(5) will result in no imports assigned to SAME_PACKAGE group because actual package java.util.concurrent.locks has only 4 domains.
         </p>
         <p>
           3) THIRD_PARTY_PACKAGE group. This group sets ordering of third party imports.


### PR DESCRIPTION
1. Corrected behaviour of SAME_PACKAGE group processing in CustomImportOrderCheck to match behaviour described on #1262.
2. Added handling of exceptional situation:
 - n parameter should be positive integer, throw IllegalArgumentException otherwise
 - if package name has fewer domains then *n*, amount of domains in package will override *n* defined in configuration
3. Documentation updated accordingly
