### PR TITLE
Fix BaseCheckTestSupport.verify fails on Windows, #1388

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -133,7 +133,8 @@ public abstract class BaseCheckTestSupport
             final String expected = aMessageFileName + ":" + aExpected[i];
             String actual = lnr.readLine();
             assertEquals("error message " + i, expected, actual);
-            String parseInt = actual.substring(actual.indexOf(":") + 1);
+            String parseInt = removeDeviceFromPathOnWindows(actual);
+            parseInt = parseInt.substring(parseInt.indexOf(":") + 1);
             parseInt = parseInt.substring(0, parseInt.indexOf(":"));
             int lineNumber = Integer.parseInt(parseInt);
 			Integer integer = Arrays.asList(aWarnsExpected).contains(lineNumber) ? lineNumber : 0;
@@ -186,5 +187,13 @@ public abstract class BaseCheckTestSupport
            }
        }
        return null;
+   }
+
+   private static String removeDeviceFromPathOnWindows(String string) {
+       String os = System.getProperty("os.name", "Unix");
+       if (os.startsWith("Windows")) {
+           return string.substring(string.indexOf(":") + 1);
+       }
+       return string;
    }
 }


### PR DESCRIPTION
I am not sure this is the best approach, we could check it with regex for example. I am open to any suggestions.