### PR TITLE
Remove dead code from NewHandler in Indentation check. #1270

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1160,7 +1160,6 @@
             <regex><pattern>.*.checks.indentation.LineWrappingHandler</pattern><branchRate>87</branchRate><lineRate>95</lineRate></regex>
             <regex><pattern>.*.checks.indentation.MethodCallLineWrapHandler</pattern><branchRate>0</branchRate><lineRate>0</lineRate></regex>
             <regex><pattern>.*.checks.indentation.MethodDefHandler</pattern><branchRate>87</branchRate><lineRate>100</lineRate></regex>
-            <regex><pattern>.*.checks.indentation.NewHandler</pattern><branchRate>83</branchRate><lineRate>77</lineRate></regex>
             <regex><pattern>.*.checks.indentation.ObjectBlockHandler</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.indentation.SynchronizedHandler</pattern><branchRate>100</branchRate><lineRate>100</lineRate></regex>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
@@ -50,34 +50,7 @@ public class NewHandler extends AbstractExpressionHandler {
         }
 
         final DetailAST lparen = getMainAst().findFirstToken(TokenTypes.LPAREN);
-        final DetailAST rparen = getMainAst().findFirstToken(TokenTypes.RPAREN);
         checkLParen(lparen);
-
-        if (rparen == null || lparen == null
-            || rparen.getLineNo() == lparen.getLineNo()) {
-            return;
-        }
-
-        if (getMainAst().getType() != TokenTypes.OBJBLOCK) {
-            return;
-        }
-
-        // if this method name is on the same line as a containing
-        // method, don't indent, this allows expressions like:
-        //    method("my str" + method2(
-        //        "my str2"));
-        // as well as
-        //    method("my str" +
-        //        method2(
-        //            "my str2"));
-        //
-
-        checkExpressionSubtree(
-            getMainAst().findFirstToken(TokenTypes.ELIST),
-            new IndentLevel(getLevel(), getBasicOffset()),
-            false, true);
-
-        checkRParen(lparen, rparen);
     }
 
     @Override


### PR DESCRIPTION
Reports are exactly the same over huge codebase:
```
--- target/checkstyle-result.xml
+++ target-6.8.1/checkstyle-result.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="6.9-SNAPSHOT">
+<checkstyle version="6.8.1">
```