### PR TITLE
'RedundantModifierCheck' was refactored, UT coverage improved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -871,9 +871,6 @@
           <regex><pattern>.*.checks.metrics.NPathComplexityCheck</pattern><branchRate>100</branchRate><lineRate>90</lineRate></regex>
 
 
-          <regex><pattern>.*.checks.modifier.RedundantModifierCheck</pattern><branchRate>97</branchRate><lineRate>96</lineRate></regex>
-
-
           <regex><pattern>.*.checks.naming.AbbreviationAsWordInNameCheck</pattern><branchRate>93</branchRate><lineRate>100</lineRate></regex>
           <regex><pattern>.*.checks.naming.AbstractAccessControlNameCheck</pattern><branchRate>95</branchRate><lineRate>80</lineRate></regex>
           <regex><pattern>.*.checks.naming.AbstractClassNameCheck</pattern><branchRate>100</branchRate><lineRate>90</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
@@ -41,6 +41,14 @@ public class RedundantModifierCheck
      */
     public static final String MSG_KEY = "redundantModifier";
 
+    /**
+     * An array of tokens for interface modifiers.
+     */
+    private static final int[] TOKENS_FOR_INTERFACE_MODIFIERS = new int[] {
+        TokenTypes.LITERAL_STATIC,
+        TokenTypes.ABSTRACT,
+    };
+
     @Override
     public int[] getDefaultTokens() {
         return new int[] {
@@ -71,16 +79,13 @@ public class RedundantModifierCheck
         if (TokenTypes.INTERFACE_DEF == ast.getType()) {
             final DetailAST modifiers =
                 ast.findFirstToken(TokenTypes.MODIFIERS);
-            if (null != modifiers) {
-                for (final int tokenType : new int[] {
-                    TokenTypes.LITERAL_STATIC,
-                    TokenTypes.ABSTRACT, }) {
-                    final DetailAST modifier =
-                            modifiers.findFirstToken(tokenType);
-                    if (null != modifier) {
-                        log(modifier.getLineNo(), modifier.getColumnNo(),
-                                MSG_KEY, modifier.getText());
-                    }
+
+            for (final int tokenType : TOKENS_FOR_INTERFACE_MODIFIERS) {
+                final DetailAST modifier =
+                        modifiers.findFirstToken(tokenType);
+                if (modifier != null) {
+                    log(modifier.getLineNo(), modifier.getColumnNo(),
+                            MSG_KEY, modifier.getText());
                 }
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierTest.java
@@ -19,14 +19,16 @@
 
 package com.puppycrawl.tools.checkstyle.checks.modifier;
 
+import static com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck.MSG_KEY;
+
 import java.io.File;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-
-import static com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck.MSG_KEY;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class RedundantModifierTest
     extends BaseCheckTestSupport {
@@ -78,5 +80,28 @@ public class RedundantModifierTest
                 new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
                         + "checkstyle/InputFinalInDefaultMethods.java").getCanonicalPath(),
                 expected);
+    }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        RedundantModifierCheck redundantModifierCheckObj = new RedundantModifierCheck();
+        int[] actual = redundantModifierCheckObj.getAcceptableTokens();
+        int[] expected = new int[] {
+            TokenTypes.METHOD_DEF,
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.ANNOTATION_FIELD_DEF,
+            TokenTypes.INTERFACE_DEF,
+        };
+        Assert.assertNotNull(actual);
+        Assert.assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetRequiredTokens() {
+        RedundantModifierCheck redundantModifierCheckObj = new RedundantModifierCheck();
+        int[] actual = redundantModifierCheckObj.getRequiredTokens();
+        int[] expected = new int[] {};
+        Assert.assertNotNull(actual);
+        Assert.assertArrayEquals(expected, actual);
     }
 }


### PR DESCRIPTION
Reports were generated and compared due to refactoring of RedundantModifierCheck: http://rdiachenko.github.io/

Reports for Guava project before check's refactoring and after are identical.