### PR TITLE
Fix Header causing exception with default config, issue #1129.

### DIFF
--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -34,6 +34,7 @@
       <classpath path="${mvn.runtime_classpath}"/>
       <property key="checkstyle.cache.file" file="${mvn.project.build.directory}/cachefile"/>
       <property key="checkstyle.header.file" file="config/java.header"/>
+      <property key="checkstyle.regexp.header.file" file="config/java_regexp.header"/>
       <property key="checkstyle.importcontrol.file" file="config/import-control.xml"/>
       <property key="checkstyle.suppressions.file"
                 file="config/suppressions.xml"/>

--- a/config/build.xml
+++ b/config/build.xml
@@ -36,6 +36,7 @@
       <classpath refid="run.classpath"/>
       <property key="checkstyle.cache.file" file="${target.dir}/cachefile"/>
       <property key="checkstyle.header.file" file="config/java.header"/>
+      <property key="checkstyle.regexp.header.file" file="config/java_regexp.header"/>
       <property key="checkstyle.importcontrol.file" file="config/import-control.xml"/>
       <property key="checkstyle.suppressions.file"
                 file="config/suppressions.xml"/>

--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -53,11 +53,14 @@
   </module>
 
   <module name="RegexpMultiline"/>
-
-  <!-- 
-  <module name="RegexpHeader"/>
+  <module name="RegexpHeader">
+    <property name="headerFile" value="${checkstyle.regexp.header.file}"/>
+    <property name="fileExtensions" value="java"/>
+  </module>
+  <!--
   <module name="UniqueProperties"/>
   -->
+
   <module name="TreeWalker">
     <property name="tabWidth" value="4"/>
 

--- a/config/java_regexp.header
+++ b/config/java_regexp.header
@@ -1,0 +1,18 @@
+^/{80}$
+^/{2} checkstyle: Checks Java source code for adherence to a set of rules.$
+^/{2} Copyright \(C\) \d\d\d\d-\d\d\d\d the original author or authors.$
+^/{2}$
+^/{2} This library is free software; you can redistribute it and/or$
+^/{2} modify it under the terms of the GNU Lesser General Public$
+^/{2} License as published by the Free Software Foundation; either$
+^/{2} version \d.\d of the License, or \(at your option\) any later version.$
+^/{2}$
+^/{2} This library is distributed in the hope that it will be useful,$
+^/{2} but WITHOUT ANY WARRANTY; without even the implied warranty of$
+^/{2} MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU$
+^/{2} Lesser General Public License for more details.$
+^/{2}$
+^/{2} You should have received a copy of the GNU Lesser General Public$
+^/{2} License along with this library; if not, write to the Free Software$
+^/{2} Foundation, Inc., \d\d Temple Place, Suite \d\d\d, Boston, MA  \d\d\d\d\d-\d\d\d\d  USA$
+^/{80}$

--- a/pom.xml
+++ b/pom.xml
@@ -747,6 +747,7 @@
               <dir>config</dir>
               <excludes>
                 <exclude>java.header</exclude>
+                <exclude>java_regexp.header</exclude>
               </excludes>
             </validationSet>
             <validationSet>
@@ -1154,9 +1155,9 @@
             <regex><pattern>.*.checks.coding.VariableDeclarationUsageDistanceCheck</pattern><branchRate>90</branchRate><lineRate>98</lineRate></regex>
 
 
-            <regex><pattern>.*.checks.header.AbstractHeaderCheck</pattern><branchRate>85</branchRate><lineRate>85</lineRate></regex>
-            <regex><pattern>.*.checks.header.HeaderCheck</pattern><branchRate>18</branchRate><lineRate>45</lineRate></regex>
-            <regex><pattern>.*.checks.header.RegexpHeaderCheck</pattern><branchRate>87</branchRate><lineRate>93</lineRate></regex>
+            <regex><pattern>.*.checks.header.AbstractHeaderCheck</pattern><branchRate>90</branchRate><lineRate>87</lineRate></regex>
+            <regex><pattern>.*.checks.header.HeaderCheck</pattern><branchRate>31</branchRate><lineRate>50</lineRate></regex>
+            <regex><pattern>.*.checks.header.RegexpHeaderCheck</pattern><branchRate>88</branchRate><lineRate>94</lineRate></regex>
 
 
             <regex><pattern>.*.checks.imports.CustomImportOrderCheck</pattern><branchRate>98</branchRate><lineRate>100</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -84,11 +84,13 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck {
     /**
      * Set the header file to check against.
      * @param fileName the file that contains the header to check against.
+     * @throws CheckstyleException if fileName is empty.
      */
-    public void setHeaderFile(String fileName) {
-        // Handle empty param
+    public void setHeaderFile(String fileName) throws CheckstyleException {
         if (StringUtils.isBlank(fileName)) {
-            return;
+            throw new CheckstyleException(
+                "property 'headerFile' is missing or invalid in module "
+                    + getConfiguration().getName());
         }
 
         filename = fileName;
@@ -229,9 +231,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck {
             loadHeaderFile();
         }
         if (readerLines.isEmpty()) {
-            throw new CheckstyleException(
-                    "property 'headerFile' is missing or invalid in module "
-                    + getConfiguration().getName());
+            setHeader(null);
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
@@ -25,6 +25,9 @@ import java.util.List;
 
 /**
  * Checks the header of the source against a fixed header file.
+ * In default configuration,if header is not specified,
+ * the default value of header is set to null
+ * and the check does not rise any violations.
  *
  * @author Lars Kühne
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -35,7 +35,9 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * Checks the header of the source against a header file that contains a
  * {@link java.util.regex.Pattern regular expression}
- * for each line of the source header.
+ * for each line of the source header. In default configuration,
+ * if header is not specified, the default value of header is set to null
+ * and the check does not rise any violations.
  *
  * @author Lars Kühne
  * @author o_sukhodolsky

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -172,17 +172,18 @@ public class HeaderCheckTest extends BaseFileSetCheckTestSupport {
     }
 
     @Test
-    public void testNoHeader()
-        throws Exception {
+    public void testNoHeader() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(HeaderCheck.class);
-        // No header file specified
         try {
             createChecker(checkConfig);
-            fail();
+            final String[] expected = {
+            };
+            verify(checkConfig, getPath("InputRegexpHeader1.java"), expected);
         }
         catch (CheckstyleException ex) {
-            // expected exception
+            // Exception is not expected
+            fail();
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
@@ -19,15 +19,20 @@
 
 package com.puppycrawl.tools.checkstyle.checks.header;
 
+import com.puppycrawl.tools.checkstyle.BaseFileSetCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import org.apache.commons.beanutils.ConversionException;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.fail;
 
 /**
  *
  * @author richter
  */
-public class RegexpHeaderCheckTest {
+public class RegexpHeaderCheckTest extends BaseFileSetCheckTestSupport {
 
     public RegexpHeaderCheckTest() {
     }
@@ -86,4 +91,33 @@ public class RegexpHeaderCheckTest {
         }
     }
 
+    @Test
+    public void testDefaultConfiguration() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(RegexpHeaderCheck.class);
+        try {
+            createChecker(checkConfig);
+            final String[] expected = {
+            };
+            verify(checkConfig, getPath("InputRegexpHeader1.java"), expected);
+        }
+        catch (CheckstyleException ex) {
+            // Exception is not expected
+            fail();
+        }
+    }
+
+    @Test
+    public void testEmptyFilename() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(RegexpHeaderCheck.class);
+        checkConfig.addAttribute("headerFile", "");
+        try {
+            createChecker(checkConfig);
+            fail("Checker creation should not succeed with invalid headerFile");
+        }
+        catch (CheckstyleException ex) {
+            // expected exception
+        }
+    }
 }

--- a/src/xdocs/config_header.xml
+++ b/src/xdocs/config_header.xml
@@ -104,6 +104,14 @@ line 5: ////////////////////////////////////////////////////////////////////
       </subsection>
 
       <subsection name="Example">
+          <p>
+              In default configuration the check does not rise any violations. Default values of properties are used.
+          </p>
+
+          <source>
+&lt;module name=&quot;Header&quot;/&gt;
+          </source>
+
         <p>
           To configure the check to use header file <code>&quot;java.header&quot;</code> and ignore lines <code>2</code>, <code>3</code>, and <code> 4</code> and only process Java files:
         </p>
@@ -269,6 +277,13 @@ line 6: ^\W*$
       </subsection>
 
       <subsection name="Example">
+          <p>
+              In default configuration the check does not rise any violations. Default values of properties are used.
+          </p>
+          <source>
+&lt;module name=&quot;RegexpHeader&quot;/&gt;
+          </source>
+
         <p>
           To configure the check to use header file <code>&quot;java.header&quot;</code> and <code>10</code> and <code>13</code> muli-lines:
         </p>


### PR DESCRIPTION
After fix Header does not rise any violation with [default config](https://github.com/checkstyle/checkstyle/commit/6fbce5c80b62931ad2f532819f15791a36cdb6ba#diff-6e886340e5a2ff9bd26e48165c70663dL58). In accordance with [manual](http://checkstyle.sourceforge.net/config_header.html#RegexpHeader) default value for property ```header``` is ```null```. 

[Reports](http://mezk.github.io/index.html).