### PR TITLE
Issue #1288: 'AbstractClassNameCheck' refactored, UT coverage improved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1188,7 +1188,6 @@
 
 
             <regex><pattern>.*.checks.naming.AbstractAccessControlNameCheck</pattern><branchRate>95</branchRate><lineRate>80</lineRate></regex>
-            <regex><pattern>.*.checks.naming.AbstractClassNameCheck</pattern><branchRate>100</branchRate><lineRate>90</lineRate></regex>
             <regex><pattern>.*.checks.naming.AbstractNameCheck</pattern><branchRate>100</branchRate><lineRate>87</lineRate></regex>
             <regex><pattern>.*.checks.naming.AbstractTypeParameterNameCheck</pattern><branchRate>75</branchRate><lineRate>81</lineRate></regex>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
@@ -90,7 +90,7 @@ public final class AbstractClassNameCheck extends AbstractFormatCheck {
 
     @Override
     public int[] getRequiredTokens() {
-        return getDefaultTokens();
+        return new int[]{TokenTypes.CLASS_DEF};
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckTest.java
@@ -19,15 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck.ILLEGAL_ABSTRACT_CLASS_NAME;
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck.NO_ABSTRACT_CLASS_MODIFIER;
+
 import java.io.File;
+
+import org.junit.Assert;
 import org.junit.Test;
 
-import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck
-.ILLEGAL_ABSTRACT_CLASS_NAME;
-import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck
-.NO_ABSTRACT_CLASS_MODIFIER;
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class AbstractClassNameCheckTest extends BaseCheckTestSupport {
     @Test
@@ -93,5 +95,27 @@ public class AbstractClassNameCheckTest extends BaseCheckTestSupport {
 
         verify(checkConfig, getPath("naming" + File.separator
                  + "InputAbstractClassNameFormerFalsePositive.java"), expected);
+    }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        AbstractClassNameCheck classNameCheckObj = new AbstractClassNameCheck();
+        int[] actual = classNameCheckObj.getAcceptableTokens();
+        int[] expected = new int[] {
+            TokenTypes.CLASS_DEF,
+        };
+        Assert.assertNotNull(actual);
+        Assert.assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetRequiredTokens() {
+        AbstractClassNameCheck classNameCheckObj = new AbstractClassNameCheck();
+        int[] actual = classNameCheckObj.getRequiredTokens();
+        int[] expected = new int[] {
+            TokenTypes.CLASS_DEF,
+        };
+        Assert.assertNotNull(actual);
+        Assert.assertArrayEquals(expected, actual);
     }
 }


### PR DESCRIPTION
Reports for Guava and Hibernate projects before check's refactoring and after are identical: http://rdiachenko.github.io/