### PR TITLE
UT coverage 100% for ImportOrderCheck #1128

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1136,7 +1136,7 @@
             <regex><pattern>.*.checks.imports.CustomImportOrderCheck</pattern><branchRate>98</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.imports.ImportControlCheck</pattern><branchRate>85</branchRate><lineRate>73</lineRate></regex>
             <regex><pattern>.*.checks.imports.ImportControlLoader</pattern><branchRate>72</branchRate><lineRate>88</lineRate></regex>
-            <regex><pattern>.*.checks.imports.ImportOrderCheck</pattern><branchRate>91</branchRate><lineRate>99</lineRate></regex>
+            <regex><pattern>.*.checks.imports.ImportOrderCheck</pattern><branchRate>100</branchRate><lineRate>98</lineRate></regex>
 
 
             <regex><pattern>.*.checks.indentation.ArrayInitHandler</pattern><branchRate>83</branchRate><lineRate>97</lineRate></regex>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -19,13 +19,16 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import java.io.File;
-import org.junit.Test;
-
 import static com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck.MSG_ORDERING;
 import static com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck.MSG_SEPARATION;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
 public class ImportOrderCheckTest extends BaseCheckTestSupport {
     @Test
@@ -72,7 +75,7 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
     @Test
     public void testSeparated() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(ImportOrderCheck.class);
-        checkConfig.addAttribute("groups", "java.awt, javax.swing, java.io");
+        checkConfig.addAttribute("groups", "java.awt, javax.swing, java.io, java.util");
         checkConfig.addAttribute("separated", "true");
         checkConfig.addAttribute("ordered", "false");
         final String[] expected = {
@@ -92,6 +95,16 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
         };
 
         verify(checkConfig, getPath("imports" + File.separator + "InputImportOrderCaseInsensitive.java"), expected);
+    }
+
+    @Test(expected = CheckstyleException.class)
+    public void testInvalidOption() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("option", "invalid_option");
+        final String[] expected = {};
+
+        verify(checkConfig, getPath("imports" + File.separator + "InputImportOrder_Top.java"), expected);
     }
 
     @Test
@@ -265,7 +278,7 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ImportOrderCheck.class);
         checkConfig.addAttribute("option", "above");
-        checkConfig.addAttribute("groups", "org, java");
+        checkConfig.addAttribute("groups", "org, java, sun");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         final String[] expected = {
             "7: " + getCheckMessage(MSG_ORDERING, "java.lang.Math.PI"),
@@ -282,6 +295,7 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("groups", "org, java");
         final String[] expected = {
             "4: " + getCheckMessage(MSG_ORDERING, "org.abego.treelayout.Configuration.*"),
+            "9: " + getCheckMessage(MSG_ORDERING, "org.junit.Test"),
         };
         verify(checkConfig, getPath("imports" + File.separator
                  + "InputImportOrderStaticOnDemandGroupOrder.java"), expected);
@@ -294,7 +308,9 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("option", "top");
         checkConfig.addAttribute("groups", "org, java");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
-        final String[] expected = {};
+        final String[] expected = {
+            "9: " + getCheckMessage(MSG_ORDERING, "org.junit.Test"),
+        };
         verify(checkConfig, getPath("imports" + File.separator
                  + "InputImportOrderStaticOnDemandGroupOrder.java"), expected);
     }
@@ -338,4 +354,34 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
         verify(checkConfig, getPath("imports" + File.separator
                  + "InputImportOrderStaticOnDemandGroupOrderBottom.java"), expected);
     }
+
+    @Test(expected = CheckstyleException.class)
+    public void testGroupWithSlashes() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("groups", "/^javax");
+        final String[] expected = {};
+
+        verify(checkConfig, getPath("imports" + File.separator + "InputImportOrder.java"), expected);
+    }
+
+    @Test
+    public void testGroupWithDot() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("groups", "java.awt.");
+        final String[] expected = {};
+
+        verify(checkConfig, getPath("imports" + File.separator + "InputImportOrder_NoFailureForRedundantImports.java"), expected);
+    }
+
+    @Test
+    public void testMultiplePatternMatches() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("groups", "/java/,/rga/,/myO/,/org/,/organ./");
+        final String[] expected = {};
+
+        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/imports/"
+                + "InputImportOrder_MultiplePatternMatches.java").getCanonicalPath(), expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputImportOrder_MultiplePatternMatches.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputImportOrder_MultiplePatternMatches.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.imports;
+
+import java.io.File;
+
+import org.*;
+import org.myOrgorgan.Test;
+
+public class InputImportOrder_WildcardUnspecified {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputImportOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputImportOrder.java
@@ -15,5 +15,8 @@ import java.io.InputStream;
 import java.io.Reader;
 import static javax.swing.WindowConstants.*;
 
+import static sun.tools.util.ModifierFilter.ALL_ACCESS;
+import static sun.tools.util.ModifierFilter.PACKAGE;
+
 public class InputImportOrder {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputImportOrderStaticOnDemandGroupOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputImportOrderStaticOnDemandGroupOrder.java
@@ -6,6 +6,7 @@ import static org.abego.treelayout.Configuration.*;
 import org.*;
 
 import java.util.Set;
+import org.junit.Test;
 
 public class InputImportOrderStaticOnDemandGroupOrder
 {


### PR DESCRIPTION
Also removed validation `if (ident != null)` from `private void doVisitToken(FullIdent ident, boolean isStatic, boolean previous)` because it cannot be covered (`ident==null` will not be possible on files that will be successfully compiled).
You can refer reports [BEFORE](http://ivanov-alex.github.io/target_ImportOrder_BEFORE/site/checkstyle.html) and [AFTER](http://ivanov-alex.github.io/target_ImportOrder_AFTER/site/checkstyle.html) as a proof. Reports are identical.