### PR TITLE
Fix overly-strict interpretation of the Google style guide regarding …

### DIFF
--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -196,7 +196,7 @@
              value="Method name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="SingleLineJavadoc">
-            <property name="ignoreInlineTags" value="false"/>
+            <property name="ignoreInlineTags" value="true"/>
         </module>
         <module name="EmptyCatchBlock">
             <property name="exceptionVariableName" value="expected"/>


### PR DESCRIPTION
…single-line Javadoc.

Section 7.1.1 of the Google Style Guide states "The single-line form may be
substituted when there are no at-clauses present". It doesn't define at-clauses
directly, but section 7.1.3 strongly suggests that it's referring to out-of-line
tags like `@param` and `@return`, not inline tags like `@link` and `@code`. This matches
my experience inside Google, and a random web search shows that at least one
other Google person considers this a bug: https://github.com/grpc/grpc-java/issues/111.