### PR TITLE
Add test case and refactor JavadocUtils. #1308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1130,7 +1130,6 @@
             <regex><pattern>.*.checks.javadoc.AtclauseOrderCheck</pattern><branchRate>88</branchRate><lineRate>88</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocMethodCheck</pattern><branchRate>91</branchRate><lineRate>98</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.JavadocStyleCheck</pattern><branchRate>89</branchRate><lineRate>98</lineRate></regex>
-            <regex><pattern>.*.checks.javadoc.JavadocUtils</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.javadoc.WriteTagCheck</pattern><branchRate>100</branchRate><lineRate>91</lineRate></regex>
 
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
@@ -142,22 +142,20 @@ public final class JavadocUtils {
                 final Pattern tagPattern = Pattern.compile(".*?\\{@(\\p{Alpha}+)\\s+(.*?)\\}");
                 final Matcher tagMatcher = tagPattern.matcher(commentContents);
                 while (tagMatcher.find()) {
-                    if (tagMatcher.groupCount() == 2) {
-                        final String tagName = tagMatcher.group(1);
-                        final String tagValue = tagMatcher.group(2).trim();
-                        final int line = cmt.getStartLineNo() + i;
-                        int col = commentOffset + tagMatcher.start(1) - 1;
-                        if (i == 0) {
-                            col += cmt.getStartColNo();
-                        }
-                        if (JavadocTagInfo.isValidName(tagName)) {
-                            tags.add(new JavadocTag(line, col, tagName,
-                                    tagValue));
-                        }
-                        else {
-                            invalidTags.add(new InvalidJavadocTag(line, col,
-                                    tagName));
-                        }
+                    final String tagName = tagMatcher.group(1);
+                    final String tagValue = tagMatcher.group(2).trim();
+                    final int line = cmt.getStartLineNo() + i;
+                    int col = commentOffset + tagMatcher.start(1) - 1;
+                    if (i == 0) {
+                        col += cmt.getStartColNo();
+                    }
+                    if (JavadocTagInfo.isValidName(tagName)) {
+                        tags.add(new JavadocTag(line, col, tagName,
+                                tagValue));
+                    }
+                    else {
+                        invalidTags.add(new InvalidJavadocTag(line, col,
+                                tagName));
                     }
                     // else Error: Unexpected match count for inline Javadoc
                     // tag!
@@ -270,7 +268,7 @@ public final class JavadocUtils {
      */
     public static boolean branchContains(DetailNode node, int type) {
         DetailNode curNode = node;
-        while (curNode != null) {
+        while (true) {
 
             if (type == curNode.getType()) {
                 return true;
@@ -334,12 +332,10 @@ public final class JavadocUtils {
      */
     public static DetailNode getPreviousSibling(DetailNode node) {
         final DetailNode parent = node.getParent();
-        if (parent != null) {
-            final int previousSiblingIndex = node.getIndex() - 1;
-            final DetailNode[] children = parent.getChildren();
-            if (previousSiblingIndex >= 0) {
-                return children[previousSiblingIndex];
-            }
+        final int previousSiblingIndex = node.getIndex() - 1;
+        final DetailNode[] children = parent.getChildren();
+        if (previousSiblingIndex >= 0) {
+            return children[previousSiblingIndex];
         }
         return null;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputCorrectJavaDocParagraphCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputCorrectJavaDocParagraphCheck.java
@@ -90,3 +90,10 @@ class InputCorrectJavaDocParagraphCheck {
         boolean emulated() {return false;}
     };
 }
+
+/*
+ *  This comment has paragraph without '<p>' tag.
+ *
+ *  It's fine, because this is plain comment.
+ */
+class ClassWithPlainComment {}


### PR DESCRIPTION
Reports were generated for the following config before and after changes:
```xml
        <module name="JavadocParagraph"/>
        <module name="AtclauseOrder"/>
        <module name="JavadocType">
            <property name="authorFormat" value="\S"/>
        </module>
        <module name="JavadocMethod">
            <property name="allowUndeclaredRTE" value="true"/>
            <property name="allowThrowsTagsForSubclasses" value="true"/>
            <property name="allowMissingPropertyJavadoc" value="true"/>
        </module>
        <module name="JavadocVariable"/>
        <module name="JavadocStyle">
            <property name="scope" value="public"/>
        </module>
        <module name="JavadocTagContinuationIndentation"/>
        <module name="SingleLineJavadoc"/>
        <module name="SummaryJavadoc"/>
        <module name="NonEmptyAtclauseDescription"/>
```

Reports are identical:
```
diff pre/checkstyle-result.xml post/checkstyle-result.xml
Files are the same.
```