### PR TITLE
Add tests and refactor TagParser for JavadocStyle check. #1308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1145,7 +1145,6 @@
             <regex><pattern>.*.checks.javadoc.JavadocParagraphCheck</pattern><branchRate>92</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocStyleCheck</pattern><branchRate>89</branchRate><lineRate>98</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocUtils</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
-            <regex><pattern>.*.checks.javadoc.TagParser</pattern><branchRate>92</branchRate><lineRate>98</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.WriteTagCheck</pattern><branchRate>100</branchRate><lineRate>91</lineRate></regex>
 
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
@@ -113,7 +113,7 @@ class TagParser {
                         incompleteTag ? "" : getTagId(text, position);
                 // is this closed tag
                 final boolean closedTag =
-                        endTag.getLineNo() < nLines && endTag.getColumnNo() > 0
+                        endTag.getLineNo() < nLines
                          && text[endTag.getLineNo()]
                          .charAt(endTag.getColumnNo() - 1) == '/';
                 // add new tag
@@ -143,7 +143,6 @@ class TagParser {
         //identifier but is valid for generics
         return column < text.length()
                 && (Character.isJavaIdentifierStart(text.charAt(column))
-                    || Character.isJavaIdentifierPart(text.charAt(column))
                     || text.charAt(column) == '/')
                 || column >= text.length();
     }
@@ -199,8 +198,7 @@ class TagParser {
     private static Point skipHtmlComment(String[] text, Point from) {
         Point to = from;
         to = findChar(text, '>', to);
-        while (to.getLineNo() < text.length
-               && !text[to.getLineNo()]
+        while (!text[to.getLineNo()]
                .substring(0, to.getColumnNo() + 1).endsWith("-->")) {
             to = findChar(text, '>', getNextCharPos(text, to));
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputJavadocStyleCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputJavadocStyleCheck.java
@@ -347,4 +347,13 @@ public class InputJavadocStyleCheck
             
         } 
 
+        /**
+         * Link to some page in two lines.
+         * <a
+         * href="someLink"/>
+         */
+        void tagInTwoLines() {
+            
+        } 
+
 }


### PR DESCRIPTION
Reports are identical:
```
diff 6.8.1/checkstyle-result.xml 6.9/checkstyle-result.xml -U 0
--- 6.8.1/checkstyle-result.xml
+++ 6.9/checkstyle-result.xml
@@ -2 +2 @@
-<checkstyle version="6.8.1">
+<checkstyle version="6.9-SNAPSHOT">
```

Config used:
```xml
      <module name="JavadocStyle">
        <property name="scope" value="private"/>
        <property name="excludeScope" value="package"/>
        <property name="endOfSentenceFormat" value="\."/>
        <property name="checkEmptyJavadoc" value="true"/>
      </module>
```