### PR TITLE
Fix JavadocTypeCheck not checking inner classes, fix issue #1421

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -184,13 +184,15 @@ public class JavadocTypeCheck
             if (cmt == null) {
                 log(lineNo, JAVADOC_MISSING);
             }
-            else if (ScopeUtils.isOuterMostType(ast)) {
-                // don't check author/version for inner classes
+            else {
                 final List<JavadocTag> tags = getJavadocTags(cmt);
-                checkTag(lineNo, tags, JavadocTagInfo.AUTHOR.getName(),
-                         authorFormatPattern, authorFormat);
-                checkTag(lineNo, tags, JavadocTagInfo.VERSION.getName(),
-                         versionFormatPattern, versionFormat);
+                if (ScopeUtils.isOuterMostType(ast)) {
+                    // don't check author/version for inner classes
+                    checkTag(lineNo, tags, JavadocTagInfo.AUTHOR.getName(),
+                            authorFormatPattern, authorFormat);
+                    checkTag(lineNo, tags, JavadocTagInfo.VERSION.getName(),
+                            versionFormatPattern, versionFormat);
+                }
 
                 final List<String> typeParamNames =
                     CheckUtils.getTypeParameterNames(ast);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -324,6 +324,17 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
+    public void testTypeParametersInInnerClass() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(JavadocTypeCheck.class);
+        final String[] expected = {
+            "13:8: " + getCheckMessage(UNUSED_TAG, "@param", "<C>"),
+            "15: " + getCheckMessage(MISSING_TAG, "@param <B>"),
+        };
+        verify(checkConfig, getPath("InputTypeParamsTagsInnerClass.java"), expected);
+    }
+
+    @Test
     public void testAllowMissingTypeParameters() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocTypeCheck.class);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputTypeParamsTagsInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputTypeParamsTagsInnerClass.java
@@ -1,0 +1,17 @@
+package com.puppycrawl.tools.checkstyle;
+
+/**
+ * Some explanation.
+ * @author Nobody
+ * @version 1.0
+ */
+public class InputTypeParamsTagsInnerClass {
+
+    /**
+     * Example inner class.
+     * @param <A> documented parameter
+     * @param <C> extra parameter
+     */
+    public static class InnerClass<A,B> {
+    }
+}


### PR DESCRIPTION
Problem was that JavadocTypeCheck was only checking class when was the most outer type in file, now is checking inner classes as well, but for them is not checking for javadoc version and author params (because for them they are not appropriate).