### PR TITLE
Issue #1288: 'ConstantNameCheck' refactored, UT coverage improved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -871,7 +871,6 @@
           <regex><pattern>.*.checks.naming.AbstractClassNameCheck</pattern><branchRate>100</branchRate><lineRate>90</lineRate></regex>
           <regex><pattern>.*.checks.naming.AbstractNameCheck</pattern><branchRate>100</branchRate><lineRate>87</lineRate></regex>
           <regex><pattern>.*.checks.naming.AbstractTypeParameterNameCheck</pattern><branchRate>75</branchRate><lineRate>81</lineRate></regex>
-          <regex><pattern>.*.checks.naming.ConstantNameCheck</pattern><branchRate>88</branchRate><lineRate>92</lineRate></regex>
           <regex><pattern>.*.checks.naming.LocalFinalVariableNameCheck</pattern><branchRate>87</branchRate><lineRate>85</lineRate></regex>
           <regex><pattern>.*.checks.naming.LocalVariableNameCheck</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
           <regex><pattern>.*.checks.naming.MemberNameCheck</pattern><branchRate>91</branchRate><lineRate>85</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
@@ -76,10 +76,8 @@ public class ConstantNameCheck
 
         final DetailAST modifiersAST =
             ast.findFirstToken(TokenTypes.MODIFIERS);
-        final boolean isStatic = modifiersAST != null
-            && modifiersAST.branchContains(TokenTypes.LITERAL_STATIC);
-        final boolean isFinal = modifiersAST != null
-            && modifiersAST.branchContains(TokenTypes.FINAL);
+        final boolean isStatic = modifiersAST.branchContains(TokenTypes.LITERAL_STATIC);
+        final boolean isFinal = modifiersAST.branchContains(TokenTypes.FINAL);
 
         if (isStatic  && isFinal && shouldCheckInScope(modifiersAST)
                 || ScopeUtils.inAnnotationBlock(ast)
@@ -88,8 +86,7 @@ public class ConstantNameCheck
             // Handle the serialVersionUID and serialPersistentFields constants
             // which are used for Serialization. Cannot enforce rules on it. :-)
             final DetailAST nameAST = ast.findFirstToken(TokenTypes.IDENT);
-            if (nameAST != null
-                && !"serialVersionUID".equals(nameAST.getText())
+            if (!"serialVersionUID".equals(nameAST.getText())
                 && !"serialPersistentFields".equals(nameAST.getText())) {
                 retVal = true;
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
@@ -19,14 +19,18 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 import static org.junit.Assert.fail;
+
+import java.io.File;
+
+import org.junit.Assert;
+import org.junit.Test;
+
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
-import java.io.File;
-import org.junit.Test;
-
-import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class ConstantNameCheckTest
     extends BaseCheckTestSupport {
@@ -133,5 +137,16 @@ public class ConstantNameCheckTest
                 new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
                         + "checkstyle/InputStaticModifierInInterface.java").getCanonicalPath(),
                 expected);
+    }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        ConstantNameCheck constantNameCheckObj = new ConstantNameCheck();
+        int[] actual = constantNameCheckObj.getAcceptableTokens();
+        int[] expected = new int[] {
+            TokenTypes.VARIABLE_DEF,
+        };
+        Assert.assertNotNull(actual);
+        Assert.assertArrayEquals(expected, actual);
     }
 }


### PR DESCRIPTION
Reports for Guava and Hibernate projects before check's refactoring and after are identical: http://rdiachenko.github.io/