### PR TITLE
Changed SAME_PACKAGE rule for CustomImportOrderCheck #1262

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -42,35 +42,42 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * STATIC group. This group sets the ordering of static imports.
  * </pre>
  *
- * <pre>
+ * <p>
  * SAME_PACKAGE(n) group. This group sets the ordering of the same package imports.
- * 'n' - a number of the first package domains. For example:
- * </pre>
+ * Imports are considered on SAME_PACKAGE group if <b>n</b> first domains in package name
+ * and import name are identical.
+ * </p>
  *
  * <pre>
  * <code>
- * package java.util.concurrent;
+ * package java.util.concurrent.locks;
  *
- * import java.util.regex.Pattern;
- * import java.util.List;
- * import java.util.StringTokenizer;
- * import java.util.regex.Pattern;
- * import java.util.*;
- * import java.util.concurrent.AbstractExecutorService;
- * import java.util.concurrent.*;
- *
- * And we have such configuration: SAME_PACKAGE (3).
- * Same package imports are java.util.*, java.util.concurrent.*,
- * java.util.concurrent.AbstractExecutorService,
- * java.util.List and java.util.StringTokenizer
+ * import java.io.File;
+ * import java.util.*; //#1
+ * import java.util.List; //#2
+ * import java.util.StringTokenizer; //#3
+ * import java.util.concurrent.*; //#4
+ * import java.util.concurrent.AbstractExecutorService; //#5
+ * import java.util.concurrent.locks.LockSupport; //#6
+ * import java.util.regex.Pattern; //#7
+ * import java.util.regex.Matcher; //#8
  * </code>
  * </pre>
  *
- * <pre>
+ * <p>
+ * If we have SAME_PACKAGE(3) on configuration file,
+ * imports #4-6 will be considered as a SAME_PACKAGE group (java.util.concurrent.*,
+ * java.util.concurrent.AbstractExecutorService, java.util.concurrent.locks.LockSupport).
+ * SAME_PACKAGE(2) will include #1-8. SAME_PACKAGE(4) will include only #6.
+ * SAME_PACKAGE(5) will result in no imports assigned to SAME_PACKAGE group because
+ * actual package java.util.concurrent.locks has only 4 domains.
+ * </p>
+ *
+ * <p>
  * THIRD_PARTY_PACKAGE group. This group sets ordering of third party imports.
  * Third party imports are all imports except STATIC,
  * SAME_PACKAGE(n), STANDARD_JAVA_PACKAGE and SPECIAL_IMPORTS.
- * </pre>
+ * </p>
  *
  * <pre>
  * STANDARD_JAVA_PACKAGE group. This group sets ordering of standard java/javax imports.
@@ -82,7 +89,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </pre>
  *
  * <p>
- * NOTICE!
+ * NOTE!
  * </p>
  * <p>
  * Use the separator '###' between rules.
@@ -624,9 +631,10 @@ public class CustomImportOrderCheck extends Check {
      */
     private boolean matchesSamePackageImportGroup(boolean isStatic,
         String importFullPath, String currentGroup) {
-        final String importPath = importFullPath.substring(0, importFullPath.lastIndexOf('.'));
+        final String importPathTrimmedToSamePackageDepth =
+                getFirstNDomainsFromIdent(this.samePackageMatchingDepth, importFullPath);
         return !isStatic && SAME_PACKAGE_RULE_GROUP.equals(currentGroup)
-                && samePackageDomainsRegExp.contains(importPath);
+                && samePackageDomainsRegExp.equals(importPathTrimmedToSamePackageDepth);
     }
 
     /**
@@ -771,8 +779,22 @@ public class CustomImportOrderCheck extends Check {
      */
     private static String createSamePackageRegexp(int firstPackageDomainsCount,
              DetailAST packageNode) {
-        final StringBuilder builder = new StringBuilder();
         final String packageFullPath = getFullImportIdent(packageNode);
+        return getFirstNDomainsFromIdent(firstPackageDomainsCount, packageFullPath);
+    }
+
+    /**
+     * Extracts defined amount of domains from the left side of package/import identifier
+     * @param firstPackageDomainsCount
+     *        number of first package domains.
+     * @param packageFullPath
+     *        full identifier containing path to package or imported object.
+     * @return String with defined amount of domains or full identifier
+     *        (if full identifier had less domain then specified)
+     */
+    private static String getFirstNDomainsFromIdent(
+            final int firstPackageDomainsCount, final String packageFullPath) {
+        final StringBuilder builder = new StringBuilder();
         final StringTokenizer tokens = new StringTokenizer(packageFullPath, ".");
         int count = firstPackageDomainsCount;
 
@@ -780,7 +802,7 @@ public class CustomImportOrderCheck extends Check {
             builder.append(tokens.nextToken()).append('.');
             count--;
         }
-        return builder.append("*").toString();
+        return builder.toString();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -150,8 +150,6 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
                 "STATIC###SAME_PACKAGE(3)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-            "5: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
             "6: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
             "7: " + getCheckMessage(MSG_ORDER, "STATIC"),
             "8: " + getCheckMessage(MSG_ORDER, "STATIC"),
@@ -165,25 +163,6 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testOnlySamePackage() throws Exception {
-        final DefaultConfiguration checkConfig =
-                createCheckConfig(CustomImportOrderCheck.class);
-        checkConfig.addAttribute("customImportOrderRules", "SAME_PACKAGE(3)");
-        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
-        final String[] expected = {
-            "4: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-            "6: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-            "7: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-            "8: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-            "9: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-        };
-
-        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
-                + "checkstyle/imports/"
-                + "InputCustomImportOrderSamePackage2.java").getCanonicalPath(), expected);
-    }
-
-    @Test
     public void testWithoutLineSeparator() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(CustomImportOrderCheck.class);
@@ -193,8 +172,6 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
                 "STATIC###SAME_PACKAGE(3)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
-            "5: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
             "6: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
             "7: " + getCheckMessage(MSG_ORDER, "STATIC"),
             "8: " + getCheckMessage(MSG_ORDER, "STATIC"),
@@ -366,6 +343,80 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
 
         String expected = "";
         assertEquals(expected, (String) actual);
+    }
+
+    public void testSamePackageDepth2() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
+        checkConfig.addAttribute("separateLineBetweenGroups", "false");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(2)");
+        final String[] expected = {
+            "7: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "8: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "9: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "10: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "11: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "12: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "13: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "14: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            };
+
+        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/imports/"
+                + "InputCustomImportOrderSamePackageDepth2-5.java").getCanonicalPath(), expected);
+    }
+
+    @Test
+    public void testSamePackageDepth3() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
+        checkConfig.addAttribute("separateLineBetweenGroups", "false");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(3)");
+        final String[] expected = {
+            "10: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "11: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            "12: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            };
+
+        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/imports/"
+                + "InputCustomImportOrderSamePackageDepth2-5.java").getCanonicalPath(), expected);
+    }
+
+    @Test
+    public void testSamePackageDepth4() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
+        checkConfig.addAttribute("separateLineBetweenGroups", "false");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(4)");
+        final String[] expected = {
+            "12: " + getCheckMessage(MSG_ORDER, "SAME_PACKAGE"),
+            };
+
+        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/imports/"
+                + "InputCustomImportOrderSamePackageDepth2-5.java").getCanonicalPath(), expected);
+    }
+
+    @Test
+    public void testSamePackageDepthLongerThenActualPackage() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "false");
+        checkConfig.addAttribute("separateLineBetweenGroups", "false");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(5)");
+        final String[] expected = {};
+
+        verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/imports/"
+                + "InputCustomImportOrderSamePackageDepth2-5.java").getCanonicalPath(), expected);
     }
 
     @Test(expected = CheckstyleException.class)

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackageDepth2-5.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackageDepth2-5.java
@@ -1,0 +1,17 @@
+package java.util.concurrent.locks;
+// SAME_PACKAGE(2) should include #1-8
+// SAME_PACKAGE(3) should include #4-6
+// SAME_PACKAGE(4) should include only #6
+// SAME_PACKAGE(5) should include no imports because actual package has only 4 domains 
+import java.io.File;
+import java.util.*; //#1
+import java.util.List; //#2
+import java.util.StringTokenizer; //#3
+import java.util.concurrent.*; //#4
+import java.util.concurrent.AbstractExecutorService; //#5
+import java.util.concurrent.locks.LockSupport; //#6
+import java.util.regex.Pattern; //#7
+import java.util.regex.Matcher; //#8
+
+public class InputCustomImportOrderSamePackage2 {
+}

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -708,24 +708,22 @@ public class SomeClass { ... }
         </p>
         <p>
           2) SAME_PACKAGE(n) group. This group sets the ordering of the same package imports.
-          n' - a number of the first package domains. For example:
+          Imports are considered on SAME_PACKAGE group if <b>n</b> first domains in package name and import name are identical. For example:
         </p>
         <source>
- package java.util.concurrent;
-
- import java.util.regex.Pattern;
- import java.util.List;
- import java.util.StringTokenizer;
- import java.util.regex.Pattern;
- import java.util.*;
- import java.util.concurrent.AbstractExecutorService;
- import java.util.concurrent.*;
+package java.util.concurrent.locks;
+import java.io.File;
+import java.util.*; //#1
+import java.util.List; //#2
+import java.util.StringTokenizer; //#3
+import java.util.concurrent.*; //#4
+import java.util.concurrent.AbstractExecutorService; //#5
+import java.util.concurrent.locks.LockSupport; //#6
+import java.util.regex.Pattern; //#7
+import java.util.regex.Matcher; //#8
         </source>
         <p>
-          And we have such configuration: SAME_PACKAGE (3).
-          Same package imports are java.util.*, java.util.concurrent.*,
-          java.util.concurrent.AbstractExecutorService,
-          java.util.List and java.util.StringTokenizer
+          If we have SAME_PACKAGE(3) on configuration file, imports #4-6 will be considered as a SAME_PACKAGE group (java.util.concurrent.*, java.util.concurrent.AbstractExecutorService, java.util.concurrent.locks.LockSupport). SAME_PACKAGE(2) will include #1-8. SAME_PACKAGE(4) will include only #6. SAME_PACKAGE(5) will result in no imports assigned to SAME_PACKAGE group because actual package java.util.concurrent.locks has only 4 domains.
         </p>
         <p>
           3) THIRD_PARTY_PACKAGE group. This group sets ordering of third party imports.


### PR DESCRIPTION
As a base for reports configuration from google_checks.xml was taken (referenced as OLD further), modified by replacing "com.google" with SAME_PACKAGE (referenced as NEW further) and executed on several projects from http:/github.com/google
Switching from "com.google" to SAME_PACKAGE results in many errors, fixing SAME_PACKAGE logic removes them.

**Guava project:**
Summary: most errors are gone, report after the change is identical to validation using configuration from google_checks.xml
[Report using OLD configuration on 6.8.1](http://ivanov-alex.github.io/i1262/target_Guava_OLD/site/checkstyle.html)
[Report using NEW configuration on 6.8.1](http://ivanov-alex.github.io/i1262/target_Guava_Before/site/checkstyle.html)
[Report using NEW configuration on 6.9-SNAPSHOT](http://ivanov-alex.github.io/i1262/target_Guava_After/site/checkstyle.html)
[comparison NEW configuration on 6.8.1 to 6.9-SNAPSHOT](https://www.diffchecker.com/mku11l4z)

**Bazel project:**
Summary: most errors gone (60 instead of 5676). Few new errors on the end of report: Google project has code in com.facebook hierarchy, now Checkstyle requires them to be ordered as SAME_PACKAGE (after static)
[Report using OLD configuration on 6.8.1](http://ivanov-alex.github.io/i1262/target_bazel_OLD/site/checkstyle.html)
[Report using NEW configuration on 6.8.1](http://ivanov-alex.github.io/i1262/target_bazel_before/site/checkstyle.html)
[Report using NEW configuration on 6.9-SNAPSHOT](http://ivanov-alex.github.io/i1262/target_bazel_After/site/checkstyle.html)
[comparison NEW configuration on 6.8.1 to 6.9-SNAPSHOT](https://www.diffchecker.com/l9pec3oh)

Comparison of check using 6.8.1 code with configuration from google_checks.xml and fixed code with modified configuration where "com.google" replaced with SAME_PACKAGE
[comparison OLD configuration on 6.8.1 to NEW on 6.9-SNAPSHOT](https://www.diffchecker.com/induceyp)
Difference is on files that have "com.facebook" package.