### PR TITLE
Improved UT coverage for CustomImportOrder #1128

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -810,12 +810,10 @@
           <regex><pattern>.*.checks.header.RegexpHeaderCheck</pattern><branchRate>87</branchRate><lineRate>93</lineRate></regex>
 
 
-          <regex><pattern>.*.checks.imports.CustomImportOrderCheck</pattern><branchRate>93</branchRate><lineRate>91</lineRate></regex>
-          <regex><pattern>.*.checks.imports.Guard</pattern><branchRate>86</branchRate><lineRate>100</lineRate></regex>
+          <regex><pattern>.*.checks.imports.CustomImportOrderCheck</pattern><branchRate>98</branchRate><lineRate>100</lineRate></regex>
           <regex><pattern>.*.checks.imports.ImportControlCheck</pattern><branchRate>85</branchRate><lineRate>73</lineRate></regex>
           <regex><pattern>.*.checks.imports.ImportControlLoader</pattern><branchRate>72</branchRate><lineRate>88</lineRate></regex>
           <regex><pattern>.*.checks.imports.ImportOrderCheck</pattern><branchRate>91</branchRate><lineRate>99</lineRate></regex>
-          <regex><pattern>.*.checks.imports.PkgControl</pattern><branchRate>80</branchRate><lineRate>100</lineRate></regex>
 
 
           <regex><pattern>.*.checks.indentation.ArrayInitHandler</pattern><branchRate>83</branchRate><lineRate>97</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -296,22 +296,16 @@ public class CustomImportOrderCheck extends Check {
     /**
      * Sets a custom import order from the rules in the string format specified
      * by user.
-     * @param inputCustoimportOrder
+     * @param inputCustomImportOrder
      *        user value.
      */
-    public final void setCustomImportOrderRules(final String inputCustoimportOrder) {
+    public final void setCustomImportOrderRules(final String inputCustomImportOrder) {
         customImportOrderRules.clear();
-        try {
-            for (String currentState : inputCustoimportOrder
-                    .split("\\s*###\\s*")) {
-                addRuleastoList(currentState);
-            }
-            customImportOrderRules.add(NON_GROUP_RULE_GROUP);
+        for (String currentState : inputCustomImportOrder
+                .split("\\s*###\\s*")) {
+            addRuleastoList(currentState);
         }
-        catch (StringIndexOutOfBoundsException exp) {
-            //if the structure of the input rule isn't correct
-            throw new RuntimeException("Unable to parse input rule: " + exp);
-        }
+        customImportOrderRules.add(NON_GROUP_RULE_GROUP);
     }
 
     @Override
@@ -340,8 +334,7 @@ public class CustomImportOrderCheck extends Check {
     @Override
     public void visitToken(DetailAST ast) {
         if (ast.getType() == TokenTypes.PACKAGE_DEF) {
-            if (customImportOrderRules.contains(SAME_PACKAGE_RULE_GROUP)
-                    && samePackageMatchingDepth != -1) {
+            if (customImportOrderRules.contains(SAME_PACKAGE_RULE_GROUP)) {
                 samePackageDomainsRegExp = createSamePackageRegexp(
                         samePackageMatchingDepth, ast);
             }
@@ -640,12 +633,7 @@ public class CustomImportOrderCheck extends Check {
 
             final String rule = ruleStr.substring(ruleStr.indexOf('(') + 1,
                     ruleStr.indexOf(')'));
-            try {
-                samePackageMatchingDepth = Integer.parseInt(rule);
-            }
-            catch (NumberFormatException e) {
-                samePackageDomainsRegExp = rule;
-            }
+            samePackageMatchingDepth = Integer.parseInt(rule);
             if (samePackageMatchingDepth <= 0) {
                 throw new IllegalArgumentException(
                         "SAME_PACKAGE rule parameter should be positive integer: " + ruleStr);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderThirdPartyPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderThirdPartyPackage.java
@@ -9,6 +9,7 @@ import javax.swing.*;
 
 import static sun.tools.util.CommandLine.parse;
 import static sun.tools.util.ModifierFilter.ALL_ACCESS;
+import static sun.tools.util.ModifierFilter.ALL_ACCESS;
 
 public class InputCustomImportOrderThirdPartyPackage
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder_NoImports.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder_NoImports.java
@@ -1,0 +1,5 @@
+package com.puppycrawl.tools.checkstyle.imports;
+
+
+public class InputCustomImportOrder_NoImports {
+}


### PR DESCRIPTION
Improved coverage.
Few minor changes were introduced: removed try-catch where they are not required.
Reports are prepared to justify these changes:
[BEFORE](http://ivanov-alex.github.io/target_CustomImportOrder_BEFORE/site/checkstyle.html)
[AFTER](http://ivanov-alex.github.io/target_CustomImportOrder_AFTER/site/checkstyle.html)
**reports are identical**

Coverage will be 100% after #1263.