### PR TITLE
Issue #1288: 'ParameterNameCheck' refactored, UT coverage improved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -877,7 +877,6 @@
           <regex><pattern>.*.checks.naming.MemberNameCheck</pattern><branchRate>91</branchRate><lineRate>85</lineRate></regex>
           <regex><pattern>.*.checks.naming.MethodNameCheck</pattern><branchRate>100</branchRate><lineRate>93</lineRate></regex>
           <regex><pattern>.*.checks.naming.PackageNameCheck</pattern><branchRate>100</branchRate><lineRate>88</lineRate></regex>
-          <regex><pattern>.*.checks.naming.ParameterNameCheck</pattern><branchRate>75</branchRate><lineRate>80</lineRate></regex>
           <regex><pattern>.*.checks.naming.StaticVariableNameCheck</pattern><branchRate>81</branchRate><lineRate>87</lineRate></regex>
 
           <regex><pattern>.*.checks.regexp.CommentSuppressor</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -69,8 +69,6 @@ public class ParameterNameCheck
 
     @Override
     protected boolean mustCheckName(DetailAST ast) {
-        return !(
-            ast.getParent() != null
-                && ast.getParent().getType() == TokenTypes.LITERAL_CATCH);
+        return ast.getParent().getType() != TokenTypes.LITERAL_CATCH;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -19,11 +19,14 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+
+import org.junit.Assert;
 import org.junit.Test;
 
-import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class ParameterNameCheckTest
     extends BaseCheckTestSupport {
@@ -63,5 +66,16 @@ public class ParameterNameCheckTest
         final String[] expected = {
         };
         verify(checkConfig, getPath("InputSimple.java"), expected);
+    }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        ParameterNameCheck parameterNameCheckObj = new ParameterNameCheck();
+        int[] actual = parameterNameCheckObj.getAcceptableTokens();
+        int[] expected = new int[] {
+            TokenTypes.PARAMETER_DEF,
+        };
+        Assert.assertNotNull(actual);
+        Assert.assertArrayEquals(expected, actual);
     }
 }


### PR DESCRIPTION
Reports for Guava and Hibernate projects before check's refactoring and after are identical: http://rdiachenko.github.io/