### PR TITLE
Fix OneStatementPerLine on multiple field initialization bug, issue #1237

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1113,7 +1113,6 @@
             <regex><pattern>.*.checks.coding.ModifiedControlVariableCheck</pattern><branchRate>91</branchRate><lineRate>97</lineRate></regex>
             <regex><pattern>.*.checks.coding.MultipleStringLiteralsCheck</pattern><branchRate>90</branchRate><lineRate>96</lineRate></regex>
             <regex><pattern>.*.checks.coding.MultipleVariableDeclarationsCheck</pattern><branchRate>96</branchRate><lineRate>100</lineRate></regex>
-            <regex><pattern>.*.checks.coding.OneStatementPerLineCheck</pattern><branchRate>93</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.coding.OverloadMethodsDeclarationOrderCheck</pattern><branchRate>93</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.coding.PackageDeclarationCheck</pattern><branchRate>75</branchRate><lineRate>85</lineRate></regex>
             <regex><pattern>.*.checks.coding.ParameterAssignmentCheck</pattern><branchRate>80</branchRate><lineRate>96</lineRate></regex>

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineTest.java
@@ -13,9 +13,9 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck;
 
 public class OneStatementPerLineTest extends BaseCheckTestSupport{
-    
+
     static ConfigurationBuilder builder;
-    
+
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
         builder = new ConfigurationBuilder(new File("src/it/"));
@@ -23,31 +23,38 @@ public class OneStatementPerLineTest extends BaseCheckTestSupport{
 
     @Test
     public void oneStatmentTest() throws IOException, Exception {
-        
+
         String msg = getCheckMessage(OneStatementPerLineCheck.class, "multiple.statements.line");
 
         final String[] expected = {
-            "45:18: " + msg,
-            "47:19: " + msg,
-            "49:40: " + msg,
-            "52:23: " + msg,
-            "53:33: " + msg,
-            "54:55: " + msg,
-            "63:11: " + msg,
-            "90:22: " + msg,
-            "92:23: " + msg,
-            "94:44: " + msg,
-            "97:27: " + msg,
-            "98:37: " + msg,
-            "99:59: " + msg,
+            "6:59: " + msg,
+            "58:21: " + msg,
+            "60:21: " + msg,
+            "62:42: " + msg,
+            "65:25: " + msg,
+            "66:35: " + msg,
+            "76:14: " + msg,
+            "103:25: " + msg,
+            "105:25: " + msg,
+            "107:46: " + msg,
+            "110:29: " + msg,
+            "111:39: " + msg,
+            "119:15: " + msg,
+            "131:23: " + msg,
+            "146:59: " + msg,
+            "155:4: " + msg,
+            "186:19: " + msg,
+            "204:15: " + msg,
+            "212:15: " + msg,
+            "224:6: " + msg,
+            "233:22: " + msg,
+            "323:39: " + msg,
         };
-        
+
         Configuration checkConfig = builder.getCheckConfig("OneStatementPerLine");
         String filePath = builder.getFilePath("OneStatementPerLineInput");
-        
+
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }
 }
-
-

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineInput.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineInput.java
@@ -1,5 +1,18 @@
 package com.google.checkstyle.test.chapter4formatting.rule43onestatement;
 
+/**
+ * Two import statements on the same line are illegal.
+ */
+import java.io.EOFException; import java.io.BufferedReader; //violation
+
+/**
+ * Two import statements and one 'empty' statement
+ * which are not on the same line are legal.
+ */
+import java.lang.annotation.Annotation;
+;
+import java.lang.String;
+
 public class OneStatementPerLineInput {
 
   /**
@@ -13,7 +26,7 @@ public class OneStatementPerLineInput {
   private int two = 0;
 
   /**
-   * Simple legal method
+   * Simple legal method.
    */
   public void doLegal() {
     one = 1;
@@ -33,37 +46,37 @@ public class OneStatementPerLineInput {
    * Within the for-header there are 3 Statements, but this is legal.
    */
   public void doLegalForLoop() {
-    for (int i = 0, j = 0, k = 1; i < 20; i++) { //it's ok. 
+    for (int i = 0, j = 0, k = 1; i < 20; i++) { //it's ok.
       one = i;
     }
   }
 
   /**
-   * Simplest form a an illegal layout.
+   * Simplest form of illegal layouts.
    */
   public void doIllegal() {
-    one = 1; two = 2; //warn
+    one = 1; two = 2; //violation
     if (one == 1) {
-        one++; two++; //warn
+        one++; two++; //violation
     }
-    if (one != 1) { one++; } else { one--; } //warn
+    if (one != 1) { one++; } else { one--; } //violation
     int n = 10;
 
-    doLegal(); doLegal(); //warn
-    while (one == 1) {one++; two--;} //warn
-    for (int i = 0, j = 0, k = 1; i < 20; i++) {  one = i; } //warn
+    doLegal(); doLegal(); //violation
+    while (one == 1) {one++; two--;} //violation
+
   }
-  
+
   /**
    * While theoretically being distributed over two lines, this is a sample
    * of 2 statements on one line.
    */
   public void doIllegal2() {
     one = 1
-    ; two = 2; //warn
+    ; two = 2; //violation
   }
-  
-  class Inner 
+
+  class Inner
   {
       /**
        * Dummy variable to work on.
@@ -76,27 +89,237 @@ public class OneStatementPerLineInput {
       private int two = 0;
 
       /**
-       * Simple legal method
+       * Simple legal method.
        */
       public void doLegal() {
         one = 1;
         two = 2;
       }
-      
+
       /**
        * Simplest form a an illegal layout.
        */
       public void doIllegal() {
-        one = 1; two = 2; //warn
+        one = 1; two = 2; //violation
         if (one == 1) {
-            one++; two++; //warn
+            one++; two++; //violation
         }
-        if (one != 1) { one++; } else { one--; } //warn
+        if (one != 1) { one++; } else { one--; } //violation
         int n = 10;
 
-        doLegal(); doLegal(); //warn
-        while (one == 1) {one++; two--;} //warn
-        for (int i = 0, j = 0, k = 1; i < 20; i++) {  one = i; } //warn
+        doLegal(); doLegal(); //violation
+        while (one == 1) {one++; two--;} //violation
+
       }
   }
+
+  /**
+   * Two declaration statements on the same line are illegal.
+   */
+  int a; int b; //violation
+
+  /**
+   * Two declaration statements which are not on the same line
+   * are legal.
+   */
+  int c;
+  int d;
+
+  /**
+   * Two assignment (declaration) statements on the same line are illegal.
+   */
+  int e = 1; int f = 2; //violation
+
+  /**
+   * Two assignment (declaration) statements on the different lines
+   * are legal.
+   */
+  int g = 1;
+  int h = 2;
+
+  /**
+   * This method contains
+   * two object creation statements on the same line.
+   */
+  private void foo() {
+    //Two object creation statements on the same line are illegal.
+    Object obj1 = new Object(); Object obj2 = new Object(); //violation
+  }
+
+  /**
+   * According to java language specifications,
+   * statements end with ';'. That is why ';;'
+   * may be considered as two empty statements on the same line
+   * and rises violation.
+   */
+  ;; //violation
+
+  /**
+   * One multiline  assignment (declaration) statement
+   * is legal.
+   */
+  int i = 1, j = 2,
+      k = 5;
+
+  /**
+   * One multiline  assignment (declaration) statement
+   * is legal.
+   */
+  int l = 1,
+      m = 2,
+      n = 5;
+
+  /**
+   * One multiline  assignment (declaration) statement
+   * is legal.
+   */
+  int w = 1,
+      x = 2,
+      y = 5
+          ;
+
+  /**
+   * Two multiline  assignment (declaration) statements
+   * are illegal.
+   */
+  int o = 1, p = 2,
+      r = 5; int t; //violation
+
+  /**
+   * Two assignment (declaration) statement
+   * which are not on the same lines and are legal.
+   */
+  int four = 1,
+      five = 5
+          ;
+  int seven = 2;
+
+  /**
+   * Two statements on the same line
+   * (they both are distributed over two lines)
+   * are illegal.
+   */
+  int var1 = 5,
+      var4 = 5; int var2 = 6,
+      var3 = 5; //violation
+
+  /**
+   * Two statements on the same line
+   * (they both are distributed over two lines)
+   * are illegal.
+   */
+  int var6 = 5; int var7 = 6,
+      var8 = 5; //violation
+
+  /**
+   * Two statements on the same line
+   * (they both are distributed over two lines)
+   * are illegal.
+   */
+  private void foo2() {
+    toString(
+
+    ); toString (
+
+    ); //violation
+  }
+
+
+  /**
+   * While theoretically being distributed over two lines, this is a sample
+   * of 2 statements on one line.
+   */
+  int var9 = 1, var10 = 5
+      ; int var11 = 2; //violation
+
+
+  /**
+   * Multiline for loop statement is legal.
+   */
+  private void foo3() {
+    for (int n = 0,
+         k = 1;
+         n < 5; n++,
+             k--) {
+
+    }
+  }
+
+  /**
+   * Two multiline statements (which are not on the same line)
+   * are legal.
+   */
+  int var12,
+      var13 = 12;
+  int var14 = 5,
+      var15 = 6;
+
+  /**
+   * This method contains break and while loop statements.
+   */
+  private void foo4() {
+    do {
+      var9++;
+      if (var10 > 4) {
+        break; //legal
+      }
+      var11++;
+      var9++;
+    } while (var11 < 7); //legal
+
+    /**
+     * One statement inside for block is legal
+     */
+    for (int i = 0; i < 10; i++) one = 5; //legal
+
+    /**
+     * One statement inside for block where
+     * increment expression is empty is legal
+     */
+    for (int i = 0; i < 10;) one = 5; //legal
+
+    /**
+     * One statement inside for block where
+     * increment and conditional expressions are empty
+     * (forever loop) is legal
+     */
+    for (int i = 0;;) one = 5; //legal
+  }
+
+  public void foo5() {
+    /**
+     * a "forever" loop.
+     */
+    for(;;){} //legal
+  }
+
+  public void foo6() {
+  /**
+   * One statement inside for block is legal
+   */
+    for (;;) { one = 5; } //legal
+  }
+
+  /**
+   * One statement inside multiline for loop is legal.
+   */
+  private void foo7() {
+    for(int n = 0,
+            k = 1
+            ; n<5
+            ;
+            n++, k--) { var1++; } //legal
+    }
+
+  /**
+   * Two statements on the same lne
+   * inside multiline for loop are illegal.
+   */
+  private void foo8() {
+    for(int n = 0,
+            k = 1
+            ; n<5
+            ;
+            n++, k--) { var1++; var2++; } //violation
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
@@ -32,8 +32,14 @@ public class OneStatementPerLineCheckTest extends BaseCheckTestSupport {
     public void testMultiCaseClass() throws Exception {
         DefaultConfiguration checkConfig = createCheckConfig(OneStatementPerLineCheck.class);
         final String[] expected = {
-            "99:18: " + getCheckMessage(MSG_KEY),
-            "127:11: " + getCheckMessage(MSG_KEY),
+            "24:59: " + getCheckMessage(MSG_KEY),
+            "112:21: " + getCheckMessage(MSG_KEY),
+            "139:14: " + getCheckMessage(MSG_KEY),
+            "165:15: " + getCheckMessage(MSG_KEY),
+            "177:23: " + getCheckMessage(MSG_KEY),
+            "197:19: " + getCheckMessage(MSG_KEY),
+            "200:59: " + getCheckMessage(MSG_KEY),
+            "209:4: " + getCheckMessage(MSG_KEY),
         };
 
         verify(checkConfig,
@@ -47,5 +53,22 @@ public class OneStatementPerLineCheckTest extends BaseCheckTestSupport {
         Assert.assertNotNull(check.getAcceptableTokens());
         Assert.assertNotNull(check.getDefaultTokens());
         Assert.assertNotNull(check.getRequiredTokens());
+    }
+
+    @Test
+    public void testWithMultilineStatements() throws Exception {
+        DefaultConfiguration checkConfig = createCheckConfig(OneStatementPerLineCheck.class);
+        final String[] expected = {
+            "44:21: " + getCheckMessage(MSG_KEY),
+            "61:17: " + getCheckMessage(MSG_KEY),
+            "69:17: " + getCheckMessage(MSG_KEY),
+            "81:10: " + getCheckMessage(MSG_KEY),
+            "90:28: " + getCheckMessage(MSG_KEY),
+            "135:39: " + getCheckMessage(MSG_KEY),
+        };
+
+        verify(checkConfig,
+            getPath("checks/coding/OneStatementPerLineCheckInput2.java"),
+            expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckInput.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckInput.java
@@ -19,7 +19,20 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 /**
- * This Class contains no logic, but serves as test-input for the unit tests for the 
+ * Two import statements on the same line are illegal.
+ */
+import java.io.EOFException; import java.io.BufferedReader;
+
+/**
+ * Two import statements and one 'empty' statement
+ * which are not on the same line are legal.
+ */
+import java.lang.annotation.Annotation;
+;
+import java.lang.String;
+
+/**
+ * This Class contains no logic, but serves as test-input for the unit tests for the
  * <code>OneStatementPerLineCheck</code>-checkstyle enhancement.
  * @author Alexander Jesse
  * @see com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck
@@ -93,13 +106,12 @@ public class OneStatementPerLineCheckInput {
   }
 
   /**
-   * Simplest form a an illegal layout.
+   * Simplest form of an illegal layout.
    */
   public void doIllegal() {
     one = 1; two = 2;
   }
 
-  
   /**
    * Smalltalk-style is considered as one statement.
    */
@@ -114,10 +126,10 @@ public class OneStatementPerLineCheckInput {
   public void doIllegalSmallTalk2() {
     SmallTalkStyle smalltalker = new SmallTalkStyle();
     smalltalker.doSomething1()
-               .doSomething2()
-               .doSomething3();
+        .doSomething2()
+        .doSomething3();
   }
-  
+
   /**
    * While theoretically being distributed over two lines, this is a sample
    * of 2 statements on one line.
@@ -126,7 +138,7 @@ public class OneStatementPerLineCheckInput {
     one = 1
     ; two = 2;
   }
-  
+
   /**
    * The StringBuffer is a Java-API-class that permits smalltalk-style concatenation
    * on the <code>append</code>-method.
@@ -137,7 +149,7 @@ public class OneStatementPerLineCheckInput {
     sb.append("test2 ").append("test3 ");
     appendToSpringBuffer(sb, "test4");
   }
-  
+
   /**
    * indirect stringbuffer-method. Used only internally.
    * @param sb The stringbuffer we want to append something
@@ -145,5 +157,101 @@ public class OneStatementPerLineCheckInput {
    */
   private void appendToSpringBuffer(StringBuffer sb, String text) {
     sb.append(text);
+  }
+
+  /**
+   * Two declaration statements on the same line are illegal.
+   */
+  int a; int b;
+
+  /**
+   * Two declaration statements which are not on the same line
+   * are legal.
+   */
+  int c;
+  int d;
+
+  /**
+   * Two assignment (declaration) statements on the same line are illegal.
+   */
+  int e = 1; int f = 2;
+
+  /**
+   * Two assignment (declaration) statements on the different lines
+   * are legal.
+   */
+  int g = 1;
+  int h = 2;
+
+  /**
+   * This method contains two increment statements
+   * and two object creation statements on the same line.
+   */
+  private void foo() {
+    //This is two assignment (declaration)
+    //statements on different lines
+    int var1 = 1;
+    int var2 = 2;
+
+    //Two increment statements on the same line are illegal.
+    var1++; var2++;
+
+    //Two object creation statements on the same line are illegal.
+    Object obj1 = new Object(); Object obj2 = new Object();
+  }
+
+  /**
+   * According to java language specifications,
+   * statements end with ';'. That is why ';;'
+   * may be considered as two empty statements on the same line
+   * and rises violation.
+   */
+  ;;
+
+  /**
+   * This method contains break, while-loop
+   * and for-loop statements.
+   */
+  private void foo3() {
+    do {
+      one++;
+      if (two > 4) {
+        break; //legal
+      }
+      one++;
+      two++;
+    } while (two < 7); //legal
+
+    /**
+     *  One statement inside for block is legal.
+     */
+    for (int i = 0; i < 10; i++) one = 5;
+
+    /**
+     *  One statement inside for block where
+     *  increment expression is empty is legal.
+     */
+    for (int i = 0; i < 10;) one = 5;
+
+    /**
+     *  One statement inside for block where
+     *  increment and conditional expressions are empty
+     *  (forever loop) is legal
+     */
+    for (int i = 0;;) one = 5;
+  }
+
+  public void foo4() {
+    /**
+     * a "forever" loop.
+     */
+    for(;;){} //legal
+  }
+
+  public void foo5() {
+    /**
+     *  One statement inside for block is legal
+     */
+    for (;;) { one = 5; }
   }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckInput2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckInput2.java
@@ -1,0 +1,137 @@
+package com.puppycrawl.tools.checkstyle.checks.coding;
+
+/*
+    This class provides test input for OneStatementPerLineCheck with different
+    types of multiline statements.
+    A Java statement is the smallest unit that is a complete instruction.
+    Statements must end with a semicolon.
+    Statements generally contain expressions (expressions have a value).
+    One of the simplest is the Assignment Statement.
+
+    <variable> = <expression>;
+ */
+public class OneStatementPerLineCheckInput2 {
+
+    /**
+     * One multiline  assignment (declaration) statement
+     * is legal.
+     */
+    int e = 1, f = 2,
+        g = 5;
+
+    /**
+     * One multiline  assignment (declaration) statement
+     * is legal.
+     */
+    int h = 1,
+        i = 2,
+        j = 5;
+
+    /**
+     * One multiline  assignment (declaration) statement
+     * is legal.
+     */
+    int k = 1,
+        l = 2,
+        m = 5
+        ;
+
+    /**
+     * Two multiline  assignment (declaration) statements
+     * on the same line are illegal.
+     */
+    int o = 1, p = 2,
+        r = 5; int t;
+
+    /**
+     * Two assignment (declaration) statement
+     * which are not on the same line are legal.
+     */
+    int one = 1,
+        three = 5;
+    int two = 2;
+
+    /**
+     * Two statements on the same line
+     * (they both are distributed over two lines)
+     * are illegal.
+     */
+    int var1 = 5,
+        var4 = 5; int var2 = 6,
+        var3 = 5;
+
+    /**
+     * Two statements on the same line
+     * (the second is distributed over two lines)
+     * are illegal.
+     */
+    int var6 = 5; int var7 = 6,
+        var8 = 5;
+
+    /**
+     * Two statements on the same line
+     * (they both are distributed over two lines)
+     * are illegal.
+     */
+    private void foo() {
+        toString(
+
+        );toString(
+
+        );
+    }
+
+    /**
+     * While theoretically being distributed over three lines, this is a sample
+     * of 2 statements on one line.
+     */
+    int var9 = 1,
+        var10 = 5
+            ; int var11 = 2;
+
+    /**
+     * Multiline for loop statement is legal.
+     */
+    private void foo2() {
+        for (int n = 0,
+             k = 1;
+             n < 5; n++,
+                 k--) {
+
+        }
+    }
+
+    /**
+     * Multiline for loop statement is legal.
+     */
+    private void foo3() {
+        for(int n = 0,
+            k = 1
+            ; n<5
+            ;
+            n++, k--) {}
+    }
+
+    /**
+     * One statement inside multiline for loop block is legal.
+     */
+    private void foo4() {
+        for(int n = 0,
+            k = 1
+            ; n<5
+            ; ) { int a = 5,
+        b = 2;}
+    }
+
+    /**
+     * Two statements on the same lne
+     * inside multiline for loop block are illegal.
+     */
+    private void foo5() {
+        for(int n = 0,
+            k = 1
+            ; n<5
+            ;
+            n++, k--) { var1++; var2++; }
+    }
+}

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -545,7 +545,7 @@
       </tr>
       <tr>
         <td><a href="config_coding.html#OneStatementPerLine">OneStatementPerLine</a></td>
-        <td>Checks there is only one statement per line.</td>
+        <td>Checks that there is only one statement per line.</td>
       </tr>
       <tr>
         <td><a href="config_design.html#OneTopLevelClass">OneTopLevelClass</a></td>

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -2596,17 +2596,48 @@ case 5:
 
     <section name="OneStatementPerLine">
       <subsection name="Description">
-        <p>
-          Checks that there is only one statement per line. The following line
-          will be flagged as an error:
-        </p>
-
-        <source>    x = 1; y = 2; // Two statements on a single line.</source>
+          <p>
+          Checks that there is only one statement per line.
+          </p>
+          <p>
+              Rationale: It's very difficult to read multiple statements on one line.
+          </p>
+          <p>
+              In the Java programming language, statements are the fundamental unit of
+              execution. All statements except blocks are terminated by a semicolon.
+              Blocks are denoted by open and close curly braces.
+          </p>
+          <p>
+              OneStatementPerLineCheck checks the following types of statements:
+              variable declaration statements, empty statements, import statements,
+              assignment statements, expression statements, increment statements,
+              object creation statements, 'for loop' statements, 'break' statements,
+              'continue' statements, 'return' statements.
+          </p>
       </subsection>
 
       <subsection name="Examples">
+          <p>
+              The following examples will be flagged as a violation:
+          </p>
+          <source>
+//Each line causes violation:
+int var1; int var2;
+var1 = 1; var2 = 2;
+int var1 = 1; int var2 = 2;
+var1++; var2++;
+Object obj1 = new Object(); Object obj2 = new Object();
+import java.io.EOFException; import java.io.BufferedReader;
+;; //two empty statements on the same line.
+
+//Multi-line statements:
+int var1 = 1
+; var2 = 2; //violation here
+int o = 1, p = 2,
+r = 5; int t; //violation here
+          </source>
         <p>
-          To configure the check:
+            An example of how to configure this Check:
         </p>
         <source>
 &lt;module name=&quot;OneStatementPerLine&quot;/&gt;


### PR DESCRIPTION
@romani 
I completely reworked the check, because it detected only expression statements which are on the same line. I provided a bundle of UTs with comments to explain new check logic.

[REPORTS] (http://mezk.github.io)



