### PR TITLE
Fixed overly strong type cast, issue #1555.

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
@@ -50,8 +50,8 @@ public class ArrayInitHandler extends BlockParentHandler {
             return new IndentLevel(getLineStart(parentAST));
         }
         else {
-            // at this point getParent() is instance of ArrayInitHandler
-            return ((ArrayInitHandler) getParent()).getChildrenExpectedLevel();
+            // at this point getParent() is instance of BlockParentHandler
+            return ((BlockParentHandler) getParent()).getChildrenExpectedLevel();
         }
     }
 


### PR DESCRIPTION
Fixed IDEA's inspection violation: "Overly strong type cast".

[NOTE](https://www.jetbrains.com/idea/documentation/inspections/OverlyStrongTypeCast.html): this inspection reports any instances of type casts which are overly strong. For instance, casting an object to ArrayList when casting it to List would do just as well. 