### PR TITLE
Replace Arrays.asList() with Collections.singletonList(). #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -197,7 +196,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     private boolean allowMissingPropertyJavadoc;
 
     /** List of annotations that could allow missed documentation. */
-    private List<String> allowedAnnotations = Arrays.asList("Override");
+    private List<String> allowedAnnotations = Collections.singletonList("Override");
 
     /** Method names that match this pattern do not require javadoc blocks. */
     private Pattern ignoreMethodNamesRegex;


### PR DESCRIPTION
Fixes `ArraysAsListWithZeroOrOneArgument` inspection violation.

Description:
>Reports any calls to Arrays.asList() with zero arguments or only one argument. Such calls could be replaced with either a call to Collections.singletonList() or Collections.emptyList() which will save some memory.