### PR TITLE
Issue #1293: Refactoring of Nested*DepthCheck-family

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1095,7 +1095,6 @@
 
 
             <regex><pattern>.*.checks.coding.AbstractIllegalMethodCheck</pattern><branchRate>100</branchRate><lineRate>93</lineRate></regex>
-            <regex><pattern>.*.checks.coding.AbstractNestedDepthCheck</pattern><branchRate>100</branchRate><lineRate>93</lineRate></regex>
             <regex><pattern>.*.checks.coding.AbstractSuperCheck</pattern><branchRate>78</branchRate><lineRate>89</lineRate></regex>
             <regex><pattern>.*.checks.coding.CovariantEqualsCheck</pattern><branchRate>95</branchRate><lineRate>96</lineRate></regex>
             <regex><pattern>.*.checks.coding.DeclarationOrderCheck</pattern><branchRate>82</branchRate><lineRate>93</lineRate></regex>
@@ -1116,9 +1115,6 @@
             <regex><pattern>.*.checks.coding.ModifiedControlVariableCheck</pattern><branchRate>91</branchRate><lineRate>97</lineRate></regex>
             <regex><pattern>.*.checks.coding.MultipleStringLiteralsCheck</pattern><branchRate>90</branchRate><lineRate>96</lineRate></regex>
             <regex><pattern>.*.checks.coding.MultipleVariableDeclarationsCheck</pattern><branchRate>96</branchRate><lineRate>100</lineRate></regex>
-            <regex><pattern>.*.checks.coding.NestedForDepthCheck</pattern><branchRate>50</branchRate><lineRate>100</lineRate></regex>
-            <regex><pattern>.*.checks.coding.NestedIfDepthCheck</pattern><branchRate>75</branchRate><lineRate>88</lineRate></regex>
-            <regex><pattern>.*.checks.coding.NestedTryDepthCheck</pattern><branchRate>50</branchRate><lineRate>87</lineRate></regex>
             <regex><pattern>.*.checks.coding.OneStatementPerLineCheck</pattern><branchRate>93</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.coding.OverloadMethodsDeclarationOrderCheck</pattern><branchRate>93</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.coding.PackageDeclarationCheck</pattern><branchRate>75</branchRate><lineRate>85</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.java
@@ -52,14 +52,6 @@ public abstract class AbstractNestedDepthCheck extends Check {
     }
 
     /**
-     * Getter for maximum allowed nesting depth.
-     * @return maximum allowed nesting depth.
-     */
-    public final int getMax() {
-        return max;
-    }
-
-    /**
      * Setter for maximum allowed nesting depth.
      * @param max maximum allowed nesting depth.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheck.java
@@ -69,15 +69,11 @@ public final class NestedForDepthCheck extends AbstractNestedDepthCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (TokenTypes.LITERAL_FOR == ast.getType()) {
-            nestIn(ast, MSG_KEY);
-        }
+        nestIn(ast, MSG_KEY);
     }
 
     @Override
     public void leaveToken(DetailAST ast) {
-        if (TokenTypes.LITERAL_FOR == ast.getType()) {
-            nestOut();
-        }
+        nestOut();
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedIfDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedIfDepthCheck.java
@@ -55,42 +55,17 @@ public final class NestedIfDepthCheck extends AbstractNestedDepthCheck {
     }
 
     @Override
-    public void visitToken(DetailAST ast) {
-        if (ast.getType() == TokenTypes.LITERAL_IF) {
-            visitLiteralIf(ast);
-        }
-        else {
-            throw new IllegalStateException(ast.toString());
-        }
-    }
-
-    @Override
-    public void leaveToken(DetailAST ast) {
-        if (ast.getType() == TokenTypes.LITERAL_IF) {
-            leaveLiteralIf(ast);
-        }
-        else {
-            throw new IllegalStateException(ast.toString());
-        }
-    }
-
-    /**
-     * Increases current nesting depth.
-     * @param literalIf node for if.
-     */
-    private void visitLiteralIf(DetailAST literalIf) {
+    public void visitToken(DetailAST literalIf) {
         if (!CheckUtils.isElseIf(literalIf)) {
             nestIn(literalIf, MSG_KEY);
         }
     }
 
-    /**
-     * Decreases current nesting depth.
-     * @param literalIf node for if.
-     */
-    private void leaveLiteralIf(DetailAST literalIf) {
+    @Override
+    public void leaveToken(DetailAST literalIf) {
         if (!CheckUtils.isElseIf(literalIf)) {
             nestOut();
         }
     }
+
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedTryDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedTryDepthCheck.java
@@ -53,35 +53,13 @@ public final class NestedTryDepthCheck extends AbstractNestedDepthCheck {
     }
 
     @Override
-    public void visitToken(DetailAST ast) {
-        if (ast.getType() == TokenTypes.LITERAL_TRY) {
-            visitLiteralTry(ast);
-        }
-        else {
-            throw new IllegalStateException(ast.toString());
-        }
-    }
-
-    @Override
-    public void leaveToken(DetailAST ast) {
-        if (ast.getType() == TokenTypes.LITERAL_TRY) {
-            leaveLiteralTry();
-        }
-        else {
-            throw new IllegalStateException(ast.toString());
-        }
-    }
-
-    /**
-     * Increases current nesting depth.
-     * @param literalTry node for try.
-     */
-    private void visitLiteralTry(DetailAST literalTry) {
+    public void visitToken(DetailAST literalTry) {
         nestIn(literalTry, MSG_KEY);
     }
 
-    /** Decreases current nesting depth */
-    private void leaveLiteralTry() {
+    @Override
+    public void leaveToken(DetailAST literalTry) {
         nestOut();
     }
+
 }


### PR DESCRIPTION
No need to check token types every time because there is only one token type in getAcceptableTokens().
Checkstyle reports on Guava: http://baratali.github.io/ (reports are identical before and after my changes)