### PR TITLE
Issue #1288: 'MemberNameCheck' refactored, UT coverage improved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -874,7 +874,6 @@
           <regex><pattern>.*.checks.naming.ConstantNameCheck</pattern><branchRate>88</branchRate><lineRate>92</lineRate></regex>
           <regex><pattern>.*.checks.naming.LocalFinalVariableNameCheck</pattern><branchRate>87</branchRate><lineRate>85</lineRate></regex>
           <regex><pattern>.*.checks.naming.LocalVariableNameCheck</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
-          <regex><pattern>.*.checks.naming.MemberNameCheck</pattern><branchRate>91</branchRate><lineRate>85</lineRate></regex>
           <regex><pattern>.*.checks.naming.MethodNameCheck</pattern><branchRate>100</branchRate><lineRate>93</lineRate></regex>
           <regex><pattern>.*.checks.naming.PackageNameCheck</pattern><branchRate>100</branchRate><lineRate>88</lineRate></regex>
           <regex><pattern>.*.checks.naming.ParameterNameCheck</pattern><branchRate>75</branchRate><lineRate>80</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheck.java
@@ -70,8 +70,7 @@ public class MemberNameCheck
     protected final boolean mustCheckName(DetailAST ast) {
         final DetailAST modifiersAST =
             ast.findFirstToken(TokenTypes.MODIFIERS);
-        final boolean isStatic = modifiersAST != null
-            && modifiersAST.branchContains(TokenTypes.LITERAL_STATIC);
+        final boolean isStatic = modifiersAST.branchContains(TokenTypes.LITERAL_STATIC);
 
         return !isStatic && !ScopeUtils.inInterfaceOrAnnotationBlock(ast)
             && !ScopeUtils.isLocalVariableDef(ast)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheckTest.java
@@ -19,12 +19,16 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+
 import java.io.File;
+
+import org.junit.Assert;
 import org.junit.Test;
 
-import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class MemberNameCheckTest
     extends BaseCheckTestSupport {
@@ -234,6 +238,17 @@ public class MemberNameCheckTest
         verify(checkConfig,
               getPath("naming" + File.separator + "InputMemberNameExtended.java"),
               expected);
+    }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        MemberNameCheck memberNameCheckObj = new MemberNameCheck();
+        int[] actual = memberNameCheckObj.getAcceptableTokens();
+        int[] expected = new int[] {
+            TokenTypes.VARIABLE_DEF,
+        };
+        Assert.assertNotNull(actual);
+        Assert.assertArrayEquals(expected, actual);
     }
 }
 


### PR DESCRIPTION
Reports for Guava and Hibernate projects before check's refactoring and after are identical: http://rdiachenko.github.io/