### PR TITLE
Prevent corrupting Properties with non-String data. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -112,7 +112,7 @@ final class PropertyCacheFile {
                 if (!currentConfigHash.equals(cachedConfigHash)) {
                     // Detected configuration change - clear cache
                     details.clear();
-                    details.put(CONFIG_HASH_KEY, currentConfigHash);
+                    details.setProperty(CONFIG_HASH_KEY, currentConfigHash);
                 }
             }
             finally {
@@ -121,7 +121,7 @@ final class PropertyCacheFile {
         }
         else {
             // put the hash in the file if the file is going to be created
-            details.put(CONFIG_HASH_KEY, currentConfigHash);
+            details.setProperty(CONFIG_HASH_KEY, currentConfigHash);
         }
     }
 
@@ -169,7 +169,7 @@ final class PropertyCacheFile {
      * @param timestamp the timestamp of the file
      */
     void put(String fileName, long timestamp) {
-        details.put(fileName, Long.toString(timestamp));
+        details.setProperty(fileName, Long.toString(timestamp));
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -403,12 +403,12 @@ public class CheckstyleAntTask extends Task {
         final Map<String, Object> antProps = this.getProject().getProperties();
         for (Map.Entry<String, Object> entry : antProps.entrySet()) {
             final String value = String.valueOf(entry.getValue());
-            retVal.put(entry.getKey(), value);
+            retVal.setProperty(entry.getKey(), value);
         }
 
         // override with properties specified in subelements
         for (Property p : overrideProps) {
-            retVal.put(p.getKey(), p.getValue());
+            retVal.setProperty(p.getKey(), p.getValue());
         }
 
         return retVal;


### PR DESCRIPTION
Fixes `UseOfPropertiesAsHashtable` inspection violations.

Description:
>Reports any calls to the java.util.Hashtable methods put(), putAll() or get() on a java.util.Properties object. For reasons lost to history, Properties inherits from Hashtable, but use of those methods is discouraged to prevent corruption of properties values with non-String data.