### PR TITLE
Issue #1293: Refactoring of IllegalTypeCheck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1112,7 +1112,6 @@
             <regex><pattern>.*.checks.coding.ExplicitInitializationCheck</pattern><branchRate>91</branchRate><lineRate>97</lineRate></regex>
             <regex><pattern>.*.checks.coding.FinalLocalVariableCheck</pattern><branchRate>83</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.coding.IllegalInstantiationCheck</pattern><branchRate>81</branchRate><lineRate>97</lineRate></regex>
-            <regex><pattern>.*.checks.coding.IllegalTypeCheck</pattern><branchRate>93</branchRate><lineRate>94</lineRate></regex>
             <regex><pattern>.*.checks.coding.ModifiedControlVariableCheck</pattern><branchRate>91</branchRate><lineRate>97</lineRate></regex>
             <regex><pattern>.*.checks.coding.OverloadMethodsDeclarationOrderCheck</pattern><branchRate>93</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.coding.ParameterAssignmentCheck</pattern><branchRate>80</branchRate><lineRate>96</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -251,7 +251,7 @@ public final class IllegalTypeCheck extends AbstractFormatCheck {
      */
     private void visitImport(DetailAST importAst) {
         if (!isStarImport(importAst)) {
-            final String canonicalName = getCanonicalName(importAst);
+            final String canonicalName = getImportedTypeCanonicalName(importAst);
             extendIllegalClassNamesWithShortName(canonicalName);
         }
     }
@@ -327,14 +327,12 @@ public final class IllegalTypeCheck extends AbstractFormatCheck {
      * @param importAst {@link TokenTypes#IMPORT Import}
      * @return Imported canonical type's name.
      */
-    private static String getCanonicalName(DetailAST importAst) {
+    private static String getImportedTypeCanonicalName(DetailAST importAst) {
         final StringBuilder canonicalNameBuilder = new StringBuilder();
         DetailAST toVisit = importAst;
         while (toVisit != null) {
             toVisit = getNextSubTreeNode(toVisit, importAst);
-            if (toVisit != null
-                   && (toVisit.getType() == TokenTypes.IDENT
-                      || toVisit.getType() == TokenTypes.STAR)) {
+            if (toVisit != null && toVisit.getType() == TokenTypes.IDENT) {
                 canonicalNameBuilder.append(toVisit.getText());
                 final DetailAST nextSubTreeNode = getNextSubTreeNode(toVisit, importAst);
                 if (nextSubTreeNode.getType() != TokenTypes.SEMI) {
@@ -390,15 +388,6 @@ public final class IllegalTypeCheck extends AbstractFormatCheck {
     }
 
     /**
-     * Get the list of illegal variable types.
-     * @return array of illegal variable types
-     */
-    public String[] getIllegalClassNames() {
-        return illegalClassNames.toArray(
-            new String[illegalClassNames.size()]);
-    }
-
-    /**
      * Set the list of ignore method names.
      * @param methodNames array of ignored method names
      */
@@ -408,30 +397,12 @@ public final class IllegalTypeCheck extends AbstractFormatCheck {
     }
 
     /**
-     * Get the list of ignored method names.
-     * @return array of ignored method names
-     */
-    public String[] getIgnoredMethodNames() {
-        return ignoredMethodNames.toArray(
-            new String[ignoredMethodNames.size()]);
-    }
-
-    /**
      * Set the list of legal abstract class names.
      * @param classNames array of legal abstract class names
      */
     public void setLegalAbstractClassNames(String... classNames) {
         legalAbstractClassNames.clear();
         Collections.addAll(legalAbstractClassNames, classNames);
-    }
-
-    /**
-     * Get the list of legal abstract class names.
-     * @return array of legal abstract class names
-     */
-    public String[] getLegalAbstractClassNames() {
-        return legalAbstractClassNames.toArray(
-            new String[legalAbstractClassNames.size()]);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class IllegalTypeCheckTest extends BaseCheckTestSupport {
     private DefaultConfiguration checkConfig;
@@ -167,5 +169,21 @@ public class IllegalTypeCheckTest extends BaseCheckTestSupport {
         Assert.assertNotNull(check.getAcceptableTokens());
         Assert.assertNotNull(check.getDefaultTokens());
         Assert.assertNotNull(check.getRequiredTokens());
+    }
+
+    @Test
+    public void testImproperToken() throws Exception {
+        IllegalTypeCheck check = new IllegalTypeCheck();
+
+        DetailAST classDefAst = new DetailAST();
+        classDefAst.setType(TokenTypes.CLASS_DEF);
+
+        try {
+            check.visitToken(classDefAst);
+            Assert.fail();
+        }
+        catch (IllegalStateException e) {
+            // it is OK
+        }
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputIllegalType.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputIllegalType.java
@@ -18,4 +18,7 @@ public class InputIllegalType {
     static class SomeStaticClass {
         
     }
+    
+    InputIllegalType(Integer i) {}
+    private void table2(Integer i) {}
 }


### PR DESCRIPTION
Checkstyle reports: http://baratali.github.io/illegal_type/
**The reports are identical**

Details:
1) Removed useless getters
2) In getCanonicalName(importAst) method, check for STAR token is not necessary because this method receives only imports without 'stars': https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java#L252
