### PR TITLE
Refactoring of AbstractIllegalCheck and its children. Improved UT coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -765,7 +765,6 @@
           <regex><pattern>.*.checks.blocks.RightCurlyCheck</pattern><branchRate>88</branchRate><lineRate>95</lineRate></regex>
 
 
-          <regex><pattern>.*.checks.coding.AbstractIllegalCheck</pattern><branchRate>64</branchRate><lineRate>100</lineRate></regex>
           <regex><pattern>.*.checks.coding.AbstractIllegalMethodCheck</pattern><branchRate>100</branchRate><lineRate>92</lineRate></regex>
           <regex><pattern>.*.checks.coding.AbstractNestedDepthCheck</pattern><branchRate>100</branchRate><lineRate>86</lineRate></regex>
           <regex><pattern>.*.checks.coding.AbstractSuperCheck</pattern><branchRate>78</branchRate><lineRate>88</lineRate></regex>
@@ -782,9 +781,7 @@
           <regex><pattern>.*.checks.coding.FinalLocalVariableCheck</pattern><branchRate>79</branchRate><lineRate>100</lineRate></regex>
           <regex><pattern>.*.checks.coding.HiddenFieldCheck</pattern><branchRate>96</branchRate><lineRate>97</lineRate></regex>
           <regex><pattern>.*.checks.coding.HiddenFieldCheck\$.*</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
-          <regex><pattern>.*.checks.coding.IllegalCatchCheck</pattern><branchRate>100</branchRate><lineRate>92</lineRate></regex>
           <regex><pattern>.*.checks.coding.IllegalInstantiationCheck</pattern><branchRate>77</branchRate><lineRate>94</lineRate></regex>
-          <regex><pattern>.*.checks.coding.IllegalThrowsCheck</pattern><branchRate>93</branchRate><lineRate>84</lineRate></regex>
           <regex><pattern>.*.checks.coding.IllegalTokenCheck</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>
           <regex><pattern>.*.checks.coding.IllegalTokenTextCheck</pattern><branchRate>60</branchRate><lineRate>88</lineRate></regex>
           <regex><pattern>.*.checks.coding.IllegalTypeCheck</pattern><branchRate>93</branchRate><lineRate>93</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalCheck.java
@@ -36,7 +36,6 @@ public abstract class AbstractIllegalCheck extends Check {
      * @param initialNames the initial class names to treat as illegal
      */
     protected AbstractIllegalCheck(final String... initialNames) {
-        assert initialNames != null;
         setIllegalClassNames(initialNames);
     }
 
@@ -58,7 +57,6 @@ public abstract class AbstractIllegalCheck extends Check {
      *            array of illegal exception classes
      */
     public final void setIllegalClassNames(final String... classNames) {
-        assert classNames != null;
         illegalClassNames.clear();
         for (final String name : classNames) {
             illegalClassNames.add(name);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheckTest.java
@@ -19,14 +19,15 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import static com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck.MSG_KEY;
+
 import java.io.File;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-
-import static com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck.MSG_KEY;
 
 public class IllegalCatchCheckTest extends BaseCheckTestSupport {
     @Test
@@ -73,5 +74,13 @@ public class IllegalCatchCheckTest extends BaseCheckTestSupport {
         };
 
         verify(checkConfig, getPath("coding" + File.separator + "InputIllegalCatchCheck2.java"), expected);
+    }
+
+    @Test
+    public void testTokensNotNull() {
+        IllegalCatchCheck check = new IllegalCatchCheck();
+        Assert.assertNotNull(check.getAcceptableTokens());
+        Assert.assertNotNull(check.getDefaultTokens());
+        Assert.assertNotNull(check.getRequiredTokens());
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheckTest.java
@@ -19,13 +19,15 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import org.junit.Test;
+import static com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheck.MSG_KEY;
 
 import java.io.File;
 
-import static com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheck.MSG_KEY;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
 public class IllegalThrowsCheckTest extends BaseCheckTestSupport {
     @Test
@@ -46,6 +48,10 @@ public class IllegalThrowsCheckTest extends BaseCheckTestSupport {
         DefaultConfiguration checkConfig = createCheckConfig(IllegalThrowsCheck.class);
         checkConfig.addAttribute("illegalClassNames",
                                  "java.lang.Error, java.lang.Exception, NullPointerException");
+
+        // check that incorrect names don't break the Check
+        checkConfig.addAttribute("illegalClassNames",
+                "java.lang.IOException.");
 
         String[] expected = {
             "5:33: " + getCheckMessage(MSG_KEY, "NullPointerException"),
@@ -99,6 +105,7 @@ public class IllegalThrowsCheckTest extends BaseCheckTestSupport {
     @Test
     public void testIgnoreOverriddenMethods() throws Exception {
         DefaultConfiguration checkConfig = createCheckConfig(IllegalThrowsCheck.class);
+        checkConfig.addAttribute("ignoreOverriddenMethods", "true");
 
         String[] expected = {
 
@@ -106,5 +113,32 @@ public class IllegalThrowsCheckTest extends BaseCheckTestSupport {
 
         verify(checkConfig, getPath("coding" + File.separator
                 + "InputIllegalThrowsCheckIgnoreOverriddenMethods.java"), expected);
+    }
+
+    /**
+     * Test to validate the IllegalThrowsCheck without <b>ignoreOverriddenMethods</b>
+     * property.
+     * @throws Exception
+     */
+    @Test
+    public void testNotIgnoreOverriddenMethods() throws Exception {
+        DefaultConfiguration checkConfig = createCheckConfig(IllegalThrowsCheck.class);
+        checkConfig.addAttribute("ignoreOverriddenMethods", "false");
+
+        String[] expected = {
+            "7:36: " + getCheckMessage(MSG_KEY, "RuntimeException"),
+            "12:51: " + getCheckMessage(MSG_KEY, "RuntimeException"),
+        };
+
+        verify(checkConfig, getPath("coding" + File.separator
+                + "InputIllegalThrowsCheckIgnoreOverriddenMethods.java"), expected);
+    }
+
+    @Test
+    public void testTokensNotNull() {
+        IllegalThrowsCheck check = new IllegalThrowsCheck();
+        Assert.assertNotNull(check.getAcceptableTokens());
+        Assert.assertNotNull(check.getDefaultTokens());
+        Assert.assertNotNull(check.getRequiredTokens());
     }
 }


### PR DESCRIPTION
getRequiredTokens() and getAcceptableTokens() are useless in these Checks as they are copy-paste of getDefaultTokens() method.
AbstractIllegalCheck, IllegalCatchCheck, IllegalThrowCheck - 100% UT coverage