### PR TITLE
Rename variables with 'standard' names of unexpected types. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -247,18 +247,18 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
         }
 
         // Process each file
-        for (final File f : files) {
-            if (!Utils.fileExtensionMatches(f, fileExtensions)) {
+        for (final File file : files) {
+            if (!Utils.fileExtensionMatches(file, fileExtensions)) {
                 continue;
             }
-            final String fileName = f.getAbsolutePath();
+            final String fileName = file.getAbsolutePath();
             fireFileStarted(fileName);
             final SortedSet<LocalizedMessage> fileMessages = Sets.newTreeSet();
             try {
-                final FileText theText = new FileText(f.getAbsoluteFile(),
+                final FileText theText = new FileText(file.getAbsoluteFile(),
                         charset);
                 for (final FileSetCheck fsc : fileSetChecks) {
-                    fileMessages.addAll(fsc.process(f, theText));
+                    fileMessages.addAll(fsc.process(file, theText));
                 }
             }
             catch (final IOException ioe) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -437,12 +437,12 @@ public final class ConfigurationLoader {
         parsePropertyString(value, fragments, propertyRefs);
 
         final StringBuilder sb = new StringBuilder();
-        final Iterator<String> i = fragments.iterator();
-        final Iterator<String> j = propertyRefs.iterator();
-        while (i.hasNext()) {
-            String fragment = i.next();
+        final Iterator<String> fragmentsIterator = fragments.iterator();
+        final Iterator<String> propertyRefsIterator = propertyRefs.iterator();
+        while (fragmentsIterator.hasNext()) {
+            String fragment = fragmentsIterator.next();
             if (fragment == null) {
-                final String propertyName = j.next();
+                final String propertyName = propertyRefsIterator.next();
                 fragment = props.resolve(propertyName);
                 if (fragment == null) {
                     if (defaultValue != null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -170,12 +170,12 @@ public final class TreeWalker
             throw new CheckstyleException(
                 "TreeWalker is not allowed as a parent of " + name);
         }
-        final Check c = (Check) module;
-        c.contextualize(childContext);
-        c.configure(childConf);
-        c.init();
+        final Check check = (Check) module;
+        check.contextualize(childContext);
+        check.configure(childConf);
+        check.init();
 
-        registerCheck(c);
+        registerCheck(check);
     }
 
     @Override
@@ -345,9 +345,9 @@ public final class TreeWalker
             checks = ordinaryChecks;
         }
 
-        for (Check ch : checks) {
-            ch.setFileContents(contents);
-            ch.beginTree(rootAST);
+        for (Check check : checks) {
+            check.setFileContents(contents);
+            check.beginTree(rootAST);
         }
     }
 
@@ -366,8 +366,8 @@ public final class TreeWalker
             checks = ordinaryChecks;
         }
 
-        for (Check ch : checks) {
-            ch.finishTree(rootAST);
+        for (Check check : checks) {
+            check.finishTree(rootAST);
         }
     }
 
@@ -393,8 +393,8 @@ public final class TreeWalker
             visitors = tokenToOrdinaryChecks.get(tokenType);
         }
 
-        for (Check c : visitors) {
-            c.visitToken(ast);
+        for (Check check : visitors) {
+            check.visitToken(ast);
         }
     }
 
@@ -421,8 +421,8 @@ public final class TreeWalker
             visitors = tokenToOrdinaryChecks.get(tokenType);
         }
 
-        for (Check ch : visitors) {
-            ch.leaveToken(ast);
+        for (Check check : visitors) {
+            check.leaveToken(ast);
         }
     }
 
@@ -464,11 +464,11 @@ public final class TreeWalker
 
     @Override
     public void destroy() {
-        for (Check c : ordinaryChecks) {
-            c.destroy();
+        for (Check check : ordinaryChecks) {
+            check.destroy();
         }
-        for (Check c : commentChecks) {
-            c.destroy();
+        for (Check check : commentChecks) {
+            check.destroy();
         }
         if (cache != null) {
             try {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
@@ -56,14 +56,14 @@ public final class Utils {
                 ImmutableMap.builder();
         final Field[] fields = TokenTypes.class.getDeclaredFields();
         String[] tempTokenValueToName = new String[0];
-        for (final Field f : fields) {
+        for (final Field field : fields) {
             // Only process the int declarations.
-            if (f.getType() != Integer.TYPE) {
+            if (field.getType() != Integer.TYPE) {
                 continue;
             }
 
-            final String name = f.getName();
-            final int tokenValue = getIntFromField(f, name);
+            final String name = field.getName();
+            final int tokenValue = getIntFromField(field, name);
             builder.put(name, tokenValue);
             if (tokenValue > tempTokenValueToName.length - 1) {
                 final String[] temp = new String[tokenValue + 1];

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -283,13 +283,13 @@ public class CheckstyleAntTask extends Task {
         }
 
         // Create the checker
-        Checker c = null;
+        Checker checker = null;
         try {
-            c = createChecker();
+            checker = createChecker();
 
             final SeverityLevelCounter warningCounter =
                 new SeverityLevelCounter(SeverityLevel.WARNING);
-            c.addListener(warningCounter);
+            checker.addListener(warningCounter);
 
             // Process the files
             long startTime = System.currentTimeMillis();
@@ -303,7 +303,7 @@ public class CheckstyleAntTask extends Task {
             log("Using configuration " + configLocation, Project.MSG_VERBOSE);
 
             startTime = System.currentTimeMillis();
-            final int numErrs = c.process(files);
+            final int numErrs = checker.process(files);
             endTime = System.currentTimeMillis();
             log("To process the files took " + (endTime - startTime) + " ms.",
                 Project.MSG_VERBOSE);
@@ -326,8 +326,8 @@ public class CheckstyleAntTask extends Task {
             }
         }
         finally {
-            if (c != null) {
-                c.destroy();
+            if (checker != null) {
+                checker.destroy();
             }
         }
     }
@@ -337,7 +337,7 @@ public class CheckstyleAntTask extends Task {
      * @return new instance of <code>Checker</code>
      */
     private Checker createChecker() {
-        Checker c = null;
+        Checker checker = null;
         try {
             final Properties props = createOverridingProperties();
             final Configuration config =
@@ -355,15 +355,15 @@ public class CheckstyleAntTask extends Task {
                 Checker.class.getClassLoader();
             context.add("moduleClassLoader", moduleClassLoader);
 
-            c = new Checker();
+            checker = new Checker();
 
-            c.contextualize(context);
-            c.configure(config);
+            checker.contextualize(context);
+            checker.configure(config);
 
             // setup the listeners
             final AuditListener[] listeners = getListeners();
             for (AuditListener element : listeners) {
-                c.addListener(element);
+                checker.addListener(element);
             }
         }
         catch (final Exception e) {
@@ -371,7 +371,7 @@ public class CheckstyleAntTask extends Task {
                     + e.getMessage(), e);
         }
 
-        return c;
+        return checker;
     }
 
     /**
@@ -437,8 +437,8 @@ public class CheckstyleAntTask extends Task {
         }
         else {
             for (int i = 0; i < formatterCount; i++) {
-                final Formatter f = formatters.get(i);
-                listeners[i] = f.createListener(this);
+                final Formatter formatter = formatters.get(i);
+                listeners[i] = formatter.createListener(this);
             }
         }
         return listeners;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -327,8 +327,8 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
      */
     public int getChildCount(int type) {
         int count = 0;
-        for (AST i = getFirstChild(); i != null; i = i.getNextSibling()) {
-            if (i.getType() == type) {
+        for (AST ast = getFirstChild(); ast != null; ast = ast.getNextSibling()) {
+            if (ast.getType() == type) {
                 count++;
             }
         }
@@ -350,9 +350,9 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
      */
     public DetailAST findFirstToken(int type) {
         DetailAST retVal = null;
-        for (DetailAST i = getFirstChild(); i != null; i = i.getNextSibling()) {
-            if (i.getType() == type) {
-                retVal = i;
+        for (DetailAST ast = getFirstChild(); ast != null; ast = ast.getNextSibling()) {
+            if (ast.getType() == type) {
+                retVal = ast;
                 break;
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -153,11 +153,11 @@ public final class FileText extends AbstractList<String> {
         final BufferedReader br =
             new BufferedReader(new StringReader(fullText));
         while (true) {
-            final String l = br.readLine();
-            if (null == l) {
+            final String line = br.readLine();
+            if (null == line) {
                 break;
             }
-            lines.add(l);
+            lines.add(line);
         }
         this.lines = lines.toArray(new String[lines.size()]);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -160,8 +160,8 @@ public class TranslationCheck
         List<File> propFiles, String basenameSeparator) {
         final Map<String, Set<File>> propFileMap = Maps.newHashMap();
 
-        for (final File f : propFiles) {
-            final String identifier = extractPropertyIdentifier(f,
+        for (final File file : propFiles) {
+            final String identifier = extractPropertyIdentifier(file,
                 basenameSeparator);
 
             Set<File> fileSet = propFileMap.get(identifier);
@@ -169,7 +169,7 @@ public class TranslationCheck
                 fileSet = Sets.newHashSet();
                 propFileMap.put(identifier, fileSet);
             }
-            fileSet.add(f);
+            fileSet.add(file);
         }
         return propFileMap;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -204,11 +204,11 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck {
         final LineNumberReader lnr = new LineNumberReader(headerReader);
         readerLines.clear();
         while (true) {
-            final String l = lnr.readLine();
-            if (l == null) {
+            final String line = lnr.readLine();
+            if (line == null) {
                 break;
             }
-            readerLines.add(l);
+            readerLines.add(line);
         }
         postprocessHeaderLines();
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
@@ -53,17 +53,17 @@ public final class JavadocUtils {
 
         String[] tempTokenValueToName = new String[0];
 
-        for (final Field f : fields) {
+        for (final Field field : fields) {
 
             // Only process public int fields.
-            if (!Modifier.isPublic(f.getModifiers())
-                    || f.getType() != Integer.TYPE) {
+            if (!Modifier.isPublic(field.getModifiers())
+                    || field.getType() != Integer.TYPE) {
                 continue;
             }
 
-            final String name = f.getName();
+            final String name = field.getName();
 
-            final int tokenValue = Utils.getIntFromField(f, name);
+            final int tokenValue = Utils.getIntFromField(field, name);
             builder.put(name, tokenValue);
             if (tokenValue > tempTokenValueToName.length - 1) {
                 final String[] temp = new String[tokenValue + 1];
@@ -231,19 +231,21 @@ public final class JavadocUtils {
 
     /**
      * Returns the first child token that has a specified type.
-     * @param node
+     * @param detailNode
      *        Javadoc AST node
      * @param type
      *        the token type to match
      * @return the matching token, or null if no match
      */
-    public static DetailNode findFirstToken(DetailNode node, int type) {
+    public static DetailNode findFirstToken(DetailNode detailNode, int type) {
         DetailNode retVal = null;
-        for (DetailNode i = getFirstChild(node); i != null; i = getNextSibling(i)) {
-            if (i.getType() == type) {
-                retVal = i;
+        DetailNode node = getFirstChild(detailNode);
+        while (node != null) {
+            if (node.getType() == type) {
+                retVal = node;
                 break;
             }
+            node = getNextSibling(node);
         }
         return retVal;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -205,8 +205,8 @@ public class JavaNCSSCheck extends Check {
         //check if token is countable
         if (isCountable(ast)) {
             //increment the stacked counters
-            for (final Counter c : counters) {
-                c.increment();
+            for (final Counter counter : counters) {
+                counter.increment();
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/AbstractCellEditor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/AbstractCellEditor.java
@@ -111,14 +111,14 @@ public class AbstractCellEditor implements CellEditor {
 
     /** @see CellEditor */
     @Override
-    public void addCellEditorListener(CellEditorListener l) {
-        listenerList.add(CellEditorListener.class, l);
+    public void addCellEditorListener(CellEditorListener listener) {
+        listenerList.add(CellEditorListener.class, listener);
     }
 
     /** @see CellEditor */
     @Override
-    public void removeCellEditorListener(CellEditorListener l) {
-        listenerList.remove(CellEditorListener.class, l);
+    public void removeCellEditorListener(CellEditorListener listener) {
+        listenerList.remove(CellEditorListener.class, listener);
     }
 
     /*

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/AbstractTreeTableModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/AbstractTreeTableModel.java
@@ -109,13 +109,13 @@ public abstract class AbstractTreeTableModel implements TreeTableModel {
     }
 
     @Override
-    public void addTreeModelListener(TreeModelListener l) {
-        listenerList.add(TreeModelListener.class, l);
+    public void addTreeModelListener(TreeModelListener listener) {
+        listenerList.add(TreeModelListener.class, listener);
     }
 
     @Override
-    public void removeTreeModelListener(TreeModelListener l) {
-        listenerList.remove(TreeModelListener.class, l);
+    public void removeTreeModelListener(TreeModelListener listener) {
+        listenerList.remove(TreeModelListener.class, listener);
     }
 
     /*

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
@@ -88,15 +88,15 @@ class FileDrop {
      * sets all elements contained within as drop targets, though only
      * the top level container will change borders.
      *
-     * @param c Component on which files will be dropped.
+     * @param component Component on which files will be dropped.
      * @param listener Listens for <tt>filesDropped</tt>.
      * @since 1.0
      */
     FileDrop(
-            final Component c,
+            final Component component,
             final Listener listener)
             throws TooManyListenersException {
-        this(   c, // Drop target
+        this(   component, // Drop target
                 BorderFactory.createMatteBorder(2, 2, 2, 2, DEFAULT_BORDER_COLOR), // Drag border
                 true, // Recursive
                 listener);
@@ -109,23 +109,23 @@ class FileDrop {
      * <tt>System.out</tt> or <tt>System.err</tt>. A <tt>null</tt> value for
      * the parameter <tt>out</tt> will result in no debugging output.
      *
-     * @param c Component on which files will be dropped.
+     * @param component Component on which files will be dropped.
      * @param dragBorder Border to use on <tt>JComponent</tt> when dragging occurs.
      * @param recursive Recursively set children as drop targets.
      * @param listener Listens for <tt>filesDropped</tt>.
      * @since 1.0
      */
     FileDrop(
-            final Component c,
+            final Component component,
             final Border dragBorder,
             final boolean recursive,
             final Listener listener)
             throws TooManyListenersException {
-        dropListener = new FileDropTargetListener(c, dragBorder, listener);
-        makeDropTarget(c, recursive);
+        dropListener = new FileDropTargetListener(component, dragBorder, listener);
+        makeDropTarget(component, recursive);
     }
 
-    private void makeDropTarget(final Component c, boolean recursive)
+    private void makeDropTarget(final Component component, boolean recursive)
             throws TooManyListenersException {
         // Make drop target
         final DropTarget dt = new DropTarget();
@@ -133,25 +133,25 @@ class FileDrop {
 
         // Listen for hierarchy changes and remove the
         // drop target when the parent gets cleared out.
-        c.addHierarchyListener(new HierarchyListener() {
+        component.addHierarchyListener(new HierarchyListener() {
             @Override
             public void hierarchyChanged(HierarchyEvent evt) {
-                final Component parent = c.getParent();
+                final Component parent = component.getParent();
                 if (parent == null) {
-                    c.setDropTarget(null);
+                    component.setDropTarget(null);
                 }
                 else {
-                    new DropTarget(c, dropListener);
+                    new DropTarget(component, dropListener);
                 }
             }
         });
 
-        if (c.getParent() != null) {
-            new DropTarget(c, dropListener);
+        if (component.getParent() != null) {
+            new DropTarget(component, dropListener);
         }
 
-        if (recursive && c instanceof Container) {
-            final Container cont = (Container) c;
+        if (recursive && component instanceof Container) {
+            final Container cont = (Container) component;
             final Component[] comps = cont.getComponents();
             for (Component element : comps) {
                 makeDropTarget(element, recursive);
@@ -183,11 +183,11 @@ class FileDrop {
      * This will recursively unregister all components contained within
      * <var>c</var> if <var>c</var> is a {@link Container}.
      *
-     * @param c The component to unregister as a drop target
+     * @param component The component to unregister as a drop target
      * @since 1.0
      */
-    static void remove(Component c) {
-        remove(c, true);
+    static void remove(Component component) {
+        remove(component, true);
     }
 
     /**
@@ -195,14 +195,14 @@ class FileDrop {
      * from the all children. You should call this if you add and remove
      * components after you've set up the drag-and-drop.
      *
-     * @param c The component to unregister
+     * @param component The component to unregister
      * @param recursive Recursively unregister components within a container
      * @since 1.0
      */
-    static void remove(Component c, boolean recursive) {
-        c.setDropTarget(null);
-        if (recursive && c instanceof Container) {
-            final Component[] comps = ((Container) c).getComponents();
+    static void remove(Component component, boolean recursive) {
+        component.setDropTarget(null);
+        if (recursive && component instanceof Container) {
+            final Component[] comps = ((Container) component).getComponents();
             for (Component element : comps) {
                 remove(element, recursive);
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
@@ -319,7 +319,7 @@ public class JTreeTable extends JTable {
         public Component getTableCellEditorComponent(JTable table,
                 Object value,
                 boolean isSelected,
-                int r, int c) {
+                int row, int column) {
             return tree;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
@@ -43,8 +43,8 @@ public class Main {
         final ParseTreeInfoPanel panel = new ParseTreeInfoPanel();
         frame.getContentPane().add(panel);
         if (args.length >= 1) {
-            final File f = new File(args[0]);
-            panel.openFile(f, frame);
+            final File file = new File(args[0]);
+            panel.openFile(file, frame);
         }
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -68,11 +68,11 @@ public class ParseTreeInfoPanel extends JPanel {
 
     private static class JavaFileFilter extends FileFilter {
         @Override
-        public boolean accept(File f) {
-            if (f == null) {
+        public boolean accept(File file) {
+            if (file == null) {
                 return false;
             }
-            return f.isDirectory() || f.getName().endsWith(".java");
+            return file.isDirectory() || file.getName().endsWith(".java");
         }
 
         @Override


### PR DESCRIPTION
Fixes `StandardVariableNames` inspection violations.

Description:
>Reports on any variables with 'standard' names which are of unexpected types. Such names may be confusing. Standard names and types are as follows:
* i, j, k, m, n - int
* f - float
* d - double
* b - byte
* c, ch - char
* l - long
* s, str - String