### PR TITLE
Add new option for RightCurlyCheck, issue #1019.

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyRightCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyRightCurlyTest.java
@@ -101,8 +101,11 @@ public class LeftCurlyRightCurlyTest extends BaseCheckTestSupport{
         newCheckConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF");
         
         String checkMessageNew = getCheckMessage(RightCurlyCheck.class, "line.new", "}");
+        String checkMessageAlone = getCheckMessage(RightCurlyCheck.class, "line.alone", "}");
         final String[] expected = {
+            "97:5: " + checkMessageAlone,
             "97:6: " + checkMessageNew,
+            "108:5: " + checkMessageAlone,
             "108:6: " + checkMessageNew,
             "122:6: " + checkMessageNew,
         };

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java
@@ -25,9 +25,28 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
  * @author Oliver Burn
  */
 public enum RightCurlyOption {
+
     /**
-     * Represents the policy that the brace must be alone on the line. For
-     * example:
+     * Represents the policy that the brace must be alone on the line
+     * and allows single-line format of block.
+     * For example:
+     *
+     * <pre>
+     * //Brace is alone on the line
+     * try {
+     * ...
+     * }
+     * inally {
+     *
+     * // Single-line format of block
+     * private int foo() { return 1; }
+     * </pre>
+     **/
+    ALONE_OR_SINGLELINE,
+
+    /**
+     * Represents the policy that the brace must be alone on the line.
+     * For example:
      *
      * <pre>
      * try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -45,8 +45,6 @@ public class RightCurlyCheckTest extends BaseCheckTestSupport {
             "28:17: " + getCheckMessage(MSG_KEY_LINE_SAME, "}"),
             "40:13: " + getCheckMessage(MSG_KEY_LINE_SAME, "}"),
             "44:13: " + getCheckMessage(MSG_KEY_LINE_SAME, "}"),
-            "93:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
-            "93:27: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
             "93:27: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}"),
             "97:54: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}"),
         };
@@ -61,8 +59,6 @@ public class RightCurlyCheckTest extends BaseCheckTestSupport {
             "28:17: " + getCheckMessage(MSG_KEY_LINE_SAME, "}"),
             "40:13: " + getCheckMessage(MSG_KEY_LINE_SAME, "}"),
             "44:13: " + getCheckMessage(MSG_KEY_LINE_SAME, "}"),
-            "93:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
-            "93:27: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
             "93:27: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}"),
             "97:54: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}"),
         };
@@ -74,7 +70,6 @@ public class RightCurlyCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
         final String[] expected = {
             "93:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
-            "93:27: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
         };
         verify(checkConfig, getPath("InputLeftCurlyOther.java"), expected);
     }
@@ -84,7 +79,9 @@ public class RightCurlyCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
         checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF");
         final String[] expected = {
+            "111:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
             "111:10: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
+            "122:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
             "122:10: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
             "136:10: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
         };
@@ -147,12 +144,94 @@ public class RightCurlyCheckTest extends BaseCheckTestSupport {
     @Test
     public void testWithAnnotations() throws Exception {
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
-        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT");
+        checkConfig.addAttribute("tokens", "LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, "
+            + "LITERAL_ELSE, CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, "
+            + "STATIC_INIT, INSTANCE_INIT");
         final String[] expected = {
-            "9:57: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
-            "16:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "9:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "12:65: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "23:46: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "27:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "30:35: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "33:36: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "39:73: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "41:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "46:58: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "48:97: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "51:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "54:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "61:38: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "68:62: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "77:28: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "79:21: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "81:20: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "83:14: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "94:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "104:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "108:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "112:52: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "112:112: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "115:18: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
+            "119:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "122:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "124:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "128:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "137:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "139:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "149:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "151:75: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "152:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "152:93: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "153:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "154:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "154:93: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "160:37: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
+            "167:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "182:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "189:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "189:13: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
+            "198:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "198:10: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
+            "202:49: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "202:50: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
+            "205:75: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "205:76: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "205:77: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
+            "209:76: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "217:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+
         };
         verify(checkConfig, getPath("InputRightCurlyAnnotations.java"), expected);
+    }
+
+    @Test
+    public void testAloneOrSingleLine() throws Exception {
+        checkConfig.addAttribute("option", RightCurlyOption.ALONE_OR_SINGLELINE.toString());
+        checkConfig.addAttribute("tokens", "LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, "
+            + "LITERAL_ELSE, CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, "
+            + "STATIC_INIT, INSTANCE_INIT");
+        final String[] expected = {
+            "60:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "69:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "74:52: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "77:18: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
+            "85:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "97:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "99:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "119:37: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
+            "126:37: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
+            "148:13: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
+            "157:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "157:10: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
+            "161:49: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "161:50: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
+            "164:75: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "164:76: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+            "164:77: " + getCheckMessage(MSG_KEY_LINE_NEW, "}"),
+            "176:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}"),
+
+        };
+        verify(checkConfig, getPath("InputRightCurlyAloneOrSingleline.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputRightCurlyAloneOrSingleline.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputRightCurlyAloneOrSingleline.java
@@ -1,134 +1,94 @@
 package com.puppycrawl.tools.checkstyle;
 
-@TestClassAnnotation
-class InputRightCurlyAnnotations
-{
+public class InputRightCurlyAloneOrSingleline {
 
-    @Deprecated
-    @Override
-    public boolean equals(Object other) { boolean flag = true; return flag; } //violation
+    public boolean equals(Object other) { boolean flag = true; return flag; } 
 
-    @Override
-    public String toString() { String s = "toString"; return s; } //violation
-
-    @Override
-    @SuppressWarnings("unused")
     public int hashCode()
-    {
+    { 
         int a = 10;
         return 1;
     }
 
-    @SuppressWarnings("unused")
-    private void foo2() { int a = 9; return; } //violation
+    private void foo()
+    { int var1 = 5; var2 = 6; } 
 
-    @SuppressWarnings("unused")
-    private void foo3()
-    { int var1 = 5; var2 = 6; } //violation
+    private void foo1() { return; } 
 
-    @Deprecated
-    private void foo4() { return; } //violation
+    private String foo2() { return toString();
+    } 
 
-    @SuppressWarnings("unused")
-    private int foo5() { return 1; } //violation
-
-    @SuppressWarnings("unused")
-    private String foo6() { return toString();
-    }
-
-    private String foo7() { String s = toString(); return s.toString(); } //violation
-
-    private void foo8() { ; return; } //violation
+    private void foo3() { ; return; } 
 
     private int var1;
     private int var2;
-    @SuppressWarnings("unused")
-    public InputRightCurlyAnnotations() { this.var1 = 1; } //violation
-    @SuppressWarnings("unused")
-    public InputRightCurlyAnnotations(int var1, int var2) { this.var1 = var1; this.var2 = var2; } //violation
+    public InputRightCurlyAloneOrSingleline() { this.var1 = 1; } 
+    public InputRightCurlyAloneOrSingleline(int var1, int var2) { this.var1 = var1; this.var2 = var2; } 
 
-    @SuppressWarnings("unused")
-    private void foo9() { ;; } //violation
+    private void foo4() { ;; } 
 
-    @SuppressWarnings("unused")
-    private void foo10() { ; } //violation
+    private void foo5() { ; } 
 
-    @SuppressWarnings("unused")
-    private void foo11() {  } //it's ok - empty block
+    private void foo6() {  } 
 
-    @SuppressWarnings("unused")
     private void foo12() {
-        try { int i = 5; int b = 10; } //violation
-        catch (Exception e) { } //it's ok - empty block
-    }
+        try { int i = 5; int b = 10; } 
+        catch (Exception e) { } 
+    } 
 
-    @Deprecated
-    @SuppressWarnings("unused")
     private void foo13() {
-        for (int i = 0; i < 10; i++) { int a = 5; int b = 6; } //violation
+        for (int i = 0; i < 10; i++) { int a = 5; int b = 6; } 
 
         do
         {
             var1 = 2;
-        }
+        } 
         while (var2 == 2);
-    }
+    } 
 
-    static { int a; int b; } //violation
+    static { int a; int b; } 
 
-    static { int a; } //violation
+    { int c; int d;} 
 
-    { int c; int d;} //violation
-
-    { int c; } //violation
-
-    @Deprecated
     private void foo14() {
         if (var1 > 0) {
             return;
-        }
-    }
+        } 
+    } 
 
-    @Deprecated
     private void foo15() {
         class A { int a; } var1++; //violation
-        class B {  }
+        class B {  } 
         if(true) {
 
-        }
+        } 
         else;
     }
 
-    @Deprecated
     private void foo16() {
         if (true) { return; } else { } //violation
         if (false) {
         }
-
-        if (true) { return; } else { } //violation
     }
 
-    @Deprecated
-    private void foo17() { int var1 = 5; var2 = 6; } @Deprecated private void foo18() {int var1 = 5; var2 = 6; } //violation
+    private void foo17() { int var1 = 5; var2 = 6; } private void foo18() {int var1 = 5; var2 = 6; } //violation
 
     private void foo19() {int var1 = 5;
         var2 = 6;} //violation
 
-    @SuppressWarnings("Hello, world!")
     private String foo20() {
-        do { var2 ++; } //violation
+        do { var2 ++; }  
         while (var2 < 15);
 
-        while (var1 < 10) { var1++; } //violation
+        while (var1 < 10) { var1++; } 
 
         do { var2++; var1++; } while (var2 < 15); return ""+0xCAFEBABE; //violation
     }
 
     private void foo21() {
-        new Object() { @Override protected void finalize() { "".toString(); }}; //violation
-    }
+        new Object() { @Override protected void finalize() { "".toString(); }}; 
+    } 
 
-    @SuppressWarnings("All")
     void foo22() {
         long startTime = System.nanoTime();
         try {
@@ -139,19 +99,18 @@ class InputRightCurlyAnnotations
         } finally { toString(); } //violation
     }
 
-    @SuppressWarnings("")
     void doDoubleBraceInitialization() {
         java.util.Map<String, String> map = new java.util.LinkedHashMap<String, String>() {{
             put("Hello", "World");
             put("first", "second");
             put("polygene", "lubricants");
             put("alpha", "betical");
-        }}; //violation
+        }}; // it's ok
 
-        Thread t = new Thread() {@Override public void run() {super.run();}}; //violation
-        new Object() { @Override protected void finalize() { "".toString(); }  { int a = 5; }}; //violation
-        new Object() { @Override protected void finalize() { "".toString(); }  int b = 10; }; //violation
-        new Object() { @Override protected void finalize() { "".toString(); }  { int c = 5; } int d = 8; }; //violation
+        Thread t = new Thread() {@Override public void run() {super.run();}};
+        new Object() { @Override protected void finalize() { "".toString(); }  { int a = 5; }};
+        new Object() { @Override protected void finalize() { "".toString(); }  int b = 10; };
+        new Object() { @Override protected void finalize() { "".toString(); }  { int c = 5; } int d = 8; };
 
         java.util.Map<String, String> map2 = new java.util.LinkedHashMap<String, String>() {{
             put("Hello", "World");
@@ -164,14 +123,14 @@ class InputRightCurlyAnnotations
             put("Hello", "World");
             put("first", "second");
             put("polygene", "lubricants");
-            put("alpha", "betical");}};  //violation
+            put("alpha", "betical");}}; //violation
 
         java.util.Map<String, String> map4 = new java.util.LinkedHashMap<String, String>() {{
             put("Hello", "World");
             put("first", "second");
             put("polygene", "lubricants");
             put("alpha", "betical");
-            }
+        }
         };
 
         foo23(new java.util.HashSet<String>() {{
@@ -179,7 +138,7 @@ class InputRightCurlyAnnotations
             add("AB21/X");
             add("YYLEX");
             add("AR5E");
-        }}); //violation
+        }});  //it's ok, can't be formatted better
 
         foo23(new java.util.HashSet<String>() {{
             add("XZ13s");
@@ -206,7 +165,7 @@ class InputRightCurlyAnnotations
 
     private java.util.ArrayList foo28(int delta) {
         return new java.util.ArrayList() {
-        @Override public int size() { return Math.max(0, super.size() + 1);}; //violation
+            @Override public int size() { return Math.max(0, super.size() + 1);};
         };
     }
 

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -307,6 +307,25 @@
             </pre>
           </td>
         </tr>
+
+          <tr>
+              <td><code>alone_or_singleline</code></td>
+              <td>
+                  The brace must be alone on the line, yet
+                  single-line format of block is allowed.
+                  For example:
+                  <pre>
+    // Brace is alone on the line
+    try {
+    ...
+    }
+    finally {
+
+    // Single-line format of block
+    private int foo() { return 1; }
+                  </pre>
+              </td>
+          </tr>
       </table>
     </subsection>
 


### PR DESCRIPTION
@romani 
I've added new option "alone_or_singleline" for RightCurlyCheck to enforce "{" to be alone on line and allow [single-line-single-statement](https://github.com/MEZk/checkstyle/commit/a756f4db8c07505aaead9cd6df97b59182f0193c#diff-78a4d0ad2378fd234b5628cb24fcd469R41) format of block. I've also provided UTs and generated [reports](http://mezk.github.io/index.html) to see the difference between ALONE and ALONE_OR_SINGLELINE options. As you can see from the reports, new option makes sense, single-line-sigle-statement blocks are often used in methods and constructors (especially in hibernate and apache-ant).
