### PR TITLE
Rename variables with questionable names. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
@@ -169,17 +169,17 @@ public final class Utils {
      * Returns the length of a String prefix with tabs expanded.
      * Each tab is counted as the number of characters is takes to
      * jump to the next tab stop.
-     * @param string the input String
+     * @param inputString the input String
      * @param toIdx index in string (exclusive) where the calculation stops
      * @param tabWidth the distance between tab stop position.
      * @return the length of string.substring(0, toIdx) with tabs expanded.
      */
-    public static int lengthExpandedTabs(String string,
+    public static int lengthExpandedTabs(String inputString,
                                          int toIdx,
                                          int tabWidth) {
         int len = 0;
         for (int idx = 0; idx < toIdx; idx++) {
-            if (string.charAt(idx) == '\t') {
+            if (inputString.charAt(idx) == '\t') {
                 len = (len / tabWidth + 1) * tabWidth;
             }
             else {
@@ -253,13 +253,13 @@ public final class Utils {
      * prefixes at the expense of some readability. Suggested by SimplifyStartsWith PMD rule:
      * http://pmd.sourceforge.net/pmd-5.3.1/pmd-java/rules/java/optimizations.html#SimplifyStartsWith
      *
-     * @param string the <code>String</code> to check
+     * @param value the <code>String</code> to check
      * @param prefix the prefix to find
      * @return <code>true</code> if the <code>char</code> is a prefix of the given
      * <code>String</code>; <code>false</code> otherwise.
      */
-    public static boolean startsWithChar(String string, char prefix) {
-        return !string.isEmpty() && string.charAt(0) == prefix;
+    public static boolean startsWithChar(String value, char prefix) {
+        return !value.isEmpty() && value.charAt(0) == prefix;
     }
 
     /**
@@ -269,13 +269,13 @@ public final class Utils {
      * suffixes at the expense of some readability. Suggested by SimplifyStartsWith PMD rule:
      * http://pmd.sourceforge.net/pmd-5.3.1/pmd-java/rules/java/optimizations.html#SimplifyStartsWith
      *
-     * @param string the <code>String</code> to check
+     * @param value the <code>String</code> to check
      * @param suffix the suffix to find
      * @return <code>true</code> if the <code>char</code> is a suffix of the given
      * <code>String</code>; <code>false</code> otherwise.
      */
-    public static boolean endsWithChar(String string, char suffix) {
-        return !string.isEmpty() && string.charAt(string.length() - 1) == suffix;
+    public static boolean endsWithChar(String value, char suffix) {
+        return !value.isEmpty() && value.charAt(value.length() - 1) == suffix;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -135,9 +135,9 @@ public final class FileContents implements CommentListener {
      **/
     public void reportCComment(int startLineNo, int startColNo,
             int endLineNo, int endColNo) {
-        final String[] cc = extractCComment(startLineNo, startColNo,
+        final String[] cComment = extractCComment(startLineNo, startColNo,
                 endLineNo, endColNo);
-        final Comment comment = new Comment(cc, startColNo, endLineNo,
+        final Comment comment = new Comment(cComment, startColNo, endLineNo,
                 endColNo);
 
         // save the comment

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
@@ -71,9 +71,9 @@ public class LineColumn implements Comparable<LineColumn> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final LineColumn that = (LineColumn) o;
-        return Objects.equals(line, that.line)
-                && Objects.equals(col, that.col);
+        final LineColumn lineColumn = (LineColumn) o;
+        return Objects.equals(line, lineColumn.line)
+                && Objects.equals(col, lineColumn.col);
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -210,16 +210,16 @@ public final class LocalizedMessage
         if (object == null || getClass() != object.getClass()) {
             return false;
         }
-        final LocalizedMessage that = (LocalizedMessage) object;
-        return Objects.equals(lineNo, that.lineNo)
-                && Objects.equals(colNo, that.colNo)
-                && Objects.equals(severityLevel, that.severityLevel)
-                && Objects.equals(moduleId, that.moduleId)
-                && Objects.equals(key, that.key)
-                && Objects.equals(bundle, that.bundle)
-                && Objects.equals(sourceClass, that.sourceClass)
-                && Objects.equals(customMessage, that.customMessage)
-                && Arrays.equals(args, that.args);
+        final LocalizedMessage localizedMessage = (LocalizedMessage) object;
+        return Objects.equals(lineNo, localizedMessage.lineNo)
+                && Objects.equals(colNo, localizedMessage.colNo)
+                && Objects.equals(severityLevel, localizedMessage.severityLevel)
+                && Objects.equals(moduleId, localizedMessage.moduleId)
+                && Objects.equals(key, localizedMessage.key)
+                && Objects.equals(bundle, localizedMessage.bundle)
+                && Objects.equals(sourceClass, localizedMessage.sourceClass)
+                && Objects.equals(customMessage, localizedMessage.customMessage)
+                && Arrays.equals(args, localizedMessage.args);
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -209,16 +209,16 @@ public final class AnnotationUseStyleCheck extends Check {
      * Retrieves an {@link Enum Enum} type from a @{link String String}.
      * @param <T> the enum type
      * @param enuclass the enum class
-     * @param string the string representing the enum
+     * @param value the string representing the enum
      * @return the enum type
      */
     private static <T extends Enum<T>> T getOption(final Class<T> enuclass,
-        final String string) {
+        final String value) {
         try {
-            return Enum.valueOf(enuclass, string.trim().toUpperCase(Locale.ENGLISH));
+            return Enum.valueOf(enuclass, value.trim().toUpperCase(Locale.ENGLISH));
         }
         catch (final IllegalArgumentException iae) {
-            throw new ConversionException("unable to parse " + string, iae);
+            throw new ConversionException("unable to parse " + value, iae);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -347,8 +347,8 @@ public class FinalLocalVariableCheck extends Check {
             case TokenTypes.INSTANCE_INIT:
             case TokenTypes.METHOD_DEF:
                 final Map<String, DetailAST> state = scopeStack.pop();
-                for (DetailAST var : state.values()) {
-                    log(var.getLineNo(), var.getColumnNo(), MSG_KEY, var
+                for (DetailAST node : state.values()) {
+                    log(node.getLineNo(), node.getColumnNo(), MSG_KEY, node
                         .getText());
                 }
                 break;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -322,14 +322,14 @@ public class UnnecessaryParenthesesCheck extends Check {
      * Returns the specified string chopped to <code>MAX_QUOTED_LENGTH</code>
      * plus an ellipsis (...) if the length of the string exceeds <code>
      * MAX_QUOTED_LENGTH</code>.
-     * @param string the string to potentially chop.
+     * @param value the string to potentially chop.
      * @return the chopped string if <code>string</code> is longer than
      *         <code>MAX_QUOTED_LENGTH</code>; otherwise <code>string</code>.
      */
-    private static String chopString(String string) {
-        if (string.length() > MAX_QUOTED_LENGTH) {
-            return string.substring(0, MAX_QUOTED_LENGTH) + "...\"";
+    private static String chopString(String value) {
+        if (value.length() > MAX_QUOTED_LENGTH) {
+            return value.substring(0, MAX_QUOTED_LENGTH) + "...\"";
         }
-        return string;
+        return value;
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -198,9 +198,9 @@ public class JavadocTypeCheck
 
                 if (!allowMissingParamTags) {
                     //Check type parameters that should exist, do
-                    for (final String string : typeParamNames) {
+                    for (final String typeParamName : typeParamNames) {
                         checkTypeParamTag(
-                            lineNo, tags, string);
+                            lineNo, tags, typeParamName);
                     }
                 }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilter.java
@@ -63,8 +63,8 @@ class IntRangeFilter implements IntFilter {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final IntRangeFilter that = (IntRangeFilter) o;
-        return Objects.equals(lowerBound, that.lowerBound)
-                && Objects.equals(upperBound, that.upperBound);
+        final IntRangeFilter intRangeFilter = (IntRangeFilter) o;
+        return Objects.equals(lowerBound, intRangeFilter.lowerBound)
+                && Objects.equals(upperBound, intRangeFilter.upperBound);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressElement.java
@@ -165,11 +165,11 @@ public class SuppressElement
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final SuppressElement that = (SuppressElement) o;
-        return Objects.equals(filePattern, that.filePattern)
-                && Objects.equals(checkPattern, that.checkPattern)
-                && Objects.equals(moduleId, that.moduleId)
-                && Objects.equals(linesCSV, that.linesCSV)
-                && Objects.equals(columnsCSV, that.columnsCSV);
+        final SuppressElement suppressElement = (SuppressElement) o;
+        return Objects.equals(filePattern, suppressElement.filePattern)
+                && Objects.equals(checkPattern, suppressElement.checkPattern)
+                && Objects.equals(moduleId, suppressElement.moduleId)
+                && Objects.equals(linesCSV, suppressElement.linesCSV)
+                && Objects.equals(columnsCSV, suppressElement.columnsCSV);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -238,20 +238,20 @@ public class SuppressWithNearbyCommentFilter
         /**
          * Expand based on a matching comment.
          * @param comment the comment.
-         * @param string the string to expand.
+         * @param stringToExpand the string to expand.
          * @param regexp the parsed expander.
          * @return the expanded string
          */
         private static String expandFrocomment(
             String comment,
-            String string,
+            String stringToExpand,
             Pattern regexp) {
             final Matcher matcher = regexp.matcher(comment);
             // Match primarily for effect.
             if (!matcher.find()) {
-                return string;
+                return stringToExpand;
             }
-            String result = string;
+            String result = stringToExpand;
             for (int i = 0; i <= matcher.groupCount(); i++) {
                 // $n expands comment match like in Pattern.subst().
                 result = result.replaceAll("\\$" + i, matcher.group(i));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -233,20 +233,20 @@ public class SuppressionCommentFilter
         /**
          * Expand based on a matching comment.
          * @param comment the comment.
-         * @param string the string to expand.
+         * @param stringToExpand the string to expand.
          * @param regexp the parsed expander.
          * @return the expanded string
          */
         private static String expandFromCoont(
             String comment,
-            String string,
+            String stringToExpand,
             Pattern regexp) {
             final Matcher matcher = regexp.matcher(comment);
             // Match primarily for effect.
             if (!matcher.find()) {
-                return string;
+                return stringToExpand;
             }
-            String result = string;
+            String result = stringToExpand;
             for (int i = 0; i <= matcher.groupCount(); i++) {
                 // $n expands comment match like in Pattern.subst().
                 result = result.replaceAll("\\$" + i, matcher.group(i));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
@@ -64,8 +64,8 @@ public class SuppressionFilter
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final SuppressionFilter that = (SuppressionFilter) obj;
-        return Objects.equals(filters, that.filters);
+        final SuppressionFilter suppressionFilter = (SuppressionFilter) obj;
+        return Objects.equals(filters, suppressionFilter.filters);
     }
 
     @Override


### PR DESCRIPTION
Fixes `QuestionableName` inspection violations.

Description:
>Reports on any variables, methods, or classes with questionable names. This inspection is best used to report common metasyntactic variables which may be used as names by lazy or confused developers.
 Use the list below to specify names which should be reported