### PR TITLE
Replace toArray() argument with correctly sized array. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
@@ -32,6 +32,7 @@ import java.util.regex.PatternSyntaxException;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.lang3.ArrayUtils;
 
+import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
@@ -76,7 +77,8 @@ public final class Utils {
 
         TOKEN_NAME_TO_VALUE = builder.build();
         TOKEN_VALUE_TO_NAME = tempTokenValueToName;
-        final Integer[] ids = TOKEN_NAME_TO_VALUE.values().toArray(new Integer[0]);
+        final ImmutableCollection<Integer> values = TOKEN_NAME_TO_VALUE.values();
+        final Integer[] ids = values.toArray(new Integer[values.size()]);
         TOKEN_IDS = ArrayUtils.toPrimitive(ids);
     }
 


### PR DESCRIPTION
Fixes `ToArrayCallWithZeroLengthArrayArgument` inspection violation.

Description:
>Reports any call to toArray() on an object of type or subtype java.util.Collection with a zero-length array argument. When passing in an array of too small size, the toArray() method has to construct a new array of the right size using reflection. This has significantly worse performance than passing in an array of at least the size of the collection itself.