### PR TITLE
Remove dead code from ArrayInitHandler in Indentation check. #1270

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1161,7 +1161,7 @@
 
             <regex><pattern>.*.checks.imports.CustomImportOrderCheck</pattern><branchRate>98</branchRate><lineRate>100</lineRate></regex>
 
-            <regex><pattern>.*.checks.indentation.ArrayInitHandler</pattern><branchRate>83</branchRate><lineRate>97</lineRate></regex>
+            <regex><pattern>.*.checks.indentation.ArrayInitHandler</pattern><branchRate>87</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.indentation.BlockParentHandler</pattern><branchRate>86</branchRate><lineRate>98</lineRate></regex>
             <regex><pattern>.*.checks.indentation.ElseHandler</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.indentation.AbstractExpressionHandler</pattern><branchRate>91</branchRate><lineRate>97</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
@@ -49,11 +49,9 @@ public class ArrayInitHandler extends BlockParentHandler {
             // note: assumes new or assignment is line to align with
             return new IndentLevel(getLineStart(parentAST));
         }
-        else if (getParent() instanceof ArrayInitHandler) {
-            return ((ArrayInitHandler) getParent()).getChildrenExpectedLevel();
-        }
         else {
-            return getParent().getLevel();
+            // at this point getParent() is instance of ArrayInitHandler
+            return ((ArrayInitHandler) getParent()).getChildrenExpectedLevel();
         }
     }
 


### PR DESCRIPTION
No differences in reports:
```
diff target-6.9/checkstyle-result.xml target-6.8.1/checkstyle-result.xml
--- target-6.9/checkstyle-result.xml
+++ target-6.8.1/checkstyle-result.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="6.9-SNAPSHOT">
+<checkstyle version="6.8.1">
```
![image](https://cloud.githubusercontent.com/assets/5467276/8755859/4265bfde-2cce-11e5-8f8a-3173a2590ed3.png)
![image](https://cloud.githubusercontent.com/assets/5467276/8755863/4e4c05d8-2cce-11e5-9867-3f024cf0f780.png)
