### PR TITLE
Add test coverage to MethodCallHandler in Indentation check. #1270

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1169,7 +1169,6 @@
             <regex><pattern>.*.checks.indentation.ImportHandler</pattern><branchRate>50</branchRate><lineRate>87</lineRate></regex>
             <regex><pattern>.*.checks.indentation.IndentationCheck</pattern><branchRate>100</branchRate><lineRate>93</lineRate></regex>
             <regex><pattern>.*.checks.indentation.LineWrappingHandler</pattern><branchRate>87</branchRate><lineRate>95</lineRate></regex>
-            <regex><pattern>.*.checks.indentation.MethodCallHandler</pattern><branchRate>63</branchRate><lineRate>87</lineRate></regex>
             <regex><pattern>.*.checks.indentation.MethodCallLineWrapHandler</pattern><branchRate>0</branchRate><lineRate>0</lineRate></regex>
             <regex><pattern>.*.checks.indentation.MethodDefHandler</pattern><branchRate>87</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.indentation.NewHandler</pattern><branchRate>83</branchRate><lineRate>77</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -38,11 +38,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
      */
     public MethodCallHandler(IndentationCheck indentCheck,
         DetailAST ast, AbstractExpressionHandler parent) {
-        super(indentCheck,
-            ast.getType() == TokenTypes.METHOD_CALL
-                ? "method call" : "ctor call",
-            ast,
-            parent);
+        super(indentCheck, "method call", ast, parent);
     }
 
     @Override
@@ -52,30 +48,17 @@ public class MethodCallHandler extends AbstractExpressionHandler {
         if (getParent() instanceof MethodCallHandler) {
             final MethodCallHandler container =
                     (MethodCallHandler) getParent();
-            if (container != null) {
-                if (areOnSameLine(container.getMainAst(), getMainAst())) {
-                    return container.getLevel();
-                }
-
-                // we should increase indentation only if this is the first
-                // chained method call which was moved to the next line
-                if (isChainedMethodCallWrapped()) {
-                    return container.getLevel();
-                }
-                else {
-                    return new IndentLevel(container.getLevel(), getBasicOffset());
-                }
+            if (areOnSameLine(container.getMainAst(), getMainAst())) {
+                return container.getLevel();
             }
-
-            // if we get here, we are the child of the left hand side (name
-            //  side) of a method call with no "containing" call, use
-            //  the first non-method call parent
-
-            AbstractExpressionHandler p = getParent();
-            while (p instanceof MethodCallHandler) {
-                p = p.getParent();
+            // we should increase indentation only if this is the first
+            // chained method call which was moved to the next line
+            if (isChainedMethodCallWrapped()) {
+                return container.getLevel();
             }
-            return p.suggestedChildLevel(this);
+            else {
+                return new IndentLevel(container.getLevel(), getBasicOffset());
+            }
         }
 
         // if our expression isn't first on the line, just use the start
@@ -100,15 +83,12 @@ public class MethodCallHandler extends AbstractExpressionHandler {
         final DetailAST dot = main.getFirstChild();
         final DetailAST target = dot.getFirstChild();
 
-        if (dot.getType() == TokenTypes.DOT
-            && target.getType() == TokenTypes.METHOD_CALL) {
-            final DetailAST dot1 = target.getFirstChild();
-            final DetailAST target1 = dot1.getFirstChild();
+        final DetailAST dot1 = target.getFirstChild();
+        final DetailAST target1 = dot1.getFirstChild();
 
-            if (dot1.getType() == TokenTypes.DOT
-                && target1.getType() == TokenTypes.METHOD_CALL) {
-                result = true;
-            }
+        if (dot1.getType() == TokenTypes.DOT
+            && target1.getType() == TokenTypes.METHOD_CALL) {
+            result = true;
         }
         return result;
     }
@@ -126,14 +106,9 @@ public class MethodCallHandler extends AbstractExpressionHandler {
         // call name
 
         DetailAST astNode = ast.getFirstChild();
-        while (astNode != null && astNode.getType() == TokenTypes.DOT) {
+        while (astNode.getType() == TokenTypes.DOT) {
             astNode = astNode.getFirstChild();
         }
-
-        if (astNode == null) {
-            astNode = ast;
-        }
-
         return astNode;
     }
 
@@ -157,8 +132,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
     @Override
     public void checkIndentation() {
         final DetailAST exprNode = getMainAst().getParent();
-        if (exprNode.getParent().getType() != TokenTypes.LCURLY
-            && exprNode.getParent().getType() != TokenTypes.SLIST) {
+        if (exprNode.getParent().getType() != TokenTypes.SLIST) {
             return;
         }
         final DetailAST methodName = getMainAst().getFirstChild();
@@ -197,13 +171,6 @@ public class MethodCallHandler extends AbstractExpressionHandler {
      * method calls are chained returns right paren for last call.
      */
     private static DetailAST getMethodCallLastNode(DetailAST firstNode) {
-        DetailAST lastNode;
-        if (firstNode.getNextSibling() == null) {
-            lastNode = firstNode.getLastChild();
-        }
-        else {
-            lastNode = firstNode.getNextSibling();
-        }
-        return lastNode;
+        return firstNode.getLastChild();
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1471,6 +1471,27 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
+    public void testAnonymousClassInMethod() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+        checkConfig.addAttribute("tabWidth", "8");
+        checkConfig.addAttribute("basicOffset", "2");
+        checkConfig.addAttribute("braceAdjustment", "0");
+        checkConfig.addAttribute("caseIndent", "2");
+        checkConfig.addAttribute("lineWrappingIndentation", "4");
+        checkConfig.addAttribute("throwsIndent", "4");
+        checkConfig.addAttribute("arrayInitIndent", "2");
+        final String[] expected = {
+            "19: " + getCheckMessage(MSG_ERROR, "method def modifier", 8, 2),
+            "20: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 16, 4),
+            "21: " + getCheckMessage(MSG_ERROR_MULTI, "method def modifier", 24, "18, 20, 22"),
+            "23: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "method def", 32, "20, 22, 24"),
+            "24: " + getCheckMessage(MSG_ERROR_MULTI, "method def rcurly",  24, "18, 20, 22"),
+            "26: " + getCheckMessage(MSG_ERROR, "method def rcurly", 8, 2),
+        };
+        verifyWarns(checkConfig, getPath("indentation/InputAnonymousClassInMethod.java"), expected);
+    }
+
+    @Test
     public void testAnnotationDefinition() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
         checkConfig.addAttribute("tabWidth", "4");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputAnonymousClassInMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputAnonymousClassInMethod.java
@@ -1,0 +1,27 @@
+package com.puppycrawl.tools.checkstyle.indentation; //indent:0 exp:0
+
+import java.io.File; //indent:0 exp:0
+import java.io.FileFilter; //indent:0 exp:0
+
+/**                                                                         //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration: //indent:1 exp:1
+ *                                                                          //indent:1 exp:1
+ * arrayInitIndent = 2                                                      //indent:1 exp:1
+ * basicOffset = 2                                                          //indent:1 exp:1
+ * braceAdjustment = 0                                                      //indent:1 exp:1
+ * caseIndent = 2                                                           //indent:1 exp:1
+ * forceStrictCondition = false                                             //indent:1 exp:1
+ * lineWrappingIndentation = 4                                              //indent:1 exp:1
+ * tabWidth = 8                                                             //indent:1 exp:1
+ * throwsIndent = 4                                                         //indent:1 exp:1
+ */                                                                         //indent:1 exp:1
+public class InputAnonymousClassInMethod { //indent:0 exp:0
+	private void walkDir(File dir, FileFilter fileFilter) { //indent:8 exp:2 warn
+		walkDir( dir, new FileFilter() { //indent:16 exp:4 warn
+			@Override //indent:24 exp:8 warn
+			public boolean accept(File path) { //indent:24 exp:24
+				return ( path.isDirectory() ); //indent:32 exp:12 warn
+			} //indent:24 exp:8 warn
+		} ); //indent:16 exp:16
+	} //indent:8 exp:2 warn
+} //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputMethodCallLineWrap.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputMethodCallLineWrap.java
@@ -52,4 +52,14 @@ public class InputMethodCallLineWrap { //indent:0 exp:0
               ); //indent:14 exp:16 warn
         } //indent:8 exp:8
     }; //indent:4 exp:4
+
+    void chaining() { //indent:4 exp:4
+        toString() //indent:8 exp:8
+                .getClass(); //indent:16 exp:16
+        toString().contains(//indent:8 exp:8
+            new String(//indent:12 exp:12
+                    "a" //indent:20 exp:20
+            )//indent:12 exp:12
+        ); //indent:8 exp:8
+    } //indent:4 exp:4
 } //indent:0 exp:0


### PR DESCRIPTION
Reports are identical:
```
diff target-6.8.1/checkstyle-result.xml target-6.9/checkstyle-result.xml
--- target-6.8.1/checkstyle-result.xml
+++ target-6.9/checkstyle-result.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="6.8.1">
+<checkstyle version="6.9-SNAPSHOT">
```
![image](https://cloud.githubusercontent.com/assets/5467276/8764025/7d0957b6-2dbb-11e5-920c-480324852c2e.png)
![image](https://cloud.githubusercontent.com/assets/5467276/8764026/85f1e942-2dbb-11e5-9351-968363c4f29c.png)
