### PR TITLE
Issue #1293: Refactoring of IllegalTokenCheck and IllegalTokenTextCheck. Coverage has been improved.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1142,8 +1142,6 @@
             <regex><pattern>.*.checks.coding.FallThroughCheck</pattern><branchRate>90</branchRate><lineRate>97</lineRate></regex>
             <regex><pattern>.*.checks.coding.FinalLocalVariableCheck</pattern><branchRate>82</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.coding.IllegalInstantiationCheck</pattern><branchRate>81</branchRate><lineRate>97</lineRate></regex>
-            <regex><pattern>.*.checks.coding.IllegalTokenCheck</pattern><branchRate>83</branchRate><lineRate>100</lineRate></regex>
-            <regex><pattern>.*.checks.coding.IllegalTokenTextCheck</pattern><branchRate>60</branchRate><lineRate>92</lineRate></regex>
             <regex><pattern>.*.checks.coding.IllegalTypeCheck</pattern><branchRate>93</branchRate><lineRate>94</lineRate></regex>
             <regex><pattern>.*.checks.coding.InnerAssignmentCheck</pattern><branchRate>88</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.coding.ModifiedControlVariableCheck</pattern><branchRate>91</branchRate><lineRate>97</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
@@ -19,10 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import com.google.common.collect.ImmutableMap;
-import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import org.apache.commons.beanutils.ConversionException;
-
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -32,6 +28,11 @@ import java.nio.file.Paths;
 import java.util.ResourceBundle;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
+import org.apache.commons.beanutils.ConversionException;
+
+import com.google.common.collect.ImmutableMap;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * Contains utility methods.
@@ -44,6 +45,9 @@ public final class Utils {
     private static final ImmutableMap<String, Integer> TOKEN_NAME_TO_VALUE;
     /** maps from a token value to name */
     private static final String[] TOKEN_VALUE_TO_NAME;
+
+    /** Array of all token IDs */
+    private static final int[] TOKEN_IDS;
 
     // initialise the constants
     static {
@@ -71,11 +75,27 @@ public final class Utils {
 
         TOKEN_NAME_TO_VALUE = builder.build();
         TOKEN_VALUE_TO_NAME = tempTokenValueToName;
+
+        final Integer[] ids = TOKEN_NAME_TO_VALUE.values().toArray(new Integer[0]);
+        TOKEN_IDS = new int[ids.length];
+        for (int i = 0; i < ids.length; i++) {
+            TOKEN_IDS[i] = ids[i].intValue();
+        }
     }
 
 
     /** stop instances being created **/
     private Utils() {
+    }
+
+    /**
+     * Get all token IDs that are available in TokenTypes.
+     * @return array of token IDs
+     */
+    public static int[] getAllTokenIds() {
+        final int[] safeCopy = new int[TOKEN_IDS.length];
+        System.arraycopy(TOKEN_IDS, 0, safeCopy, 0, TOKEN_IDS.length);
+        return safeCopy;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheck.java
@@ -23,7 +23,6 @@ import com.puppycrawl.tools.checkstyle.Utils;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import java.util.Set;
 
 /**
  * <p>
@@ -70,20 +69,12 @@ public class IllegalTokenCheck
 
     @Override
     public int[] getAcceptableTokens() {
-        // Any tokens set by property 'tokens' are acceptable
-        int[] tokensToCopy = getDefaultTokens();
-        final Set<String> tokenNames = getTokenNames();
-        if (!tokenNames.isEmpty()) {
-            tokensToCopy = new int[tokenNames.size()];
-            int i = 0;
-            for (String name : tokenNames) {
-                tokensToCopy[i] = Utils.getTokenId(name);
-                i++;
-            }
-        }
-        final int[] copy = new int[tokensToCopy.length];
-        System.arraycopy(tokensToCopy, 0, copy, 0, tokensToCopy.length);
-        return copy;
+        return Utils.getAllTokenIds();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return new int[0];
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -19,11 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import java.util.regex.Pattern;
+
 import com.puppycrawl.tools.checkstyle.Utils;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.checks.AbstractFormatCheck;
-import java.util.Set;
-import java.util.regex.Pattern;
 
 /**
  * <p>
@@ -79,15 +79,12 @@ public class IllegalTokenTextCheck
 
     @Override
     public int[] getAcceptableTokens() {
-        // Any tokens set by property 'tokens' are acceptable
-        final Set<String> tokenNames = getTokenNames();
-        final int[] result = new int[tokenNames.size()];
-        int i = 0;
-        for (final String name : tokenNames) {
-            result[i] = Utils.getTokenId(name);
-            i++;
-        }
-        return result;
+        return Utils.getAllTokenIds();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return new int[0];
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
@@ -21,6 +21,8 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import static com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck.MSG_KEY;
 
+import java.text.MessageFormat;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -36,6 +38,7 @@ public class IllegalTokenTextCheckTest
             createCheckConfig(IllegalTokenTextCheck.class);
         checkConfig.addAttribute("tokens", "STRING_LITERAL");
         checkConfig.addAttribute("format", "a href");
+        checkConfig.addAttribute("ignoreCase", "false");
         final String[] expected = {
             "24:28: " + getCheckMessage(MSG_KEY, "a href"),
         };
@@ -53,6 +56,37 @@ public class IllegalTokenTextCheckTest
         final String[] expected = {
             "24:28: " + getCheckMessage(MSG_KEY, "a href"),
             "25:32: " + getCheckMessage(MSG_KEY, "a href"),
+        };
+        verify(checkConfig, getPath("InputIllegalTokens.java"), expected);
+    }
+
+    @Test
+    public void testCustomMessage()
+        throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(IllegalTokenTextCheck.class);
+        checkConfig.addAttribute("tokens", "STRING_LITERAL");
+        checkConfig.addAttribute("format", "a href");
+
+        String customMessage = "My custom message";
+        checkConfig.addAttribute("message", customMessage);
+        final String[] expected = {
+            "24:28: " + MessageFormat.format(customMessage, "a href"),
+        };
+        verify(checkConfig, getPath("InputIllegalTokens.java"), expected);
+    }
+
+    @Test
+    public void testNullCustomMessage()
+        throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(IllegalTokenTextCheck.class);
+        checkConfig.addAttribute("tokens", "STRING_LITERAL");
+        checkConfig.addAttribute("format", "a href");
+
+        checkConfig.addAttribute("message", null);
+        final String[] expected = {
+            "24:28: " + getCheckMessage(MSG_KEY, "a href"),
         };
         verify(checkConfig, getPath("InputIllegalTokens.java"), expected);
     }


### PR DESCRIPTION
Refactoring reason:
These Checks accept any token type user provide them. It means that acceptable tokens are all tokens from TokenTypes class.
Now these Checks' `getAcceptableTokens()` method analyzes and copies user's set of tokens provided in a configuration. I think it is incorrect because Check's acceptable tokens should not depend on configuration.
I've changed this method to return all token IDs.