### PR TITLE
Minor typo on site homepage: 'desig' -> 'design'

### DIFF
--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -78,7 +78,7 @@
     <section name="Features">
       <p>
         Checkstyle can check many aspects of your source code.
-        It can find class design problems, method desig problems.
+        It can find class design problems, method design problems.
         It also have ability to check code layout and formatting issues.
       </p>
 

--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -79,7 +79,7 @@
       <p>
         Checkstyle can check many aspects of your source code.
         It can find class design problems, method design problems.
-        It also have ability to check code layout and formatting issues.
+        It also has the ability to check code layout and formatting issues.
       </p>
 
       <p>


### PR DESCRIPTION
Spotted a minor typo when on the [Sourceforge page](http://checkstyle.sourceforge.net/), so said I'd submit.