### PR TITLE
Fix RightCurlyCheck with same option not to rise expression in single…

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyRightCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyRightCurlyTest.java
@@ -112,4 +112,17 @@ public class LeftCurlyRightCurlyTest extends BaseCheckTestSupport {
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(newCheckConfig, filePath, expected, warnList);
     }
+
+    @Test
+    public void rightCurlyTestSame() throws Exception {
+        DefaultConfiguration newCheckConfig = createCheckConfig(RightCurlyCheck.class);
+        newCheckConfig.addAttribute("option", RightCurlyOption.SAME.toString());
+
+        final String[] expected = {
+        };
+
+        String filePath = builder.getFilePath("RightCurlyInputSame");
+        Integer[] warnList = builder.getLinesWithWarn(filePath);
+        verify(newCheckConfig, filePath, expected, warnList);
+    }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyInputSame.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyInputSame.java
@@ -1,0 +1,9 @@
+package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
+
+public class RightCurlyInputSame {
+    public static void main(String[] args) {
+        boolean after = false;
+        try {
+        } finally { after = true; }
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -76,6 +76,7 @@ import com.puppycrawl.tools.checkstyle.checks.CheckUtils;
  * @author o_sukhodolsky
  * @author maxvetrenko
  * @author Andrei Selkin
+ * @author <a href="mailto:piotr.listkiewicz@gmail.com">liscju</a>
  */
 public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
     /**
@@ -192,7 +193,8 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
         String violation = "";
 
         if (bracePolicy == RightCurlyOption.SAME
-                && !hasLineBreakBefore(rcurly)) {
+                && !hasLineBreakBefore(rcurly)
+                && lcurly.getLineNo() != rcurly.getLineNo()) {
             violation = MSG_KEY_LINE_BREAK_BEFORE;
         }
         else if (shouldCheckLastRcurly) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -46,7 +46,6 @@ public class RightCurlyCheckTest extends BaseCheckTestSupport {
             "40:13: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 13),
             "44:13: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 13),
             "93:27: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 27),
-            "97:54: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 54),
         };
         verify(checkConfig, getPath("InputLeftCurlyOther.java"), expected);
     }
@@ -60,9 +59,16 @@ public class RightCurlyCheckTest extends BaseCheckTestSupport {
             "40:13: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 13),
             "44:13: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 13),
             "93:27: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 27),
-            "97:54: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 54),
         };
         verify(checkConfig, getPath("InputLeftCurlyOther.java"), expected);
+    }
+
+    @Test
+    public void testSameOmitOneLiners() throws Exception {
+        checkConfig.addAttribute("option", RightCurlyOption.SAME.toString());
+        final String[] expected = {
+        };
+        verify(checkConfig, getPath("InputRightCurlySameForOneLiners.java"), expected);
     }
 
     @Test
@@ -125,10 +131,6 @@ public class RightCurlyCheckTest extends BaseCheckTestSupport {
     @Test
     public void testForceLineBreakBefore2() throws Exception {
         final String[] expected = {
-            "24:33: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 33),
-            "32:44: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 44),
-            "32:63: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 63),
-            "52:48: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 48),
         };
         verify(checkConfig, getPath("InputRightCurlyLineBreakBefore.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputRightCurlySameForOneLiners.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputRightCurlySameForOneLiners.java
@@ -1,0 +1,18 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for checkstyle.
+// Created: 2015
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle;
+
+/**
+ * Test case for RightCurly with option SAME to omit oneliners
+ * @see https://github.com/checkstyle/checkstyle/issues/1416
+ * @author <a href="mailto:piotr.listkiewicz@gmail.com">liscju</a>
+ */
+public class InputRightCurlySameForOneLiners {
+    public static void main(String[] args) {
+        boolean after = false;
+        try {
+        } finally { after = true; }
+    }
+}


### PR DESCRIPTION
…-line blocks - issue #1416 
Add additional guard to not raise error when block is in single line, removed test which test old behaviour of one line block(raising error)