### PR TITLE
CustomImportOrderCheck. Fix #1263

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.imports;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.api.Check;
@@ -38,30 +39,30 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * </p>
  * The rule consists of:
  *
- * <pre>
- * STATIC group. This group sets the ordering of static imports.
- * </pre>
+ * <p>
+ * 1. STATIC group. This group sets the ordering of static imports.
+ * </p>
  *
  * <p>
- * SAME_PACKAGE(n) group. This group sets the ordering of the same package imports.
+ * 2. SAME_PACKAGE(n) group. This group sets the ordering of the same package imports.
  * Imports are considered on SAME_PACKAGE group if <b>n</b> first domains in package name
  * and import name are identical.
  * </p>
  *
  * <pre>
- * {@code
- * package java.util.concurrent.locks;
+ *{@code
+ *package java.util.concurrent.locks;
  *
- * import java.io.File;
- * import java.util.*; //#1
- * import java.util.List; //#2
- * import java.util.StringTokenizer; //#3
- * import java.util.concurrent.*; //#4
- * import java.util.concurrent.AbstractExecutorService; //#5
- * import java.util.concurrent.locks.LockSupport; //#6
- * import java.util.regex.Pattern; //#7
- * import java.util.regex.Matcher; //#8
- * }
+ *import java.io.File;
+ *import java.util.*; //#1
+ *import java.util.List; //#2
+ *import java.util.StringTokenizer; //#3
+ *import java.util.concurrent.*; //#4
+ *import java.util.concurrent.AbstractExecutorService; //#5
+ *import java.util.concurrent.locks.LockSupport; //#6
+ *import java.util.regex.Pattern; //#7
+ *import java.util.regex.Matcher; //#8
+ *}
  * </pre>
  *
  * <p>
@@ -74,19 +75,20 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * </p>
  *
  * <p>
- * THIRD_PARTY_PACKAGE group. This group sets ordering of third party imports.
+ * 3. THIRD_PARTY_PACKAGE group. This group sets ordering of third party imports.
  * Third party imports are all imports except STATIC,
  * SAME_PACKAGE(n), STANDARD_JAVA_PACKAGE and SPECIAL_IMPORTS.
  * </p>
  *
- * <pre>
- * STANDARD_JAVA_PACKAGE group. This group sets ordering of standard java/javax imports.
- * </pre>
+ * <p>
+ * 4. STANDARD_JAVA_PACKAGE group. By default this group sets ordering of standard java/javax
+ * imports.
+ * </p>
  *
- * <pre>
- * SPECIAL_IMPORTS group. This group may contains some imports
+ * <p>
+ * 5. SPECIAL_IMPORTS group. This group may contains some imports
  * that have particular meaning for the user.
- * </pre>
+ * </p>
  *
  * <p>
  * NOTE!
@@ -98,9 +100,57 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * To set Regexps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
  * thirdPartyPackageRegExp and standardPackageRegExp options.
  * </p>
+ * <p>
+ * Pretty often one import can match more than one group. For example, static import from standard
+ * package or regular expressions are configured to allow one import match multiple groups.
+ * In this case, group will be assigned according to priorities:
+ * </p>
+ * <ol>
+ * <li>
+ *    STATIC has top priority
+ * </li>
+ * <li>
+ *    SAME_PACKAGE has second priority
+ * </li>
+ * <li>
+ *    STANDARD_JAVA_PACKAGE and SPECIAL_IMPORTS will compete using "best match" rule: longer
+ *    matching substring wins; in case of the same length, lower position of matching substring
+ *    wins; if position is the same, order of rules in configuration solves the puzzle.
+ * </li>
+ * <li>
+ *    THIRD_PARTY has the least priority
+ * </li>
+ * </ol>
+ * <p>
+ *    Few examples to illustrate "best match":
+ * </p>
+ * <p>
+ *    1. patterns STANDARD_JAVA_PACKAGE = "Check", SPECIAL_IMPORTS="ImportOrderCheck" and input
+ *    file:
+ * </p>
+ * <pre>
+ *{@code
+ *import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+ *import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;}
+ * </pre>
+ * <p>
+ *    Result: imports will be assigned to SPECIAL_IMPORTS, because matching substring length is 16.
+ *    Matching substring for STANDARD_JAVA_PACKAGE is 5.
+ * </p>
+ * <p>
+ *    2. patterns STANDARD_JAVA_PACKAGE = "Check", SPECIAL_IMPORTS="Avoid" and file:
+ * </p>
+ * <pre>
+ *{@code
+ *import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;}
+ * </pre>
+ * <p>
+ *   Result: import will be assigned to SPECIAL_IMPORTS. Matching substring length is 5 for both
+ *   patterns. However, "Avoid" position is lower then "Check" position.
+ * </p>
  *
  * <pre>
- * Properties:
+ *    Properties:
  * </pre>
  * <table summary="Properties" border="1">
  *     <tr><th>name</th><th>Description</th><th>type</th><th>default value</th></tr>
@@ -120,9 +170,9 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *          in ASCII sort order.</td><td>boolean</td><td>false</td></tr>
  * </table>
  *
- * <pre>
+ * <p>
  * For example:
- * </pre>
+ * </p>
  *        <p>To configure the check so that it matches default Eclipse formatter configuration
  *        (tested on Kepler, Luna and Mars):</p>
  *        <ul>
@@ -133,7 +183,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *          <li>groups are separated by, at least, one blank line</li>
  *        </ul>
  * <pre>
- *        {@code
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
  *    &lt;property name=&quot;customImportOrderRules&quot;
  *        value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS&quot;/&gt;
@@ -141,7 +190,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *    &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
  *    &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
- *        }
  * </pre>
  *
  *        <p>To configure the check so that it matches default IntelliJ IDEA formatter
@@ -161,7 +209,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *        </p>
  *
  * <pre>
- *        {@code
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
  *    &lt;property name=&quot;customImportOrderRules&quot;
  *        value=&quot;THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE
@@ -171,7 +218,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *    &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
  *    &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;false&quot;/&gt;
  *&lt;/module&gt;
- *        }
  * </pre>
  *
  * <p>To configure the check so that it matches default NetBeans formatter
@@ -182,20 +228,18 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *     <li>static imports are not separated, they will be sorted along with other imports</li>
  * </ul>
  *
- *        {@code
+ * <pre>
  *&lt;module name=&quot;CustomImportOrder&quot;/&gt;
- *        }
+ * </pre>
  * <p>To set Regexps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
  *         thirdPartyPackageRegExp and standardPackageRegExp options.</p>
  * <pre>
- * {@code
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
  *    &lt;property name=&quot;customImportOrderRules&quot;
  *    value=&quot;STATIC###SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE&quot;/&gt;
  *    &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;com|org&quot;/&gt;
  *    &lt;property name=&quot;standardPackageRegExp&quot; value=&quot;^(java|javax)\.&quot;/&gt;
  * &lt;/module&gt;
- * }
  * </pre>
  * <p>
  * Also, this check can be configured to force empty line separator between
@@ -203,11 +247,9 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * </p>
  *
  * <pre>
- * {@code
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
  *    &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
- * }
  * </pre>
  * <p>
  * It is possible to enforce
@@ -215,20 +257,20 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * of imports in groups using the following configuration:
  * </p>
  * <pre>
- * {@code &lt;module name=&quot;CustomImportOrder&quot;&gt;
+ * &lt;module name=&quot;CustomImportOrder&quot;&gt;
  *    &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
- * }
  * </pre>
  * <p>
  * Example of ASCII order:
  * </p>
  * <pre>
- * {@code import java.awt.Dialog;
- * import java.awt.Window;
- * import java.awt.color.ColorSpace;
- * import java.awt.Frame; // violation here - in ASCII order 'F' should go before 'c',
- *                        // as all uppercase come before lowercase letters}
+ * {@code
+ *import java.awt.Dialog;
+ *import java.awt.Window;
+ *import java.awt.color.ColorSpace;
+ *import java.awt.Frame; // violation here - in ASCII order 'F' should go before 'c',
+ *                       // as all uppercase come before lowercase letters}
  * </pre>
  * <p>
  * To force checking imports sequence such as:
@@ -252,12 +294,11 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * </pre>
  * configure as follows:
  * <pre>
- * {@code
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
  *    &lt;property name=&quot;customImportOrderRules&quot;
  *    value=&quot;SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STATIC###SPECIAL_IMPORTS&quot;/&gt;
  *    &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;android.*&quot;/&gt;
- * &lt;/module&gt;}
+ * &lt;/module&gt;
  * </pre>
  *
  * @author maxvetrenko
@@ -572,110 +613,65 @@ public class CustomImportOrderCheck extends Check {
      * @return import valid group.
      */
     private String getImportGroup(boolean isStatic, String importPath) {
-        for (String group : customImportOrderRules) {
-            if (matchesImportGroup(isStatic, importPath, group)) {
-                return group;
+        RuleMatchForImport bestMatch = new RuleMatchForImport(NON_GROUP_RULE_GROUP, 0, 0);
+        if (isStatic && customImportOrderRules.contains(STATIC_RULE_GROUP)) {
+            bestMatch.group = STATIC_RULE_GROUP;
+            bestMatch.matchLength = importPath.length();
+        }
+        else if (customImportOrderRules.contains(SAME_PACKAGE_RULE_GROUP)) {
+            final String importPathTrimmedToSamePackageDepth =
+                    getFirstNDomainsFromIdent(samePackageMatchingDepth, importPath);
+            if (samePackageDomainsRegExp.equals(importPathTrimmedToSamePackageDepth)) {
+                bestMatch.group = SAME_PACKAGE_RULE_GROUP;
+                bestMatch.matchLength = importPath.length();
             }
         }
-        return NON_GROUP_RULE_GROUP;
+        if (bestMatch.group.equals(NON_GROUP_RULE_GROUP)) {
+            for (String group : customImportOrderRules) {
+                if (STANDARD_JAVA_PACKAGE_RULE_GROUP.equals(group)) {
+                    bestMatch = findBetterPatternMatch(importPath,
+                            STANDARD_JAVA_PACKAGE_RULE_GROUP, standardPackageRegExp, bestMatch);
+                }
+                if (SPECIAL_IMPORTS_RULE_GROUP.equals(group)) {
+                    bestMatch = findBetterPatternMatch(importPath,
+                            SPECIAL_IMPORTS_RULE_GROUP, specialImportsRegExp, bestMatch);
+                }
+            }
+        }
+        if (bestMatch.group.equals(NON_GROUP_RULE_GROUP)
+                && customImportOrderRules.contains(THIRD_PARTY_PACKAGE_RULE_GROUP)
+                && thirdPartyPackageRegExp.matcher(importPath).find()) {
+            bestMatch.group = THIRD_PARTY_PACKAGE_RULE_GROUP;
+        }
+        return bestMatch.group;
     }
 
-    /**
-     * Checks if the import is placed in the correct group.
-     * @param isStatic
-     *        if import is static.
+    /** Tries to find better matching regular expression:
+     * longer matching substring wins; in case of the same length,
+     * lower position of matching substring wins.
      * @param importPath
-     *        import full path.
-     * @param currentGroup
-     *        current group.
-     * @return true, if import placed in the correct group.
+     *      Full import identifier
+     * @param group
+     *      Import group we are trying to assign the import
+     * @param regExp
+     *      Regular expression for import group
+     * @param currentBestMatch
+     *      object with currently best match
+     * @return better match (if found) or the same (currentBestMatch)
      */
-    private boolean matchesImportGroup(boolean isStatic, String importPath, String currentGroup) {
-        return matchesStaticImportGroup(isStatic, currentGroup)
-                || matchesSamePackageImportGroup(isStatic, importPath, currentGroup)
-                || matchesSpecialImportsGroup(isStatic, importPath, currentGroup)
-                || matchesStandardImportGroup(isStatic, importPath, currentGroup)
-                || matchesThirdPartyImportGroup(isStatic, importPath, currentGroup);
-    }
-
-    /**
-     * Checks if the import is placed in the STATIC group.
-     * @param isStatic
-     *        is static import.
-     * @param currentGroup
-     *        current group.
-     * @return true, if the import is placed in the static group.
-     */
-    private static boolean matchesStaticImportGroup(boolean isStatic, String currentGroup) {
-        return isStatic && STATIC_RULE_GROUP.equals(currentGroup);
-    }
-
-    /**
-     * Checks if the import is placed in the correct group.
-     * @param isStatic
-     *        if import is static.
-     * @param importFullPath
-     *        import full path.
-     * @param currentGroup
-     *        current group.
-     * @return true, if the import is placed in the same package group.
-     */
-    private boolean matchesSamePackageImportGroup(boolean isStatic,
-        String importFullPath, String currentGroup) {
-        final String importPathTrimmedToSamePackageDepth =
-                getFirstNDomainsFromIdent(samePackageMatchingDepth, importFullPath);
-        return !isStatic && SAME_PACKAGE_RULE_GROUP.equals(currentGroup)
-                && samePackageDomainsRegExp.equals(importPathTrimmedToSamePackageDepth);
-    }
-
-    /**
-     * Checks if the import is placed in the correct group.
-     * @param isStatic
-     *        if import is static.
-     * @param currentImport
-     *        import full path.
-     * @param currentGroup
-     *        current group.
-     * @return true, if the import is placed in the standard group.
-     */
-    private boolean matchesStandardImportGroup(boolean isStatic,
-        String currentImport, String currentGroup) {
-        return !isStatic && STANDARD_JAVA_PACKAGE_RULE_GROUP.equals(currentGroup)
-                && standardPackageRegExp.matcher(currentImport).find();
-    }
-
-    /**
-     * Checks if the import is placed in the correct group.
-     * @param isStatic
-     *        if import is static.
-     * @param currentImport
-     *        import full path.
-     * @param currentGroup
-     *        current group.
-     * @return true, if the import is placed in the special group.
-     */
-    private boolean matchesSpecialImportsGroup(boolean isStatic,
-        String currentImport, String currentGroup) {
-        return !isStatic && SPECIAL_IMPORTS_RULE_GROUP.equals(currentGroup)
-                && specialImportsRegExp.matcher(currentImport).find();
-    }
-
-    /**
-     * Checks if the import is placed in the correct group.
-     * @param isStatic
-     *        if import is static.
-     * @param currentImport
-     *        import full path.
-     * @param currentGroup
-     *        current group.
-     * @return true, if the import is placed in the third party group.
-     */
-    private boolean matchesThirdPartyImportGroup(boolean isStatic,
-        String currentImport, String currentGroup) {
-        return !isStatic && THIRD_PARTY_PACKAGE_RULE_GROUP.equals(currentGroup)
-                && thirdPartyPackageRegExp.matcher(currentImport).find()
-                && !standardPackageRegExp.matcher(currentImport).find()
-                && !specialImportsRegExp.matcher(currentImport).find();
+    private static RuleMatchForImport findBetterPatternMatch(String importPath, String group,
+            Pattern regExp, RuleMatchForImport currentBestMatch) {
+        RuleMatchForImport betterMatchCandidate = currentBestMatch;
+        final Matcher matcher = regExp.matcher(importPath);
+        while (matcher.find()) {
+            final int length = matcher.end() - matcher.start();
+            if (length > betterMatchCandidate.matchLength
+                    || length == betterMatchCandidate.matchLength
+                        && matcher.start() < betterMatchCandidate.matchPosition) {
+                betterMatchCandidate = new RuleMatchForImport(group, length, matcher.start());
+            }
+        }
+        return betterMatchCandidate;
     }
 
     /**
@@ -864,6 +860,34 @@ public class CustomImportOrderCheck extends Check {
          */
         public boolean isStaticImport() {
             return staticImport;
+        }
+    }
+
+    /**
+     * Contains matching attributes assisting in definition of "best matching"
+     * group for import.
+     * @author ivanov-alex
+     */
+    private static class RuleMatchForImport {
+        /** Import group for current best match. */
+        private String group;
+        /** Length of matching string for current best match. */
+        private int matchLength;
+        /** Position of matching string for current best match. */
+        private final int matchPosition;
+
+        /** Constructor to initialize the fields.
+         * @param group
+         *        Matched group.
+         * @param length
+         *        Matching length.
+         * @param position
+         *        Matching position.
+         */
+        RuleMatchForImport(String group, int length, int position) {
+            this.group = group;
+            matchLength = length;
+            matchPosition = position;
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -385,6 +385,13 @@ public class CustomImportOrderCheck extends Check {
     private final List<ImportDetails> importToGroupList = new ArrayList<>();
 
     /**
+     * Default constructor. Initiates list of rules
+     */
+    public CustomImportOrderCheck() {
+        customImportOrderRules.add(NON_GROUP_RULE_GROUP);
+    }
+
+    /**
      * Sets standardRegExp specified by user.
      * @param regexp
      *        user value.
@@ -498,20 +505,17 @@ public class CustomImportOrderCheck extends Check {
             return;
         }
 
-        final ImportDetails firstImport = importToGroupList.get(0);
-        String currentGroup = getImportGroup(firstImport.isStaticImport(),
-                firstImport.getImportFullPath());
+        String currentGroup = getNextImportGroup(0);
         int currentGroupNumber = customImportOrderRules.indexOf(currentGroup);
         String previousImportFromCurrentGroup = null;
 
         for (ImportDetails importObject : importToGroupList) {
             final String importGroup = importObject.getImportGroup();
             final String fullImportIdent = importObject.getImportFullPath();
-
             if (importGroup.equals(currentGroup)) {
                 if (sortImportsInGroupAlphabetically
-                        && previousImportFromCurrentGroup != null
-                        && compareImports(fullImportIdent, previousImportFromCurrentGroup) < 0) {
+                    && previousImportFromCurrentGroup != null
+                    && compareImports(fullImportIdent, previousImportFromCurrentGroup) < 0) {
                     log(importObject.getLineNumber(), MSG_LEX,
                             fullImportIdent, previousImportFromCurrentGroup);
                 }
@@ -523,7 +527,8 @@ public class CustomImportOrderCheck extends Check {
                 //not the last group, last one is always NON_GROUP
                 if (customImportOrderRules.size() > currentGroupNumber + 1) {
                     final String nextGroup = getNextImportGroup(currentGroupNumber + 1);
-                    if (importGroup.equals(nextGroup)) {
+                    // if import is from next group
+                    if (importGroup.equals(nextGroup) && previousImportFromCurrentGroup != null) {
                         if (separateLineBetweenGroups
                                 && !hasEmptyLineBefore(importObject.getLineNumber())) {
                             log(importObject.getLineNumber(), MSG_LINE_SEPARATOR, fullImportIdent);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -508,7 +508,26 @@ public class CustomImportOrderCheck extends Check {
         String currentGroup = getNextImportGroup(0);
         int currentGroupNumber = customImportOrderRules.indexOf(currentGroup);
         String previousImportFromCurrentGroup = null;
+        
+        ImportDetails firstImportObject = importToGroupList.get(0);
+        final String firstImportGroup = firstImportObject.getImportGroup();
+        final String firstImportFullIdent = firstImportObject.getImportFullPath();
+        if( firstImportGroup == NON_GROUP_RULE_GROUP ) {
+            logWrongImportGroupOrder(firstImportObject.getLineNumber(),
+                    firstImportGroup, currentGroup, firstImportFullIdent);
+        }
+        else {
+            currentGroup = firstImportGroup;
+            currentGroupNumber = customImportOrderRules.indexOf(firstImportGroup);
+            previousImportFromCurrentGroup = firstImportFullIdent;
+        }
+//        if (separateLineBetweenGroups
+//                && !hasEmptyLineBefore(firstImportObject.getLineNumber())) {
+//            log(firstImportObject.getLineNumber(), MSG_LINE_SEPARATOR, firstImportFullIdent);
+//        }
+        importToGroupList.remove(0);
 
+        
         for (ImportDetails importObject : importToGroupList) {
             final String importGroup = importObject.getImportGroup();
             final String fullImportIdent = importObject.getImportFullPath();
@@ -528,7 +547,7 @@ public class CustomImportOrderCheck extends Check {
                 if (customImportOrderRules.size() > currentGroupNumber + 1) {
                     final String nextGroup = getNextImportGroup(currentGroupNumber + 1);
                     // if import is from next group
-                    if (importGroup.equals(nextGroup) && previousImportFromCurrentGroup != null) {
+                    if (importGroup.equals(nextGroup) /*&& previousImportFromCurrentGroup != null*/) {
                         if (separateLineBetweenGroups
                                 && !hasEmptyLineBefore(importObject.getLineNumber())) {
                             log(importObject.getLineNumber(), MSG_LINE_SEPARATOR, fullImportIdent);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -185,7 +185,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
                 "STATIC###SAME_PACKAGE(3)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
-/// TODO: revise 
+            "3: " + getCheckMessage(MSG_NONGROUP_IMPORT, "com.google.common.*"),
             "5: " + getCheckMessage(MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
             "6: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
             "7: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "java.awt.Button.ABORT"),
@@ -211,7 +211,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
                 "STATIC###SAME_PACKAGE(3)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
-/// TODO: revise 
+            "3: " + getCheckMessage(MSG_NONGROUP_IMPORT, "com.google.common.*"),
             "5: " + getCheckMessage(MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
             "6: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
             "7: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "java.awt.Button.ABORT"),
@@ -236,7 +236,6 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
                 "STATIC###STANDARD_JAVA_PACKAGE");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
-/// TODO: revise 
             "4: " + getCheckMessage(MSG_LEX, "java.io.File.createTempFile", "javax.swing.WindowConstants.*"),
             "8: " + getCheckMessage(MSG_LEX, "com.*", "com.puppycrawl.tools.*"),
         };
@@ -270,9 +269,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
                 "STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE");
         final String[] expected = {
-/// TODO: revise 
             "5: " + getCheckMessage(MSG_NONGROUP_EXPECTED, THIRD, "org.w3c.dom.Node"),
-//            "3: " + getCheckMessage(MSG_ORDER, "STANDARD_JAVA_PACKAGE"),
         };
 
         verify(checkConfig, getPath("imports" + File.separator
@@ -393,17 +390,17 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
         checkConfig.addAttribute("separateLineBetweenGroups", "false");
         checkConfig.addAttribute("customImportOrderRules",
-                "SAME_PACKAGE(2)");
+                "SAME_PACKAGE(2)###THIRD_PARTY_PACKAGE");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
-            "6: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.*"),
-            "7: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.List"),
-            "8: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.StringTokenizer"),
-            "9: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
-            "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.AbstractExecutorService"),
-            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.locks.LockSupport"),
-            "12: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.regex.Pattern"),
-            "13: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.regex.Matcher"),
+            //"6: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
+            "7: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.*"),
+            "8: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.List"),
+            "9: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.StringTokenizer"),
+            "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
+            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.AbstractExecutorService"),
+            "12: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.locks.LockSupport"),
+            "13: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.regex.Pattern"),
+            "14: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.regex.Matcher"),
             };
 
         verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
@@ -418,11 +415,11 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
         checkConfig.addAttribute("separateLineBetweenGroups", "false");
         checkConfig.addAttribute("customImportOrderRules",
-                "SAME_PACKAGE(3)");
+                "SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE");
         final String[] expected = {
-            "9: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
-            "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.AbstractExecutorService"),
-            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.locks.LockSupport"),
+            "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
+            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.AbstractExecutorService"),
+            "12: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.locks.LockSupport"),
             };
 
         verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
@@ -437,9 +434,9 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
         checkConfig.addAttribute("separateLineBetweenGroups", "false");
         checkConfig.addAttribute("customImportOrderRules",
-                "SAME_PACKAGE(4)");
+                "SAME_PACKAGE(4)###THIRD_PARTY_PACKAGE");
         final String[] expected = {
-            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.locks.LockSupport"),
+            "12: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.locks.LockSupport"),
             };
 
         verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
@@ -454,7 +451,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
         checkConfig.addAttribute("separateLineBetweenGroups", "false");
         checkConfig.addAttribute("customImportOrderRules",
-                "SAME_PACKAGE(5)");
+                "SAME_PACKAGE(5)###THIRD_PARTY_PACKAGE");
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
         verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -60,6 +60,16 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
+    public void testDefault() throws Exception { //without any property specified
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(CustomImportOrderCheck.class);
+        final String[] expected = {};
+
+        verify(checkConfig, getPath("imports" + File.separator
+                + "InputCustomImportOrder.java"), expected);
+    }
+
+    @Test
     public void testCustom() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(CustomImportOrderCheck.class);
@@ -175,6 +185,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
                 "STATIC###SAME_PACKAGE(3)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
+/// TODO: revise 
             "5: " + getCheckMessage(MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
             "6: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
             "7: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "java.awt.Button.ABORT"),
@@ -200,6 +211,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
                 "STATIC###SAME_PACKAGE(3)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
+/// TODO: revise 
             "5: " + getCheckMessage(MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
             "6: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
             "7: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "java.awt.Button.ABORT"),
@@ -224,6 +236,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
                 "STATIC###STANDARD_JAVA_PACKAGE");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
+/// TODO: revise 
             "4: " + getCheckMessage(MSG_LEX, "java.io.File.createTempFile", "javax.swing.WindowConstants.*"),
             "8: " + getCheckMessage(MSG_LEX, "com.*", "com.puppycrawl.tools.*"),
         };
@@ -257,7 +270,9 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
                 "STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE");
         final String[] expected = {
+/// TODO: revise 
             "5: " + getCheckMessage(MSG_NONGROUP_EXPECTED, THIRD, "org.w3c.dom.Node"),
+//            "3: " + getCheckMessage(MSG_ORDER, "STANDARD_JAVA_PACKAGE"),
         };
 
         verify(checkConfig, getPath("imports" + File.separator
@@ -380,14 +395,15 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
                 "SAME_PACKAGE(2)");
         final String[] expected = {
-            "7: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.*"),
-            "8: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.List"),
-            "9: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.StringTokenizer"),
-            "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
-            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.AbstractExecutorService"),
-            "12: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.locks.LockSupport"),
-            "13: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.regex.Pattern"),
-            "14: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.regex.Matcher"),
+            "5: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
+            "6: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.*"),
+            "7: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.List"),
+            "8: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.StringTokenizer"),
+            "9: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
+            "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.AbstractExecutorService"),
+            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.locks.LockSupport"),
+            "12: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.regex.Pattern"),
+            "13: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.regex.Matcher"),
             };
 
         verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
@@ -404,9 +420,9 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
                 "SAME_PACKAGE(3)");
         final String[] expected = {
-            "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
-            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.AbstractExecutorService"),
-            "12: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.locks.LockSupport"),
+            "9: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
+            "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.AbstractExecutorService"),
+            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.locks.LockSupport"),
             };
 
         verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
@@ -423,7 +439,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
                 "SAME_PACKAGE(4)");
         final String[] expected = {
-            "12: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.locks.LockSupport"),
+            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.locks.LockSupport"),
             };
 
         verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
@@ -586,5 +602,20 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         createChecker(checkConfig);
         verify(checkConfig, getPath("imports" + File.separator
                 + "InputCustomImportOrder_MultiplePatternMatches.java"), expected);
+    }
+
+    @Test
+    public void testNonGroupImportOnTop() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("customImportOrderRules",
+                "STANDARD_JAVA_PACKAGE");
+        String[] expected = {
+            "3: " + getCheckMessage(MSG_NONGROUP_IMPORT, "com.puppycrawl.tools.checkstyle.BaseCheckTestSupport"),
+        };
+
+        createChecker(checkConfig);
+        verify(checkConfig, getPath("imports" + File.separator
+                + "InputCustomImportOrder_NonGroupImportOnTop.java"), expected);
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackage.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackage.java
@@ -1,6 +1,6 @@
 //Moved to noncompilable because UT requires imports from the same package
 package java.util.concurrent;
-import com.google.common.*;
+import com.google.common.*; // warn, non-group import shoul be in the end
 import java.util.StringTokenizer;
 import java.util.*; //warn, LEX, should be before "java.util.StringTokenizer"
 import java.util.concurrent.*; //warn, ORDER, should be on SAME_PACKAGE, now NOT_ASSIGNED
@@ -18,6 +18,14 @@ public class InputCustomImportOrderSamePackage {
 test: testStaticSamePackage()
 configuration:
         checkConfig.addAttribute("thirdPartyPackageRegExp", "org.");
+        checkConfig.addAttribute("customImportOrderRules",
+                "STATIC###SAME_PACKAGE(3)");
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
+
+test: testWithoutLineSeparator()
+configuration:
+        checkConfig.addAttribute("thirdPartyPackageRegExp", "org.");
+        checkConfig.addAttribute("separateLineBetweenGroups", "false");
         checkConfig.addAttribute("customImportOrderRules",
                 "STATIC###SAME_PACKAGE(3)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackageDepth2-5.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackageDepth2-5.java
@@ -3,7 +3,6 @@ package java.util.concurrent.locks;
 // SAME_PACKAGE(3) should include #4-6
 // SAME_PACKAGE(4) should include only #6
 // SAME_PACKAGE(5) should include no imports because actual package has only 4 domains 
-import java.io.File;
 import java.util.*; //#1
 import java.util.List; //#2
 import java.util.StringTokenizer; //#3
@@ -15,3 +14,39 @@ import java.util.regex.Matcher; //#8
 
 public class InputCustomImportOrderSamePackage2 {
 }
+
+/*
+test: testSamePackageDepth2()
+configuration:
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
+        checkConfig.addAttribute("separateLineBetweenGroups", "false");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(2)");
+*/
+
+/*
+test: testSamePackageDepth3()
+configuration:
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
+        checkConfig.addAttribute("separateLineBetweenGroups", "false");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(3)");
+*/
+
+/*
+test: testSamePackageDepth4()
+configuration:
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
+        checkConfig.addAttribute("separateLineBetweenGroups", "false");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(3)");
+*/
+
+/*
+test: testSamePackageDepthLongerThenActualPackage()
+configuration:
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
+        checkConfig.addAttribute("separateLineBetweenGroups", "false");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(3)");
+*/

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackageDepth2-5.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackageDepth2-5.java
@@ -3,6 +3,7 @@ package java.util.concurrent.locks;
 // SAME_PACKAGE(3) should include #4-6
 // SAME_PACKAGE(4) should include only #6
 // SAME_PACKAGE(5) should include no imports because actual package has only 4 domains 
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import java.util.*; //#1
 import java.util.List; //#2
 import java.util.StringTokenizer; //#3
@@ -21,7 +22,7 @@ configuration:
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
         checkConfig.addAttribute("separateLineBetweenGroups", "false");
         checkConfig.addAttribute("customImportOrderRules",
-                "SAME_PACKAGE(2)");
+                "SAME_PACKAGE(2)###THIRD_PARTY_PACKAGE");
 */
 
 /*
@@ -30,7 +31,7 @@ configuration:
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
         checkConfig.addAttribute("separateLineBetweenGroups", "false");
         checkConfig.addAttribute("customImportOrderRules",
-                "SAME_PACKAGE(3)");
+                "SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE");
 */
 
 /*
@@ -39,7 +40,7 @@ configuration:
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
         checkConfig.addAttribute("separateLineBetweenGroups", "false");
         checkConfig.addAttribute("customImportOrderRules",
-                "SAME_PACKAGE(3)");
+                "SAME_PACKAGE(4)###THIRD_PARTY_PACKAGE");
 */
 
 /*
@@ -48,5 +49,5 @@ configuration:
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
         checkConfig.addAttribute("separateLineBetweenGroups", "false");
         checkConfig.addAttribute("customImportOrderRules",
-                "SAME_PACKAGE(3)");
+                "SAME_PACKAGE(5)###THIRD_PARTY_PACKAGE");
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/DOMSource.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/DOMSource.java
@@ -5,3 +5,13 @@ import javax.xml.transform.Source;
 import org.w3c.dom.Node;
 
 class DOMSource {}
+
+/*
+test: testPossibleIndexOutOfBoundsException()
+configuration:
+        checkConfig.addAttribute("thirdPartyPackageRegExp", ".*");
+        checkConfig.addAttribute("specialImportsRegExp", "com.google");
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
+        checkConfig.addAttribute("customImportOrderRules",
+                "STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE");
+*/

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder2.java
@@ -1,20 +1,28 @@
 package com.puppycrawl.tools.checkstyle.imports;
 
 import static java.io.File.createTempFile;
-import static java.awt.Button.ABORT;
+import static java.awt.Button.ABORT; //warn, LEXIC, should be before java.io.File.createTempFile
 import static javax.swing.WindowConstants.*;
 
-import java.util.List;
-import java.util.StringTokenizer;
-import java.util.*;
-import java.util.concurrent.AbstractExecutorService;
-import java.util.concurrent.*;
+import java.util.List; //warn, LEXIC, should be before javax.swing.WindowConstants.*
+import java.util.StringTokenizer; //warn, LEXIC, should be before javax.swing.WindowConstants.*
+import java.util.*; //warn, LEXIC, should be before javax.swing.WindowConstants.*
+import java.util.concurrent.AbstractExecutorService; //warn, LEXIC, should be before javax.swing.WindowConstants.*
+import java.util.concurrent.*; //warn, LEXIC, should be before javax.swing.WindowConstants.*
 
 import com.puppycrawl.tools.*;
-import com.*;
+import com.*; //warn, LEXIC, should be before com.puppycrawl.tools.*
 
-import com.google.common.base.*;
+import com.google.common.base.*; //warn, LEXIC, should be before com.puppycrawl.tools.*
 import org.junit.*;
 
 public class InputCustomImportOrder2 {
 }
+/*
+test: testOrderRuleWithOneGroup()
+configuration:
+        checkConfig.addAttribute("thirdPartyPackageRegExp", "org.");
+        checkConfig.addAttribute("customImportOrderRules",
+                "STANDARD_JAVA_PACKAGE");
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
+*/

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder_MultiplePatternMatches.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder_MultiplePatternMatches.java
@@ -1,0 +1,6 @@
+package com.puppycrawl.tools.checkstyle.imports;
+
+import org.junit.Test;
+
+public class InputCustomImportOrder_MultiplePatternMatches {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder_NonGroupImportOnTop.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder_NonGroupImportOnTop.java
@@ -1,0 +1,17 @@
+package com.puppycrawl.tools.checkstyle.imports;
+
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport; // warn, non-group import shoul be in the end
+
+import java.io.File;
+
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+
+public class InputCustomImportOrder_NonGroupImportOnTop {
+}
+
+/*
+test: testNonGroupImportOnTop()
+configuration:
+        checkConfig.addAttribute("customImportOrderRules",
+                "STANDARD_JAVA_PACKAGE");
+*/

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder_OverlappingPatterns.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder_OverlappingPatterns.java
@@ -1,0 +1,37 @@
+package com.puppycrawl.tools.checkstyle.checks.imports;
+
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderOption;
+
+// every import from javadoc package has comment in brackets indicating presence of keywords
+// Javadoc, Check, Tag. For example J_T = Javadoc, no Check, Tag
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl; //warn, should be on THIRD-PARTY (J__)
+
+// STANDARD - keyword Check
+
+import com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck; // (JC_)
+import com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck; // (_C_)
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagContinuationIndentationCheck; // (JCT)
+
+// SPECIAL_IMPORTS - keyword Tag
+
+import com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocTag; // (J_T)
+//import com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser; // (__T)
+import com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck; //warn, should be on STANDARD (_CT)
+
+import com.puppycrawl.tools.*;
+//import com.puppycrawl.tools.checkstyle.checks.javadoc.HtmlTag; //warn, should be on SPECIAL (__T)
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTag; //warn, should be on SPECIAL (J_T)
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck; //warn, should be on STANDARD  (JC_)
+import com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck; //warn, should be on STANDARD (_C_)
+
+public class InputCustomImportOrder_OverlappingPatterns {
+}
+/*
+test: testRulesOrder_ThirdBeforeSame()
+configuration:
+        checkConfig.addAttribute("customImportOrderRules",
+                "THIRD_PARTY_PACKAGE###SAME_PACKAGE(3)###SPECIAL_IMPORTS");
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
+*/

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -825,7 +825,49 @@ import java.util.regex.Matcher; //#8
         <p>
           Use the separator '###' between rules.
         </p>
-      </subsection>
+        <p>
+          To set Regexps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
+          thirdPartyPackageRegExp and standardPackageRegExp options.
+        </p>
+        <p>
+          Pretty often one import can match more than one group. For example, static import from standard
+          package or regular expressions are configured to allow one import match multiple groups.
+          In this case, group will be assigned according to priorities:
+        </p>
+        <ol>
+          <li>STATIC has top priority</li>
+          <li>SAME_PACKAGE has second priority</li>
+          <li>STANDARD_JAVA_PACKAGE and SPECIAL_IMPORTS will compete using "best match" rule: longer
+          matching substring wins; in case of the same length, lower position of matching substring
+          wins; if position is the same, order of rules in configuration solves the puzzle.</li>
+          <li>THIRD_PARTY has the least priority</li>
+        </ol>
+        <p>
+          Few examples to illustrate "best match":
+        </p>
+        <p>
+          1. patterns STANDARD_JAVA_PACKAGE = "Check", SPECIAL_IMPORTS="ImportOrderCheck" and input file:
+        </p>
+        <source>
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+        </source>
+        <p>
+          Result: imports will be assigned to SPECIAL_IMPORTS, because matching substring length is 16. Matching
+          substring for STANDARD_JAVA_PACKAGE is 5.
+        </p>
+        <p>
+          2. patterns STANDARD_JAVA_PACKAGE = "Check", SPECIAL_IMPORTS="Avoid" and file:
+        </p>
+        <source>
+import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
+        </source>
+        <p>
+          Result: import will be assigned to SPECIAL_IMPORTS. Matching substring length is 5 for both
+          patterns. However, "Avoid" position is lower then "Check" position.
+        </p>
+
+    </subsection>
 
       <subsection name="Properties">
         <table>


### PR DESCRIPTION
Reports are pending...

Difference between current solution and solution after the fix is a starting point for reviewing the list of imports is a starting point.
Both solutions show violations only when actual sorting problem exists. So no "false positive" happens in both cases. However, both solutions will return different amount of violations due to different starting point.

**Current solution** takes the very first import as a starting point. It defines "current" group based on this import and every time it see import from the group that should go before "current" group, violation is submitted. Most negative scenario: first import doesn't match any group, it is assigned to default "no group" section. As a result, only imports that cannot be assigned to defined groups on config will be treated as correctly placed and all the imports that match groups defined will receive violations.
For example
Config:
```xml
        <module name="CustomImportOrder">
            <property name="customImportOrderRules" value="SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
            <property name="specialImportsRegExp" value="^com.google"/>
            <property name="thirdPartyPackageRegExp" value="^org"/>
            <property name="sortImportsInGroupAlphabetically" value="true"/>
            <property name="separateLineBetweenGroups" value="true"/>
        </module>
```
Source:
```java
1 import com.puppycrawl.tools.checkstyle.CustomImportOrderCheck; //doesn't match any group on config
2 
3 import com.google.common.annotations.Beta;
4 import com.google.common.annotations.GwtCompatible;
5
6 import org.androidannotations.helper.ModelConstants.generationSuffix;
7 
8 import java.io.Serializable;
9 import java.util.Iterator;
10 import java.util.Set;
11
12 import javax.annotation.Nullable;
13
14 import com.puppycrawl.tools.checkstyle.ImportOrderCheck; //doesn't match any group on config
15 import net.sourceforge.pmd.lang.ast.Node; //doesn't match any group on config
```
Result (all imports except of 1,14,15 have violations)
```
Starting audit...
test.java:3: warning: Import statement is in the wrong order. Should be in the 'SPECIAL_IMPORTS' group.
test.java:4: warning: Import statement is in the wrong order. Should be in the 'SPECIAL_IMPORTS' group.
test.java:6: warning: Import statement is in the wrong order. Should be in the 'THIRD_PARTY_PACKAGE' group.
test.java:8: warning: Import statement is in the wrong order. Should be in the 'STANDARD_JAVA_PACKAGE' group.
test.java:9: warning: Import statement is in the wrong order. Should be in the 'STANDARD_JAVA_PACKAGE' group.
test.java:10: warning: Import statement is in the wrong order. Should be in the 'STANDARD_JAVA_PACKAGE' group.
test.java:12: warning: Import statement is in the wrong order. Should be in the 'STANDARD_JAVA_PACKAGE' group.
Audit done.
```

**Fixed solution** takes first group with imports from configuration as a starting point. All the imports from another groups that go before import from first group will receive violation.
Most negative scenario: when first group on configuration has the only import placed in the end of all imports.
Source
```java
1 import com.puppycrawl.tools.checkstyle.ImportOrderCheck;
2
3 import org.androidannotations.helper.ModelConstants.generationSuffix;
4 
5 import java.io.Serializable;
6 import java.util.Iterator;
7 import java.util.Set;
8 
9 import javax.annotation.Nullable;
10
11 import com.puppycrawl.tools.checkstyle.ImportOrderCheck;
12 import net.sourceforge.pmd.lang.ast.Node; 
13
14 import com.google.common.annotations.Beta;
15 import com.google.common.annotations.GwtCompatible;
```
Result
```
Starting audit...
test.java:1: warning: Imports without groups should be placed at the end of the import list.
test.java:3: warning: Import statement is in the wrong order. Should be in the 'THIRD_PARTY_PACKAGE' group.
test.java:5: warning: Import statement is in the wrong order. Should be in the 'STANDARD_JAVA_PACKAGE' group.
test.java:6: warning: Import statement is in the wrong order. Should be in the 'STANDARD_JAVA_PACKAGE' group.
test.java:7: warning: Import statement is in the wrong order. Should be in the 'STANDARD_JAVA_PACKAGE' group.
test.java:9: warning: Import statement is in the wrong order. Should be in the 'STANDARD_JAVA_PACKAGE' group.
test.java:11: warning: Imports without groups should be placed at the end of the import list.
test.java:12: warning: Imports without groups should be placed at the end of the import list.
Audit done.
```