### PR TITLE
Add test coverage to JavadocTagContinuationIndentation check. #1308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1178,7 +1178,6 @@
             <regex><pattern>.*.checks.javadoc.JavadocPackageCheck</pattern><branchRate>80</branchRate><lineRate>95</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocParagraphCheck</pattern><branchRate>92</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocStyleCheck</pattern><branchRate>89</branchRate><lineRate>98</lineRate></regex>
-            <regex><pattern>.*.checks.javadoc.JavadocTagContinuationIndentationCheck</pattern><branchRate>81</branchRate><lineRate>86</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocTypeCheck</pattern><branchRate>95</branchRate><lineRate>93</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocUtils</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.SummaryJavadocCheck</pattern><branchRate>93</branchRate><lineRate>100</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -82,8 +82,7 @@ public class JavadocTagContinuationIndentationCheck extends AbstractJavadocCheck
             if (textNode != null && textNode.getType() == JavadocTokenTypes.TEXT
                     && textNode.getChildren().length > 1) {
                 final DetailNode whitespace = JavadocUtils.getFirstChild(textNode);
-                if (whitespace.getType() == JavadocTokenTypes.WS
-                        && whitespace.getText().length() - 1 < offset) {
+                if (whitespace.getText().length() - 1 < offset) {
                     log(textNode.getLineNumber(), MSG_KEY, offset);
                 }
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -56,7 +56,20 @@ public class JavadocTagContinuationIndentationCheckTest
             "310: " + getCheckMessage(MSG_KEY, 4),
             "322: " + getCheckMessage(MSG_KEY, 4),
         };
-        verify(checkConfig, getPath("javadoc/InputJavaDocTagContinuationIndentation.java"), expected);
+        verify(checkConfig, getPath("javadoc/InputJavaDocTagContinuationIndentation.java"),
+                expected);
     }
 
+    @Test
+    public void testCheckWithOffset3() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(JavadocTagContinuationIndentationCheck.class);
+        checkConfig.addAttribute("offset", "3");
+        final String[] expected = {
+            "7: " + getCheckMessage(MSG_KEY, 3),
+            "19: " + getCheckMessage(MSG_KEY, 3),
+        };
+        verify(checkConfig, getPath("javadoc/InputJavaDocTagContinuationIndentationOffset3.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputJavaDocTagContinuationIndentation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputJavaDocTagContinuationIndentation.java
@@ -319,7 +319,10 @@ enum Foo1 {}
  * @since Some javadoc.
  *     Some javadoc.
  * @serialData Some javadoc.
- *   Some javadoc. // warn
+ *   Line below is empty on purpose. // warn
+ *
  * @author max
+ * @see {@link com.puppycrawl.tools.checkstyle.AllChecksPresentOnAvailableChecksPageTest
+ *   some description} // no warning, as this is just inline tag description
  */
 interface FooIn1 {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputJavaDocTagContinuationIndentationOffset3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputJavaDocTagContinuationIndentationOffset3.java
@@ -1,0 +1,36 @@
+package com.puppycrawl.tools.checkstyle.javadoc;
+
+/**
+ * Some javadoc.
+ *
+ * @since Some javadoc.
+ *   Some javadoc. // warn
+ * @version 1.0
+ * @deprecated Some javadoc.
+ *    Some javadoc.
+ * @see Some javadoc.
+ * @author max
+ *     Some javadoc.
+ */
+class JavaDocTagContinuationIndentationOffset3 {
+	/**
+     * The client's first name.
+     * @serial Some javadoc.
+	*   Some javadoc. // warn
+     */
+    private String fFirstName;
+     
+    /**
+     * The client's first name.
+     * @serial
+     *    Some javadoc.
+     */
+    private String sSecondName;
+      
+    /**
+     * The client's first name.
+     * @serialField
+     *     Some javadoc.
+     */
+    private String tThirdName;
+}


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/5467276/8661116/9eb14b44-29b5-11e5-92a0-0fed67bcbe8d.png)

After:
![image](https://cloud.githubusercontent.com/assets/5467276/8661126/ab0184f4-29b5-11e5-8aae-16464a1d2571.png)
