### PR TITLE
 LeftCurlyCheck have hidden option, issue #975 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1113,7 +1113,7 @@
 
 
             <regex><pattern>.*.checks.blocks.EmptyBlockCheck</pattern><branchRate>88</branchRate><lineRate>100</lineRate></regex>
-            <regex><pattern>.*.checks.blocks.LeftCurlyCheck</pattern><branchRate>87</branchRate><lineRate>94</lineRate></regex>
+            <regex><pattern>.*.checks.blocks.LeftCurlyCheck</pattern><branchRate>89</branchRate><lineRate>96</lineRate></regex>
             <regex><pattern>.*.checks.blocks.NeedBracesCheck</pattern><branchRate>80</branchRate><lineRate>97</lineRate></regex>
             <regex><pattern>.*.checks.blocks.RightCurlyCheck</pattern><branchRate>88</branchRate><lineRate>95</lineRate></regex>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -118,6 +118,14 @@ public class LeftCurlyCheck
         this.maxLineLength = maxLineLength;
     }
 
+    /**
+     * Sets whether check should ignore enums when left curly brace policy is EOL.
+     * @param ignoreEnums check's option for ignoring enums.
+     */
+    public void setIgnoreEnums(boolean ignoreEnums) {
+        this.ignoreEnums = ignoreEnums;
+    }
+
     @Override
     public int[] getDefaultTokens() {
         return new int[] {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -223,4 +223,23 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
         };
         verify(checkConfig, getPath("InputLeftCurlyLineBreakAfter.java"), expected);
     }
+
+    @Test
+    public void testIgnoreEnumsOptionTrue() throws Exception {
+        checkConfig.addAttribute("option", LeftCurlyOption.EOL.toString());
+        checkConfig.addAttribute("ignoreEnums", "true");
+        final String[] expectedWhileTrue = {
+        };
+        verify(checkConfig, getPath("InputLeftCurlyEnums.java"), expectedWhileTrue);
+    }
+
+    @Test
+    public void testIgnoreEnumsOptionFalse() throws Exception {
+        checkConfig.addAttribute("option", LeftCurlyOption.EOL.toString());
+        checkConfig.addAttribute("ignoreEnums", "false");
+        final String[] expectedWhileFalse = {
+            "4:17: " + getCheckMessage(MSG_KEY_LINE_BREAK_AFTER, "{"),
+        };
+        verify(checkConfig, getPath("InputLeftCurlyEnums.java"), expectedWhileFalse);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputLeftCurlyEnums.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputLeftCurlyEnums.java
@@ -1,0 +1,16 @@
+package com.puppycrawl.tools.checkstyle;
+
+public class InputLeftCurlyEnums {
+    enum Colors {RED,
+        BLUE,
+        GREEN
+    }
+
+    enum Languages {
+        JAVA,
+        PHP,
+        SCALA,
+        C,
+        PASCAL
+    }
+}

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -250,7 +250,7 @@ try {
           </tr>
           <tr>
             <td>ignoreEnums</td>
-            <td>If true, Check will ignore enums</td>
+            <td>If true, Check will ignore enums when left curly brace policy is EOL</td>
             <td><a href="property_types.html#boolean">boolean</a></td>
             <td>true</td>
           </tr>


### PR DESCRIPTION
Added setter for ```ignoreEnums```, updated javadoc/xdoc and provided tests for option.