### PR TITLE
Copy collections and arrays before assigning to fields. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
@@ -30,7 +30,7 @@ import java.util.Properties;
 public final class PropertiesExpander
     implements PropertyResolver {
     /** the underlying Properties object. */
-    private final Properties properties;
+    private final Properties properties = new Properties();
 
     /**
      * Creates a new PropertiesExpander.
@@ -42,7 +42,7 @@ public final class PropertiesExpander
         if (properties == null) {
             throw new IllegalArgumentException("cannot pass null");
         }
-        this.properties = properties;
+        this.properties.putAll(properties);
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -87,7 +87,7 @@ public final class FileContents implements CommentListener {
      */
     public FileContents(FileText text) {
         fileName = text.getFile().toString();
-        this.text = text;
+        this.text = new FileText(text);
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -38,6 +38,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import com.google.common.io.Closeables;
 
 /**
@@ -184,6 +186,18 @@ public final class FileText extends AbstractList<String> {
         charset = null;
         fullText = buf.toString();
         this.lines = lines.toArray(new String[lines.size()]);
+    }
+
+    /**
+     * Copy constructor.
+     * @param fileText to make copy of
+     */
+    public FileText(FileText fileText) {
+        this.file = fileText.file;
+        this.charset = fileText.charset;
+        this.fullText = fileText.fullText;
+        this.lines = fileText.lines.clone();
+        this.lineBreaks = ArrayUtils.clone(fileText.lineBreaks);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -46,8 +47,8 @@ public class ClassResolver {
     public ClassResolver(ClassLoader loader, String pkg, Set<String> imports) {
         this.loader = loader;
         this.pkg = pkg;
-        this.imports = imports;
-        imports.add("java.lang.*");
+        this.imports = new HashSet<>(imports);
+        this.imports.add("java.lang.*");
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -658,7 +658,7 @@ public abstract class AbstractJavadocCheck extends Check {
         public ParseErrorMessage(int lineNumber, String messageKey, Object ... messageArguments) {
             this.lineNumber = lineNumber;
             this.messageKey = messageKey;
-            this.messageArguments = messageArguments;
+            this.messageArguments = messageArguments.clone();
         }
 
         public int getLineNumber() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTags.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTags.java
@@ -21,6 +21,8 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
+
 /**
  * Value object for combining the list of valid validTags with information
  * about invalid validTags encountered in a certain Javadoc comment.
@@ -39,8 +41,8 @@ public final class JavadocTags {
      */
     public JavadocTags(List<JavadocTag> tags,
             List<InvalidJavadocTag> invalidTags) {
-        validTags = tags;
-        this.invalidTags = invalidTags;
+        validTags = ImmutableList.copyOf(tags);
+        this.invalidTags = ImmutableList.copyOf(invalidTags);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
@@ -76,7 +76,7 @@ class MultilineDetector {
      * @param text the text to process
      */
     public void processLines(FileText text) {
-        this.text = text;
+        this.text = new FileText(text);
         resetState();
 
         if (!Strings.isNullOrEmpty(options.getFormat())) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import javax.swing.JTextArea;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 
 /**
@@ -47,7 +48,7 @@ public class CodeSelector {
                         final List<Integer> lines2position) {
         this.ast = ast;
         this.editor = editor;
-        this.lines2position = lines2position;
+        this.lines2position = ImmutableList.copyOf(lines2position);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
@@ -86,6 +86,7 @@ import javax.swing.tree.TreeCellRenderer;
 import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 
 /**
@@ -475,6 +476,6 @@ public class JTreeTable extends JTable {
     }
 
     public void setLinePositionMap(List<Integer> lines2position) {
-        this.lines2position = lines2position;
+        this.lines2position = ImmutableList.copyOf(lines2position);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/ClassResolverTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/ClassResolverTest.java
@@ -59,6 +59,7 @@ public class ClassResolverTest {
         }
 
         imps.add("java.text.ChoiceFormat");
+        cr = new ClassResolver(Thread.currentThread().getContextClassLoader(), null, imps);
         cr.resolve("ChoiceFormat", "");
 
         cr = new ClassResolver(Thread.currentThread().getContextClassLoader(),


### PR DESCRIPTION
Fixes AssignmentToCollectionFieldFromParameter violations.

Description:
>Reports any attempt to assign an array or Collection field from a method parameter. Since the array or Collection may have its contents modified by the calling method, this construct may result in an object having its state modified unexpectedly. While occasionally useful for performance reasons, this construct is inherently bug-prone.