### PR TITLE
Coverage has been increased to 100% in TrailingCommentCheck. Issue #1290

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1092,7 +1092,6 @@
                   <regex><pattern>.*.checks.NewlineAtEndOfFileCheck</pattern><branchRate>83</branchRate><lineRate>88</lineRate></regex>
                   <regex><pattern>.*.checks.OuterTypeFilenameCheck</pattern><branchRate>71</branchRate><lineRate>92</lineRate></regex>
                   <regex><pattern>.*.checks.SuppressWarningsHolder</pattern><branchRate>75</branchRate><lineRate>93</lineRate></regex>
-                  <regex><pattern>.*.checks.TrailingCommentCheck</pattern><branchRate>90</branchRate><lineRate>93</lineRate></regex>
                   <regex><pattern>.*.checks.TranslationCheck</pattern><branchRate>81</branchRate><lineRate>83</lineRate></regex>
                   <regex><pattern>.*.checks.UniquePropertiesCheck\$.*</pattern><branchRate>75</branchRate><lineRate>90</lineRate></regex>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -155,7 +155,7 @@ public class TrailingCommentCheck extends AbstractFormatCheck {
                 comment = cppComments.get(lineNo);
                 lineBefore = line.substring(0, comment.getStartColNo());
             }
-            else if (cComments.containsKey(lineNo)) {
+            else {
                 final List<TextBlock> commentList = cComments.get(lineNo);
                 comment = commentList.get(commentList.size() - 1);
                 lineBefore = line.substring(0, comment.getStartColNo());
@@ -168,8 +168,7 @@ public class TrailingCommentCheck extends AbstractFormatCheck {
                     }
                 }
             }
-            if (comment != null
-                && !blankLinePattern.matcher(lineBefore).find()
+            if (!blankLinePattern.matcher(lineBefore).find()
                 && !isLegalComment(comment)) {
                 log(lineNo.intValue(), MSG_KEY);
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
@@ -21,11 +21,13 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck.MSG_KEY;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
 
 public class TrailingCommentCheckTest extends BaseCheckTestSupport {
     private DefaultConfiguration checkConfig;
@@ -59,5 +61,17 @@ public class TrailingCommentCheckTest extends BaseCheckTestSupport {
             "19: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputTrailingComment.java"), expected);
+    }
+
+    @Test
+    public void testCallVisitToken() throws Exception {
+        TrailingCommentCheck check = new TrailingCommentCheck();
+        try {
+            check.visitToken(new DetailAST());
+            Assert.fail();
+        }
+        catch (IllegalStateException ex) {
+            "visitToken() shouldn't be called.".equals(ex.getMessage());
+        }
     }
 }


### PR DESCRIPTION
Reports are identical:
before: http://sabaka.github.io/TrailingComment/master/checkstyle.html
after: http://sabaka.github.io/TrailingComment/checkstyle.html