### PR TITLE
Issue #1566: Checkstyle violations fixes

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
@@ -98,24 +98,21 @@ public abstract class AbstractDeclarationCollector extends Check {
         DetailAST ast) {
         final LexicalFrame frame = frameStack.peek();
         switch (ast.getType()) {
-            case TokenTypes.VARIABLE_DEF :  {
+            case TokenTypes.VARIABLE_DEF :
                 collectVariableDeclarations(ast, frame);
                 break;
-            }
-            case TokenTypes.PARAMETER_DEF : {
-                final DetailAST nameAST = ast.findFirstToken(TokenTypes.IDENT);
-                frame.addName(nameAST.getText());
+            case TokenTypes.PARAMETER_DEF :
+                final DetailAST parameterAST = ast.findFirstToken(TokenTypes.IDENT);
+                frame.addName(parameterAST.getText());
                 break;
-            }
             case TokenTypes.CLASS_DEF :
             case TokenTypes.INTERFACE_DEF :
             case TokenTypes.ENUM_DEF :
-            case TokenTypes.ANNOTATION_DEF : {
-                final DetailAST nameAST = ast.findFirstToken(TokenTypes.IDENT);
-                frame.addName(nameAST.getText());
+            case TokenTypes.ANNOTATION_DEF :
+                final DetailAST classAST = ast.findFirstToken(TokenTypes.IDENT);
+                frame.addName(classAST.getText());
                 frameStack.addFirst(new ClassFrame(frame));
                 break;
-            }
             case TokenTypes.SLIST :
                 frameStack.addFirst(new BlockFrame(frame));
                 break;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -130,10 +130,14 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
          */
         private final Multiset<String> duplicatedStrings = HashMultiset
                 .create();
+        /**
+         * Lock for this class to synchronize on
+         */
+        private final Object lock = new Object();
 
         @Override
         public Object put(Object key, Object value) {
-            synchronized (this) {
+            synchronized (lock) {
                 final Object oldValue = super.put(key, value);
                 if (oldValue != null && key instanceof String) {
                     final String keyString = (String) key;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -260,21 +260,15 @@ public final class AnnotationUseStyleCheck extends Check {
     private void checkStyleType(final DetailAST annotation) {
 
         switch (this.style) {
-
-            case COMPACT_NO_ARRAY: {
+            case COMPACT_NO_ARRAY:
                 checkCompactNoArrayStyle(annotation);
                 break;
-            }
-
-            case COMPACT: {
+            case COMPACT:
                 checkCompactStyle(annotation);
                 break;
-            }
-
-            case EXPANDED: {
+            case EXPANDED:
                 checkExpandedStyle(annotation);
                 break;
-            }
             default:
                 break;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -138,19 +138,17 @@ public class RequireThisCheck extends AbstractDeclarationCollector {
             case TokenTypes.ANNOTATION_FIELD_DEF:
                 // no need to check annotations content
                 break;
-            case TokenTypes.METHOD_CALL: {
+            case TokenTypes.METHOD_CALL:
                 // let's check method calls
                 if (checkMethods && isClassMethod(ast.getText())) {
                     log(ast, "require.this.method", ast.getText());
                 }
                 break;
-            }
-            default: {
+            default:
                 if (checkFields) {
                     processField(ast, parentType);
                 }
                 break;
-            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java
@@ -54,8 +54,8 @@ public class CodeSelector {
      * Set a selection position from AST line and Column
      */
     public void select() {
-        int start = lines2position.get(ast.getLineNo()) + ast.getColumnNo();
-        int end = findLastPosition(ast);
+        final int start = lines2position.get(ast.getLineNo()) + ast.getColumnNo();
+        final int end = findLastPosition(ast);
 
         editor.setSelectedTextColor(Color.blue);
         editor.requestFocusInWindow();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
@@ -150,7 +150,7 @@ public class JTreeTable extends JTable {
                 public void actionPerformed(ActionEvent e) {
                     final TreePath selected = tree.getSelectionPath();
 
-                    DetailAST ast = (DetailAST) selected.getLastPathComponent();
+                    final DetailAST ast = (DetailAST) selected.getLastPathComponent();
                     new CodeSelector(ast, editor, lines2position).select();
 
                     if (tree.isExpanded(selected)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
@@ -48,7 +48,7 @@ public class Main {
         }
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
-        Runnable runner = new FrameShower(frame);
+        final Runnable runner = new FrameShower(frame);
         EventQueue.invokeLater(runner);
     }
 
@@ -57,7 +57,7 @@ public class Main {
      * @param ast
      */
     public static void displayAst(DetailAST ast) {
-        JFrame frame = new JFrame("CheckStyle");
+        final JFrame frame = new JFrame("CheckStyle");
         final ParseTreeInfoPanel panel = new ParseTreeInfoPanel();
         frame.getContentPane().add(panel);
         panel.openAst(ast, frame);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -113,7 +113,7 @@ public class ParseTreeInfoPanel extends JPanel {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            final JFileChooser fc = new JFileChooser( lastDirectory );
+            final JFileChooser fc = new JFileChooser(lastDirectory);
             final FileFilter filter = new JavaFileFilter();
             fc.setFileFilter(filter);
             final Component parent =
@@ -249,7 +249,7 @@ public class ParseTreeInfoPanel extends JPanel {
         setLayout(new BorderLayout());
 
         parseTreeModel = new ParseTreeModel(null);
-        JTreeTable treeTable = new JTreeTable(parseTreeModel);
+        final JTreeTable treeTable = new JTreeTable(parseTreeModel);
         final JScrollPane sp = new JScrollPane(treeTable);
         this.add(sp, BorderLayout.NORTH);
 


### PR DESCRIPTION
The following violations were fixed:
- AvoidNestedBlocks
- FinalLocalVariable
- UnusedImports
- RegexpSingleline: Using THIS as a lock is a bad practice (use class variable instead)