### PR TITLE
Fix comparison of double value with zero. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -173,7 +173,7 @@ public class ExplicitInitializationCheck extends Check {
             case TokenTypes.NUM_INT:
             case TokenTypes.NUM_LONG:
                 final String text = expr.getText();
-                return 0 == CheckUtils.parseFloat(text, type);
+                return 0.0 == CheckUtils.parseFloat(text, type);
             default:
                 return false;
         }


### PR DESCRIPTION
Fixes `FloatingPointEquality` inspection violation.

Description:
>Reports floating-point values being compared with an == or != operator. Floating point values are inherently inaccurate, and comparing them for exact equality is almost never the desired semantics. This inspection ignores comparisons with zero and infinity literals.