### PR TITLE
Replace Class.newInstance() with Constructor.newInstance(). #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -112,10 +112,10 @@ class PackageObjectFactory implements ModuleFactory {
         throws CheckstyleException {
         try {
             final Class<?> clazz = Class.forName(className, true, moduleClassLoader);
-            return clazz.newInstance();
+            return clazz.getDeclaredConstructor().newInstance();
         }
-        catch (final ClassNotFoundException | InstantiationException | IllegalAccessException e) {
-            throw new CheckstyleException("Unable to find class for " + className, e);
+        catch (final ReflectiveOperationException exception) {
+            throw new CheckstyleException("Unable to find class for " + className, exception);
         }
     }
 


### PR DESCRIPTION
Fixes ClassNewInstance inspection violation.

Description:
>Reports any calls to java.lang.Class.newInstance(). The newInstance method propagates any exception thrown by the no-arg constructor, including checked exceptions. Use of this method effectively bypasses the compile-time exception checking that would otherwise be performed by the compiler. Replacing such a method call with a call to the java.lang.reflect.Constructor.newInstance() method avoids this problem by wrapping any exception thrown by the constructor in a java.lang.reflect.InvocationTargetException.