### PR TITLE
Import which produces error on MacOSX jdk has been deleted

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderThirdPartyPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderThirdPartyPackage.java
@@ -1,6 +1,5 @@
 package com.puppycrawl.tools.checkstyle.imports;
 
-import org.antlr.v4.*;
 
 import org.junit.*;
 


### PR DESCRIPTION
mvn cobertura:check passed, so it was not required