### PR TITLE
Issue #1013. Fix NoWhitespaceAfterCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -19,8 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
-import org.apache.commons.lang3.ArrayUtils;
-
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -29,8 +27,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <p>
  * Checks that there is no whitespace after a token.
  * More specifically, it checks that it is not followed by whitespace,
- * or (if line breaks are allowed) all characters on the line after are
- * whitespace. To forbid line breaks after a token, set property
+ * or (if linebreaks are allowed) all characters on the line after are
+ * whitespace. To forbid linebreaks after a token, set property
  * allowLineBreaks to false.
  * </p>
   * <p> By default the check will check the following operators:
@@ -41,9 +39,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *  {@link TokenTypes#INC INC},
  *  {@link TokenTypes#LNOT LNOT},
  *  {@link TokenTypes#UNARY_MINUS UNARY_MINUS},
+ *  {@link TokenTypes#UNARY_PLUS UNARY_PLUS},
+ *  {@link TokenTypes#TYPECAST TYPECAST},
  *  {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR},
- *  {@link TokenTypes#UNARY_PLUS UNARY_PLUS}. It also supports the operator
- *  {@link TokenTypes#TYPECAST TYPECAST}.
+ *  {@link TokenTypes#INDEX_OP INDEX_OP}.
+ * </p>
+ * <p>
+ * The check processes
+ * {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR},
+ * {@link TokenTypes#INDEX_OP INDEX_OP}
+ * specially from other tokens. Actually it is checked that there is
+ * no whitespace before this tokens, not after them.
  * </p>
  * <p>
  * An example of how to configure the check is:
@@ -51,7 +57,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  * &lt;module name="NoWhitespaceAfter"/&gt;
  * </pre>
- * <p> An example of how to configure the check to forbid line breaks after
+ * <p> An example of how to configure the check to forbid linebreaks after
  * a {@link TokenTypes#DOT DOT} token is:
  * </p>
  * <pre>
@@ -63,6 +69,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * @author Rick Giles
  * @author lkuehne
  * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
+ * @author attatrol
  */
 public class NoWhitespaceAfterCheck extends Check {
 
@@ -87,6 +94,7 @@ public class NoWhitespaceAfterCheck extends Check {
             TokenTypes.LNOT,
             TokenTypes.DOT,
             TokenTypes.ARRAY_DECLARATOR,
+            TokenTypes.INDEX_OP,
         };
     }
 
@@ -103,48 +111,55 @@ public class NoWhitespaceAfterCheck extends Check {
             TokenTypes.DOT,
             TokenTypes.TYPECAST,
             TokenTypes.ARRAY_DECLARATOR,
-            TokenTypes.GENERIC_START,
-            TokenTypes.GENERIC_END,
+            TokenTypes.INDEX_OP,
         };
     }
 
-    @Override
-    public int[] getRequiredTokens() {
-        return ArrayUtils.EMPTY_INT_ARRAY;
+    /**
+     * Control whether whitespace is flagged at linebreaks.
+     * @param allowLineBreaks whether whitespace should be
+     *     flagged at linebreaks.
+     */
+    public void setAllowLineBreaks(boolean allowLineBreaks) {
+        this.allowLineBreaks = allowLineBreaks;
     }
 
     @Override
     public void visitToken(DetailAST ast) {
-        final DetailAST astNode = getPreceded(ast);
-        final String line = getLine(ast.getLineNo() - 1);
-        final int after = getPositionAfter(astNode);
+        final DetailAST whitespaceFollowedAst = getWhitespaceFollowedNode(ast);
 
-        if ((after >= line.length() || Character.isWhitespace(line.charAt(after)))
-                 && hasRedundantWhitespace(line, after)) {
-            log(astNode.getLineNo(), after,
-                MSG_KEY, astNode.getText());
+        final int whitespaceColumnNo = getPositionAfter(whitespaceFollowedAst);
+        final int whitespaceLineNo = whitespaceFollowedAst.getLineNo();
+
+        if (hasTrailingWhitespace(ast, whitespaceColumnNo, whitespaceLineNo)) {
+            log(whitespaceLineNo, whitespaceColumnNo,
+                MSG_KEY, whitespaceFollowedAst.getText());
         }
     }
 
     /**
-     * Gets possible place where redundant whitespace could be.
-     * @param ast Node representing token.
-     * @return possible place of redundant whitespace.
+     * For a visited ast node returns node that should be checked
+     * for not being followed by whitespace.
+     * @param ast
+     *        , visited node.
+     * @return node before ast.
      */
-    private static DetailAST getPreceded(DetailAST ast) {
-        DetailAST preceded;
-
+    private static DetailAST getWhitespaceFollowedNode(DetailAST ast) {
+        DetailAST whitespaceFollowedAst;
         switch (ast.getType()) {
             case TokenTypes.TYPECAST:
-                preceded = ast.findFirstToken(TokenTypes.RPAREN);
+                whitespaceFollowedAst = ast.findFirstToken(TokenTypes.RPAREN);
                 break;
             case TokenTypes.ARRAY_DECLARATOR:
-                preceded = getArrayTypeOrIdentifier(ast);
+                whitespaceFollowedAst = getArrayDeclaratorPreviousElement(ast);
+                break;
+            case TokenTypes.INDEX_OP:
+                whitespaceFollowedAst = getIndexOpPreviousElement(ast);
                 break;
             default:
-                preceded = ast;
+                whitespaceFollowedAst = ast;
         }
-        return preceded;
+        return whitespaceFollowedAst;
     }
 
     /**
@@ -153,8 +168,8 @@ public class NoWhitespaceAfterCheck extends Check {
      * @return position after token.
      */
     private static int getPositionAfter(DetailAST ast) {
-        int after;
-        //If target of possible redundant whitespace is in method definition
+        final int after;
+        //If target of possible redundant whitespace is in method definition.
         if (ast.getType() == TokenTypes.IDENT
                 && ast.getNextSibling() != null
                 && ast.getNextSibling().getType() == TokenTypes.LPAREN) {
@@ -169,163 +184,219 @@ public class NoWhitespaceAfterCheck extends Check {
     }
 
     /**
-     * Gets target place of possible redundant whitespace (array's type or identifier)
-     *  after which {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR} is set.
-     * @param arrayDeclarator {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR}
-     * @return target place before possible redundant whitespace.
+     * Checks if there is unwanted whitespace after the visited node.
+     * @param ast
+     *        , visited node.
+     * @param whitespaceColumnNo
+     *        , column number of a possible whitespace.
+     * @param whitespaceLineNo
+     *        , line number of a possible whitespace.
+     * @return true if whitespace found.
      */
-    private static DetailAST getArrayTypeOrIdentifier(DetailAST arrayDeclarator) {
-        DetailAST typeOrIdent = arrayDeclarator;
-        if (isArrayInstantiation(arrayDeclarator)) {
-            typeOrIdent = arrayDeclarator.getParent().getFirstChild();
+    boolean hasTrailingWhitespace(DetailAST ast,
+        int whitespaceColumnNo, int whitespaceLineNo) {
+        final boolean result;
+        final int astLineNo = ast.getLineNo();
+        final String line = getLine(astLineNo - 1);
+        if (astLineNo == whitespaceLineNo && whitespaceColumnNo < line.length()) {
+            result = Character.isWhitespace(line.charAt(whitespaceColumnNo));
         }
-        else if (isMultiDimensionalArray(arrayDeclarator)) {
-            if (isCStyleMultiDimensionalArrayDeclaration(arrayDeclarator)) {
-                if (arrayDeclarator.getParent().getType() != TokenTypes.ARRAY_DECLARATOR) {
-                    typeOrIdent = getArrayIdentifier(arrayDeclarator);
-                }
+        else {
+            result = !allowLineBreaks;
+        }
+        return result;
+    }
+
+    /**
+     * Returns proper argument for getPositionAfter method, it is a token after
+     * {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR}, in can be {@link TokenTypes#RBRACK
+     * RBRACK}, {@link TokenTypes#IDENT IDENT} or an array type definition (literal).
+     * @param ast
+     *        , {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR} node.
+     * @return previous node by text order.
+     */
+    private static DetailAST getArrayDeclaratorPreviousElement(DetailAST ast) {
+        final DetailAST previousElement;
+        final DetailAST firstChild = ast.getFirstChild();
+        if (firstChild.getType() == TokenTypes.ARRAY_DECLARATOR) {
+            // second or higher array index
+            previousElement = firstChild.findFirstToken(TokenTypes.RBRACK);
+        }
+        else {
+            // first array index, is preceded with identifier or type
+            final DetailAST parent = getFirstNonArrayDeclaratorParent(ast);
+            switch (parent.getType()) {
+                // generics
+                case TokenTypes.TYPE_ARGUMENT:
+                    final DetailAST wildcard = parent.findFirstToken(TokenTypes.WILDCARD_TYPE);
+                    if (wildcard == null) {
+                        // usual generic type argument like <char[]>
+                        previousElement = getTypeLastNode(ast);
+                    }
+                    else {
+                        // constructions with wildcard like <? extends String[]>
+                        previousElement = getTypeLastNode(ast.getFirstChild());
+                    }
+                    break;
+                // 'new' is a special case with its own subtree structure
+                case TokenTypes.LITERAL_NEW:
+                    previousElement = getTypeLastNode(parent);
+                    break;
+                // mundane array declaration, can be either java style or C style
+                case TokenTypes.TYPE:
+                    previousElement = getPreviousNodeWithParentOfTypeAst(ast, parent);
+                    break;
+                // i.e. boolean[].class
+                case TokenTypes.DOT:
+                    previousElement = getTypeLastNode(ast);
+                    break;
+                // java 8 method reference
+                case TokenTypes.METHOD_REF:
+                    final DetailAST ident = getIdentLastToken(ast);
+                    if (ident == null) {
+                        //i.e. int[]::new
+                        previousElement = ast.getFirstChild();
+                    }
+                    else {
+                        previousElement = ident;
+                    }
+                    break;
+                default:
+                    throw new IllegalStateException("unexpected ast syntax" + parent);
+            }
+        }
+        return previousElement;
+    }
+
+    /**
+     * Gets previous node for {@link TokenTypes#INDEX_OP INDEX_OP} token
+     * for usage in getPositionAfter method, it is a simplified copy of
+     * getArrayDeclaratorPreviousElement method.
+     * @param ast
+     *        , {@link TokenTypes#INDEX_OP INDEX_OP} node.
+     * @return previous node by text order.
+     */
+    private static DetailAST getIndexOpPreviousElement(DetailAST ast) {
+        DetailAST result;
+        final DetailAST firstChild = ast.getFirstChild();
+        if (firstChild.getType() == TokenTypes.INDEX_OP) {
+            // second or higher array index
+            result = firstChild.findFirstToken(TokenTypes.RBRACK);
+        }
+        else {
+            final DetailAST ident = getIdentLastToken(ast);
+            if (ident == null) {
+                // construction like ((byte[]) pixels)[0]
+                result = ast.findFirstToken(TokenTypes.RPAREN);
             }
             else {
-                DetailAST arrayIdentifier = arrayDeclarator.getFirstChild();
-                while (arrayIdentifier != null) {
-                    typeOrIdent = arrayIdentifier;
-                    arrayIdentifier = arrayIdentifier.getFirstChild();
-                }
+                result = ident;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Get node that owns {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR} sequence.
+     * @param ast
+     *        , {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR} node.
+     * @return owner node.
+     */
+    private static DetailAST getFirstNonArrayDeclaratorParent(DetailAST ast) {
+        DetailAST parent = ast.getParent();
+        while (parent.getType() == TokenTypes.ARRAY_DECLARATOR) {
+            parent = parent.getParent();
+        }
+        return parent;
+    }
+
+    /**
+     * Searches parameter node for a type node.
+     * Returns it or its last node if it has an extended structure.
+     * @param ast
+     *        , subject node.
+     * @return type node.
+     */
+    private static DetailAST getTypeLastNode(DetailAST ast) {
+        DetailAST result = ast.findFirstToken(TokenTypes.TYPE_ARGUMENTS);
+        if (result == null) {
+            result = getIdentLastToken(ast);
+            if (result == null) {
+                //primitive literal expected
+                result = ast.getFirstChild();
             }
         }
         else {
-            if (isCStyleArrayDeclaration(arrayDeclarator)) {
-                typeOrIdent = getArrayIdentifier(arrayDeclarator);
+            result = result.findFirstToken(TokenTypes.GENERIC_END);
+        }
+        return result;
+    }
+
+    /**
+     * Finds previous node by text order for an array declarator,
+     * which parent type is {@link TokenTypes#TYPE TYPE}.
+     * @param ast
+     *        , array declarator node.
+     * @param parent
+     *        , its parent node.
+     * @return previous node by text order.
+     */
+    private static DetailAST getPreviousNodeWithParentOfTypeAst(DetailAST ast, DetailAST parent) {
+        final DetailAST previousElement;
+        final DetailAST ident = getIdentLastToken(parent.getParent());
+        final DetailAST lastTypeNode = getTypeLastNode(ast);
+        // sometimes there are ident-less sentences
+        // i.e. "(Object[]) null", but in casual case should be
+        // checked whether ident or lastTypeNode has preceding position
+        // determining if it is java style or C style
+        if (ident == null || ident.getLineNo() > ast.getLineNo()) {
+            previousElement = lastTypeNode;
+        }
+        else if (ident.getLineNo() < ast.getLineNo()) {
+            previousElement = ident;
+        }
+        //ident and lastTypeNode lay on one line
+        else {
+            if (ident.getColumnNo() > ast.getColumnNo()
+                || lastTypeNode.getColumnNo() > ident.getColumnNo()) {
+                previousElement = lastTypeNode;
             }
             else {
-                if (isArrayUsedAsTypeForGenericBoundedWildcard(arrayDeclarator)) {
-                    typeOrIdent = arrayDeclarator.getParent();
+                previousElement = ident;
+            }
+        }
+        return previousElement;
+    }
+
+    /**
+     * Gets leftmost token of identifier.
+     * @param ast
+     *        , token possibly possessing an identifier.
+     * @return leftmost token of identifier.
+     */
+    private static DetailAST getIdentLastToken(DetailAST ast) {
+        // single identifier token as a name is the most common case
+        DetailAST result = ast.findFirstToken(TokenTypes.IDENT);
+        if (result == null) {
+            final DetailAST dot = ast.findFirstToken(TokenTypes.DOT);
+            // method call case
+            if (dot == null) {
+                final DetailAST methodCall = ast.findFirstToken(TokenTypes.METHOD_CALL);
+                if (methodCall != null) {
+                    result = methodCall.findFirstToken(TokenTypes.RPAREN);
+                }
+            }
+            // qualified name case
+            else {
+                if (dot.findFirstToken(TokenTypes.DOT) == null) {
+                    result = dot.getFirstChild().getNextSibling();
                 }
                 else {
-                    typeOrIdent = arrayDeclarator.getFirstChild();
+                    result = dot.findFirstToken(TokenTypes.IDENT);
                 }
             }
         }
-        return typeOrIdent;
-    }
-
-    /**
-     * Gets array identifier, e.g.:
-     * <p>
-     * {@code
-     * int[] someArray;
-     * }
-     * </p>
-     * <p>
-     * someArray is identifier.
-     * </p>
-     * @param arrayDeclarator {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR}
-     * @return array identifier.
-     */
-    private static DetailAST getArrayIdentifier(DetailAST arrayDeclarator) {
-        return arrayDeclarator.getParent().getNextSibling();
-    }
-
-    /**
-     * Checks if current array is multidimensional.
-     * @param arrayDeclaration {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR}
-     * @return true if current array is multidimensional.
-     */
-    private static boolean isMultiDimensionalArray(DetailAST arrayDeclaration) {
-        return arrayDeclaration.getParent().getType() == TokenTypes.ARRAY_DECLARATOR
-                || arrayDeclaration.getFirstChild().getType() == TokenTypes.ARRAY_DECLARATOR;
-    }
-
-    /**
-     * Checks if current array declaration is part of array instantiation.
-     * @param arrayDeclaration {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR}
-     * @return true if current array declaration is part of array instantiation.
-     */
-    private static boolean isArrayInstantiation(DetailAST arrayDeclaration) {
-        return arrayDeclaration.getParent().getType() == TokenTypes.LITERAL_NEW;
-    }
-
-    /**
-     * Checks if current array is used as type for generic bounded wildcard.
-     * <p>
-     * E.g. {@code <? extends String[]>} or {@code <? super Object[]>}.
-     * </p>
-     * @param arrayDeclarator {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR}
-     * @return true if current array is used as type for generic bounded wildcard.
-     */
-    private static boolean isArrayUsedAsTypeForGenericBoundedWildcard(DetailAST arrayDeclarator) {
-        final int firstChildType = arrayDeclarator.getFirstChild().getType();
-        return firstChildType == TokenTypes.TYPE_UPPER_BOUNDS
-                || firstChildType == TokenTypes.TYPE_LOWER_BOUNDS;
-    }
-
-    /**
-     * Control whether whitespace is flagged at line breaks.
-     * @param allowLineBreaks whether whitespace should be
-     *     flagged at line breaks.
-     */
-    public void setAllowLineBreaks(boolean allowLineBreaks) {
-        this.allowLineBreaks = allowLineBreaks;
-    }
-
-    /**
-     * Checks if current array is declared in C style, e.g.:
-     * <p>
-     * {@code
-     * int array[] = { ... }; //C style
-     * }
-     * </p>
-     * <p>
-     * {@code
-     * int[] array = { ... }; //Java style
-     * }
-     * </p>
-     * @param arrayDeclaration {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR}
-     * @return true if array is declared in C style
-     */
-    private static boolean isCStyleArrayDeclaration(DetailAST arrayDeclaration) {
-        boolean result = false;
-        final DetailAST identifier = getArrayIdentifier(arrayDeclaration);
-        if (identifier != null) {
-            final int arrayDeclarationStart = arrayDeclaration.getColumnNo();
-            final int identifierEnd = identifier.getColumnNo() + identifier.getText().length();
-            result = arrayDeclarationStart == identifierEnd
-                     || arrayDeclarationStart > identifierEnd;
-        }
         return result;
     }
 
-    /**
-     * Works with multidimensional arrays.
-     * @param arrayDeclaration {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR}
-     * @return true if multidimensional array is declared in C style.
-     */
-    private static boolean isCStyleMultiDimensionalArrayDeclaration(DetailAST arrayDeclaration) {
-        boolean result = false;
-        DetailAST parentArrayDeclaration = arrayDeclaration;
-        while (parentArrayDeclaration != null) {
-            if (parentArrayDeclaration.getParent() != null
-                    && parentArrayDeclaration.getParent().getType() == TokenTypes.TYPE) {
-                result = isCStyleArrayDeclaration(parentArrayDeclaration);
-            }
-            parentArrayDeclaration = parentArrayDeclaration.getParent();
-        }
-        return result;
-    }
-
-    /**
-     * Checks if current line has redundant whitespace after specified index.
-     * @param line line of java source.
-     * @param after specified index.
-     * @return true if line contains redundant whitespace.
-     */
-    private boolean hasRedundantWhitespace(String line, int after) {
-        boolean result = !allowLineBreaks;
-        for (int i = after + 1; !result && i < line.length(); i++) {
-            if (!Character.isWhitespace(line.charAt(i))) {
-                result = true;
-            }
-        }
-        return result;
-    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/InputNoWhitespaceAfterMethodRef.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/InputNoWhitespaceAfterMethodRef.java
@@ -1,0 +1,12 @@
+package com.puppycrawl.tools.checkstyle.whitespace;
+
+import java.util.List;
+
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.sun.corba.se.impl.protocol.giopmsgheaders.Message;
+
+public class InputNoWhitespaceAfterMethodRef
+{
+    IntFunction<int[]> arrayMaker = int []::new;//incorrect 10:40
+    Function<Integer, Message[]> messageArrayFactory = Message []::new;//incorrect 11:63
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputNoWhitespaceAfterArrayDeclarations2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputNoWhitespaceAfterArrayDeclarations2.java
@@ -1,0 +1,108 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace;
+
+import java.util.List;
+
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+public class InputNoWhitespaceAfterArrayDeclarations2
+{
+
+    public class A {
+        public int[][] create(int i, int j) {
+            return new int[3] [3];//incorrect, 12:30 
+        }
+    }
+    
+    public class B {
+        public int create(int i, int j) [][] {//incorrect, 17:40
+            return new int     [3][i + j] ;//incorrect,18:27
+        }
+    }
+    
+    public class C {
+        public int[][] create(int i, int j) {
+            return new int[i + j][i + j];//correct
+        }
+    }
+    
+    public class D {
+        public int[][]   [] create(int i, int j) {//incorrect, 29:23
+            return new int  [ i + j ]    [ i + j ]               [ 0 ]     ;//incorrect 30:27,38,51
+        }
+    }
+    
+    public class E {
+        public int create(int i, int j, int   [][] k)[] [][] {//incorrect, 35:44,56
+            int e [][] [] = new int[i + j] [2][i + j];//incorrect, 36:18,23,43
+            e [0] [1][2] = 0; e[1][1][1] = 0;//incorrect, 37:14,18
+            return e;
+        }
+    }
+    public static class F {
+        public static Integer [][][] create(int i, int j) {//incorrect, 42:23
+            int[][] [] f= new int[   0][1    ][    2    ]   ;
+            return new Integer[i + j][i + j][0];
+        }
+    }
+    public class G {
+        public List<String> [] [] [] create(int i, int j) {//incorrect, 48:28,31,34
+            //cannot build with this check - generic array creation error, but whitespaces still catched
+            //List<String> g[][] [] = new List<String> [0][1][2];//incorrect 49:33,55
+            //return new List<String>[i + j][i + j][0];//correct
+            int g[][][] = new int [0][1][2];
+            g[  0][0   ][   0   ]=0;
+            g [0][0][0]=0;//incorrect 54:14
+            g[0] [0][0]=0;//incorrect 55:17
+            g [0] [0] [0]        =0;//incorrect 56:14,18,22
+            return null;
+        }
+
+    }
+    public class H {
+        public List<Integer> create(int i, int j)     []      [][] {//incorrect, 62:46,53
+            return null;
+        }
+    }
+    
+    Object someStuff4 = boolean [].class;//incorrect, 67:32
+    String[][] someStuff5 = new String[4][9];
+    String[][] someStuff6 = (java.lang.String  []  []) someStuff5;//incorrect, 69:46,50
+    String[][] someStuff7 = (String [][]) someStuff5;//incorrect, 70:36
+    
+    //this is legal until allowLineBreaks is set to false 
+    int someStuff8
+    [];
+    
+    //this is legal until allowLineBreaks is set to false
+    int[]
+    someStuff81;
+    
+    //incorrect 81:40
+    Integer someStuff9[][][] = (Integer [][][]) InputNoWhitespaceAfterArrayDeclarations2.F.create(1,2);
+    
+    //type arguments
+    List<char[]> someStuff10;//correct
+    List<char [][]> someStuff11;//incorrect 85:14
+    List<InputNoWhitespaceAfterArrayDeclarations2.A []> someStuff12;//incorrect 86:52
+    public void foo(java.util.List<? extends String[]> bar, Comparable<? super Object []> baz) { }//incorrect 87:86
+    
+    Integer someStuff13 = F.create(1,1)[0][0][0];
+    Integer someStuff131 = F.create(1,1)  [0][0]   [0];//incorrect 90:41,49
+    Object[] someStuff14 = (Object[]) null;
+    Object[] someStuff15 = (Object  []  ) null;//incorrect 92:35
+    
+    byte someStuff16 = ((byte[]) someStuff4) [0];//incorrect 94:45
+    
+    public void bar() {
+        if(someStuff15 instanceof Object  []) {//incorrect 97:41
+    
+        }
+        if(someStuff15 instanceof Object[]  []) {//incorrect 100:43
+          
+        }
+        if(someStuff15 instanceof Object[][]) {
+          
+        }
+    }
+
+}

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -390,6 +390,16 @@ for (Iterator foo = very.long.line.iterator();
           forbid linebreaks after a token, set property <code>allowLineBreaks</code> to <code>
           false</code>.
         </p>
+        <p>
+          The check processes
+          <a
+          href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR">ARRAY_DECLARATOR</a>
+          and
+          <a
+          href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP">INDEX_OP</a>
+          tokens specially from other tokens. Actually it is checked that there is
+          no whitespace before this tokens, not after them.
+          </p>
       </subsection>
 
       <subsection name="Properties">
@@ -434,9 +444,7 @@ for (Iterator foo = very.long.line.iterator();
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR">ARRAY_DECLARATOR</a>,
               <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_START">GENERIC_START</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_END">GENERIC_END</a>.
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP">INDEX_OP</a>.
             </td>
 
             <td>
@@ -457,7 +465,9 @@ for (Iterator foo = very.long.line.iterator();
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">UNARY_PLUS</a>,
               <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR">ARRAY_DECLARATOR</a>.
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR">ARRAY_DECLARATOR</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP">INDEX_OP</a>.
             </td>
           </tr>
         </table>


### PR DESCRIPTION
It satisfies issue #1013

1. Behavior of NoWhitespaceAfterCheck for specific token type <code>TokenTypes.ARRAY_DECLARATOR</code> is overhauled.
Now check generates error if there are whitespaces in highlighted places:
<code>
int█[ ]█[ ] a;</code>
<code>int a█[ ]█[ ];</code>
<code>String█[ ]█[ ] someStuff6 = (java.lang.String█[ ]█[ ]) someStuff5;</code>
<code>return new Integer█[  i + j  ]█[i + j]█[0];
</code>
it does not check for whitespace validity inside brackets.

2. Token <code>TokenTypes.INDEX_OP</code> is added to the lists of default and accepted tokens due to its simularity with <code>TokenTypes.ARRAY_DECLARATOR</code>.

3. Other token types processing remains intact.

4. There is an error in Travis-CI build job no.8:
<code>[ERROR] src/main/java/org/orekit/propagation/semianalytical/dsst/forces/DSSTThirdBody.java[1087:77] (whitespace) NoWhitespaceAfter: 'fact' is followed by whitespace.</code>
https://travis-ci.org/checkstyle/checkstyle/jobs/72631540

It happens because updated check finds waste whitespace in Orecit source:
https://www.orekit.org/forge/projects/orekit/repository/revisions/master/entry/src/main/java/org/orekit/propagation/semianalytical/dsst/forces/DSSTThirdBody.java