### PR TITLE
Fix FallThroughCheck fails on if with no else, issue #1395.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1132,7 +1132,7 @@
             <regex><pattern>.*.checks.coding.AbstractSuperCheck</pattern><branchRate>78</branchRate><lineRate>89</lineRate></regex>
             <regex><pattern>.*.checks.coding.DeclarationOrderCheck</pattern><branchRate>82</branchRate><lineRate>93</lineRate></regex>
             <regex><pattern>.*.checks.coding.ExplicitInitializationCheck</pattern><branchRate>91</branchRate><lineRate>97</lineRate></regex>
-            <regex><pattern>.*.checks.coding.FinalLocalVariableCheck</pattern><branchRate>82</branchRate><lineRate>100</lineRate></regex>
+            <regex><pattern>.*.checks.coding.FinalLocalVariableCheck</pattern><branchRate>83</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.coding.IllegalInstantiationCheck</pattern><branchRate>81</branchRate><lineRate>97</lineRate></regex>
             <regex><pattern>.*.checks.coding.IllegalTokenCheck</pattern><branchRate>83</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.coding.IllegalTokenTextCheck</pattern><branchRate>60</branchRate><lineRate>92</lineRate></regex>

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4842fallthrow/FallThroughTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4842fallthrow/FallThroughTest.java
@@ -29,11 +29,13 @@ public class FallThroughTest extends BaseCheckTestSupport{
         final String[] expected = {
             "14:13: " + msg,
             "38:13: " + msg, 
+            "47:13: " + msg,
             "53:13: " + msg,
             "70:13: " + msg,
             "87:13: " + msg,
             "105:13: " + msg,
             "123:13: " + msg,
+            "179:11: " + msg,
             "369:11: " + msg,
             "372:11: " + msg,
             "374:41: " + msg,

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4842fallthrow/FallThroughInput.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4842fallthrow/FallThroughInput.java
@@ -44,7 +44,7 @@ public class FallThroughInput
                 if (true) {
                     return;
                 }
-            case 14:
+            case 14:  //warn
                 if (true) {
                     return;
                 } else {
@@ -176,7 +176,7 @@ public class FallThroughInput
               if (true) {
                   return;
               }
-          case 14:
+          case 14:  //warn
               if (true) {
                   return;
               } else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -223,7 +223,10 @@ public class FallThroughCheck extends Check {
 
         if (isTerminated && elseStmt != null) {
             isTerminated = isTerminated(elseStmt.getFirstChild(),
-                                        useBreak, useContinue);
+                useBreak, useContinue);
+        }
+        else if (elseStmt == null) {
+            isTerminated = false;
         }
         return isTerminated;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -152,15 +152,17 @@ public class FinalLocalVariableCheck extends Check {
                 break;
 
             case TokenTypes.PARAMETER_DEF:
-                if (ScopeUtils.inInterfaceBlock(ast)
-                    || inAbstractOrNativeMethod(ast)
-                    || inLambda(ast)) {
-                    break;
+                if (!inLambda(ast)
+                        && !ast.branchContains(TokenTypes.FINAL)
+                        && !inAbstractOrNativeMethod(ast)
+                        && !ScopeUtils.inInterfaceBlock(ast)) {
+                    insertVariable(ast);
                 }
+                break;
             case TokenTypes.VARIABLE_DEF:
                 if (ast.getParent().getType() != TokenTypes.OBJBLOCK
-                        && shouldCheckEnhancedForLoopVariable(ast)
                         && isVariableInForInit(ast)
+                        && shouldCheckEnhancedForLoopVariable(ast)
                         && !ast.branchContains(TokenTypes.FINAL)) {
                     insertVariable(ast);
                 }
@@ -234,17 +236,18 @@ public class FinalLocalVariableCheck extends Check {
      * @return true if ast is a descendant of an abstract or native method.
      */
     private static boolean inAbstractOrNativeMethod(DetailAST ast) {
+        boolean abstractOrNative = false;
         DetailAST parent = ast.getParent();
-        while (parent != null) {
+        while (parent != null && !abstractOrNative) {
             if (parent.getType() == TokenTypes.METHOD_DEF) {
                 final DetailAST modifiers =
                     parent.findFirstToken(TokenTypes.MODIFIERS);
-                return modifiers.branchContains(TokenTypes.ABSTRACT)
+                abstractOrNative = modifiers.branchContains(TokenTypes.ABSTRACT)
                         || modifiers.branchContains(TokenTypes.LITERAL_NATIVE);
             }
             parent = parent.getParent();
         }
-        return false;
+        return abstractOrNative;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheckTest.java
@@ -38,11 +38,13 @@ public class FallThroughCheckTest extends BaseCheckTestSupport {
         final String[] expected = {
             "14:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "38:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "47:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "53:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "70:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "87:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "105:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "123:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "179:11: " + getCheckMessage(MSG_FALL_THROUGH),
             "369:11: " + getCheckMessage(MSG_FALL_THROUGH),
             "372:11: " + getCheckMessage(MSG_FALL_THROUGH),
             "374:40: " + getCheckMessage(MSG_FALL_THROUGH),
@@ -64,12 +66,14 @@ public class FallThroughCheckTest extends BaseCheckTestSupport {
         final String[] expected = {
             "14:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "38:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "47:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "53:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "70:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "87:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "105:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "123:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "123:13: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
+            "179:11: " + getCheckMessage(MSG_FALL_THROUGH),
             "369:11: " + getCheckMessage(MSG_FALL_THROUGH),
             "372:11: " + getCheckMessage(MSG_FALL_THROUGH),
             "374:40: " + getCheckMessage(MSG_FALL_THROUGH),
@@ -94,6 +98,7 @@ public class FallThroughCheckTest extends BaseCheckTestSupport {
         final String[] expected = {
             "14:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "38:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "47:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "53:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "70:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "87:13: " + getCheckMessage(MSG_FALL_THROUGH),
@@ -101,6 +106,7 @@ public class FallThroughCheckTest extends BaseCheckTestSupport {
             "123:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "145:11: " + getCheckMessage(MSG_FALL_THROUGH),
             "170:11: " + getCheckMessage(MSG_FALL_THROUGH),
+            "179:11: " + getCheckMessage(MSG_FALL_THROUGH),
             "186:11: " + getCheckMessage(MSG_FALL_THROUGH),
             "204:11: " + getCheckMessage(MSG_FALL_THROUGH),
             "222:11: " + getCheckMessage(MSG_FALL_THROUGH),
@@ -137,5 +143,24 @@ public class FallThroughCheckTest extends BaseCheckTestSupport {
         Assert.assertNotNull(check.getAcceptableTokens());
         Assert.assertNotNull(check.getDefaultTokens());
         Assert.assertNotNull(check.getRequiredTokens());
+    }
+
+    @Test
+    public void testFallThroughNoElse() throws Exception {
+        DefaultConfiguration checkConfig = createCheckConfig(FallThroughCheck.class);
+        final String[] expected = {
+            "20:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "35:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "39:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "46:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "60:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "67:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "80:21: " + getCheckMessage(MSG_FALL_THROUGH),
+            "86:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            "88:13: " + getCheckMessage(MSG_FALL_THROUGH),
+        };
+        verify(checkConfig,
+            getPath("coding" + File.separator + "InputFallThrough2.java"),
+            expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputFallThrough2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputFallThrough2.java
@@ -1,0 +1,95 @@
+package com.puppycrawl.tools.checkstyle.coding;
+
+public class InputFallThrough2 {
+    enum Test {
+        A, B, C
+    }
+
+    public static void test() {
+        Test test = Test.A;
+        int variable = 0;
+
+        switch (test) {
+            case A:
+                break;
+            case B:
+                if (variable == 1) {
+                    // some work
+                    break;
+                }
+            case C:
+                break;
+        }
+
+        int var2 = 1;
+        switch (variable) {
+            case 0:
+            case 1:
+            case 2:
+                System.out.println(var2);
+                break;
+            case 3:
+                if (true) {
+                    return;
+                }
+            case 4:
+                if (var2 == 2) {
+                    break;
+                }
+            case 5:
+                if (var2 == 1) {
+
+                }
+                else if (true) {
+                    return;
+                }
+            case 6:
+                if (var2 > 1) {
+                    break;
+                }
+                else {
+                    break;
+                }
+            case 7:
+                if (var2 ==1) {
+                    break;
+                }
+                else if (true) {
+                    return;
+                }
+            case 8:
+                if(var2 == 5) {
+                    System.out.println("0xB16B00B5");
+                }
+                else {
+                    break;
+                }
+            case 9:
+                if(var2 == 5) {
+                    System.out.println("0xCAFED00D");
+                }
+                else {
+                    System.out.printf("0x4B1D");
+                }
+                break;
+            case 10:
+                int var3 = 0xDEADBEEF;
+                switch (var3) {
+                    case 0xCAFEBABE:
+                        System.out.printf("0x1CEB00DA");
+                    default:
+                        System.out.printf("");
+                }
+                if(true) {
+                    break;
+                }
+            case 11:
+                if(false) {break;}
+            case 12:
+                if(true);
+                break;
+            default:
+                break;
+        }
+    }
+}


### PR DESCRIPTION
@romani 
[Reports issue#1395](http://mezk.github.io)

| Source | 6.8.1-RELEASE | 6.9-SNAPSHOT | Сomparison
|:-----------|------------:|:------------:|-----------:|
| hibernate       |        [8](http://mezk.github.io/hibernate_6.8.1_issue1395/checkstyle.html) |     [8](http://mezk.github.io/hibernate_6.9-SNAPSHOT_issue1395/checkstyle.html)     | equal
| spring     |      0 |    0    | equal
| checkstyle       |        [67](http://mezk.github.io/checkstyle_6.8.1_issue1395/checkstyle.html)|     [68](http://mezk.github.io/checkstyle_6.9-SNAPSHOT_issue1395/checkstyle.html)  | +1 violation [(line 160) ](http://mezk.github.io/checkstyle_6.9-SNAPSHOT_issue1395/xref/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.html#L160)   
| sevntu-checkstyle         |          [3](http://mezk.github.io/sevntu-checkstyle_6.8.1_issue1395/checkstyle.html) |      [3](http://mezk.github.io/sevntu-checkstyle_issue1395/checkstyle.html) | equal

[cobertura coverage report after fix](http://mezk.github.io/cobertura_issue1395/com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck.html)

Additional [test inputs](https://github.com/checkstyle/checkstyle/commit/29a3d60dfa6a7ab1c6383b68af343f9ce2757d72#diff-a66b9e060d0527888fa4f1cce592b67cR12).
I'll provide more reports if needed.

And due to FinalLocalVariableCheck line 160, Travis fails the build, because the following code rises violation:

````java
case TokenTypes.PARAMETER_DEF:
    if (ScopeUtils.inInterfaceBlock(ast)
         || inAbstractOrNativeMethod(ast)
         || inLambda(ast)) {
         break;
         } // The break statement is absent
 case TokenTypes.VARIABLE_DEF: //line 160
    if (ast.getParent().getType() != TokenTypes.OBJBLOCK
````
```
[checkstyle] /home/travis/build/checkstyle/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java:160:13: Fall through from previous branch of the switch statement.
```  

Do you think that we should suppress the violation?
````java
case TokenTypes.PARAMETER_DEF:
    if (ScopeUtils.inInterfaceBlock(ast)
         || inAbstractOrNativeMethod(ast)
         || inLambda(ast)) {
         break;
         }
         // fallthrough
 case TokenTypes.VARIABLE_DEF: //line 160
    if (ast.getParent().getType() != TokenTypes.OBJBLOCK
````
     