### PR TITLE
Issue #1288: 'AbbreviationAsWordInNameCheck' was refactored, UT coverage improved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -870,7 +870,6 @@
           <regex><pattern>.*.checks.metrics.NPathComplexityCheck</pattern><branchRate>100</branchRate><lineRate>90</lineRate></regex>
 
 
-          <regex><pattern>.*.checks.naming.AbbreviationAsWordInNameCheck</pattern><branchRate>93</branchRate><lineRate>100</lineRate></regex>
           <regex><pattern>.*.checks.naming.AbstractAccessControlNameCheck</pattern><branchRate>95</branchRate><lineRate>80</lineRate></regex>
           <regex><pattern>.*.checks.naming.AbstractClassNameCheck</pattern><branchRate>100</branchRate><lineRate>90</lineRate></regex>
           <regex><pattern>.*.checks.naming.AbstractNameCheck</pattern><branchRate>100</branchRate><lineRate>87</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -245,12 +245,10 @@ public class AbbreviationAsWordInNameCheck extends Check {
     private static boolean isInterfaceDeclaration(DetailAST variableDefAst) {
         boolean result = false;
         final DetailAST astBlock = variableDefAst.getParent();
-        if (astBlock != null) {
-            final DetailAST astParent2 = astBlock.getParent();
-            if (astParent2 != null
-                    && astParent2.getType() == TokenTypes.INTERFACE_DEF) {
-                result = true;
-            }
+        final DetailAST astParent2 = astBlock.getParent();
+
+        if (astParent2.getType() == TokenTypes.INTERFACE_DEF) {
+            result = true;
         }
         return result;
     }
@@ -267,6 +265,7 @@ public class AbbreviationAsWordInNameCheck extends Check {
         for (DetailAST child : getChildren(methodModifiersAST)) {
             if (child.getType() == TokenTypes.ANNOTATION) {
                 final DetailAST annotationIdent = child.findFirstToken(TokenTypes.IDENT);
+
                 if (annotationIdent != null && "Override".equals(annotationIdent.getText())) {
                     result = true;
                     break;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
@@ -296,6 +296,7 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         warningMessage = getCheckMessage(MSG_KEY, expectedCapitalCount);
         checkConfig.addAttribute("allowedAbbreviationLength", String.valueOf(expectedCapitalCount));
         checkConfig.addAttribute("ignoreFinal", "false");
+        checkConfig.addAttribute("allowedAbbreviations", null);
 
         final String[] expected = {
         };

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/naming/InputAbbreviationAsWordInTypeNameCheckOverridableMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/naming/InputAbbreviationAsWordInTypeNameCheckOverridableMethod.java
@@ -18,7 +18,7 @@ abstract class NonAAAAbstractClassName1 extends Class1 {
 }
 
 class Class1 {
-    
+    @SuppressWarnings(value = { "" })
     protected void oveRRRRRrriddenMethod(){
         int a = 0;
         // blah-blah


### PR DESCRIPTION
Reports for Guava and Hibernate projects before check's refactoring and after are identical: http://rdiachenko.github.io/