### PR TITLE
Remove dead code from ObjectBlockHandler in Indentation check. #1270

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1152,7 +1152,7 @@
             <regex><pattern>.*.checks.indentation.ElseHandler</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.indentation.AbstractExpressionHandler</pattern><branchRate>91</branchRate><lineRate>97</lineRate></regex>
             <regex><pattern>.*.checks.indentation.MethodCallLineWrapHandler</pattern><branchRate>0</branchRate><lineRate>0</lineRate></regex>
-            <regex><pattern>.*.checks.indentation.ObjectBlockHandler</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>
+            <regex><pattern>.*.checks.indentation.MethodDefHandler</pattern><branchRate>87</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.indentation.SynchronizedHandler</pattern><branchRate>100</branchRate><lineRate>100</lineRate></regex>
 
             <regex><pattern>.*.checks.javadoc.AbstractJavadocCheck</pattern><branchRate>90</branchRate><lineRate>93</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
@@ -89,21 +89,13 @@ public class ObjectBlockHandler extends BlockParentHandler {
     }
 
     @Override
-    protected boolean rcurlyMustStart() {
-        return false;
-    }
-
-    @Override
     protected void checkRCurly() {
-        final DetailAST lcurly = getLCurly();
         final DetailAST rcurly = getRCurly();
         final int rcurlyPos = expandedTabsColumnNo(rcurly);
         final IndentLevel level = curlyLevel();
         level.addAcceptedIndent(level.getFirstIndentLevel() + getLineWrappingIndent());
 
-        if (!level.accept(rcurlyPos)
-            && (rcurlyMustStart() || startsLine(rcurly))
-                && !areOnSameLine(rcurly, lcurly)) {
+        if (!level.accept(rcurlyPos) && startsLine(rcurly)) {
             logError(rcurly, "rcurly", rcurlyPos, curlyLevel());
         }
     }


### PR DESCRIPTION
Reports are identical:
```
--- target/checkstyle-result.xml
+++ target-6.8.1/checkstyle-result.xml
@@ -2 +2 @@
-<checkstyle version="6.9-SNAPSHOT">
+<checkstyle version="6.8.1">
```