### PR TITLE
Remove dead code from ForHandler in Indentation check. #1270

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1157,7 +1157,6 @@
             <regex><pattern>.*.checks.indentation.BlockParentHandler</pattern><branchRate>86</branchRate><lineRate>98</lineRate></regex>
             <regex><pattern>.*.checks.indentation.ElseHandler</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.indentation.AbstractExpressionHandler</pattern><branchRate>91</branchRate><lineRate>97</lineRate></regex>
-            <regex><pattern>.*.checks.indentation.ForHandler</pattern><branchRate>75</branchRate><lineRate>95</lineRate></regex>
             <regex><pattern>.*.checks.indentation.HandlerFactory</pattern><branchRate>81</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.indentation.ImportHandler</pattern><branchRate>50</branchRate><lineRate>87</lineRate></regex>
             <regex><pattern>.*.checks.indentation.IndentationCheck</pattern><branchRate>100</branchRate><lineRate>93</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ForHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ForHandler.java
@@ -78,14 +78,6 @@ public class ForHandler extends BlockParentHandler {
         lineWrap.checkIndentation();
     }
 
-    @Override
-    public IndentLevel suggestedChildLevel(AbstractExpressionHandler child) {
-        if (child instanceof ElseHandler) {
-            return getLevel();
-        }
-        return super.suggestedChildLevel(child);
-    }
-
     /**
      * Returns right parenthesis of for-loop statement.
      * @param literalForAst


### PR DESCRIPTION
Reports before and after the changes are exactly the same:
```
diff checkstyle-6.8.1.html checkstyle-6.9.html
--- checkstyle-6.8.1.html
+++ checkstyle-6.9.html
@@ -70,7 +70,7 @@
-<p>The following document contains the results of <a class="externalLink" href="http://checkstyle.sourceforge.net/">Checkstyle</a> 6.8.1 with my_check.xml ruleset.&#160;<a href="checkstyle.rss"><img alt="rss feed" src="images/rss.png" /></a></p></div>
+<p>The following document contains the results of <a class="externalLink" href="http://checkstyle.sourceforge.net/">Checkstyle</a> 6.9-SNAPSHOT with my_check.xml ruleset.&#160;<a href="checkstyle.rss"><img alt="rss feed" src="images/rss.png" /></a></p></div>
```

![image](https://cloud.githubusercontent.com/assets/5467276/8710866/4d207d1a-2b4d-11e5-96e6-10a5ff3ef945.png)
![image](https://cloud.githubusercontent.com/assets/5467276/8710872/5938a424-2b4d-11e5-8de4-7e6fed2d7ef4.png)

