### PR TITLE
Remove dead code from JavadocType check. #1308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1144,7 +1144,6 @@
             <regex><pattern>.*.checks.javadoc.JavadocMethodCheck</pattern><branchRate>91</branchRate><lineRate>98</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocParagraphCheck</pattern><branchRate>92</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocStyleCheck</pattern><branchRate>89</branchRate><lineRate>98</lineRate></regex>
-            <regex><pattern>.*.checks.javadoc.JavadocTypeCheck</pattern><branchRate>95</branchRate><lineRate>93</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocUtils</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.TagParser</pattern><branchRate>92</branchRate><lineRate>98</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.WriteTagCheck</pattern><branchRate>100</branchRate><lineRate>91</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -295,7 +295,6 @@ public class JavadocTypeCheck
         for (int i = tags.size() - 1; i >= 0; i--) {
             final JavadocTag tag = tags.get(i);
             if (tag.isParamTag()
-                && tag.getArg1() != null
                 && tag.getArg1().indexOf("<" + typeParamName + ">") == 0) {
                 found = true;
             }
@@ -319,28 +318,14 @@ public class JavadocTypeCheck
             final JavadocTag tag = tags.get(i);
             if (tag.isParamTag()) {
 
-                if (tag.getArg1() != null) {
-
-                    final Matcher matcher = pattern.matcher(tag.getArg1());
-                    String typeParamName = null;
-
-                    if (matcher.matches()) {
-                        typeParamName = matcher.group(1).trim();
-                        if (!typeParamNames.contains(typeParamName)) {
-                            log(tag.getLineNo(), tag.getColumnNo(),
-                                UNUSED_TAG,
-                                JavadocTagInfo.PARAM.getText(),
-                                "<" + typeParamName + ">");
-                        }
-                    }
-                    else {
-                        log(tag.getLineNo(), tag.getColumnNo(),
-                            UNUSED_TAG_GENERAL);
-                    }
-                }
-                else {
+                final Matcher matcher = pattern.matcher(tag.getArg1());
+                matcher.find();
+                final String typeParamName = matcher.group(1).trim();
+                if (!typeParamNames.contains(typeParamName)) {
                     log(tag.getLineNo(), tag.getColumnNo(),
-                        UNUSED_TAG_GENERAL);
+                        UNUSED_TAG,
+                        JavadocTagInfo.PARAM.getText(),
+                        "<" + typeParamName + ">");
                 }
             }
         }


### PR DESCRIPTION
Reports after and before changes are exactly the same:
```
diff pre/checkstyle-result.xml post/checkstyle-result.xml
Files are the same.
```

I couldn't compare to 6.8.1, as there were functional changes introduced recently to this check that cause differences in reports.