### PR TITLE
Replace magic constant occurrences with proper constants. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
@@ -23,6 +23,7 @@ import java.awt.EventQueue;
 import java.io.File;
 
 import javax.swing.JFrame;
+import javax.swing.WindowConstants;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 
@@ -46,7 +47,7 @@ public class Main {
             final File f = new File(args[0]);
             panel.openFile(f, frame);
         }
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 
         Runnable runner = new FrameShower(frame);
         EventQueue.invokeLater(runner);
@@ -62,7 +63,7 @@ public class Main {
         frame.getContentPane().add(panel);
         panel.openAst(ast, frame);
         frame.setSize(1500, 800);
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         frame.setVisible(true);
     }
 


### PR DESCRIPTION
Fixes MagicConstant violations.

 Description:
> Report occurrences where usages of "magic" constants only are allowed but other expressions are used instead. E.g. `new Font("Arial", 2 ) // not allowed` instead of `new Font("Arial", Font. ITALIC ) // OK`.  Please see org.intellij.lang.annotations.MagicConstant annotation description for details.