### PR TITLE
Issue #1288: 'AbstractTypeParameterNameCheck' refactored, UT coverage improved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1190,7 +1190,6 @@
             <regex><pattern>.*.checks.naming.AbstractAccessControlNameCheck</pattern><branchRate>95</branchRate><lineRate>80</lineRate></regex>
             <regex><pattern>.*.checks.naming.AbstractClassNameCheck</pattern><branchRate>100</branchRate><lineRate>90</lineRate></regex>
             <regex><pattern>.*.checks.naming.AbstractNameCheck</pattern><branchRate>100</branchRate><lineRate>87</lineRate></regex>
-            <regex><pattern>.*.checks.naming.AbstractTypeParameterNameCheck</pattern><branchRate>75</branchRate><lineRate>81</lineRate></regex>
 
             <regex><pattern>.*.checks.regexp.CommentSuppressor</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.regexp.DetectorOptions</pattern><branchRate>100</branchRate><lineRate>96</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.java
@@ -34,8 +34,6 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  */
 public abstract class AbstractTypeParameterNameCheck
     extends AbstractNameCheck {
-    /** the location of the type parameter **/
-    private int location;
 
     /**
      * Creates a new <code>AbstractTypeParameterNameCheck</code> instance.
@@ -60,20 +58,10 @@ public abstract class AbstractTypeParameterNameCheck
     }
 
     @Override
-    public final void init() {
-        this.location = getLocation();
-    }
-
-    @Override
     protected final boolean mustCheckName(DetailAST ast) {
-        DetailAST location =
+        final DetailAST location =
             ast.getParent().getParent();
-
-        if (location.getType() == TokenTypes.MODIFIERS) {
-            location = location.getParent();
-        }
-
-        return location.getType() == this.location;
+        return location.getType() == getLocation();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeParameterNameTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeParameterNameTest.java
@@ -19,14 +19,16 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+
 import java.io.File;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-
-import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class TypeParameterNameTest
     extends BaseCheckTestSupport {
@@ -129,5 +131,16 @@ public class TypeParameterNameTest
             "52:24: " + getCheckMessage(MSG_INVALID_PATTERN, "T", pattern),
         };
         verify(checkConfig, getPath("naming" + File.separator + "InputTypeParameterName.java"), expected);
+    }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        AbstractTypeParameterNameCheck typeParameterNameCheckObj = new ClassTypeParameterNameCheck();
+        int[] actual = typeParameterNameCheckObj.getAcceptableTokens();
+        int[] expected = new int[] {
+            TokenTypes.TYPE_PARAMETER,
+        };
+        Assert.assertNotNull(actual);
+        Assert.assertArrayEquals(expected, actual);
     }
 }


### PR DESCRIPTION
Reports for Guava and Hibernate projects before check's refactoring and after are identical: http://rdiachenko.github.io/

Reports were generated on all child checks of AbstractTypeParameterNameCheck:

```
<module name="ClassTypeParameterName"/>
<module name="InterfaceTypeParameterName"/>
<module name="MethodTypeParameterName"/>
```