### PR TITLE
Replace subtraction in compareTo() with Integer.compare(). #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
@@ -58,8 +58,8 @@ public class LineColumn implements Comparable<LineColumn> {
     @Override
     public int compareTo(LineColumn lineColumn) {
         return this.getLine() != lineColumn.getLine()
-            ? this.getLine() - lineColumn.getLine()
-            : this.getColumn() - lineColumn.getColumn();
+            ? Integer.compare(this.getLine(), lineColumn.getLine())
+            : Integer.compare(this.getColumn(), lineColumn.getColumn());
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -179,10 +179,10 @@ public class SuppressWithNearbyCommentFilter
         @Override
         public int compareTo(Tag other) {
             if (firstLine == other.firstLine) {
-                return lastLine - other.lastLine;
+                return Integer.compare(lastLine, other.lastLine);
             }
 
-            return firstLine - other.firstLine;
+            return Integer.compare(firstLine, other.firstLine);
         }
 
         /** {@inheritDoc} */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -182,10 +182,10 @@ public class SuppressionCommentFilter
         @Override
         public int compareTo(Tag object) {
             if (line == object.line) {
-                return column - object.column;
+                return Integer.compare(column, object.column);
             }
 
-            return line - object.line;
+            return Integer.compare(line, object.line);
         }
 
         /** {@inheritDoc} */


### PR DESCRIPTION
Fixes SubtractionInCompareTo inspection violations.

Description:
>Reports subtraction in compareTo() methods and methods implementing java.util.Comparator.compare(). While it is a common idiom to use the results of integer subtraction as the result of a compareTo() method, this construct may cause subtle and difficult bugs in cases of integer overflow.