### PR TITLE
Refactor and add test cases to JavadocParagraph check. #1308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1142,7 +1142,6 @@
             <regex><pattern>.*.checks.javadoc.AbstractJavadocCheck\$.*</pattern><branchRate>50</branchRate><lineRate>68</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.AtclauseOrderCheck</pattern><branchRate>88</branchRate><lineRate>88</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocMethodCheck</pattern><branchRate>91</branchRate><lineRate>98</lineRate></regex>
-            <regex><pattern>.*.checks.javadoc.JavadocParagraphCheck</pattern><branchRate>92</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocStyleCheck</pattern><branchRate>89</branchRate><lineRate>98</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocUtils</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.TagParser</pattern><branchRate>92</branchRate><lineRate>98</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -137,9 +137,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      */
     private void checkEmptyLine(DetailNode newline) {
         final DetailNode nearestToken = getNearestNode(newline);
-        if (!isLastEmptyLine(newline) && nearestToken != null
-                && nearestToken.getType() == JavadocTokenTypes.TEXT
-                && nearestToken.getChildren().length > 1) {
+        if (!isLastEmptyLine(newline) && nearestToken.getChildren().length > 1) {
             log(newline.getLineNumber(), MSG_TAG_AFTER);
         }
     }
@@ -168,8 +166,8 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      */
     private static DetailNode getNearestNode(DetailNode node) {
         DetailNode tag = JavadocUtils.getNextSibling(node);
-        while (tag != null && (tag.getType() == JavadocTokenTypes.LEADING_ASTERISK
-                || tag.getType() == JavadocTokenTypes.NEWLINE)) {
+        while (tag.getType() == JavadocTokenTypes.LEADING_ASTERISK
+                || tag.getType() == JavadocTokenTypes.NEWLINE) {
             tag = JavadocUtils.getNextSibling(tag);
         }
         return tag;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
@@ -83,6 +83,8 @@ public class JavadocParagraphCheckTest extends BaseCheckTestSupport {
             "72: " + getCheckMessage(MSG_MISPLACED_TAG),
             "75: " + getCheckMessage(MSG_MISPLACED_TAG),
             "75: " + getCheckMessage(MSG_LINE_BEFORE),
+            "81: " + getCheckMessage(MSG_TAG_AFTER),
+            "82: " + getCheckMessage(MSG_TAG_AFTER),
         };
         verify(checkConfig, getPath("javadoc/InputIncorrectJavaDocParagraphCheck.java"), expected);
     }
@@ -108,6 +110,8 @@ public class JavadocParagraphCheckTest extends BaseCheckTestSupport {
             "62: " + getCheckMessage(MSG_TAG_AFTER),
             "70: " + getCheckMessage(MSG_LINE_BEFORE),
             "75: " + getCheckMessage(MSG_LINE_BEFORE),
+            "81: " + getCheckMessage(MSG_TAG_AFTER),
+            "82: " + getCheckMessage(MSG_TAG_AFTER),
         };
         verify(checkConfig, getPath("javadoc/InputIncorrectJavaDocParagraphCheck.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputCorrectJavaDocParagraphCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputCorrectJavaDocParagraphCheck.java
@@ -77,8 +77,8 @@ class InputCorrectJavaDocParagraphCheck {
          */
         public static final byte NUL = 0;
            
-        /**
-         * Some Javadoc.
+        /** 
+         * Some Javadoc with space at the end of first line.
          *
          * <p>Some Javadoc.
          *

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputIncorrectJavaDocParagraphCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputIncorrectJavaDocParagraphCheck.java
@@ -75,5 +75,13 @@ class InputInCorrectJavaDocParagraphCheck {
          *     Documentation about <p> GWT emulated source</a> //WARN
          */
         boolean emulated() {return false;}
+
+        /**
+         * Double newline.
+         *
+         *
+         * Some Javadoc. //DOUBLE WARN AT TWO PREVIOUS LINES
+         */
+         void doubleNewline() {}
     };
 }


### PR DESCRIPTION
Reports are the same:
```
diff pre/checkstyle-result.xml post/checkstyle-result.xml -U 0
Files are the same.
```

I couldn't compare to 6.8.1 as there were functional changes introduced to that check recently.