### PR TITLE
Add test coverage to BlockParentHandler in Indentation check. #1270

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1153,7 +1153,6 @@
             <regex><pattern>.*.checks.imports.CustomImportOrderCheck</pattern><branchRate>98</branchRate><lineRate>100</lineRate></regex>
 
             <regex><pattern>.*.checks.indentation.ArrayInitHandler</pattern><branchRate>87</branchRate><lineRate>100</lineRate></regex>
-            <regex><pattern>.*.checks.indentation.BlockParentHandler</pattern><branchRate>86</branchRate><lineRate>98</lineRate></regex>
             <regex><pattern>.*.checks.indentation.ElseHandler</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.indentation.AbstractExpressionHandler</pattern><branchRate>91</branchRate><lineRate>97</lineRate></regex>
             <regex><pattern>.*.checks.indentation.HandlerFactory</pattern><branchRate>81</branchRate><lineRate>100</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -108,7 +108,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
      */
     protected boolean hasLabelBefore() {
         final DetailAST parent = getToplevelAST().getParent();
-        return parent != null && parent.getType() == TokenTypes.LABELED_STAT
+        return parent.getType() == TokenTypes.LABELED_STAT
             && parent.getLineNo() == getToplevelAST().getLineNo();
     }
 
@@ -146,10 +146,6 @@ public class BlockParentHandler extends AbstractExpressionHandler {
      */
     protected DetailAST getRCurly() {
         final DetailAST slist = getMainAst().findFirstToken(TokenTypes.SLIST);
-        if (slist == null) {
-            return null;
-        }
-
         return slist.findFirstToken(TokenTypes.RCURLY);
     }
 
@@ -296,8 +292,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
         // if we have multileveled expected level then we should
         // try to suggest single level to children using curlies'
         // levels.
-        if (getLevel().isMultiLevel() && hasCurlys()
-            && !areOnSameLine(getLCurly(), getRCurly())) {
+        if (getLevel().isMultiLevel() && hasCurlys()) {
             if (startsLine(getLCurly())) {
                 return new IndentLevel(expandedTabsColumnNo(getLCurly()) + getBasicOffset());
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -451,6 +451,27 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
+    public void testInvalidLabelWithWhileLoop() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+
+        checkConfig.addAttribute("arrayInitIndent", "4");
+        checkConfig.addAttribute("basicOffset", "4");
+        checkConfig.addAttribute("braceAdjustment", "0");
+        checkConfig.addAttribute("caseIndent", "4");
+        checkConfig.addAttribute("forceStrictCondition", "false");
+        checkConfig.addAttribute("lineWrappingIndentation", "4");
+        checkConfig.addAttribute("tabWidth", "4");
+        checkConfig.addAttribute("throwsIndent", "4");
+        final String[] expected = {
+            "18: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "label", 9, "4, 8"),
+            "19: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "label", 9, "8, 12"),
+            "19: " + getCheckMessage(MSG_ERROR_MULTI, "while", 9, "8, 12"),
+        };
+        verifyWarns(checkConfig, getPath("indentation/InputInvalidLabelWithWhileLoopIndent.java"),
+            expected);
+    }
+
+    @Test
     public void testValidLabel() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
@@ -1082,6 +1103,25 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
             "85: " + getCheckMessage(MSG_ERROR, "while rparen", 10, 8),
             "92: " + getCheckMessage(MSG_ERROR, "while rparen", 10, 8),
             "99: " + getCheckMessage(MSG_CHILD_ERROR, "while", 8, 12),
+        };
+        verifyWarns(checkConfig, fname, expected);
+    }
+
+    @Test
+    public void testInvalidInvalidAnonymousClass() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+
+        checkConfig.addAttribute("arrayInitIndent", "4");
+        checkConfig.addAttribute("basicOffset", "4");
+        checkConfig.addAttribute("braceAdjustment", "0");
+        checkConfig.addAttribute("caseIndent", "4");
+        checkConfig.addAttribute("forceStrictCondition", "false");
+        checkConfig.addAttribute("lineWrappingIndentation", "4");
+        checkConfig.addAttribute("tabWidth", "4");
+        checkConfig.addAttribute("throwsIndent", "4");
+        final String fname = getPath("indentation/InputInvalidAnonymousClassIndent.java");
+        final String[] expected = {
+            "28: " + getCheckMessage(MSG_ERROR_MULTI, "method def rcurly", 17, "12, 16"),
         };
         verifyWarns(checkConfig, fname, expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputInvalidAnonymousClassIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputInvalidAnonymousClassIndent.java
@@ -1,0 +1,31 @@
+package com.puppycrawl.tools.checkstyle.indentation; //indent:0 exp:0
+
+import java.util.concurrent.ThreadFactory; //indent:0 exp:0
+
+import static java.util.concurrent.Executors.newFixedThreadPool; //indent:0 exp:0
+
+/**                                                                           //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:   //indent:1 exp:1
+ *                                                                            //indent:1 exp:1
+ * arrayInitIndent = 4                                                        //indent:1 exp:1
+ * basicOffset = 4                                                            //indent:1 exp:1
+ * braceAdjustment = 0                                                        //indent:1 exp:1
+ * caseIndent = 4                                                             //indent:1 exp:1
+ * forceStrictCondition = false                                               //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                //indent:1 exp:1
+ * tabWidth = 4                                                               //indent:1 exp:1
+ * throwsIndent = 4                                                           //indent:1 exp:1
+ */                                                                           //indent:1 exp:1
+public class InputInvalidAnonymousClassIndent { //indent:0 exp:0
+
+    public InputInvalidAnonymousClassIndent() { //indent:4 exp:4
+        newFixedThreadPool(1, new ThreadFactory() { //indent:8 exp:8
+            public Thread newThread(Runnable runnable) { //indent:12 exp:12
+                if (hashCode() == 0) { //indent:16 exp:16
+                    return new Thread(); //indent:20 exp:20
+                } else { //indent:16 exp:16
+                    return new Thread(); //indent:20 exp:20
+                }}}); //indent:16 exp:17 warn
+        return; //indent:8 exp:8
+    } //indent:4 exp:4
+} //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputInvalidLabelWithWhileLoopIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputInvalidLabelWithWhileLoopIndent.java
@@ -1,0 +1,23 @@
+package com.puppycrawl.tools.checkstyle.indentation; //indent:0 exp:0
+
+/**                                                                           //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:   //indent:1 exp:1
+ *                                                                            //indent:1 exp:1
+ * arrayInitIndent = 4                                                        //indent:1 exp:1
+ * basicOffset = 4                                                            //indent:1 exp:1
+ * braceAdjustment = 0                                                        //indent:1 exp:1
+ * caseIndent = 4                                                             //indent:1 exp:1
+ * forceStrictCondition = false                                               //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                //indent:1 exp:1
+ * tabWidth = 4                                                               //indent:1 exp:1
+ * throwsIndent = 4                                                           //indent:1 exp:1
+ */                                                                           //indent:1 exp:1
+public class InputInvalidLabelWithWhileLoopIndent { //indent:0 exp:0
+
+    public InputInvalidLabelWithWhileLoopIndent() { //indent:4 exp:4
+         LOOP://indent:9 exp:8 warn
+         while (true) { //indent:9 exp:8 warn
+            break LOOP; //indent:12 exp:13 warn
+        } //indent:8 exp:8
+    } //indent:4 exp:4
+} //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputValidBlockIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/indentation/InputValidBlockIndent.java
@@ -167,3 +167,13 @@ class bug1336737 { //indent:0 exp:0
         public String toString() { return c; } //indent:8 exp:8
     } //indent:4 exp:4
 } //indent:0 exp:0
+
+class AnonymousClassWithInitializer { //indent:0 exp:0
+    void create() { //indent:4 exp:4
+        new Object() { //indent:8 exp:8
+            { //indent:12 exp:12
+                new Object(); //indent:16 exp:16
+            } //indent:12 exp:12
+        }; //indent:8 exp:8
+    } //indent:4 exp:4
+} //indent:0 exp:0


### PR DESCRIPTION
Reports over huge codebase are identical:
```
--- target/checkstyle-result.xml
+++ target-6.8.1/checkstyle-result.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="6.9-SNAPSHOT">
+<checkstyle version="6.8.1">
```
