### PR TITLE
'ModifierOrderCheck' was refactored, UT coverage improved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 #.project till https://issues.apache.org/jira/browse/MECLIPSE-735
 .settings
 .externalToolBuilders
+.classpath
+.project
 
 # Eclipse-CS Checkstyle Plug-In IDE configuration files
 .checkstyle

--- a/pom.xml
+++ b/pom.xml
@@ -872,7 +872,6 @@
           <regex><pattern>.*.checks.metrics.NPathComplexityCheck</pattern><branchRate>100</branchRate><lineRate>90</lineRate></regex>
 
 
-          <regex><pattern>.*.checks.modifier.ModifierOrderCheck</pattern><branchRate>92</branchRate><lineRate>94</lineRate></regex>
           <regex><pattern>.*.checks.modifier.RedundantModifierCheck</pattern><branchRate>97</branchRate><lineRate>96</lineRate></regex>
 
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
@@ -149,7 +149,7 @@ public class ModifierOrderCheck
         }
 
         int i = 0;
-        while (i < JLS_ORDER.length) {
+        while (modifier != null) {
             if (modifier.getType() == TokenTypes.ANNOTATION) {
                 //Annotation not at start of modifiers, bad
                 return modifier;
@@ -164,12 +164,12 @@ public class ModifierOrderCheck
                 //Current modifier is out of JLS order
                 return modifier;
             }
-            else if (!it.hasNext()) {
-                //Reached end of modifiers without problem
-                return null;
+            else if (it.hasNext()) {
+                modifier = it.next();
             }
             else {
-                modifier = it.next();
+                //Reached end of modifiers without problem
+                modifier = null;
             }
         }
 


### PR DESCRIPTION
Reports were generated and compared due to refactoring of ModifierOrderCheck: http://rdiachenko.github.io/

Reports for Guava project before check's refactoring and after are identical.