### PR TITLE
Improve test coverage in AbstractJavadocCheck. #1308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1104,11 +1104,6 @@
             <regex><pattern>.*.checks.coding.SimplifyBooleanReturnCheck</pattern><branchRate>83</branchRate><lineRate>100</lineRate></regex>
             <regex><pattern>.*.checks.coding.VariableDeclarationUsageDistanceCheck</pattern><branchRate>90</branchRate><lineRate>98</lineRate></regex>
 
-            <regex><pattern>.*.checks.javadoc.AbstractJavadocCheck</pattern><branchRate>90</branchRate><lineRate>93</lineRate></regex>
-            <regex><pattern>.*.checks.javadoc.AbstractJavadocCheck\$.*</pattern><branchRate>50</branchRate><lineRate>68</lineRate></regex>
-            <regex><pattern>.*.checks.javadoc.AtclauseOrderCheck</pattern><branchRate>88</branchRate><lineRate>88</lineRate></regex>
-            <regex><pattern>.*.checks.javadoc.WriteTagCheck</pattern><branchRate>100</branchRate><lineRate>91</lineRate></regex>
-
             <regex><pattern>.*.checks.header.AbstractHeaderCheck</pattern><branchRate>90</branchRate><lineRate>87</lineRate></regex>
 
             <regex><pattern>.*.checks.regexp.CommentSuppressor</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -1,6 +1,5 @@
 javadoc.parse.error=Javadoc comment at column {0} has parse error. Details: {1}
 javadoc.unrecognized.antlr.error=Javadoc comment at column {0} has parse error. Unrecognized error from ANTLR parser: {1}
-javadoc.parse.token.error=Javadoc comment at column {0} has parse error. Details: {1}
 javadoc.parse.rule.error=Javadoc comment at column {0} has parse error. Details: {1} while parsing {2}
 javadoc.missed.html.close=Javadoc comment at column {0} has parse error. Missed HTML close tag ''{1}''. Sometimes it means that close tag missed for one of previous tags.
 javadoc.wrong.singleton.html.tag=Javadoc comment at column {0} has parse error. It is forbidden to close singleton HTML tags. Tag: {1}.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -19,12 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck.DescriptiveErrorListener.JAVADOC_MISSED_HTML_CLOSE;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck.DescriptiveErrorListener.JAVADOC_WRONG_SINGLETON_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck.PARSE_ERROR_MESSAGE_KEY;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck.UNRECOGNIZED_ANTLR_ERROR_MESSAGE_KEY;
 
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 
 public class AbstractJavadocCheckTest extends BaseCheckTestSupport {
@@ -51,5 +56,40 @@ public class AbstractJavadocCheckTest extends BaseCheckTestSupport {
                 + "while parsing HTML_TAG"),
         };
         verify(checkConfig, getPath("javadoc/InputTestNumberFomatException.java"), expected);
+    }
+
+    @Test
+    public void testCustomTag() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(TempCheck.class);
+        final String[] expected = {
+            "4: " + getCheckMessage(UNRECOGNIZED_ANTLR_ERROR_MESSAGE_KEY, 4, "null"),
+        };
+        verify(checkConfig, getPath("javadoc/InputCustomTag.java"), expected);
+    }
+
+    @Test
+    public void testParsingErrors() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(TempCheck.class);
+        final String[] expected = {
+            "4: " + getCheckMessage(JAVADOC_MISSED_HTML_CLOSE, 4, "unclosedTag"),
+            "8: " + getCheckMessage(JAVADOC_WRONG_SINGLETON_TAG, 35, "img"),
+        };
+        verify(checkConfig, getPath("javadoc/InputParsingErrors.java"), expected);
+    }
+
+    @Test
+    public void testWithMultipleChecks() throws Exception {
+        final DefaultConfiguration checkerConfig = new DefaultConfiguration("configuration");
+        final DefaultConfiguration checksConfig = createCheckConfig(TreeWalker.class);
+        checksConfig.addChild(createCheckConfig(AtclauseOrderCheck.class));
+        checksConfig.addChild(createCheckConfig(JavadocParagraphCheck.class));
+        checkerConfig.addChild(checksConfig);
+        final Checker checker = new Checker();
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.configure(checkerConfig);
+
+        final String[] expected = {
+        };
+        verify(checker, getPath("javadoc/InputCorrectJavaDocParagraphCheck.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputCustomTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputCustomTag.java
@@ -1,0 +1,8 @@
+package com.puppycrawl.tools.checkstyle.javadoc;
+
+public class InputCustomTag {
+    /**
+     * {@customTag}
+     */
+    void customTag() {}
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputParsingErrors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputParsingErrors.java
@@ -1,0 +1,12 @@
+package com.puppycrawl.tools.checkstyle.javadoc;
+
+/**
+ * <unclosedTag>
+ */
+class InputParsingErrors {
+    /**
+     * <img src="singletonTag"/></img>
+     */
+    void singletonTag() {
+    }
+}


### PR DESCRIPTION
Reports are identical:
```
diff pre/checkstyle-result.xml post/checkstyle-result.xml -s
Files pre/checkstyle-result.xml and post/checkstyle-result.xml are identical
```

The following config was used on 10,000 source files to generate reports:
```
    <module name="TreeWalker">
        <module name="JavadocParagraph"/>
        <module name="AtclauseOrder"/>
        <module name="JavadocTagContinuationIndentation"/>
        <module name="SingleLineJavadoc"/>
        <module name="SummaryJavadoc"/>
        <module name="NonEmptyAtclauseDescription"/>
    </module>
```

Fixes #1308.