### PR TITLE
100% coverage in AvoidEscapedUnicodeCharacterCheck. Issue #1290

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1089,7 +1089,6 @@
             <regex><pattern>.*.checks.AbstractOptionCheck</pattern><branchRate>100</branchRate><lineRate>80</lineRate></regex>
             <regex><pattern>.*.checks.AbstractTypeAwareCheck</pattern><branchRate>87</branchRate><lineRate>84</lineRate></regex>
             <regex><pattern>.*.checks.AbstractTypeAwareCheck\$.*</pattern><branchRate>50</branchRate><lineRate>80</lineRate></regex>
-            <regex><pattern>.*.checks.AvoidEscapedUnicodeCharactersCheck</pattern><branchRate>97</branchRate><lineRate>98</lineRate></regex>
             <regex><pattern>.*.checks.CheckUtils</pattern><branchRate>91</branchRate><lineRate>97</lineRate></regex>
             <regex><pattern>.*.checks.ClassResolver</pattern><branchRate>85</branchRate><lineRate>93</lineRate></regex>
             <regex><pattern>.*.checks.AbstractDeclarationCollector</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -264,7 +264,7 @@ public class AvoidEscapedUnicodeCharactersCheck
             final int lineNo = semi.getLineNo();
             final String currentLine = getLine(lineNo - 1);
 
-            if (currentLine != null && sCommentRegexp.matcher(currentLine).find()) {
+            if (sCommentRegexp.matcher(currentLine).find()) {
                 result = true;
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -19,10 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport {
 
@@ -164,4 +166,14 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharactersCheck.java"), expected);
     }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        AvoidEscapedUnicodeCharactersCheck check = new AvoidEscapedUnicodeCharactersCheck();
+        int[] actual = check.getAcceptableTokens();
+        int[] expected = new int[] {TokenTypes.STRING_LITERAL, TokenTypes.CHAR_LITERAL };
+        Assert.assertNotNull(actual);
+        Assert.assertArrayEquals(expected, actual);
+    }
+
 }


### PR DESCRIPTION
Reports are identical:
before: http://sabaka.github.io/AvoidUni/master/checkstyle.html
after: http://sabaka.github.io/AvoidUni/checkstyle.html