### PR TITLE
Remove dead code from ArrayInitHandler in Indentation check. #1270

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1152,7 +1152,6 @@
 
             <regex><pattern>.*.checks.imports.CustomImportOrderCheck</pattern><branchRate>98</branchRate><lineRate>100</lineRate></regex>
 
-            <regex><pattern>.*.checks.indentation.ArrayInitHandler</pattern><branchRate>87</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.indentation.ElseHandler</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.indentation.AbstractExpressionHandler</pattern><branchRate>91</branchRate><lineRate>97</lineRate></regex>
             <regex><pattern>.*.checks.indentation.HandlerFactory</pattern><branchRate>81</branchRate><lineRate>100</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
@@ -99,14 +99,12 @@ public class ArrayInitHandler extends BlockParentHandler {
                     getIndentCheck().getLineWrappingIndentation());
 
         final int firstLine = getFirstLine(Integer.MAX_VALUE, getListChild());
-        if (hasCurlys() && firstLine == getLCurly().getLineNo()) {
-            final int lcurlyPos = expandedTabsColumnNo(getLCurly());
-            final int firstChildPos =
-                getNextFirstNonblankOnLineAfter(firstLine, lcurlyPos);
-            if (firstChildPos >= 0) {
-                expectedIndent.addAcceptedIndent(firstChildPos);
-                expectedIndent.addAcceptedIndent(lcurlyPos + getLineWrappingIndent());
-            }
+        final int lcurlyPos = expandedTabsColumnNo(getLCurly());
+        final int firstChildPos =
+            getNextFirstNonblankOnLineAfter(firstLine, lcurlyPos);
+        if (firstChildPos >= 0) {
+            expectedIndent.addAcceptedIndent(firstChildPos);
+            expectedIndent.addAcceptedIndent(lcurlyPos + getLineWrappingIndent());
         }
         return expectedIndent;
     }


### PR DESCRIPTION
Reports are identical:
```
diff target/checkstyle-result.xml target-6.8.1/checkstyle-result.xml -U 0
--- target/checkstyle-result.xml
+++ target-6.8.1/checkstyle-result.xml
@@ -2 +2 @@
-<checkstyle version="6.9-SNAPSHOT">
+<checkstyle version="6.8.1">
```