### PR TITLE
Issue #1296: 'SuppressionCommentFilter' UT coverage improved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1125,8 +1125,6 @@
             <regex><pattern>.*.checks.regexp.MultilineDetector</pattern><branchRate>58</branchRate><lineRate>87</lineRate></regex>
             <regex><pattern>.*.checks.regexp.SinglelineDetector</pattern><branchRate>93</branchRate><lineRate>96</lineRate></regex>
 
-            <regex><pattern>.*.filters.SuppressionCommentFilter</pattern><branchRate>83</branchRate><lineRate>93</lineRate></regex>
-            <regex><pattern>.*.filters.SuppressionCommentFilter\$Tag</pattern><branchRate>96</branchRate><lineRate>94</lineRate></regex>
             <regex><pattern>.*.filters.SuppressionsLoader</pattern><branchRate>63</branchRate><lineRate>77</lineRate></regex>
             <regex><pattern>.*.filters.SuppressWithNearbyCommentFilter</pattern><branchRate>76</branchRate><lineRate>89</lineRate></regex>
             <regex><pattern>.*.filters.SuppressWithNearbyCommentFilter\$Tag</pattern><branchRate>88</branchRate><lineRate>78</lineRate></regex>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -348,27 +348,18 @@ public class SuppressionCommentFilter
     /**
      * Set the format for a check.
      * @param format a <code>String</code> value
-     * @throws ConversionException if unable to create Pattern object
      */
-    public void setCheckFormat(String format)
-        throws ConversionException {
+    public void setCheckFormat(String format) {
         checkFormat = format;
-
     }
 
     /**
      * Set the format for a message.
      * @param format a <code>String</code> value
-     * @throws ConversionException unable to parse format
      */
-    public void setMessageFormat(String format)
-        throws ConversionException {
-        if (!Utils.isPatternValid(format)) {
-            throw new ConversionException("Unable to parse format: " + format);
-        }
+    public void setMessageFormat(String format) {
         messageFormat = format;
     }
-
 
     /**
      * Set whether to look in C++ comments.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
 
+import org.apache.commons.beanutils.ConversionException;
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -33,12 +35,16 @@ import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
+import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 import com.puppycrawl.tools.checkstyle.checks.FileContentsHolder;
 import com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class SuppressionCommentFilterTest
@@ -60,6 +66,7 @@ public class SuppressionCommentFilterTest
         "71:11: Catching 'Exception' is not allowed.",
         "77:11: Catching 'RuntimeException' is not allowed.",
         "78:11: Catching 'Exception' is not allowed.",
+        "86:31: Catching 'Exception' is not allowed.",
     };
 
     @Test
@@ -80,6 +87,7 @@ public class SuppressionCommentFilterTest
             "43:17: Name 'T' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "64:23: Catching 'Exception' is not allowed.",
             "71:11: Catching 'Exception' is not allowed.",
+            "86:31: Catching 'Exception' is not allowed.",
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -104,6 +112,7 @@ public class SuppressionCommentFilterTest
         filterConfig.addAttribute("checkCPP", "false");
         final String[] suppressed = {
             "16:17: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "86:31: Catching 'Exception' is not allowed.",
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -237,5 +246,43 @@ public class SuppressionCommentFilterTest
         );
 
         assertEquals("Tag[line=0; col=1; on=false; text='text']", tag.toString());
+    }
+
+    @Test(expected = ConversionException.class)
+    public void testInvalidCheckFormat() throws Exception {
+        final DefaultConfiguration filterConfig =
+            createFilterConfig(SuppressionCommentFilter.class);
+        filterConfig.addAttribute("checkFormat", "e[l");
+        final String[] suppressed = {
+        };
+        verifySuppressed(filterConfig, suppressed);
+    }
+
+    @Test(expected = ConversionException.class)
+    public void testInvalidMessageFormat() throws Exception {
+        final DefaultConfiguration filterConfig =
+            createFilterConfig(SuppressionCommentFilter.class);
+        filterConfig.addAttribute("messageFormat", "e[l");
+        final String[] suppressed = {
+        };
+        verifySuppressed(filterConfig, suppressed);
+    }
+
+    @Test
+    public void testAcceptNullLocalizedMessage() {
+        final SuppressionCommentFilter filter = new SuppressionCommentFilter();
+        final AuditEvent auditEvent = new AuditEvent(this);
+        Assert.assertTrue(filter.accept(auditEvent));
+    }
+
+    @Test
+    public void testAcceptNullFileContents() {
+        final LocalizedMessage message =
+            new LocalizedMessage(1, 1,
+                "messages.properties", "key", null, SeverityLevel.ERROR, null,
+                this.getClass(), null);
+        final AuditEvent auditEvent = new AuditEvent(this, "Test.java", message);
+        SuppressionCommentFilter filter = new SuppressionCommentFilter();
+        Assert.assertTrue(filter.accept(auditEvent));
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/InputSuppressionCommentFilter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/InputSuppressionCommentFilter.java
@@ -80,4 +80,11 @@ class InputSuppressionCommentFilter
         }
     }
 
+    public void doit4() {
+        try {
+
+        /* CHECKSTYLE:OFF */} catch(Exception e) {/* CHECKSTYLE:ON */
+
+        }
+    }
 }


### PR DESCRIPTION
Test coverage improved to 100%.

@romani please have a look at:

```
@Test
public void testAcceptNullLocalizedMessage() {...}

@Test
public void testAcceptNullFileContents() {...}
```

I didn't find other way to test the following conditions using **input data and normal logic workflow**:

- https://github.com/rdiachenko/checkstyle/blob/2b5dfeea5a0569649d46a0042c690044cc316c0d/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java#L383
- https://github.com/rdiachenko/checkstyle/blob/2b5dfeea5a0569649d46a0042c690044cc316c0d/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java#L390