### PR TITLE
Issue #1288: 'AbstractNameCheck' refactored, UT coverage improved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1189,7 +1189,6 @@
 
             <regex><pattern>.*.checks.naming.AbstractAccessControlNameCheck</pattern><branchRate>95</branchRate><lineRate>80</lineRate></regex>
             <regex><pattern>.*.checks.naming.AbstractClassNameCheck</pattern><branchRate>100</branchRate><lineRate>90</lineRate></regex>
-            <regex><pattern>.*.checks.naming.AbstractNameCheck</pattern><branchRate>100</branchRate><lineRate>87</lineRate></regex>
             <regex><pattern>.*.checks.naming.AbstractTypeParameterNameCheck</pattern><branchRate>75</branchRate><lineRate>81</lineRate></regex>
 
             <regex><pattern>.*.checks.regexp.CommentSuppressor</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractNameCheck.java
@@ -43,17 +43,6 @@ public abstract class AbstractNameCheck
         super(format);
     }
 
-    /**
-     * Decides whether the name of an AST should be checked against
-     * the format regexp.
-     * @param ast the AST to check.
-     * @return true if the IDENT subnode of ast should be checked against
-     * the format regexp.
-     */
-    protected boolean mustCheckName(DetailAST ast) {
-        return true;
-    }
-
     @Override
     public void visitToken(DetailAST ast) {
         if (mustCheckName(ast)) {
@@ -67,4 +56,13 @@ public abstract class AbstractNameCheck
             }
         }
     }
+
+    /**
+     * Decides whether the name of an AST should be checked against
+     * the format regexp.
+     * @param ast the AST to check.
+     * @return true if the IDENT subnode of ast should be checked against
+     * the format regexp.
+     */
+    protected abstract boolean mustCheckName(DetailAST ast);
 }


### PR DESCRIPTION
Reports for Guava and Hibernate projects before check's refactoring and after are identical: http://rdiachenko.github.io/

Reports were generated on all child checks of AbstractNameCheck:

```
<module name="ClassTypeParameterName"/>
<module name="InterfaceTypeParameterName"/>
<module name="MethodTypeParameterName"/>
<module name="TypeName"/>
<module name="StaticVariableName">
    <property name="format" value="^s[A-Z][a-zA-Z0-9]*$"/>
</module>
<module name="MethodName"/>
<module name="MemberName">
    <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
</module>
<module name="ConstantName"/>
<module name="LocalFinalVariableName"/>
<module name="LocalVariableName"/>
<module name="ParameterName">
    <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
</module>
```