### PR TITLE
Simplify empty string check. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -335,7 +335,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
      */
     private void processClass(DetailAST ast) {
         final DetailAST ident = ast.findFirstToken(TokenTypes.IDENT);
-        currentClass += ("".equals(currentClass) ? "" : "$")
+        currentClass += (currentClass.isEmpty() ? "" : "$")
             + ident.getText();
 
         processTypeParams(ast);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
@@ -86,7 +86,7 @@ public class ClassResolver {
         }
 
         // See if in the package
-        if (!"".equals(pkg)) {
+        if (pkg != null && !pkg.isEmpty()) {
             clazz = resolveQualifiedName(pkg + "." + name);
             if (clazz != null) {
                 return clazz;
@@ -119,8 +119,8 @@ public class ClassResolver {
     private Class<?> resolveInnerClass(String name, String currentClass)
             throws ClassNotFoundException {
         Class<?> clazz = null;
-        if (!"".equals(currentClass)) {
-            final String innerClass = (!"".equals(pkg) ? pkg + "." : "")
+        if (!currentClass.isEmpty()) {
+            final String innerClass = (!pkg.isEmpty() ? pkg + "." : "")
                 + currentClass + "$" + name;
             if (isLoadable(innerClass)) {
                 clazz = safeLoad(innerClass);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -162,7 +162,7 @@ public class TrailingCommentCheck extends AbstractFormatCheck {
                 if (comment.getText().length == 1) {
                     final String lineAfter =
                         line.substring(comment.getEndColNo() + 1).trim();
-                    if (!"".equals(lineAfter)) {
+                    if (!lineAfter.isEmpty()) {
                         // do not check comment which doesn't end line
                         continue;
                     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -92,7 +92,7 @@ public class IllegalTokenTextCheck
         final String text = ast.getText();
         if (getRegexp().matcher(text).find()) {
             String message = getMessage();
-            if ("".equals(message)) {
+            if (message.isEmpty()) {
                 message = MSG_KEY;
             }
             log(

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -150,7 +150,7 @@ public abstract class AbstractExpressionHandler {
     protected final void logError(DetailAST ast, String subtypeName,
                                   int actualLevel, IndentLevel expectedLevel) {
         final String typeStr =
-                "".equals(subtypeName) ? "" : " " + subtypeName;
+            subtypeName.isEmpty() ? "" : " " + subtypeName;
         String messageKey = MSG_ERROR;
         if (expectedLevel.isMultiLevel()) {
             messageKey = MSG_ERROR_MULTI;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
@@ -102,7 +102,7 @@ class MultilineDetector {
                         start.getColumn(), end.getLine(), end.getColumn())) {
                     currentMatches++;
                     if (currentMatches > options.getMaximum()) {
-                        if ("".equals(options.getMessage())) {
+                        if (options.getMessage().isEmpty()) {
                             options.getReporter().log(start.getLine(),
                                     REGEXP_EXCEEDED, matcher.pattern().toString());
                         }
@@ -128,7 +128,7 @@ class MultilineDetector {
     /** Perform processing at the end of a set of lines. */
     private void finish() {
         if (currentMatches < options.getMinimum()) {
-            if ("".equals(options.getMessage())) {
+            if (options.getMessage().isEmpty()) {
                 options.getReporter().log(0, REGEXP_MINIMUM,
                         options.getMinimum(), options.getFormat());
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
@@ -255,7 +255,7 @@ public class RegexpCheck extends AbstractFormatCheck {
      * @param lineNumber the line number the message relates to.
      */
     private void logMessage(int lineNumber) {
-        String msg = "".equals(getMessage()) ? getFormat() : message;
+        String msg = getMessage().isEmpty() ? getFormat() : message;
         if (errorCount >= errorLimit) {
             msg = ERROR_LIMIT_EXCEEDED_MESSAGE + msg;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java
@@ -57,7 +57,7 @@ class SinglelineDetector {
     /** Perform processing at the end of a set of lines. */
     private void finish() {
         if (currentMatches < options.getMinimum()) {
-            if ("".equals(options.getMessage())) {
+            if (options.getMessage().isEmpty()) {
                 options.getReporter().log(0, "regexp.minimum",
                         options.getMinimum(), options.getFormat());
             }
@@ -106,7 +106,7 @@ class SinglelineDetector {
 
         currentMatches++;
         if (currentMatches > options.getMaximum()) {
-            if ("".equals(options.getMessage())) {
+            if (options.getMessage().isEmpty()) {
                 options.getReporter().log(lineno, "regexp.exceeded",
                         matcher.pattern().toString());
             }


### PR DESCRIPTION
Fixes `Simplify empty string check` inspection violations.

Description:
>Reports .equals() being called to compare a String with an empty string. It is normally more performant to test a String for emptiness by comparing its .length() to zero instead.