### PR TITLE
Remove dead code from SlistHandler in Indentation check. #1270

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1167,7 +1167,6 @@
             <regex><pattern>.*.checks.indentation.NewHandler</pattern><branchRate>83</branchRate><lineRate>77</lineRate></regex>
             <regex><pattern>.*.checks.indentation.ObjectBlockHandler</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.indentation.PackageDefHandler</pattern><branchRate>50</branchRate><lineRate>85</lineRate></regex>
-            <regex><pattern>.*.checks.indentation.SlistHandler</pattern><branchRate>100</branchRate><lineRate>94</lineRate></regex>
             <regex><pattern>.*.checks.indentation.SynchronizedHandler</pattern><branchRate>100</branchRate><lineRate>100</lineRate></regex>
 
             <regex><pattern>.*.checks.javadoc.AbstractJavadocCheck</pattern><branchRate>90</branchRate><lineRate>93</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
@@ -63,15 +63,6 @@ public class SlistHandler extends BlockParentHandler {
     }
 
     @Override
-    protected DetailAST getNonlistChild() {
-        // blocks always have either block children or they are transparent
-        // and aren't checking children at all.  In the later case, the
-        // superclass will want to check single children, so when it
-        // does tell it we have none.
-        return null;
-    }
-
-    @Override
     protected DetailAST getListChild() {
         return getMainAst();
     }


### PR DESCRIPTION
Reports over large codebase are the same:
```
diff target/checkstyle-result.xml target-6.8.1/checkstyle-result.xml -U 0
--- target/checkstyle-result.xml
+++ target-6.8.1/checkstyle-result.xml
@@ -2 +2 @@
-<checkstyle version="6.9-SNAPSHOT">
+<checkstyle version="6.8.1">
```