### PR TITLE
Issue #1288: 'LocalFinalVariableNameCheck' refactored, UT coverage improved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -872,7 +872,6 @@
           <regex><pattern>.*.checks.naming.AbstractNameCheck</pattern><branchRate>100</branchRate><lineRate>87</lineRate></regex>
           <regex><pattern>.*.checks.naming.AbstractTypeParameterNameCheck</pattern><branchRate>75</branchRate><lineRate>81</lineRate></regex>
           <regex><pattern>.*.checks.naming.ConstantNameCheck</pattern><branchRate>88</branchRate><lineRate>92</lineRate></regex>
-          <regex><pattern>.*.checks.naming.LocalFinalVariableNameCheck</pattern><branchRate>87</branchRate><lineRate>85</lineRate></regex>
           <regex><pattern>.*.checks.naming.LocalVariableNameCheck</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
           <regex><pattern>.*.checks.naming.MemberNameCheck</pattern><branchRate>91</branchRate><lineRate>85</lineRate></regex>
           <regex><pattern>.*.checks.naming.MethodNameCheck</pattern><branchRate>100</branchRate><lineRate>93</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheck.java
@@ -76,8 +76,7 @@ public class LocalFinalVariableNameCheck
     protected final boolean mustCheckName(DetailAST ast) {
         final DetailAST modifiersAST =
             ast.findFirstToken(TokenTypes.MODIFIERS);
-        final boolean isFinal = modifiersAST != null
-            && modifiersAST.branchContains(TokenTypes.FINAL);
+        final boolean isFinal = modifiersAST.branchContains(TokenTypes.FINAL);
         return isFinal && ScopeUtils.isLocalVariableDef(ast);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckTest.java
@@ -19,11 +19,14 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+
+import org.junit.Assert;
 import org.junit.Test;
 
-import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class LocalFinalVariableNameCheckTest
     extends BaseCheckTestSupport {
@@ -63,6 +66,18 @@ public class LocalFinalVariableNameCheckTest
             createCheckConfig(LocalFinalVariableNameCheck.class);
         final String[] expected = {};
         verify(checkConfig, getPath("InputInner.java"), expected);
+    }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        LocalFinalVariableNameCheck localFinalVariableNameCheckObj = new LocalFinalVariableNameCheck();
+        int[] actual = localFinalVariableNameCheckObj.getAcceptableTokens();
+        int[] expected = new int[] {
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.PARAMETER_DEF,
+        };
+        Assert.assertNotNull(actual);
+        Assert.assertArrayEquals(expected, actual);
     }
 }
 


### PR DESCRIPTION
Reports for Guava and Hibernate projects before check's refactoring and after are identical: http://rdiachenko.github.io/