### PR TITLE
Issue #1289: 'TypecastParenPadCheck' refactored, UT coverage improved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1212,7 +1212,6 @@
             <regex><pattern>.*.checks.whitespace.NoWhitespaceBeforeCheck</pattern><branchRate>90</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.whitespace.OperatorWrapCheck</pattern><branchRate>68</branchRate><lineRate>81</lineRate></regex>
             <regex><pattern>.*.checks.whitespace.SeparatorWrapCheck</pattern><branchRate>100</branchRate><lineRate>93</lineRate></regex>
-            <regex><pattern>.*.checks.whitespace.TypecastParenPadCheck</pattern><branchRate>87</branchRate><lineRate>88</lineRate></regex>
             <regex><pattern>.*.checks.whitespace.WhitespaceAfterCheck</pattern><branchRate>86</branchRate><lineRate>90</lineRate></regex>
 
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheck.java
@@ -71,8 +71,7 @@ public class TypecastParenPadCheck extends AbstractParenPadCheck {
         if (ast.getType() == TokenTypes.TYPECAST) {
             processLeft(ast);
         }
-        else if (ast.getParent() != null
-                 && ast.getParent().getType() == TokenTypes.TYPECAST
+        else if (ast.getParent().getType() == TokenTypes.TYPECAST
                  && ast.getParent().findFirstToken(TokenTypes.RPAREN)
                      == ast) {
             processRight(ast);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheckTest.java
@@ -19,16 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck.WS_FOLLOWED;
+import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck.WS_NOT_FOLLOWED;
+import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck.WS_NOT_PRECEDED;
+import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck.WS_PRECEDED;
+
+import org.junit.Assert;
 import org.junit.Test;
 
-import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck.WS_FOLLOWED;
-import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck.WS_PRECEDED;
-import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck
-.WS_NOT_FOLLOWED;
-import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck
-.WS_NOT_PRECEDED;
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class TypecastParenPadCheckTest
     extends BaseCheckTestSupport {
@@ -72,5 +73,17 @@ public class TypecastParenPadCheckTest
         };
         verify(checkConfig, getPath("whitespace/InputWhitespaceAround.java"),
                expected);
+    }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        TypecastParenPadCheck typecastParenPadCheckObj = new TypecastParenPadCheck();
+        int[] actual = typecastParenPadCheckObj.getAcceptableTokens();
+        int[] expected = new int[] {
+            TokenTypes.RPAREN,
+            TokenTypes.TYPECAST,
+        };
+        Assert.assertNotNull(actual);
+        Assert.assertArrayEquals(expected, actual);
     }
 }


### PR DESCRIPTION
Reports for Guava and Hibernate projects before check's refactoring and after are identical: http://rdiachenko.github.io/