### PR TITLE
Issue #1288: 'AbstractAccessControlNameCheck' refactored, UT coverage improved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1187,7 +1187,6 @@
             <regex><pattern>.*.checks.metrics.NPathComplexityCheck</pattern><branchRate>100</branchRate><lineRate>90</lineRate></regex>
 
 
-            <regex><pattern>.*.checks.naming.AbstractAccessControlNameCheck</pattern><branchRate>95</branchRate><lineRate>80</lineRate></regex>
             <regex><pattern>.*.checks.naming.AbstractClassNameCheck</pattern><branchRate>100</branchRate><lineRate>90</lineRate></regex>
             <regex><pattern>.*.checks.naming.AbstractNameCheck</pattern><branchRate>100</branchRate><lineRate>87</lineRate></regex>
             <regex><pattern>.*.checks.naming.AbstractTypeParameterNameCheck</pattern><branchRate>75</branchRate><lineRate>81</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractAccessControlNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractAccessControlNameCheck.java
@@ -82,11 +82,6 @@ public abstract class AbstractAccessControlNameCheck
      * @return true if we should check such member.
      */
     protected boolean shouldCheckInScope(DetailAST modifiers) {
-        if (modifiers == null) {
-            // if there are no modifiers it is a package-private
-            return applyToPackage;
-        }
-
         final boolean isPublic = modifiers
                 .branchContains(TokenTypes.LITERAL_PUBLIC);
         final boolean isProtected = modifiers


### PR DESCRIPTION
Reports for Guava and Hibernate projects before check's refactoring and after are identical: http://rdiachenko.github.io/

Reports were generated on all child checks of AbstractAccessControlNameCheck:
```
<module name="TypeName"/>
<module name="StaticVariableName">
    <property name="format" value="^s[A-Z][a-zA-Z0-9]*$"/>
</module>
<module name="MethodName"/>
<module name="MemberName">
    <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
</module>
<module name="ConstantName"/>
```