### PR TITLE
Remove unused assignments. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -292,8 +292,8 @@ public final class Main {
             throws UnsupportedEncodingException, FileNotFoundException {
 
         // setup the output stream
-        OutputStream out = null;
-        boolean closeOut = false;
+        OutputStream out;
+        boolean closeOut;
         if (outputLocation != null) {
             out = new FileOutputStream(outputLocation);
             closeOut = true;
@@ -304,7 +304,7 @@ public final class Main {
         }
 
         // setup a listener
-        AuditListener listener = null;
+        AuditListener listener;
         if ("xml".equals(format)) {
             listener = new XMLLogger(out, closeOut);
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -209,7 +209,7 @@ public final class TreeWalker
                      fileName);
             LOG.error(exceptionMsg);
             final RecognitionException re = tre.recog;
-            String message = "TokenStreamRecognitionException occured";
+            String message;
             message = re.getMessage();
             getMessageCollector().add(createLocalizedMessage(message));
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -337,7 +337,7 @@ public class CheckstyleAntTask extends Task {
      * @return new instance of <code>Checker</code>
      */
     private Checker createChecker() {
-        Checker c = null;
+        Checker c;
         try {
             final Properties props = createOverridingProperties();
             final Configuration config =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -149,8 +149,8 @@ public class TrailingCommentCheck extends AbstractFormatCheck {
 
         for (Integer lineNo : lines) {
             final String line = getLines()[lineNo - 1];
-            String lineBefore = "";
-            TextBlock comment = null;
+            String lineBefore;
+            TextBlock comment;
             if (cppComments.containsKey(lineNo)) {
                 comment = cppComments.get(lineNo);
                 lineBefore = line.substring(0, comment.getStartColNo());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -176,8 +176,8 @@ public class LeftCurlyCheck
 
     @Override
     public void visitToken(DetailAST ast) {
-        DetailAST startToken = null;
-        DetailAST brace = null;
+        DetailAST startToken;
+        DetailAST brace;
 
         switch (ast.getType()) {
             case TokenTypes.CTOR_DEF:

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -186,7 +186,7 @@ public class NeedBracesCheck extends Check {
      * @return true if current statement is single-line statement.
      */
     private static boolean isSingleLineStatement(DetailAST statement) {
-        boolean result = false;
+        boolean result;
         final int type = statement.getType();
 
         if (type == TokenTypes.LITERAL_IF) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -272,8 +272,8 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
         // Attempt to locate the tokens to do the check
         boolean shouldCheckLastRcurly = false;
         DetailAST rcurly = null;
-        DetailAST lcurly = null;
-        DetailAST nextToken = null;
+        DetailAST lcurly;
+        DetailAST nextToken;
 
         switch (ast.getType()) {
             case TokenTypes.LITERAL_TRY:

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -238,7 +238,7 @@ public class FallThroughCheck extends Check {
      * @return true if loop is terminated.
      */
     private boolean checkLoop(final DetailAST ast) {
-        DetailAST loopBody = null;
+        DetailAST loopBody;
         if (ast.getType() == TokenTypes.LITERAL_DO) {
             final DetailAST lparen = ast.findFirstToken(TokenTypes.DO_WHILE);
             loopBody = lparen.getPreviousSibling();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -265,7 +265,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
 
             if (!isVariableMatchesIgnorePattern(variable.getText())) {
                 final DetailAST semicolonAst = ast.getNextSibling();
-                Entry<DetailAST, Integer> entry = null;
+                Entry<DetailAST, Integer> entry;
                 if (validateBetweenScopes) {
                     entry = calculateDistanceBetweenScopes(semicolonAst, variable);
                 }
@@ -548,7 +548,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
         DetailAST firstNodeInsideBlock = null;
 
         if (!isVariableInOperatorExpr(block, variable)) {
-            DetailAST currentNode = null;
+            DetailAST currentNode;
 
             // Find currentNode for DO-WHILE block.
             if (block.getType() == TokenTypes.LITERAL_DO) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -637,7 +637,7 @@ public class VisibilityModifierCheck
      * @return String representation of given type's name.
      */
     private static String getTypeName(DetailAST type, boolean isCanonicalName) {
-        String typeName = "";
+        String typeName;
         if (isCanonicalName) {
             typeName = getCanonicalName(type);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -134,7 +134,7 @@ final class ImportControlLoader extends AbstractLoader {
      * @throws CheckstyleException if an error occurs.
      */
     static PkgControl load(final URI uri) throws CheckstyleException {
-        InputStream is = null;
+        InputStream is;
         try {
             is = uri.toURL().openStream();
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -364,7 +364,7 @@ public abstract class AbstractJavadocCheck extends Check {
      * @return token type from JavadocTokenTypes
      */
     private static int getTokenType(ParseTree node) {
-        int tokenType = Integer.MIN_VALUE;
+        int tokenType;
 
         if (node.getChildCount() == 0) {
             tokenType = ((TerminalNode) node).getSymbol().getType();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -146,7 +146,7 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
      */
     private void checkOrderInTagSection(DetailNode javadoc) {
         int indexOrderOfPreviousTag = 0;
-        int indexOrderOfCurrentTag = 0;
+        int indexOrderOfCurrentTag;
 
         for (DetailNode node : javadoc.getChildren()) {
             if (node.getType() == JavadocTokenTypes.JAVADOC_TAG) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -339,7 +339,7 @@ public class JavaNCSSCheck extends Check {
      * @return true if the expression is countable, false otherwise
      */
     private static boolean isExpressionCountable(DetailAST ast) {
-        boolean countable = true;
+        boolean countable;
 
         //count expressions only if they are direct child to a slist (method
         // body, for loop...)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -124,7 +124,7 @@ public class SuppressWithNearbyCommentFilter
                 }
                 format = expandFrocomment(
                     text, filter.influenceFormat, filter.commentRegexp);
-                int influence = 0;
+                int influence;
                 try {
                     if (Utils.startsWithChar(format, '+')) {
                         format = format.substring(1);


### PR DESCRIPTION
Fixes UnusedAssignment inspection violations.

Description:
>This inspection points out the cases where a variable value is never used after its assignment, i.e.:
- the variable never gets read after assignment OR
- the value is always overwritten with another assignment before the next variable read OR
- the variable initializer is redundant (for one of the above two reasons) OR
- the variable is never used.