### PR TITLE
Coverage has been increased to 100% in AnnotationUseStyleCheck. Issue #908

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1105,10 +1105,6 @@
             <regex><pattern>.*.checks.UniquePropertiesCheck\$.*</pattern><branchRate>75</branchRate><lineRate>90</lineRate></regex>
 
 
-            <regex><pattern>.*.checks.annotation.AnnotationUseStyleCheck</pattern><branchRate>93</branchRate><lineRate>96</lineRate></regex>
-            <regex><pattern>.*.checks.annotation.SuppressWarningsCheck</pattern><branchRate>79</branchRate><lineRate>96</lineRate></regex>
-
-
             <regex><pattern>.*.checks.blocks.EmptyBlockCheck</pattern><branchRate>88</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.blocks.LeftCurlyCheck</pattern><branchRate>89</branchRate><lineRate>96</lineRate></regex>
             <regex><pattern>.*.checks.blocks.NeedBracesCheck</pattern><branchRate>80</branchRate><lineRate>97</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -258,19 +258,25 @@ public final class AnnotationUseStyleCheck extends Check {
      * @param annotation the annotation token
      */
     private void checkStyleType(final DetailAST annotation) {
-        if (ElementStyle.IGNORE == this.style
-            || this.style == null) {
-            return;
-        }
 
-        if (ElementStyle.COMPACT_NO_ARRAY == this.style) {
-            this.checkCompactNoArrayStyle(annotation);
-        }
-        else if (ElementStyle.COMPACT == this.style) {
-            this.checkCompactStyle(annotation);
-        }
-        else if (ElementStyle.EXPANDED == this.style) {
-            this.checkExpandedStyle(annotation);
+        switch (this.style) {
+
+            case COMPACT_NO_ARRAY: {
+                checkCompactNoArrayStyle(annotation);
+                break;
+            }
+
+            case COMPACT: {
+                checkCompactStyle(annotation);
+                break;
+            }
+
+            case EXPANDED: {
+                checkExpandedStyle(annotation);
+                break;
+            }
+            default:
+                break;
         }
     }
 
@@ -356,8 +362,7 @@ public final class AnnotationUseStyleCheck extends Check {
      * @param annotation the annotation token
      */
     private void checkTrailingComma(final DetailAST annotation) {
-        if (TrailingArrayComma.IGNORE == this.comma
-            || this.comma == null) {
+        if (TrailingArrayComma.IGNORE == this.comma) {
             return;
         }
 
@@ -413,8 +418,7 @@ public final class AnnotationUseStyleCheck extends Check {
      * @param ast the annotation token
      */
     private void checkCheckClosingParens(final DetailAST ast) {
-        if (ClosingParens.IGNORE == this.parens
-            || this.parens == null) {
+        if (ClosingParens.IGNORE == this.parens) {
             return;
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleTest.java
@@ -27,10 +27,14 @@ import static com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseSty
 
 import java.io.File;
 
+import org.apache.commons.beanutils.ConversionException;
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
 
 public class AnnotationUseStyleTest extends BaseCheckTestSupport {
     /**
@@ -211,4 +215,41 @@ public class AnnotationUseStyleTest extends BaseCheckTestSupport {
 
         verify(checkConfig, getPath("annotation" + File.separator + "AnnotationsUseStyleParams.java"), expected);
     }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        AnnotationUseStyleCheck constantNameCheckObj = new AnnotationUseStyleCheck();
+        int[] actual = constantNameCheckObj.getAcceptableTokens();
+        int[] expected = new int[] {TokenTypes.ANNOTATION };
+        Assert.assertNotNull(actual);
+        Assert.assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetOption() throws Exception {
+        AnnotationUseStyleCheck check = new AnnotationUseStyleCheck();
+        try {
+            check.setElementStyle("SHOULD_PRODUCE_ERROR");
+        }
+        catch (ConversionException ex) {
+            ex.getMessage().startsWith("unable to parse");
+            return;
+        }
+
+        Assert.fail();
+    }
+
+    @Test
+    public void testStyleNotInList() throws Exception {
+        DefaultConfiguration checkConfig = createCheckConfig(AnnotationUseStyleCheck.class);
+        checkConfig.addAttribute("closingParens", "ignore");
+        checkConfig.addAttribute("elementStyle", "COMPACT_NO_ARRAY");
+        checkConfig.addAttribute("trailingArrayComma", "ignore");
+        final String[] expected = {
+        };
+
+        verify(checkConfig, getPath("annotation" + File.separator + "InputAnnotationUseStyleCheckTest.java"), expected);
+
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/annotation/InputAnnotationUseStyleCheckTest.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/annotation/InputAnnotationUseStyleCheckTest.java
@@ -1,0 +1,12 @@
+package com.puppycrawl.tools.checkstyle.annotation;
+
+
+@interface SomeArrays32 {
+    @Another32(value={"foo", "bar"}) //expanded
+    DOGS[] pooches();
+}
+
+
+@interface Another32 {
+    String[] value();
+}


### PR DESCRIPTION
Report before changes: http://sabaka.github.io/AnnotationUseStyle/master/checkstyle.html
Report after changes: http://sabaka.github.io/AnnotationUseStyle/checkstyle.html

Tester config: https://github.com/sabaka/contribution/blob/master/checkstyle-tester/projects-to-test-on.properties