### PR TITLE
Make "private" methods "static" where possible. #46

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -134,7 +134,7 @@ final class PropertyCacheFile {
             }
             finally {
                 if (out != null) {
-                    this.flushAndCloseOutStream(out);
+                    flushAndCloseOutStream(out);
                 }
             }
         }
@@ -144,7 +144,7 @@ final class PropertyCacheFile {
      * Flushes and closes output stream.
      * @param stream the output stream
      */
-    private void flushAndCloseOutStream(OutputStream stream) {
+    private static void flushAndCloseOutStream(OutputStream stream) {
         try {
             Flushables.flush(stream, false);
             Closeables.close(stream, false);
@@ -180,7 +180,7 @@ final class PropertyCacheFile {
      * @param configuration the GlobalProperties
      * @return the hashcode for <code>configuration</code>
      */
-    private String getConfigHashCode(Serializable configuration) {
+    private static String getConfigHashCode(Serializable configuration) {
         try {
             // im-memory serialization of Configuration
 
@@ -191,7 +191,7 @@ final class PropertyCacheFile {
                 oos.writeObject(configuration);
             }
             finally {
-                this.flushAndCloseOutStream(oos);
+                flushAndCloseOutStream(oos);
             }
 
             // Instead of hexEncoding baos.toByteArray() directly we

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
@@ -130,7 +130,7 @@ public abstract class AbstractViolationReporter
      * @return name of a resource bundle that contains the messages
      * used by the module.
      */
-    String getMessageBundle(final String className) {
+    static String getMessageBundle(final String className) {
         final int endIndex = className.lastIndexOf('.');
         final String messages = "messages";
         if (endIndex < 0) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
@@ -94,7 +94,7 @@ public abstract class AbstractDeclarationCollector extends Check {
      * @param frameStack Stack containing the FrameTree being built
      * @param ast AST to parse
      */
-    private void collectDeclarations(Deque<LexicalFrame> frameStack,
+    private static void collectDeclarations(Deque<LexicalFrame> frameStack,
         DetailAST ast) {
         final LexicalFrame frame = frameStack.peek();
         switch (ast.getType()) {
@@ -146,7 +146,7 @@ public abstract class AbstractDeclarationCollector extends Check {
      * @param ast variable token
      * @param frame current frame
      */
-    private void collectVariableDeclarations(DetailAST ast, LexicalFrame frame) {
+    private static void collectVariableDeclarations(DetailAST ast, LexicalFrame frame) {
         final String name =
                 ast.findFirstToken(TokenTypes.IDENT).getText();
         if (frame instanceof ClassFrame) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -180,7 +180,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
      * @return true  if exception is unchecked
      *         false if exception is checked
      */
-    protected boolean isUnchecked(Class<?> exception) {
+    protected static boolean isUnchecked(Class<?> exception) {
         return isSubclass(exception, RuntimeException.class)
             || isSubclass(exception, Error.class);
     }
@@ -195,7 +195,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
      * @return true  if aChild is subclass of aParent
      *         false otherwise
      */
-    protected boolean isSubclass(Class<?> child, Class<?> parent) {
+    protected static boolean isSubclass(Class<?> child, Class<?> parent) {
         return parent != null && child != null
             &&  parent.isAssignableFrom(child);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -220,7 +220,7 @@ public class AvoidEscapedUnicodeCharactersCheck
      * @param literal String literal.
      * @return true if literal has Unicode chars.
      */
-    private boolean hasUnicodeChar(String literal) {
+    private static boolean hasUnicodeChar(String literal) {
         return sUnicodeRegexp.matcher(literal).find();
     }
 
@@ -230,7 +230,7 @@ public class AvoidEscapedUnicodeCharactersCheck
      * @param pattern RegExp for valid characters.
      * @return true, if String literal contains Unicode control chars.
      */
-    private boolean isOnlyUnicodeValidChars(String literal, Pattern pattern) {
+    private static boolean isOnlyUnicodeValidChars(String literal, Pattern pattern) {
         final int unicodeMatchesCounter =
                 countMatches(sUnicodeRegexp, literal);
         final int unicodeValidMatchesCouter =
@@ -278,7 +278,7 @@ public class AvoidEscapedUnicodeCharactersCheck
      * @param target String literal.
      * @return count of regexp matchers.
      */
-    private int countMatches(Pattern pattern, String target) {
+    private static int countMatches(Pattern pattern, String target) {
         int matcherCounter = 0;
         final Matcher matcher = pattern.matcher(target);
         while (matcher.find()) {
@@ -292,7 +292,7 @@ public class AvoidEscapedUnicodeCharactersCheck
      * @param ast current token.
      * @return variable definition.
      */
-    private DetailAST getVariableDef(DetailAST ast) {
+    private static DetailAST getVariableDef(DetailAST ast) {
         DetailAST result = ast.getParent();
         while (result != null
                 && result.getType() != TokenTypes.VARIABLE_DEF) {
@@ -306,7 +306,7 @@ public class AvoidEscapedUnicodeCharactersCheck
      * @param ast current token.
      * @return semi token or null.
      */
-    private DetailAST getSemi(DetailAST ast) {
+    private static DetailAST getSemi(DetailAST ast) {
         DetailAST result = ast.getParent();
         while (result != null
                 && result.getLastChild().getType() != TokenTypes.SEMI) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -290,7 +290,7 @@ public class SuppressWarningsHolder
      * @param ast annotation token
      * @return list values
      */
-    private List<String> getAllAnnotationValues(DetailAST ast) {
+    private static List<String> getAllAnnotationValues(DetailAST ast) {
         // get values of annotation
         List<String> values = null;
         final DetailAST lparenAST = ast.findFirstToken(TokenTypes.LPAREN);
@@ -326,7 +326,7 @@ public class SuppressWarningsHolder
      * @param values list of values in the annotation
      * @return whether annotation is empty or contains some values
      */
-    private boolean isAnnotationEmpty(List<String> values) {
+    private static boolean isAnnotationEmpty(List<String> values) {
         return values == null;
     }
 
@@ -335,7 +335,7 @@ public class SuppressWarningsHolder
      * @param ast the AST node to get the child of
      * @return get target of annotation
      */
-    private DetailAST getAnnotationTarget(DetailAST ast) {
+    private static DetailAST getAnnotationTarget(DetailAST ast) {
         DetailAST targetAST = null;
         DetailAST parentAST = ast.getParent();
         if (parentAST != null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -186,7 +186,7 @@ public class UncommentedMainCheck
      * @param method the METHOD_DEF node
      * @return true if check passed, false otherwise
      */
-    private boolean checkName(DetailAST method) {
+    private static boolean checkName(DetailAST method) {
         final DetailAST ident = method.findFirstToken(TokenTypes.IDENT);
         return "main".equals(ident.getText());
     }
@@ -196,7 +196,7 @@ public class UncommentedMainCheck
      * @param method the METHOD_DEF node
      * @return true if check passed, false otherwise
      */
-    private boolean checkModifiers(DetailAST method) {
+    private static boolean checkModifiers(DetailAST method) {
         final DetailAST modifiers =
             method.findFirstToken(TokenTypes.MODIFIERS);
 
@@ -209,7 +209,7 @@ public class UncommentedMainCheck
      * @param method the METHOD_DEF node
      * @return true if check passed, false otherwise
      */
-    private boolean checkType(DetailAST method) {
+    private static boolean checkType(DetailAST method) {
         final DetailAST type =
             method.findFirstToken(TokenTypes.TYPE).getFirstChild();
         return type.getType() == TokenTypes.LITERAL_VOID;
@@ -220,7 +220,7 @@ public class UncommentedMainCheck
      * @param method the METHOD_DEF node
      * @return true if check passed, false otherwise
      */
-    private boolean checkParams(DetailAST method) {
+    private static boolean checkParams(DetailAST method) {
         final DetailAST params = method.findFirstToken(TokenTypes.PARAMETERS);
         if (params.getChildCount() != 1) {
             return false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -95,7 +95,7 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
      * @return line number of first occurrence. If no key found in properties
      *         file, 0 is returned
      */
-    protected int getLineNumber(List<String> lines, String keyName) {
+    protected static int getLineNumber(List<String> lines, String keyName) {
         final String keyPatternString =
                 "^" + keyName.replace(" ", "\\\\ ") + "[\\s:=].*$";
         final Pattern keyPattern = Pattern.compile(keyPatternString);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -182,7 +182,7 @@ public final class AnnotationUseStyleCheck extends Check {
      * @throws ConversionException if cannot convert string.
      */
     public void setElementStyle(final String style) {
-        this.style = this.getOption(ElementStyle.class, style);
+        this.style = getOption(ElementStyle.class, style);
     }
 
     /**
@@ -192,7 +192,7 @@ public final class AnnotationUseStyleCheck extends Check {
      * @throws ConversionException if cannot convert string.
      */
     public void setTrailingArrayComma(final String comma) {
-        this.comma = this.getOption(TrailingArrayComma.class, comma);
+        this.comma = getOption(TrailingArrayComma.class, comma);
     }
 
     /**
@@ -202,7 +202,7 @@ public final class AnnotationUseStyleCheck extends Check {
      * @throws ConversionException if cannot convert string.
      */
     public void setClosingParens(final String parens) {
-        this.parens = this.getOption(ClosingParens.class, parens);
+        this.parens = getOption(ClosingParens.class, parens);
     }
 
     /**
@@ -212,7 +212,7 @@ public final class AnnotationUseStyleCheck extends Check {
      * @param string the string representing the enum
      * @return the enum type
      */
-    private <T extends Enum<T>> T getOption(final Class<T> enuclass,
+    private static <T extends Enum<T>> T getOption(final Class<T> enuclass,
         final String string) {
         try {
             return Enum.valueOf(enuclass, string.trim().toUpperCase(Locale.ENGLISH));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
@@ -148,7 +148,7 @@ public final class MissingOverrideCheck extends Check {
             this.getFileContents().getJavadocBefore(ast.getLineNo());
 
 
-        final boolean containastag = this.containsJavadocTag(javadoc);
+        final boolean containastag = containsJavadocTag(javadoc);
         if (containastag && !JavadocTagInfo.INHERIT_DOC.isValidOn(ast)) {
             this.log(ast.getLineNo(), MSG_KEY_TAG_NOT_VALID_ON,
                 JavadocTagInfo.INHERIT_DOC.getText());
@@ -178,7 +178,7 @@ public final class MissingOverrideCheck extends Check {
      * @param javadoc the javadoc of the AST
      * @return true if contains the tag
      */
-    private boolean containsJavadocTag(final TextBlock javadoc) {
+    private static boolean containsJavadocTag(final TextBlock javadoc) {
         if (javadoc == null) {
             return false;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -141,14 +141,14 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
     /** {@inheritDoc} */
     @Override
     public void visitToken(final DetailAST ast) {
-        final DetailAST annotation = this.getSuppressWarnings(ast);
+        final DetailAST annotation = getSuppressWarnings(ast);
 
         if (annotation == null) {
             return;
         }
 
         final DetailAST warningHolder =
-            this.findWarningsHolder(annotation);
+            findWarningsHolder(annotation);
 
         final DetailAST token =
                 warningHolder.findFirstToken(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
@@ -177,7 +177,7 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
                     //typical case
                     case TokenTypes.STRING_LITERAL:
                         final String warningText =
-                            this.removeQuotes(warning.getFirstChild().getText());
+                            removeQuotes(warning.getFirstChild().getText());
                         this.logMatch(warning.getLineNo(),
                                 warning.getColumnNo(), warningText);
                         break;
@@ -210,7 +210,7 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
      * @param ast the AST
      * @return the {@link SuppressWarnings SuppressWarnings} annotation
      */
-    private DetailAST getSuppressWarnings(DetailAST ast) {
+    private static DetailAST getSuppressWarnings(DetailAST ast) {
         final DetailAST annotation = AnnotationUtility.getAnnotation(
             ast, SuppressWarningsCheck.SUPPRESS_WARNINGS);
 
@@ -242,7 +242,7 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
      * @param annotation the annotation
      * @return a Token representing the expr.
      */
-    private DetailAST findWarningsHolder(final DetailAST annotation) {
+    private static DetailAST findWarningsHolder(final DetailAST annotation) {
         final DetailAST annValuePair =
             annotation.findFirstToken(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
         final DetailAST annArrayInit;
@@ -275,7 +275,7 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
      * @param warning the warning string
      * @return the string without two quotes
      */
-    private String removeQuotes(final String warning) {
+    private static String removeQuotes(final String warning) {
         return warning.substring(1, warning.length() - 1);
     }
 
@@ -290,13 +290,13 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
     private void walkConditional(final DetailAST cond) {
         if (cond.getType() != TokenTypes.QUESTION) {
             final String warningText =
-                this.removeQuotes(cond.getText());
+                removeQuotes(cond.getText());
             this.logMatch(cond.getLineNo(), cond.getColumnNo(), warningText);
             return;
         }
 
-        this.walkConditional(this.getCondLeft(cond));
-        this.walkConditional(this.getCondRight(cond));
+        this.walkConditional(getCondLeft(cond));
+        this.walkConditional(getCondRight(cond));
     }
 
     /**
@@ -307,7 +307,7 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
      * @return either the value
      * or another conditional
      */
-    private DetailAST getCondLeft(final DetailAST cond) {
+    private static DetailAST getCondLeft(final DetailAST cond) {
         final DetailAST colon = cond.findFirstToken(TokenTypes.COLON);
         return colon.getPreviousSibling();
     }
@@ -320,7 +320,7 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
      * @return either the value
      * or another conditional
      */
-    private DetailAST getCondRight(final DetailAST cond) {
+    private static DetailAST getCondRight(final DetailAST cond) {
         final DetailAST colon = cond.findFirstToken(TokenTypes.COLON);
         return colon.getNextSibling();
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -237,7 +237,7 @@ public class LeftCurlyCheck
      * @param ast <code>DetailAST</code>.
      * @return <code>DetailAST</code>.
      */
-    private DetailAST skipAnnotationOnlyLines(DetailAST ast) {
+    private static DetailAST skipAnnotationOnlyLines(DetailAST ast) {
         final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
         if (modifiers == null) {
             return ast;
@@ -268,7 +268,7 @@ public class LeftCurlyCheck
      * @param modifiers <code>DetailAST</code>.
      * @return <code>DetailAST</code> or null if there are no annotations.
      */
-    private DetailAST findLastAnnotation(DetailAST modifiers) {
+    private static DetailAST findLastAnnotation(DetailAST modifiers) {
         DetailAST annot = modifiers.findFirstToken(TokenTypes.ANNOTATION);
         while (annot != null && annot.getNextSibling() != null
                && annot.getNextSibling().getType() == TokenTypes.ANNOTATION) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -204,7 +204,7 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
      * @param ast detail ast.
      * @return object that contain all details to make a validation.
      */
-    private Details getDetails(DetailAST ast) {
+    private static Details getDetails(DetailAST ast) {
         // Attempt to locate the tokens to do the check
         boolean shouldCheckLastRcurly = false;
         DetailAST rcurly = null;
@@ -289,7 +289,7 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
      * @param lcurly left curly.
      * @return true if definition body is empty.
      */
-    private boolean isEmptyBody(DetailAST lcurly) {
+    private static boolean isEmptyBody(DetailAST lcurly) {
         boolean result = false;
         if (lcurly.getParent().getType() == TokenTypes.OBJBLOCK) {
             if (lcurly.getNextSibling().getType() == TokenTypes.RCURLY) {
@@ -307,7 +307,7 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
      * @param ast the given node.
      * @return the token which represents next lexical item.
      */
-    private DetailAST getNextToken(DetailAST ast) {
+    private static DetailAST getNextToken(DetailAST ast) {
         DetailAST next = null;
         DetailAST parent = ast;
         while (parent != null && next == null) {
@@ -324,7 +324,7 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
      * @return
      *        True, if right curly has line break before.
      */
-    private boolean hasLineBreakBefore(DetailAST rightCurly) {
+    private static boolean hasLineBreakBefore(DetailAST rightCurly) {
         if (rightCurly != null) {
             final DetailAST previousToken = rightCurly.getPreviousSibling();
             if (previousToken != null && rightCurly.getLineNo() == previousToken.getLineNo()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -175,7 +175,7 @@ public abstract class AbstractSuperCheck
      * @param parent parent AST
      * @return tru if no parameters found
      */
-    private boolean isZeroParameters(DetailAST parent) {
+    private static boolean isZeroParameters(DetailAST parent) {
 
         final DetailAST args = parent.getNextSibling();
         return args == null || args.getType() != TokenTypes.ELIST || args.getChildCount() != 0;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -167,7 +167,7 @@ public class EqualsAvoidNullCheck extends Check {
      * @param objCalledOn object AST
      * @return if it is string literal
      */
-    private boolean isStringLiteral(DetailAST objCalledOn) {
+    private static boolean isStringLiteral(DetailAST objCalledOn) {
         return objCalledOn.getType() == TokenTypes.STRING_LITERAL
                 || objCalledOn.getType() == TokenTypes.LITERAL_NEW
                 || objCalledOn.getType() == TokenTypes.DOT;
@@ -187,7 +187,7 @@ public class EqualsAvoidNullCheck extends Check {
      * @param expr the argument expression
      * @return - true if any child matches the set of tokens, false if not
      */
-    private boolean containsAllSafeTokens(final DetailAST expr) {
+    private static boolean containsAllSafeTokens(final DetailAST expr) {
         DetailAST arg = expr.getFirstChild();
 
         if (arg.branchContains(TokenTypes.METHOD_CALL)) {
@@ -214,7 +214,7 @@ public class EqualsAvoidNullCheck extends Check {
      * @param currentAST current token in the argument expression
      * @return the next relevant token
      */
-    private DetailAST skipVariableAssign(final DetailAST currentAST) {
+    private static DetailAST skipVariableAssign(final DetailAST currentAST) {
         if (currentAST.getType() == TokenTypes.ASSIGN
                 && currentAST.getFirstChild().getType() == TokenTypes.IDENT) {
             return currentAST.getFirstChild().getNextSibling();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
@@ -107,7 +107,7 @@ public class EqualsHashCodeCheck
      * @param firstChild the AST to check
      * @return true iff firstChild is a parameter of an Object type.
      */
-    private boolean isObjectParam(AST firstChild) {
+    private static boolean isObjectParam(AST firstChild) {
         final AST modifiers = firstChild.getFirstChild();
         final AST type = modifiers.getNextSibling();
         switch (type.getFirstChild().getType()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -107,7 +107,7 @@ public class ExplicitInitializationCheck extends Check {
      * @param exprStart exprssion
      * @return true is literal is initialized by zero symbol
      */
-    private boolean isZeroChar(DetailAST exprStart) {
+    private static boolean isZeroChar(DetailAST exprStart) {
         return isZero(exprStart)
             || exprStart.getType() == TokenTypes.CHAR_LITERAL
             && "'\\0'".equals(exprStart.getText());
@@ -118,7 +118,7 @@ public class ExplicitInitializationCheck extends Check {
      * @param ast Variable def AST
      * @return true is that is a case that need to be skipped.
      */
-    private boolean isSkipCase(DetailAST ast) {
+    private static boolean isSkipCase(DetailAST ast) {
         // do not check local variables and
         // fields declared in interface/annotations
         if (ScopeUtils.isLocalVariableDef(ast)
@@ -141,7 +141,7 @@ public class ExplicitInitializationCheck extends Check {
      * @param type type to check.
      * @return true if it is an object type.
      */
-    private boolean isObjectType(DetailAST type) {
+    private static boolean isObjectType(DetailAST type) {
         final int objectType = type.getFirstChild().getType();
         return objectType == TokenTypes.IDENT || objectType == TokenTypes.DOT
                 || objectType == TokenTypes.ARRAY_DECLARATOR;
@@ -153,7 +153,7 @@ public class ExplicitInitializationCheck extends Check {
      * @return true if it's a numeric type.
      * @see TokenTypes
      */
-    private boolean isNumericType(int type) {
+    private static boolean isNumericType(int type) {
         return type == TokenTypes.LITERAL_BYTE
                 || type == TokenTypes.LITERAL_SHORT
                 || type == TokenTypes.LITERAL_INT
@@ -166,7 +166,7 @@ public class ExplicitInitializationCheck extends Check {
      * @param expr node to check.
      * @return true if given node contains numeric constant for zero.
      */
-    private boolean isZero(DetailAST expr) {
+    private static boolean isZero(DetailAST expr) {
         final int type = expr.getType();
         switch (type) {
             case TokenTypes.NUM_FLOAT:

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -183,7 +183,7 @@ public class FinalLocalVariableCheck extends Check {
      * @param parentType token AST
      * @return true is token type is in arithmetic operator
      */
-    private boolean isAssignOperator(int parentType) {
+    private static boolean isAssignOperator(int parentType) {
         return TokenTypes.POST_DEC == parentType
                 || TokenTypes.DEC == parentType
                 || TokenTypes.POST_INC == parentType

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -84,7 +84,7 @@ public final class IllegalCatchCheck extends AbstractIllegalCheck {
      * @param parentToken - parent node for types (TYPE or BOR)
      * @return list, that contains all exception types in current catch
      */
-    public List<DetailAST> getAllExceptionTypes(DetailAST parentToken) {
+    public static List<DetailAST> getAllExceptionTypes(DetailAST parentToken) {
         DetailAST currentNode = parentToken.getFirstChild();
         final List<DetailAST> exceptionTypes = new LinkedList<>();
         if (currentNode.getType() == TokenTypes.BOR) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheck.java
@@ -101,7 +101,7 @@ public class IllegalTokenCheck
      * @param ast node to be represented as string
      * @return string representation of AST node
      */
-    private String convertToString(DetailAST ast) {
+    private static String convertToString(DetailAST ast) {
         final String tokenText;
         if (ast.getType() == TokenTypes.LABELED_STAT) {
             tokenText = ast.getFirstChild().getText() + ast.getText();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
@@ -208,7 +208,7 @@ public class InnerAssignmentCheck
      * @param ast assignment AST
      * @return whether the context of the assignemt AST indicates the idiom
      */
-    private boolean isInWhileIdiom(DetailAST ast) {
+    private static boolean isInWhileIdiom(DetailAST ast) {
         if (!isComparison(ast.getParent())) {
             return false;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -202,7 +202,7 @@ public class MagicNumberCheck extends Check {
      * @param constantDefAST constant ast
      * @return true if magic number is present
      */
-    private boolean isMagicNumberExists(DetailAST ast, DetailAST constantDefAST) {
+    private static boolean isMagicNumberExists(DetailAST ast, DetailAST constantDefAST) {
         boolean found = false;
         DetailAST astNode = ast.getParent();
         while (astNode != constantDefAST) {
@@ -222,7 +222,7 @@ public class MagicNumberCheck extends Check {
      * @return the constant def or null if ast is not
      * contained in a constant definition
      */
-    private DetailAST findContainingConstantDef(DetailAST ast) {
+    private static DetailAST findContainingConstantDef(DetailAST ast) {
         DetailAST varDefAST = ast;
         while (varDefAST != null
                 && varDefAST.getType() != TokenTypes.VARIABLE_DEF
@@ -284,7 +284,7 @@ public class MagicNumberCheck extends Check {
      * @return {@code true} if {@code ast} is in the scope of a valid hash
      * code method
      */
-    private boolean isInHashCodeMethod(DetailAST ast) {
+    private static boolean isInHashCodeMethod(DetailAST ast) {
         // if not in a code block, can't be in hashCode()
         if (!ScopeUtils.inCodeBlock(ast)) {
             return false;
@@ -339,7 +339,7 @@ public class MagicNumberCheck extends Check {
      *
      * @return {@code true} if {@code ast} is in the scope of field declaration
      */
-    private boolean isFieldDeclaration(DetailAST ast) {
+    private static boolean isFieldDeclaration(DetailAST ast) {
         DetailAST varDefAST = ast;
         while (varDefAST != null
                 && varDefAST.getType() != TokenTypes.VARIABLE_DEF) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -306,7 +306,7 @@ public final class ModifiedControlVariableCheck extends Check {
      * @param ast For Loop
      * @return Set of Variable Name which are managed by for
      */
-    private Set<String> getVariablesManagedByForLoop(DetailAST ast) {
+    private static Set<String> getVariablesManagedByForLoop(DetailAST ast) {
         final Set<String> initializedVariables = getForInitVariables(ast);
         final Set<String> iteratingVariables = getForIteratorVariables(ast);
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -193,7 +193,7 @@ public class RequireThisCheck extends AbstractDeclarationCollector {
      * @param parentType token Type
      * @return true if token is related to Definition Tokens
      */
-    private boolean isDeclarationToken(int parentType) {
+    private static boolean isDeclarationToken(int parentType) {
         return parentType == TokenTypes.VARIABLE_DEF
             || parentType == TokenTypes.CTOR_DEF
             || parentType == TokenTypes.METHOD_DEF

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -281,7 +281,7 @@ public class UnnecessaryParenthesesCheck extends Check {
      * @return <code>true</code> if <code>ast</code> is surrounded by
      *         parentheses.
      */
-    private boolean isSurrounded(DetailAST ast) {
+    private static boolean isSurrounded(DetailAST ast) {
         // if previous sibling is left parenthesis,
         // next sibling can't be other than right parenthesis
         final DetailAST prev = ast.getPreviousSibling();
@@ -295,7 +295,7 @@ public class UnnecessaryParenthesesCheck extends Check {
      * @return <code>true</code> if the expression is surrounded by
      *         parentheses.
      */
-    private boolean isExprSurrounded(DetailAST ast) {
+    private static boolean isExprSurrounded(DetailAST ast) {
         return ast.getFirstChild().getType() == TokenTypes.LPAREN;
     }
 
@@ -306,7 +306,7 @@ public class UnnecessaryParenthesesCheck extends Check {
      * @return <code>true</code> if <code>type</code> was found in <code>
      *         tokens</code>.
      */
-    private boolean inTokenList(int type, int... tokens) {
+    private static boolean inTokenList(int type, int... tokens) {
         // NOTE: Given the small size of the two arrays searched, I'm not sure
         //       it's worth bothering with doing a binary search or using a
         //       HashMap to do the searches.
@@ -326,7 +326,7 @@ public class UnnecessaryParenthesesCheck extends Check {
      * @return the chopped string if <code>string</code> is longer than
      *         <code>MAX_QUOTED_LENGTH</code>; otherwise <code>string</code>.
      */
-    private String chopString(String string) {
+    private static String chopString(String string) {
         if (string.length() > MAX_QUOTED_LENGTH) {
             return string.substring(0, MAX_QUOTED_LENGTH) + "...\"";
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -384,7 +384,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
      *        Variable which distance is calculated for.
      * @return entry which contains expression with variable usage and distance.
      */
-    private Entry<DetailAST, Integer> calculateDistanceInSingleScope(
+    private static Entry<DetailAST, Integer> calculateDistanceInSingleScope(
             DetailAST semicolonAst, DetailAST variableIdentAst) {
         int dist = 0;
         boolean firstUsageFound = false;
@@ -453,7 +453,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
      *        Variable which distance is calculated for.
      * @return entry which contains expression with variable usage and distance.
      */
-    private Entry<DetailAST, Integer> calculateDistanceBetweenScopes(
+    private static Entry<DetailAST, Integer> calculateDistanceBetweenScopes(
             DetailAST ast, DetailAST variable) {
         int dist = 0;
         DetailAST currentScopeAst = ast;
@@ -543,7 +543,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
      *         (not in its declaration!) than return the first Ast node
      *         of this block, otherwise - null.
      */
-    private DetailAST getFirstNodeInsideForWhileDoWhileBlocks(
+    private static DetailAST getFirstNodeInsideForWhileDoWhileBlocks(
             DetailAST block, DetailAST variable) {
         DetailAST firstNodeInsideBlock = null;
 
@@ -591,7 +591,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
      *         (not in its declaration!) than return the first Ast node
      *         of this block, otherwise - null.
      */
-    private DetailAST getFirstNodeInsideIfBlock(
+    private static DetailAST getFirstNodeInsideIfBlock(
             DetailAST block, DetailAST variable) {
         DetailAST firstNodeInsideBlock = null;
 
@@ -652,7 +652,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
      *         (not in its declaration!) than return the first Ast node
      *         of this block, otherwise - null.
      */
-    private DetailAST getFirstNodeInsideSwitchBlock(
+    private static DetailAST getFirstNodeInsideSwitchBlock(
             DetailAST block, DetailAST variable) {
         DetailAST firstNodeInsideBlock = null;
 
@@ -758,7 +758,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
      * @return true if operator contains variable in its declaration, otherwise
      *         - false.
      */
-    private boolean isVariableInOperatorExpr(
+    private static boolean isVariableInOperatorExpr(
             DetailAST operator, DetailAST variable) {
         boolean isVarInOperatorDeclr = false;
         final DetailAST openingBracket =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -120,7 +120,7 @@ public class DesignForExtensionCheck extends Check {
      * @param ast modifier ast
      * @return tru in modifier is in checked ones
      */
-    private boolean isPrivateOrFinalOrAbstract(DetailAST ast) {
+    private static boolean isPrivateOrFinalOrAbstract(DetailAST ast) {
         // method is ok if it is private or abstract or final
         final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
         return modifiers.branchContains(TokenTypes.LITERAL_PRIVATE)
@@ -134,7 +134,7 @@ public class DesignForExtensionCheck extends Check {
      * @param classDef class ast
      * @return true if Check should make a violation
      */
-    private boolean hasDefaultOrExplNonPrivateCtor(DetailAST classDef) {
+    private static boolean hasDefaultOrExplNonPrivateCtor(DetailAST classDef) {
         // check if subclassing is prevented by having only private ctors
         final DetailAST objBlock = classDef.findFirstToken(TokenTypes.OBJBLOCK);
 
@@ -165,7 +165,7 @@ public class DesignForExtensionCheck extends Check {
      * @param ast the start node for searching
      * @return the CLASS_DEF node.
      */
-    private DetailAST findContainingClass(DetailAST ast) {
+    private static DetailAST findContainingClass(DetailAST ast) {
         DetailAST searchAST = ast;
         while (searchAST.getType() != TokenTypes.CLASS_DEF
                && searchAST.getType() != TokenTypes.ENUM_DEF) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -88,7 +88,7 @@ public class HideUtilityClassConstructorCheck extends Check {
      * @param ast class definition for check.
      * @return true if a given class declared as abstract.
      */
-    private boolean isAbstract(DetailAST ast) {
+    private static boolean isAbstract(DetailAST ast) {
         return ast.findFirstToken(TokenTypes.MODIFIERS)
             .branchContains(TokenTypes.ABSTRACT);
     }
@@ -97,7 +97,7 @@ public class HideUtilityClassConstructorCheck extends Check {
      * @param ast class definition for check.
      * @return true if a given class declared as static.
      */
-    private boolean isStatic(DetailAST ast) {
+    private static boolean isStatic(DetailAST ast) {
         return ast.findFirstToken(TokenTypes.MODIFIERS)
             .branchContains(TokenTypes.LITERAL_STATIC);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheck.java
@@ -154,7 +154,7 @@ public class OneTopLevelClassCheck extends Check {
      * @param typeDef type definition node.
      * @return true if a type has a public access level modifier.
      */
-    private boolean isPublic(DetailAST typeDef) {
+    private static boolean isPublic(DetailAST typeDef) {
         final DetailAST modifiers =
                 typeDef.findFirstToken(TokenTypes.MODIFIERS);
         return modifiers.findFirstToken(TokenTypes.LITERAL_PUBLIC) != null;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -493,7 +493,7 @@ public class CustomImportOrderCheck extends Check {
      *        current group.
      * @return true, if the import is placed in the static group.
      */
-    private boolean matchesStaticImportGroup(boolean isStatic, String currentGroup) {
+    private static boolean matchesStaticImportGroup(boolean isStatic, String currentGroup) {
         return isStatic && STATIC_RULE_GROUP.equals(currentGroup);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -227,7 +227,7 @@ public class UnusedImportsCheck extends Check {
      * @param cmt The javadoc block to parse
      * @return a set of classes referenced in the javadoc block
      */
-    private Set<String> processJavadoc(TextBlock cmt) {
+    private static Set<String> processJavadoc(TextBlock cmt) {
         final Set<String> references = new HashSet<>();
         // process all the @link type tags
         // INLINEs inside BLOCKs get hidden when using ALL
@@ -254,7 +254,7 @@ public class UnusedImportsCheck extends Check {
      * @param tagType The type of tags we're interested in
      * @return the list of tags
      */
-    private List<JavadocTag> getValidTags(TextBlock cmt,
+    private static List<JavadocTag> getValidTags(TextBlock cmt,
             JavadocUtils.JavadocTagType tagType) {
         return JavadocUtils.getJavadocTags(cmt, tagType).getValidTags();
     }
@@ -264,7 +264,7 @@ public class UnusedImportsCheck extends Check {
      * @param tag The javadoc tag to parse
      * @return A list of references found in this tag
      */
-    private Set<String> processJavadocTag(JavadocTag tag) {
+    private static Set<String> processJavadocTag(JavadocTag tag) {
         final Set<String> references = new HashSet<>();
         final String identifier = tag.getArg1().trim();
         for (Pattern pattern : new Pattern[]
@@ -281,7 +281,7 @@ public class UnusedImportsCheck extends Check {
      * @param pattern The Pattern used to extract the texts
      * @return A list of texts which matched the pattern
      */
-    private Set<String> matchPattern(String identifier, Pattern pattern) {
+    private static Set<String> matchPattern(String identifier, Pattern pattern) {
         final Set<String> references = new HashSet<>();
         final Matcher matcher = pattern.matcher(identifier);
         while (matcher.find()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -134,7 +134,7 @@ public class LineWrappingHandler {
      *            first node.
      * @return indentation of first node.
      */
-    private int getFirstNodeIndent(DetailAST node) {
+    private static int getFirstNodeIndent(DetailAST node) {
         int indentLevel = node.getColumnNo();
 
         if (node.getType() == TokenTypes.LITERAL_IF
@@ -191,7 +191,7 @@ public class LineWrappingHandler {
      * @param curNode current node.
      * @return next curNode node.
      */
-    private DetailAST getNextCurNode(DetailAST curNode) {
+    private static DetailAST getNextCurNode(DetailAST curNode) {
         DetailAST nodeToVisit = curNode.getFirstChild();
         DetailAST currentNode = curNode;
 
@@ -248,7 +248,7 @@ public class LineWrappingHandler {
      * @param atNode first at-clause node.
      * @return last annotation node.
      */
-    private DetailAST getLastAnnotationNode(DetailAST atNode) {
+    private static DetailAST getLastAnnotationNode(DetailAST atNode) {
         DetailAST lastAnnotation = atNode.getParent();
         while (lastAnnotation.getNextSibling() != null
                 && lastAnnotation.getNextSibling().getType() == TokenTypes.ANNOTATION) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
@@ -89,7 +89,7 @@ public class MemberDefHandler extends AbstractExpressionHandler {
      * @param variableDef current variable_def.
      * @return true if variable_def node is array declaration.
      */
-    private boolean isArrayDeclaration(DetailAST variableDef) {
+    private static boolean isArrayDeclaration(DetailAST variableDef) {
         return variableDef.findFirstToken(TokenTypes.TYPE)
             .findFirstToken(TokenTypes.ARRAY_DECLARATOR) != null;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -121,7 +121,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
      *
      * @return the first AST of the specified method call
      */
-    private DetailAST getFirstAst(DetailAST ast) {
+    private static DetailAST getFirstAst(DetailAST ast) {
         // walk down the first child part of the dots that make up a method
         // call name
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -167,7 +167,7 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
      * @param commentBlock child node.
      * @return parent type.
      */
-    private int getParentType(DetailAST commentBlock) {
+    private static int getParentType(DetailAST commentBlock) {
         int type = 0;
         final DetailAST parentNode = commentBlock.getParent();
         if (parentNode != null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -402,7 +402,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * @param methodDef Some javadoc.
      * @return Some javadoc.
      */
-    private int getMethodsNumberOfLine(DetailAST methodDef) {
+    private static int getMethodsNumberOfLine(DetailAST methodDef) {
         int numberOfLines;
         final DetailAST lcurly = methodDef.getLastChild();
         final DetailAST rcurly = lcurly.getLastChild();
@@ -546,7 +546,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * @param ast the token of the method/constructor
      * @return the scope of the method/constructor
      */
-    private Scope calculateScope(final DetailAST ast) {
+    private static Scope calculateScope(final DetailAST ast) {
         final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
         final Scope declaredScope = ScopeUtils.getScopeFromMods(mods);
         return ScopeUtils.inInterfaceOrAnnotationBlock(ast) ? Scope.PUBLIC
@@ -560,7 +560,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * @param comment the Javadoc comment
      * @return the tags found
      */
-    private List<JavadocTag> getMethodTags(TextBlock comment) {
+    private static List<JavadocTag> getMethodTags(TextBlock comment) {
         final String[] lines = comment.getText();
         final List<JavadocTag> tags = Lists.newArrayList();
         int currentLine = comment.getStartLineNo() - 1;
@@ -665,7 +665,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * @param ast the method node.
      * @return the list of parameter nodes for ast.
      */
-    private List<DetailAST> getParameters(DetailAST ast) {
+    private static List<DetailAST> getParameters(DetailAST ast) {
         final DetailAST params = ast.findFirstToken(TokenTypes.PARAMETERS);
         final List<DetailAST> retVal = Lists.newArrayList();
 
@@ -792,7 +792,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * @param ast the method node.
      * @return whether the method is a function.
      */
-    private boolean isFunction(DetailAST ast) {
+    private static boolean isFunction(DetailAST ast) {
         boolean retVal = false;
         if (ast.getType() == TokenTypes.METHOD_DEF) {
             final DetailAST typeAST = ast.findFirstToken(TokenTypes.TYPE);
@@ -933,7 +933,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * @param ast the AST to check with
      * @return whether the AST represents a setter method
      */
-    private boolean isSetterMethod(final DetailAST ast) {
+    private static boolean isSetterMethod(final DetailAST ast) {
         // Check have a method with exactly 7 children which are all that
         // is allowed in a proper setter method which does not throw any
         // exceptions.
@@ -982,7 +982,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * @param ast the AST to check with
      * @return whether the AST represents a getter method
      */
-    private boolean isGetterMethod(final DetailAST ast) {
+    private static boolean isGetterMethod(final DetailAST ast) {
         // Check have a method with exactly 7 children which are all that
         // is allowed in a proper getter method which does not throw any
         // exceptions.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -112,7 +112,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * @param node DetailNode node.
      * @return nearest node.
      */
-    private DetailNode getNearestNode(DetailNode node) {
+    private static DetailNode getNearestNode(DetailNode node) {
         DetailNode tag = JavadocUtils.getNextSibling(node);
         while (tag != null && (tag.getType() == JavadocTokenTypes.LEADING_ASTERISK
                 || tag.getType() == JavadocTokenTypes.NEWLINE)) {
@@ -126,7 +126,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * @param newLine NEWLINE node.
      * @return true, if line is empty line.
      */
-    private boolean isEmptyLine(DetailNode newLine) {
+    private static boolean isEmptyLine(DetailNode newLine) {
         DetailNode previousSibling = JavadocUtils.getPreviousSibling(newLine);
         if (previousSibling == null
                 || previousSibling.getParent().getType() != JavadocTokenTypes.JAVADOC) {
@@ -145,7 +145,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * @param paragraphTag paragraph tag.
      * @return true, if line with paragraph tag is first line in javadoc.
      */
-    private boolean isFirstParagraph(DetailNode paragraphTag) {
+    private static boolean isFirstParagraph(DetailNode paragraphTag) {
         DetailNode previousNode = JavadocUtils.getPreviousSibling(paragraphTag);
         while (previousNode != null) {
             if (previousNode.getType() == JavadocTokenTypes.TEXT
@@ -165,7 +165,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * @param node DetailNode node.
      * @return Some nearest empty line in javadoc.
      */
-    private DetailNode getNearestEmptyLine(DetailNode node) {
+    private static DetailNode getNearestEmptyLine(DetailNode node) {
         DetailNode newLine = JavadocUtils.getPreviousSibling(node);
         while (newLine != null) {
             final DetailNode previousSibling = JavadocUtils.getPreviousSibling(newLine);
@@ -182,7 +182,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * @param newLine NEWLINE node.
      * @return true, if NEWLINE node is a last node in javadoc.
      */
-    private boolean isLastEmptyLine(DetailNode newLine) {
+    private static boolean isLastEmptyLine(DetailNode newLine) {
         DetailNode nextNode = JavadocUtils.getNextSibling(newLine);
         while (nextNode != null && nextNode.getType() != JavadocTokenTypes.JAVADOC_TAG) {
             if (nextNode.getType() == JavadocTokenTypes.TEXT

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -265,7 +265,7 @@ public class JavadocStyleCheck
      * @param comments the lines of Javadoc.
      * @return a comment text String.
      */
-    private String getCommentText(String... comments) {
+    private static String getCommentText(String... comments) {
         final StringBuffer buffer = new StringBuffer();
         for (final String line : comments) {
             final int textStart = findTextStart(line);
@@ -292,7 +292,7 @@ public class JavadocStyleCheck
      * @return the int index relative to 0 for the start of text
      *         or -1 if not found.
      */
-    private int findTextStart(String line) {
+    private static int findTextStart(String line) {
         int textStart = -1;
         for (int i = 0; i < line.length(); i++) {
             if (!Character.isWhitespace(line.charAt(i))) {
@@ -315,7 +315,7 @@ public class JavadocStyleCheck
      * Trims any trailing whitespace or the end of Javadoc comment string.
      * @param buffer the StringBuffer to trim.
      */
-    private void trimTail(StringBuffer buffer) {
+    private static void trimTail(StringBuffer buffer) {
         for (int i = buffer.length() - 1; i >= 0; i--) {
             if (Character.isWhitespace(buffer.charAt(i))) {
                 buffer.deleteCharAt(i);
@@ -447,7 +447,7 @@ public class JavadocStyleCheck
      * @param tag the HtmlTag to check.
      * @return <code>true</code> if the HtmlTag is a single tag.
      */
-    private boolean isSingleTag(HtmlTag tag) {
+    private static boolean isSingleTag(HtmlTag tag) {
         // If its a singleton tag (<p>, <br>, etc.), ignore it
         // Can't simply not put them on the stack, since singletons
         // like <dt> and <dd> (unhappily) may either be terminated
@@ -461,7 +461,7 @@ public class JavadocStyleCheck
      * @param tag the HtmlTag to check.
      * @return <code>true</code> if the HtmlTag is an allowed html tag.
      */
-    private boolean isAllowedTag(HtmlTag tag) {
+    private static boolean isAllowedTag(HtmlTag tag) {
         return ALLOWED_TAGS.contains(tag.getId().toLowerCase(Locale.ENGLISH));
     }
 
@@ -474,7 +474,7 @@ public class JavadocStyleCheck
      * @return <code>false</code> if a previous open tag was found
      *         for the token.
      */
-    private boolean isExtraHtml(String token, Deque<HtmlTag> htmlStack) {
+    private static boolean isExtraHtml(String token, Deque<HtmlTag> htmlStack) {
         boolean isExtra = true;
         for (final HtmlTag td : htmlStack) {
             // Loop, looking for tags that are closed.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -94,7 +94,7 @@ public class JavadocTagContinuationIndentationCheck extends AbstractJavadocCheck
      * @param descriptionNode DESCRIPTION node.
      * @return List with NEWLINE nodes.
      */
-    private List<DetailNode> getAllNewlineNodes(DetailNode descriptionNode) {
+    private static List<DetailNode> getAllNewlineNodes(DetailNode descriptionNode) {
         final List<DetailNode> textNodes = new ArrayList<>();
         DetailNode node = JavadocUtils.getFirstChild(descriptionNode);
         while (JavadocUtils.getNextSibling(node) != null) {
@@ -111,7 +111,7 @@ public class JavadocTagContinuationIndentationCheck extends AbstractJavadocCheck
      * @param description DESCRIPTION node.
      * @return true, if description node is a description of in-line tag.
      */
-    private boolean isInlineDescription(DetailNode description) {
+    private static boolean isInlineDescription(DetailNode description) {
         DetailNode inlineTag = description.getParent();
         while (inlineTag != null) {
             if (inlineTag.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
@@ -73,7 +73,7 @@ public class NonEmptyAtclauseDescriptionCheck extends AbstractJavadocCheck {
      * @param tagNode at-clause tag.
      * @return true, if at-clause tag is empty.
      */
-    private boolean isEmptyTag(DetailNode tagNode) {
+    private static boolean isEmptyTag(DetailNode tagNode) {
         final DetailNode tagDescription =
                 JavadocUtils.findFirstToken(tagNode, JavadocTokenTypes.DESCRIPTION);
         return tagDescription == null;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -124,7 +124,7 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
      * @param ast Javadoc root node.
      * @return first sentence.
      */
-    private String getFirstSentence(DetailNode ast) {
+    private static String getFirstSentence(DetailNode ast) {
         final StringBuilder result = new StringBuilder();
         for (DetailNode child : ast.getChildren()) {
             if (child.getType() != JavadocTokenTypes.JAVADOC_INLINE_TAG
@@ -144,7 +144,7 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
      * @param textNode node with javadoc text.
      * @return String with chars till first dot.
      */
-    private String getCharsTillDot(DetailNode textNode) {
+    private static String getCharsTillDot(DetailNode textNode) {
         final StringBuilder result = new StringBuilder();
         for (DetailNode child : textNode.getChildren()) {
             result.append(child.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
@@ -134,7 +134,7 @@ class TagParser {
      * @param pos position to check.
      * @return <code>true</code> some HTML tag starts from given position.
      */
-    private boolean isTag(String[] javadocText, Point pos) {
+    private static boolean isTag(String[] javadocText, Point pos) {
         final int column = pos.getColumnNo() + 1;
         final String text = javadocText[pos.getLineNo()];
 
@@ -153,7 +153,7 @@ class TagParser {
      * @param tagStart start position of the tag
      * @return id for given tag
      */
-    private String getTagId(String[] javadocText, Point tagStart) {
+    private static String getTagId(String[] javadocText, Point tagStart) {
         int column = tagStart.getColumnNo() + 1;
         String text = javadocText[tagStart.getLineNo()];
         if (column >= text.length()) {
@@ -185,7 +185,7 @@ class TagParser {
      * @return <code>true</code> if HTML-comments
      *         starts form given position.
      */
-    private boolean isCommentTag(String[] text, Point pos) {
+    private static boolean isCommentTag(String[] text, Point pos) {
         return text[pos.getLineNo()].startsWith("<!--", pos.getColumnNo());
     }
 
@@ -195,7 +195,7 @@ class TagParser {
      * @param from start position of HTML-comments
      * @return position after HTML-comments
      */
-    private Point skipHtmlComment(String[] text, Point from) {
+    private static Point skipHtmlComment(String[] text, Point from) {
         Point to = from;
         to = findChar(text, '>', to);
         while (to.getLineNo() < text.length
@@ -213,7 +213,7 @@ class TagParser {
      * @param from position to start search
      * @return position of next occurrence of given character
      */
-    private Point findChar(String[] text, char character, Point from) {
+    private static Point findChar(String[] text, char character, Point from) {
         Point curr = new Point(from.getLineNo(), from.getColumnNo());
         while (curr.getLineNo() < text.length
                && text[curr.getLineNo()].charAt(curr.getColumnNo()) != character) {
@@ -230,7 +230,7 @@ class TagParser {
      * @param from location to search from
      * @return location of the next character.
      */
-    private Point getNextCharPos(String[] text, Point from) {
+    private static Point getNextCharPos(String[] text, Point from) {
         int line = from.getLineNo();
         int column = from.getColumnNo() + 1;
         while (line < text.length && column >= text[line].length()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
@@ -148,7 +148,7 @@ public final class BooleanExpressionComplexityCheck extends Check {
      * @param logicalOperator logical operator
      * @return true if logical operator is part of constructor or method call
      */
-    private boolean isPassedInParameter(DetailAST logicalOperator) {
+    private static boolean isPassedInParameter(DetailAST logicalOperator) {
         return logicalOperator.getParent().getType() == TokenTypes.EXPR
             && logicalOperator.getParent().getParent().getType() == TokenTypes.ELIST;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -287,7 +287,7 @@ public class JavaNCSSCheck extends Check {
      *            the AST
      * @return true if the token is countable
      */
-    private boolean isCountable(DetailAST ast) {
+    private static boolean isCountable(DetailAST ast) {
         boolean countable = true;
 
         final int tokenType = ast.getType();
@@ -309,7 +309,7 @@ public class JavaNCSSCheck extends Check {
      * @param ast the AST
      * @return true if the variable definition is countable, false otherwise
      */
-    private boolean isVariableDefCountable(DetailAST ast) {
+    private static boolean isVariableDefCountable(DetailAST ast) {
         boolean countable = false;
 
         //count variable defs only if they are direct child to a slist or
@@ -337,7 +337,7 @@ public class JavaNCSSCheck extends Check {
      * @param ast the AST
      * @return true if the expression is countable, false otherwise
      */
-    private boolean isExpressionCountable(DetailAST ast) {
+    private static boolean isExpressionCountable(DetailAST ast) {
         boolean countable = true;
 
         //count expressions only if they are direct child to a slist (method

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
@@ -133,7 +133,7 @@ public class ModifierOrderCheck
      * @return null if the order is correct, otherwise returns the offending
      * *       modifier AST.
      */
-    DetailAST checkOrderSuggestedByJLS(List<DetailAST> modifiers) {
+    static DetailAST checkOrderSuggestedByJLS(List<DetailAST> modifiers) {
         final Iterator<DetailAST> it = modifiers.iterator();
 
         //Speed past all initial annotations

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
@@ -127,7 +127,7 @@ public final class AbstractClassNameCheck extends AbstractFormatCheck {
      * @param ast class definition for check.
      * @return true if a given class declared as abstract.
      */
-    private boolean isAbstract(DetailAST ast) {
+    private static boolean isAbstract(DetailAST ast) {
         final DetailAST abstractAST = ast.findFirstToken(TokenTypes.MODIFIERS)
             .findFirstToken(TokenTypes.ABSTRACT);
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheck.java
@@ -124,7 +124,7 @@ public class LocalVariableNameCheck
      * @param variableDef variable definition.
      * @return true if a variable is the loop's one.
      */
-    private boolean isForLoopVariable(DetailAST variableDef) {
+    private static boolean isForLoopVariable(DetailAST variableDef) {
         final int parentType = variableDef.getParent().getType();
         return parentType == TokenTypes.FOR_INIT
                 || parentType == TokenTypes.FOR_EACH_CLAUSE;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -329,7 +329,7 @@ public class EmptyLineSeparatorCheck extends Check {
      * @param token token.
      * @return true if token have empty line after.
      */
-    private boolean hasEmptyLineAfter(DetailAST token) {
+    private static boolean hasEmptyLineAfter(DetailAST token) {
         DetailAST lastToken = token.getLastChild().getLastChild();
         if (null == lastToken) {
             lastToken = token.getLastChild();
@@ -357,7 +357,7 @@ public class EmptyLineSeparatorCheck extends Check {
      * @param variableDef variable definition.
      * @return true variable definition is a type field.
      */
-    private boolean isTypeField(DetailAST variableDef) {
+    private static boolean isTypeField(DetailAST variableDef) {
         final int parentType = variableDef.getParent().getParent().getType();
         return parentType == TokenTypes.CLASS_DEF;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -217,7 +217,7 @@ public class GenericWhitespaceCheck extends Check {
      * @param ast ast
      * @return true if generic before a method ref
      */
-    private boolean isGenericBeforeMethod(DetailAST ast) {
+    private static boolean isGenericBeforeMethod(DetailAST ast) {
         return ast.getParent().getType() == TokenTypes.TYPE_ARGUMENTS
                 && ast.getParent().getParent().getType()
                     == TokenTypes.DOT

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -372,7 +372,7 @@ public class WhitespaceAroundCheck extends Check {
      * @param nextChar next symbol
      * @return true is that is end of anon inner class
      */
-    private boolean isAnnonimousInnerClassEnd(int currentType, char nextChar) {
+    private static boolean isAnnonimousInnerClassEnd(int currentType, char nextChar) {
         return currentType == TokenTypes.RCURLY
             && (nextChar == ')'
                 || nextChar == ';'
@@ -458,7 +458,7 @@ public class WhitespaceAroundCheck extends Check {
      * @param parentType parent token
      * @return true is current token inside array initialization
      */
-    private boolean isArrayInitialization(int currentType, int parentType) {
+    private static boolean isArrayInitialization(int currentType, int parentType) {
         return (currentType == TokenTypes.RCURLY
                 || currentType == TokenTypes.LCURLY)
             && (parentType == TokenTypes.ARRAY_INIT
@@ -520,7 +520,7 @@ public class WhitespaceAroundCheck extends Check {
      *         empty block contained under a <code>match</code> token type
      *         node.
      */
-    private boolean isEmptyType(DetailAST ast, int parentType) {
+    private static boolean isEmptyType(DetailAST ast, int parentType) {
         final int type = ast.getType();
         return (type == TokenTypes.RCURLY || type == TokenTypes.LCURLY)
                 && parentType == TokenTypes.OBJBLOCK;
@@ -541,7 +541,7 @@ public class WhitespaceAroundCheck extends Check {
      *         empty block contained under a <code>match</code> token type
      *         node.
      */
-    private boolean isEmptyBlock(DetailAST ast, int parentType, int match) {
+    private static boolean isEmptyBlock(DetailAST ast, int parentType, int match) {
         final int type = ast.getType();
         if (type == TokenTypes.RCURLY) {
             final DetailAST grandParent = ast.getParent().getParent();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -244,7 +244,7 @@ public class SuppressWithNearbyCommentFilter
          * @param regexp the parsed expander.
          * @return the expanded string
          */
-        private String expandFrocomment(
+        private static String expandFrocomment(
             String comment,
             String string,
             Pattern regexp) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -236,7 +236,7 @@ public class SuppressionCommentFilter
          * @param regexp the parsed expander.
          * @return the expanded string
          */
-        private String expandFromCoont(
+        private static String expandFromCoont(
             String comment,
             String string,
             Pattern regexp) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
@@ -162,7 +162,7 @@ class FileDrop {
 
 
     /** Determine if the dragged data is a file list. */
-    private boolean isDragOk(final DropTargetDragEvent evt) {
+    private static boolean isDragOk(final DropTargetDragEvent evt) {
         boolean ok = false;
         final DataFlavor[] flavors = evt.getCurrentDataFlavors();
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -276,7 +276,7 @@ public class ParseTreeInfoPanel extends JPanel {
 
     }
 
-    private void showErrorDialog(final Component parent, final String msg) {
+    private static void showErrorDialog(final Component parent, final String msg) {
         final Runnable showError = new FrameShower(parent, msg);
         SwingUtilities.invokeLater(showError);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
@@ -44,13 +44,13 @@ public class AbstractViolationReporterTest extends BaseCheckTestSupport {
     @Test
     public void testGetMessageBundleWithPackage() {
         assertEquals("com.mycompany.checks.messages",
-            emptyCheck.getMessageBundle("com.mycompany.checks.MyCoolCheck"));
+            AbstractViolationReporter.getMessageBundle("com.mycompany.checks.MyCoolCheck"));
     }
 
     @Test
     public void testGetMessageBundleWithoutPackage() {
         assertEquals("messages",
-            emptyCheck.getMessageBundle("MyCoolCheck"));
+            AbstractViolationReporter.getMessageBundle("MyCoolCheck"));
     }
 
     @Test


### PR DESCRIPTION
SonarQube rule: ["private" methods that don't access instance data should be "static"](http://nemo.sonarqube.org/coding_rules#rule_key=squid%3AS2325).

Rationale: private methods that don't access instance data can be static to prevent any misunderstanding about the contract of the method.