### PR TITLE
fix eclipse package declaration error in InputPackageDeclaration

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputPackageDeclaration.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputPackageDeclaration.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.checks.coding;
+package com.puppycrawl.tools.checkstyle.coding;
 
 class InputPackageDeclaration {
     public String value;


### PR DESCRIPTION
Fixes the following (from eclipse):
> The declared package "com.puppycrawl.tools.checkstyle.checks.coding" does not match the expected package  "com.puppycrawl.tools.checkstyle.coding"