### PR TITLE
Add test coverage to HtmlTag in Javadoc checks. #1308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1156,7 +1156,6 @@
             <regex><pattern>.*.checks.javadoc.AbstractJavadocCheck</pattern><branchRate>90</branchRate><lineRate>93</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.AbstractJavadocCheck\$.*</pattern><branchRate>50</branchRate><lineRate>68</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.AtclauseOrderCheck</pattern><branchRate>88</branchRate><lineRate>88</lineRate></regex>
-            <regex><pattern>.*.checks.javadoc.HtmlTag</pattern><branchRate>75</branchRate><lineRate>90</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocMethodCheck</pattern><branchRate>90</branchRate><lineRate>96</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocPackageCheck</pattern><branchRate>80</branchRate><lineRate>95</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocParagraphCheck</pattern><branchRate>92</branchRate><lineRate>100</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java
@@ -57,8 +57,7 @@ class HtmlTag {
      */
     HtmlTag(String id, int lineNo, int position, boolean closedTag,
             boolean incomplete, String text) {
-        this.id = !"".equals(id) && id.charAt(0) == '/'
-            ? id.substring(1) : id;
+        this.id = id;
         this.lineNo = lineNo;
         this.position = position;
         this.text = text;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputJavadocStyleCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputJavadocStyleCheck.java
@@ -338,4 +338,13 @@ public class InputJavadocStyleCheck
 		public void method21() {
 		}
 
+        /**
+         * First sentence.
+         * <
+         * /a>
+         */
+        void tagClosedInNextLine() {
+            
+        } 
+
 }


### PR DESCRIPTION
Reports on huge codebase were generated and compared - the only difference is version used to produce report:
```
--- checkstyle-result.xml
+++ checkstyle-result-2.xml
@@ -1,5 +1,5 @@
<?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="6.8.1">
+<checkstyle version="6.9-SNAPSHOT">
```