### PR TITLE
Fix for SuperClone and SuperFinalize checks reporting violations on native methods, #1367

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -229,7 +229,9 @@ public abstract class AbstractSuperCheck
         }
         final DetailAST nameAST = ast.findFirstToken(TokenTypes.IDENT);
         final String name = nameAST.getText();
-        if (!getMethodName().equals(name)) {
+        final DetailAST modifiersAST = ast.findFirstToken(TokenTypes.MODIFIERS);
+        if (!getMethodName().equals(name)
+                || modifiersAST.branchContains(TokenTypes.LITERAL_NATIVE)) {
             return false;
         }
         final DetailAST params = ast.findFirstToken(TokenTypes.PARAMETERS);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheck.java
@@ -23,6 +23,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 /**
  * <p>
  * Checks that an overriding clone() method invokes super.clone().
+ * Does not check native methods, as they have no possible java defined implementation.
  * </p>
  * <p>
  * Reference:<a

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperFinalizeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperFinalizeCheck.java
@@ -23,6 +23,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 /**
  * <p>
  * Checks that an overriding finalize() method invokes super.finalize().
+ * Does not check native methods, as they have no possible java defined implementation.
  * </p>
  * <p>
  * Reference:<a

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheckTest.java
@@ -43,6 +43,7 @@ public class NoCloneCheckTest
             "39: " + getCheckMessage(MSG_KEY),
             "52: " + getCheckMessage(MSG_KEY),
             "60: " + getCheckMessage(MSG_KEY),
+            "98: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("coding" + File.separator + "InputClone.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckTest.java
@@ -106,6 +106,7 @@ public class OneTopLevelClassCheckTest extends BaseCheckTestSupport {
             "58: " + getCheckMessage(MSG_KEY, "CloneWithTypeArgumentsAndNoSuper"),
             "67: " + getCheckMessage(MSG_KEY, "MyClassWithGenericSuperMethod"),
             "84: " + getCheckMessage(MSG_KEY, "AnotherClass"),
+            "97: " + getCheckMessage(MSG_KEY, "NativeTest"),
         };
         verify(checkConfig, getPath("coding" + File.separator + "InputClone.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputClone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputClone.java
@@ -93,3 +93,7 @@ class AnotherClass {
 	return null;
     }
 }
+
+class NativeTest {
+    public native Object clone();
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputFinalize.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputFinalize.java
@@ -51,3 +51,7 @@ class MyClassWithGenericSuperMethod1
 
     }
 }
+
+class TestNative {
+    public native void finalize();
+}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -1564,8 +1564,9 @@ if (&quot;something&quot;.equals(x))
     <section name="SuperClone">
       <subsection name="Description">
         <p>
-          Checks that an overriding <code>clone()</code> method
-          invokes <code>super.clone()</code>.
+          Checks that an overriding <code>clone()</code> method invokes
+          <code>super.clone()</code>. Does not check native methods, as
+          they have no possible java defined implementation.
         </p>
 
         <p>
@@ -1599,8 +1600,9 @@ if (&quot;something&quot;.equals(x))
     <section name="SuperFinalize">
       <subsection name="Description">
         <p>
-          Checks that an overriding <code>finalize()</code>
-          method invokes <code>super.finalize()</code>.
+          Checks that an overriding <code>finalize()</code> method invokes
+          <code>super.finalize()</code>. Does not check native methods, as
+          they have no possible java defined implementation.
         </p>
 
         <p>


### PR DESCRIPTION
Reports are here: http://vladlis.github.io/
There is only one difference after changes, which is confirmed: [link](http://vladlis.github.io/reports/tester/before/site/xref/openjdk/src/share/classes/java/lang/Object.html#L213)