### PR TITLE
Add lambda support to indentation check

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
@@ -75,6 +75,7 @@ public class HandlerFactory {
         register(TokenTypes.LITERAL_NEW, NewHandler.class);
         register(TokenTypes.INDEX_OP, IndexHandler.class);
         register(TokenTypes.LITERAL_SYNCHRONIZED, SynchronizedHandler.class);
+        register(TokenTypes.LAMBDA, LambdaHandler.class);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LambdaHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LambdaHandler.java
@@ -1,0 +1,92 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.indentation;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+
+/**
+ * Handler for lambda expressions.
+ *
+ * @author pietern
+ */
+public class LambdaHandler extends AbstractExpressionHandler {
+    /**
+     * Construct an instance of this handler with the given indentation check,
+     * abstract syntax tree, and parent handler.
+     *
+     * @param indentCheck the indentation check
+     * @param ast the abstract syntax tree
+     * @param parent the parent handler
+     */
+    public LambdaHandler(IndentationCheck indentCheck,
+                         DetailAST ast, AbstractExpressionHandler parent) {
+        super(indentCheck, "lambda", ast, parent);
+    }
+
+    @Override
+    public IndentLevel suggestedChildLevel(AbstractExpressionHandler child) {
+        return getLevel();
+    }
+
+    @Override
+    protected IndentLevel getLevelImpl() {
+        if (getParent() instanceof MethodCallHandler) {
+            return getParent().suggestedChildLevel(this);
+        }
+
+        DetailAST parent = getMainAst().getParent();
+        if (getParent() instanceof NewHandler) {
+            parent = parent.getParent();
+        }
+
+        // Use the start of the parent's line as the reference indentation level.
+        IndentLevel level = new IndentLevel(getLineStart(parent));
+
+        // If the start of the lambda is the first element on the line;
+        // assume line wrapping with respect to its parent.
+        final DetailAST firstChild = getMainAst().getFirstChild();
+        if (getLineStart(firstChild) == firstChild.getColumnNo()) {
+            level = new IndentLevel(level, getIndentCheck().getLineWrappingIndentation());
+        }
+
+        return level;
+    }
+
+    @Override
+    public void checkIndentation() {
+        // If the argument list is the first element on the line
+        final DetailAST firstChild = getMainAst().getFirstChild();
+        if (getLineStart(firstChild) == firstChild.getColumnNo()) {
+            final IndentLevel level = getLevel();
+            if (!level.isAcceptable(firstChild.getColumnNo())) {
+                logError(firstChild, "arguments", firstChild.getColumnNo(), level);
+            }
+        }
+
+        // If the "->" is the first element on the line, assume line wrapping.
+        if (getLineStart(getMainAst()) == getMainAst().getColumnNo()) {
+            final IndentLevel level =
+                new IndentLevel(getLevel(), getIndentCheck().getLineWrappingIndentation());
+            if (!level.isAcceptable(getMainAst().getColumnNo())) {
+                logError(getMainAst(), "", getMainAst().getColumnNo(), level);
+            }
+        }
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -166,7 +166,8 @@ public class LineWrappingHandler {
 
         while (curNode != null && curNode != lastNode) {
 
-            if (curNode.getType() == TokenTypes.OBJBLOCK) {
+            if (curNode.getType() == TokenTypes.OBJBLOCK
+                    || curNode.getType() == TokenTypes.SLIST) {
                 curNode = curNode.getNextSibling();
             }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -67,6 +68,8 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     private static final Pattern NONSTRICT_LEVEL_COMMENT_REGEX =
                     Pattern.compile("//indent:\\d+ exp:>=(\\d+)( warn)?");
+
+    private static final String[] EMPTY_EXPECTED = {};
 
     private static Integer[] getLinesWithWarnAndCheckComments(String aFileName,
             final int tabWidth)
@@ -1570,5 +1573,39 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
             "1: " + getCheckMessage(MSG_ERROR, "package def", 1, 0),
         };
         verifyWarns(checkConfig, getPath("indentation/InputPackageDeclaration.java"), expected);
+    }
+
+    @Test
+    public void testLambda1() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+        checkConfig.addAttribute("tabWidth", "2");
+        checkConfig.addAttribute("basicOffset", "2");
+        checkConfig.addAttribute("lineWrappingIndentation", "4");
+        final String[] expected = {
+            "45: " + getCheckMessage(MSG_ERROR, "block lcurly", 5, 4),
+            "46: " + getCheckMessage(MSG_ERROR, "block rcurly", 5, 4),
+            "49: " + getCheckMessage(MSG_ERROR, "lambda arguments", 9, 8),
+            "50: " + getCheckMessage(MSG_ERROR, "lambda", 11, 12),
+            "51: " + getCheckMessage(MSG_ERROR, "block lcurly", 9, 8),
+            "63: " + getCheckMessage(MSG_CHILD_ERROR, "block", 7, 6),
+            "64: " + getCheckMessage(MSG_ERROR, "block rcurly", 5, 4),
+            "174: " + getCheckMessage(MSG_CHILD_ERROR, "block", 9, 10),
+            "174: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 9, 10),
+            "175: " + getCheckMessage(MSG_CHILD_ERROR, "block", 11, 10),
+            "180: " + getCheckMessage(MSG_ERROR, "block rcurly", 7, 8),
+        };
+        verifyWarns(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/indentation/InputLambda1.java").getCanonicalPath(), expected, 1);
+    }
+
+    @Test
+    public void testLambda2() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+        checkConfig.addAttribute("tabWidth", "4");
+        checkConfig.addAttribute("basicOffset", "4");
+        checkConfig.addAttribute("lineWrappingIndentation", "8");
+        final String[] expected = EMPTY_EXPECTED;
+        verifyWarns(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
+                + "checkstyle/indentation/InputLambda2.java").getCanonicalPath(), expected, 0);
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/indentation/InputLambda1.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/indentation/InputLambda1.java
@@ -1,0 +1,221 @@
+package com.puppycrawl.tools.checkstyle.indentation; //indent:0 exp:0
+
+import java.util.ArrayList; //indent:0 exp:0
+import java.util.List; //indent:0 exp:0
+import java.util.Map; //indent:0 exp:0
+import java.util.StringJoiner; //indent:0 exp:0
+import java.util.stream.Collector; //indent:0 exp:0
+import java.util.stream.Collectors; //indent:0 exp:0
+import java.util.stream.IntStream; //indent:0 exp:0
+import java.util.stream.Stream; //indent:0 exp:0
+
+public class InputLambda1 { //indent:0 exp:0
+
+  interface Printer //indent:2 exp:2
+  { //indent:2 exp:2
+    void print(String s); //indent:4 exp:4
+  } //indent:2 exp:2
+
+  class LongTypeName { //indent:2 exp:2
+  } //indent:2 exp:2
+
+  interface SomeInterface { //indent:2 exp:2
+    void someFunction(LongTypeName arg); //indent:4 exp:4
+  } //indent:2 exp:2
+
+  void function1(Runnable x) { //indent:2 exp:2
+    Runnable r1 = () -> { //indent:4 exp:4
+      x.run(); //indent:6 exp:6
+    }; //indent:4 exp:4
+
+    Runnable r2 = () -> { x.run(); }; //indent:4 exp:4
+
+    Runnable r3 = () -> //indent:4 exp:4
+        x.run(); //indent:8 exp:8
+
+    Runnable r4 = () -> x.run(); //indent:4 exp:4
+
+    Printer r5 = s -> System.out.print(s); //indent:4 exp:4
+
+    Printer r6 = s -> System.out //indent:4 exp:4
+        .print(s); //indent:8 exp:8
+
+    Runnable r7 = () //indent:4 exp:4
+        -> //indent:8 exp:8
+     { //indent:5 exp:4 warn
+     }; //indent:5 exp:4 warn
+
+    Runnable r8 = //indent:4 exp:4
+         () //indent:9 exp:8 warn
+           -> //indent:11 exp:12 warn
+         {}; //indent:9 exp:8 warn
+
+    Runnable r9 = //indent:4 exp:4
+        () //indent:8 exp:8
+            -> //indent:12 exp:12
+        {}; //indent:8 exp:8
+
+    Object o = new Thread(() -> { //indent:4 exp:4
+      x.run(); //indent:6 exp:6
+    }); //indent:4 exp:4
+
+    Runnable r01 = () -> { //indent:4 exp:4
+       x.run(); //indent:7 exp:6 warn
+     }; //indent:5 exp:4 warn
+
+    Runnable r11 = //indent:4 exp:4
+        () -> { //indent:8 exp:8
+          x.run(); //indent:10 exp:10
+        }; //indent:8 exp:8
+
+    Runnable r21 = //indent:4 exp:4
+        () -> { x.run(); }; //indent:8 exp:8
+
+    Runnable r31 = //indent:4 exp:4
+        () -> x //indent:8 exp:8
+            .run(); //indent:12 exp:12
+
+    Runnable r41 = //indent:4 exp:4
+        () -> x.run(); //indent:8 exp:8
+
+    Printer r51 = //indent:4 exp:4
+        s -> System.out.print(s); //indent:8 exp:8
+
+    Printer r61 = //indent:4 exp:4
+        s -> System.out //indent:8 exp:8
+            .print(s); //indent:12 exp:12
+
+    Object o1 = new Thread( //indent:4 exp:4
+        () -> { //indent:8 exp:8
+          x.run(); //indent:10 exp:10
+        }); //indent:8 exp:8
+
+    SomeInterface i1 = (LongTypeName //indent:4 exp:4
+        arg) -> { //indent:8 exp:8
+      System.out.print(arg.toString()); //indent:6 exp:6
+    }; //indent:4 exp:4
+
+    Printer[] manyRunnable = new Printer[]{ //indent:4 exp:4
+        s -> System.out.print(s), //indent:8 exp:6,8
+        s -> { System.out.print(s); }, //indent:8 exp:6,8
+        s -> System.out //indent:8 exp:6,8
+            .print(s), //indent:12 exp:12
+        s -> { //indent:8 exp:6,8
+          System.out.print(s); //indent:10 exp:10
+        }, //indent:8 exp:8
+    }; //indent:4 exp:4
+  } //indent:2 exp:2
+
+  void function3(Runnable x) { //indent:2 exp:2
+    function1(() -> { //indent:4 exp:4
+      x.run(); //indent:6 exp:6
+    }); //indent:4 exp:4
+  } //indent:2 exp:2
+
+  class Person { //indent:2 exp:2
+    String name; //indent:4 exp:4
+    int age; //indent:4 exp:4
+    Person(String name, int age) { //indent:4 exp:4
+    } //indent:4 exp:4
+  } //indent:2 exp:2
+
+  class Foo { //indent:2 exp:2
+    String name; //indent:4 exp:4
+    List<Bar> bars = new ArrayList<>(); //indent:4 exp:4
+
+    Foo(String name) { //indent:4 exp:4
+      this.name = name; //indent:6 exp:6
+    } //indent:4 exp:4
+  } //indent:2 exp:2
+
+  class Bar { //indent:2 exp:2
+    String name; //indent:4 exp:4
+    Bar(String name) { //indent:4 exp:4
+      this.name = name; //indent:6 exp:6
+    } //indent:4 exp:4
+  } //indent:2 exp:2
+
+  public void f() { //indent:2 exp:2
+    Stream.of("d2", "a2", "b1", "b3", "c") //indent:4 exp:4
+        .map(s -> { //indent:8 exp:8
+          System.out.println("map: " + s); //indent:10 exp:10
+          return s.toUpperCase(); //indent:10 exp:10
+        }) //indent:8 exp:8
+        .anyMatch(s -> { //indent:8 exp:8
+          System.out.println("anyMatch: " + s); //indent:10 exp:10
+          return s.startsWith("A"); //indent:10 exp:10
+        }); //indent:8 exp:8
+
+    List<Person> persons = null; //indent:4 exp:4
+
+    Map<Integer, List<Person>> personsByAge = persons //indent:4 exp:4
+        .stream() //indent:8 exp:8
+        .collect(Collectors.groupingBy(p -> p.age)); //indent:8 exp:8
+
+    personsByAge //indent:4 exp:4
+        .forEach((age, p) -> System.out.format("age %s: %s\n", age, p)); //indent:8 exp:8
+
+    Collector<Person, StringJoiner, String> personNameCollector = //indent:4 exp:4
+        Collector.of( //indent:8 exp:8
+            () -> new StringJoiner(" | "), //indent:12 exp:12
+            (j, p) -> j.add(p.name.toUpperCase()), //indent:12 exp:12
+            (j1, j2) -> j1.merge(j2), //indent:12 exp:12
+            StringJoiner::toString); //indent:12 exp:12
+
+    List<Foo> foos = new ArrayList<>(); //indent:4 exp:4
+
+    foos.forEach(f -> //indent:4 exp:4
+        IntStream //indent:8 exp:8
+            .range(1, 4) //indent:12 exp:12
+            .forEach(i -> f.bars.add(new Bar("Bar" + i + " <- " + f.name)))); //indent:12 exp:12
+
+    Stream.of("d2", "a2", "b1", "b3", "c") //indent:4 exp:4
+        .filter(s -> { //indent:8 exp:8
+         System.out.println("filter: " + s); //indent:9 exp:10 warn
+           return s.startsWith("a"); //indent:11 exp:10 warn
+        }) //indent:8 exp:8
+        .map(s -> { //indent:8 exp:8
+          System.out.println("map: " + s); //indent:10 exp:10
+          return s.toUpperCase(); //indent:10 exp:10
+       }) //indent:7 exp:8 warn
+        .forEach(s -> //indent:8 exp:8
+            System.out.println("forEach: " + s)); //indent:12 exp:12
+
+    IntStream.range(1, 4) //indent:4 exp:4
+        .mapToObj(i -> new Foo("Foo" + i)) //indent:8 exp:8
+        .peek(f -> IntStream.range(1, 4) //indent:8 exp:8
+            .mapToObj(i -> new Bar("Bar" + i + " <- " + f.name)) //indent:12 exp:12
+            .forEach(f.bars::add)) //indent:12 exp:12
+        .flatMap(f -> f.bars.stream()) //indent:8 exp:8
+        .forEach(b -> System.out.println(b.name)); //indent:8 exp:8
+
+    IntStream.range(1, 4) //indent:4 exp:4
+        .mapToObj(i -> new Foo("Foo" + i)) //indent:8 exp:8
+        .peek(f -> IntStream.range(1, 4) //indent:8 exp:8
+            .mapToObj(i -> new Bar("Bar" + i + " <- " + f.name)) //indent:12 exp:12
+            .forEach(f.bars::add)) //indent:12 exp:12
+        .flatMap(f -> f.bars.stream()) //indent:8 exp:8
+        .forEach(b -> System.out.println(b.name)); //indent:8 exp:8
+  } //indent:2 exp:2
+
+  Runnable r2r(Runnable x) { //indent:2 exp:2
+    return x; //indent:4 exp:4
+  } //indent:2 exp:2
+
+  void function2(Runnable x) { //indent:2 exp:2
+    Runnable r0 = r2r(() -> { //indent:4 exp:4
+      int i = 1; //indent:6 exp:6
+    }); //indent:4 exp:4
+
+    Runnable r1 = r2r(() -> { //indent:4 exp:4
+          int i = 1; //indent:10 exp:10
+        } //indent:8 exp:8
+    ); //indent:4 exp:4
+
+    Runnable r2 = r2r(r2r(() -> { //indent:4 exp:4
+              int i = 1; //indent:14 exp:14
+            } //indent:12 exp:12
+        ) //indent:8 exp:8
+    ); //indent:4 exp:4
+  } //indent:2 exp:2
+} //indent:0 exp:0

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/indentation/InputLambda2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/indentation/InputLambda2.java
@@ -1,0 +1,42 @@
+package com.puppycrawl.tools.checkstyle.indentation; //indent:0 exp:0
+
+import java.util.function.BinaryOperator; //indent:0 exp:0
+import java.util.function.Consumer; //indent:0 exp:0
+
+public class InputLambda2 { //indent:0 exp:0
+    public <T> Consumer<Integer> params(Consumer<Integer> f1, Consumer<Integer> f2) { //indent:4 exp:4
+        return f2; //indent:8 exp:8
+    } //indent:4 exp:4
+
+    private void print(int i) { //indent:4 exp:4
+    } //indent:4 exp:4
+
+    public Consumer<Integer> returnFunctionOfLambda() { //indent:4 exp:4
+        return params( //indent:8 exp:8
+                (x) -> print(x * 1), //indent:16 exp:16
+                (x) -> print(x * 2) //indent:16 exp:16
+        ); //indent:8 exp:8
+    } //indent:4 exp:4
+
+    public static <T> BinaryOperator<T> returnLambda() { //indent:4 exp:4
+        return (t1, t2) -> { //indent:8 exp:8
+            return t1; //indent:12 exp:12
+        }; //indent:8 exp:8
+    } //indent:4 exp:4
+
+    class TwoParams { //indent:4 exp:4
+        TwoParams(Consumer<Integer> c1, Consumer<Integer> c2) { //indent:8 exp:8
+        } //indent:8 exp:8
+    } //indent:4 exp:4
+
+    public void makeTwoParams() { //indent:4 exp:4
+        TwoParams t0 = new TwoParams( //indent:8 exp:8
+                (x) -> print(x * 1), //indent:16 exp:16
+                (x) -> print(x * 2) //indent:16 exp:16
+        ); //indent:8 exp:8
+
+        TwoParams t1 = new TwoParams( //indent:8 exp:8
+                (x) -> print(x * 1), //indent:16 exp:16
+                (x) -> print(x * 2)); //indent:16 exp:16
+    } //indent:4 exp:4
+} //indent:0 exp:0


### PR DESCRIPTION
This is a first pass for lambda support in the indentation check. All unit and integration tests pass. The test case is based on the test case in this branch: https://github.com/checkstyle/checkstyle/compare/master...pirat9600q:IndentationCheck_issue281. Not all cases will be covered in this commit, but at least it's a start. I ran checkstyle against a codebase I'm working on and all the lambda related warnings disappear with this commit.

Also see #281.