### PR TITLE
JavadocType does not check parameters in inner classes, fixes  #1421

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -24,9 +24,9 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.JavadocTagInfo;
 import com.puppycrawl.tools.checkstyle.api.Scope;
-import com.puppycrawl.tools.checkstyle.ScopeUtils;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.ScopeUtils;
 import com.puppycrawl.tools.checkstyle.Utils;
 import com.puppycrawl.tools.checkstyle.checks.CheckUtils;
 import java.util.List;
@@ -36,6 +36,9 @@ import org.apache.commons.beanutils.ConversionException;
 
 /**
  * Checks the Javadoc of a type.
+ *
+ * <p>Does not perform checks for author and version tags for inner classes, as
+ * they should be redundant because of outer class.
  *
  * @author Oliver Burn
  * @author Michael Tamm
@@ -184,13 +187,15 @@ public class JavadocTypeCheck
             if (cmt == null) {
                 log(lineNo, JAVADOC_MISSING);
             }
-            else if (ScopeUtils.isOuterMostType(ast)) {
-                // don't check author/version for inner classes
+            else {
                 final List<JavadocTag> tags = getJavadocTags(cmt);
-                checkTag(lineNo, tags, JavadocTagInfo.AUTHOR.getName(),
-                         authorFormatPattern, authorFormat);
-                checkTag(lineNo, tags, JavadocTagInfo.VERSION.getName(),
-                         versionFormatPattern, versionFormat);
+                if (ScopeUtils.isOuterMostType(ast)) {
+                    // don't check author/version for inner classes
+                    checkTag(lineNo, tags, JavadocTagInfo.AUTHOR.getName(),
+                            authorFormatPattern, authorFormat);
+                    checkTag(lineNo, tags, JavadocTagInfo.VERSION.getName(),
+                            versionFormatPattern, versionFormat);
+                }
 
                 final List<String> typeParamNames =
                     CheckUtils.getTypeParameterNames(ast);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -319,6 +319,8 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
         final String[] expected = {
             "7:4: " + getCheckMessage(UNUSED_TAG, "@param", "<D123>"),
             "11: " + getCheckMessage(MISSING_TAG, "@param <C456>"),
+            "44:8: " + getCheckMessage(UNUSED_TAG, "@param", "<C>"),
+            "47: " + getCheckMessage(MISSING_TAG, "@param <B>"),
         };
         verify(checkConfig, getPath("InputTypeParamsTags.java"), expected);
     }
@@ -330,6 +332,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("allowMissingParamTags", "true");
         final String[] expected = {
             "7:4: " + getCheckMessage(UNUSED_TAG, "@param", "<D123>"),
+            "44:8: " + getCheckMessage(UNUSED_TAG, "@param", "<C>"),
         };
         verify(checkConfig, getPath("InputTypeParamsTags.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputTypeParamsTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputTypeParamsTags.java
@@ -37,4 +37,14 @@ public class InputTypeParamsTags<A,B1,C456 extends Comparable>
     public <L> void doSomethingElse2(L aAnEl)
     {
     }
+
+    /**
+     * Example inner class.
+     * @param <A> documented parameter
+     * @param <C> extra parameter
+     */
+
+    public static class InnerClass<A,B>
+    {
+    }
 }

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -97,6 +97,10 @@
             regular expression</a>.
         </p>
         <p>
+          Does not perform checks for author and version tags for inner
+          classes, as they should be redundant because of outer class.
+        </p>
+        <p>
           Error messages about type parameters for which no param tags are
           present can be suppressed by defining property
           <code>allowMissingParamTags</code>.


### PR DESCRIPTION
Checkstyle tester output - http://pbaranchikov.github.io/checkstyle/javadoc-type/checkstyle.html