### PR TITLE
Marked maxLineLength as '@Deprecated' at LeftCurlyCheck, issue #965.

### DIFF
--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -97,4 +97,10 @@
       </Or>
       <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
     </Match>
+    <Match>
+        <!-- maxLineLength is deprecated since 6.10 release -->
+        <Class name="com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck" />
+        <Field name="maxLineLength" />
+        <Bug pattern="URF_UNREAD_FIELD" />
+    </Match>
 </FindBugsFilter>

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -169,6 +169,13 @@
     </properties>
   </rule>
 
+  <rule ref="rulesets/java/design.xml/SingularField">
+    <properties>
+      <!-- maxLineLength is deprecated since 6.10 release -->
+      <property name="violationSuppressRegex" value="^Perhaps 'maxLineLength' could be replaced by a local variable.$"/>
+    </properties>
+  </rule>
+
   <rule ref="rulesets/java/empty.xml"/>
   <rule ref="rulesets/java/finalizers.xml"/>
   <rule ref="rulesets/java/imports.xml"/>
@@ -250,4 +257,11 @@
   <rule ref="rulesets/java/typeresolution.xml"/>
   <rule ref="rulesets/java/unnecessary.xml"/>
   <rule ref="rulesets/java/unusedcode.xml"/>
+
+  <rule ref="rulesets/java/unusedcode.xml/UnusedPrivateField">
+    <properties>
+      <!-- maxLineLength is deprecated since 6.10 release -->
+      <property name="violationSuppressRegex" value="^Avoid unused private fields such as 'maxLineLength'.$"/>
+    </properties>
+  </rule>
 </ruleset>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -93,10 +93,18 @@ public class LeftCurlyCheck
      */
     public static final String MSG_KEY_LINE_BREAK_AFTER = "line.break.after";
 
-    /** default maximum line length */
+    /**
+     * Default maximum line length.
+     * @deprecated since 6.10 release, option maxLineLength is not required for the Check.
+     */
+    @Deprecated
     private static final int DEFAULT_MAX_LINE_LENGTH = 80;
 
-    /** maxLineLength **/
+    /**
+     * Maximum line length.
+     * @deprecated since 6.10 release, option is not required for the Check.
+     */
+    @Deprecated
     private int maxLineLength = DEFAULT_MAX_LINE_LENGTH;
 
     /** If true, Check will ignore enums*/
@@ -113,7 +121,9 @@ public class LeftCurlyCheck
      * Sets the maximum line length used in calculating the placement of the
      * left curly brace.
      * @param maxLineLength the max allowed line length
+     * @deprecated since 6.10 release, option is not required for the Check.
      */
+    @Deprecated
     public void setMaxLineLength(int maxLineLength) {
         this.maxLineLength = maxLineLength;
     }
@@ -290,13 +300,6 @@ public class LeftCurlyCheck
                              final DetailAST startToken) {
         final String braceLine = getLine(brace.getLineNo() - 1);
 
-        // calculate the previous line length without trailing whitespace. Need
-        // to handle the case where there is no previous line, cause the line
-        // being check is the first line in the file.
-        final int prevLineLen = brace.getLineNo() == 1
-            ? maxLineLength
-            : Utils.lengthMinusTrailingWhitespace(getLine(brace.getLineNo() - 2));
-
         // Check for being told to ignore, or have '{}' which is a special case
         if (braceLine.length() <= brace.getColumnNo() + 1
                 || braceLine.charAt(brace.getColumnNo() + 1) != '}') {
@@ -307,11 +310,11 @@ public class LeftCurlyCheck
             }
             else if (getAbstractOption() == LeftCurlyOption.EOL) {
 
-                validateEol(brace, braceLine, prevLineLen);
+                validateEol(brace, braceLine);
             }
             else if (startToken.getLineNo() != brace.getLineNo()) {
 
-                validateNewLinePosion(brace, startToken, braceLine, prevLineLen);
+                validateNewLinePosion(brace, startToken, braceLine);
 
             }
         }
@@ -321,11 +324,9 @@ public class LeftCurlyCheck
      * validate EOL case
      * @param brace brase AST
      * @param braceLine line content
-     * @param prevLineLen previous line length
      */
-    private void validateEol(DetailAST brace, String braceLine, int prevLineLen) {
-        if (Utils.whitespaceBefore(brace.getColumnNo(), braceLine)
-            && prevLineLen + 2 <= maxLineLength) {
+    private void validateEol(DetailAST brace, String braceLine) {
+        if (Utils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
             log(brace, MSG_KEY_LINE_PREVIOUS, "{", brace.getColumnNo() + 1);
         }
         if (!hasLineBreakAfter(brace)) {
@@ -338,16 +339,15 @@ public class LeftCurlyCheck
      * @param brace brace AST
      * @param startToken start Token
      * @param braceLine content of line with Brace
-     * @param prevLineLen previous Line length
      */
     private void validateNewLinePosion(DetailAST brace, DetailAST startToken,
-                                       String braceLine, int prevLineLen) {
+                                       String braceLine) {
         // not on the same line
         if (startToken.getLineNo() + 1 == brace.getLineNo()) {
             if (!Utils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
                 log(brace, MSG_KEY_LINE_NEW, "{", brace.getColumnNo() + 1);
             }
-            else if (prevLineLen + 2 <= maxLineLength) {
+            else {
                 log(brace, MSG_KEY_LINE_PREVIOUS, "{", brace.getColumnNo() + 1);
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyOption.java
@@ -37,9 +37,9 @@ public enum LeftCurlyOption {
 
     /**
      * Represents the policy that if the brace will fit on the first line of
-     * the statement, taking into account maximum line length, then apply
-     * {@code EOL} rule. Otherwise apply the {@code NL}
-     * rule. {@code NLOW} is a mnemonic for "new line on wrap".
+     * the statement, then apply <code>EOL</code> rule.
+     * Otherwise apply the <code>NL</code> rule.
+     * <code>NLOW</code> is a mnemonic for "new line on wrap".
      *
      * <p> For the example above Checkstyle will enforce:
      *

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -90,13 +90,17 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
             "12:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
             "17:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "24:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "27:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "31:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "39:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
             "41:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "46:9: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 9),
+            "49:9: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 9),
             "53:9: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 9),
+            "65:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "69:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "77:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "80:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "84:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
         };
         verify(checkConfig, getPath("InputLeftCurlyMethod.java"), expected);
@@ -185,6 +189,9 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
             "10:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
             "14:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "21:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "27:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "50:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "58:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
         };
         verify(checkConfig, getPath("InputLeftCurlyAnnotations.java"), expected);
     }
@@ -284,8 +291,11 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
     @Test
     public void testCoverageIncrease() throws Exception {
         checkConfig.addAttribute("option", LeftCurlyOption.NLOW.toString());
-        checkConfig.addAttribute("maxLineLength", "10");
         final String[] expected = {
+            "12:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "21:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "30:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "39:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "53:14: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 14),
             "58:18: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 18),
             "62:18: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 18),

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -256,7 +256,9 @@ try {
           </tr>
           <tr>
             <td>maxLineLength</td>
-            <td>maximum number of characters in a line</td>
+            <td>maximum number of characters in a line. ATTENTION:
+                The option has been marked as <b>deprecated</b>
+                since checkstyle 6.10 release.</td>
             <td><a href="property_types.html#integer">integer</a></td>
             <td><code>80</code></td>
           </tr>

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -248,8 +248,9 @@
         <tr>
           <td><code>nlow</code></td>
           <td>
-            If the brace will fit on the first line of the statement, taking
-            into account maximum line length, then apply <code>eol</code> rule. Otherwise apply the <code>nl</code> rule. <code>nlow</code> is a
+            If the brace will fit on the first line of the statement,
+            then apply <code>eol</code> rule. Otherwise apply the
+            <code>nl</code> rule. <code>nlow</code> is a
             mnemonic for "new line on wrap". For the example above Checkstyle
             will enforce:
             <pre>


### PR DESCRIPTION
See issue #965 for investigation notes.