### PR TITLE
Replace String literals of length one with char literals. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -377,7 +377,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
                 fileExtensions[i] = extension;
             }
             else {
-                fileExtensions[i] = "." + extension;
+                fileExtensions[i] = '.' + extension;
             }
         }
     }
@@ -455,7 +455,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
     public void setCharset(String charset)
         throws UnsupportedEncodingException {
         if (!Charset.isSupported(charset)) {
-            final String message = "unsupported charset: '" + charset + "'";
+            final String message = "unsupported charset: '" + charset + '\'';
             throw new UnsupportedEncodingException(message);
         }
         this.charset = charset;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -178,7 +178,7 @@ public final class ConfigurationLoader {
             }
             else {
                 if (!qName.equals(METADATA)) {
-                    throw new IllegalStateException("Unknown name:" + qName + ".");
+                    throw new IllegalStateException("Unknown name:" + qName + '.');
                 }
             }
         }
@@ -385,8 +385,8 @@ public final class ConfigurationLoader {
         }
         catch (final SAXParseException e) {
             throw new CheckstyleException("unable to parse configuration stream"
-                    + " - " + e.getMessage() + ":" + e.getLineNumber()
-                    + ":" + e.getColumnNumber(), e);
+                    + " - " + e.getMessage() + ':' + e.getLineNumber()
+                    + ':' + e.getColumnNumber(), e);
         }
         catch (final ParserConfigurationException | IOException | SAXException e) {
             throw new CheckstyleException("unable to parse configuration stream", e);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -114,7 +114,7 @@ public final class DefaultConfiguration implements Configuration {
             attributeMap.put(name, value);
         }
         else {
-            attributeMap.put(name, current + "," + value);
+            attributeMap.put(name, current + ',' + value);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
@@ -115,7 +115,7 @@ public final class Utils {
                     withDotExtensions[i] = extension;
                 }
                 else {
-                    withDotExtensions[i] = "." + extension;
+                    withDotExtensions[i] = '.' + extension;
                 }
             }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -121,16 +121,16 @@ public class XMLLogger
     @Override
     public void addError(AuditEvent evt) {
         if (SeverityLevel.IGNORE != evt.getSeverityLevel()) {
-            writer.print("<error" + " line=\"" + evt.getLine() + "\"");
+            writer.print("<error" + " line=\"" + evt.getLine() + '"');
             if (evt.getColumn() > 0) {
-                writer.print(" column=\"" + evt.getColumn() + "\"");
+                writer.print(" column=\"" + evt.getColumn() + '"');
             }
             writer.print(" severity=\""
                 + evt.getSeverityLevel().getName()
-                + "\"");
+                + '"');
             writer.print(" message=\""
                 + encode(evt.getMessage())
-                + "\"");
+                + '"');
             writer.println(" source=\""
                 + encode(evt.getSourceName())
                 + "\"/>");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -392,7 +392,7 @@ public class CheckstyleAntTask extends Task {
             }
             catch (final IOException e) {
                 throw new BuildException("Error loading Properties file '"
-                        + propertiesFile + "'", e, getLocation());
+                        + propertiesFile + '\'', e, getLocation());
             }
             finally {
                 Closeables.closeQuietly(inStream);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -130,7 +130,7 @@ public abstract class AbstractFileSetCheck
                 fileExtensions[i] = extension;
             }
             else {
-                fileExtensions[i] = "." + extension;
+                fileExtensions[i] = '.' + extension;
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
@@ -137,7 +137,7 @@ public abstract class AbstractViolationReporter
             return messages;
         }
         final String packageName = className.substring(0, endIndex);
-        return packageName + "." + messages;
+        return packageName + '.' + messages;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Comment.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Comment.java
@@ -104,7 +104,7 @@ public class Comment implements TextBlock {
 
     @Override
     public String toString() {
-        return "Comment[" + firstLine + ":" + firstCol + "-"
-            + lastLine + ":" + lastCol + "]";
+        return "Comment[" + firstLine + ':' + firstCol + '-'
+            + lastLine + ':' + lastCol + ']';
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -361,7 +361,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
 
     @Override
     public String toString() {
-        return super.toString() + "[" + getLineNo() + "x" + getColumnNo() + "]";
+        return super.toString() + '[' + getLineNo() + 'x' + getColumnNo() + ']';
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
@@ -139,7 +139,7 @@ public final class FullIdent {
 
     @Override
     public String toString() {
-        return getText() + "[" + getLineNo() + "x" + getColumnNo() + "]";
+        return getText() + '[' + getLineNo() + 'x' + getColumnNo() + ']';
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
@@ -511,7 +511,7 @@ public enum JavadocTagInfo {
     @Override
     public String toString() {
         return "text [" + this.text + "] name [" + this.name
-            + "] type [" + this.type + "]";
+            + "] type [" + this.type + ']';
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -461,7 +461,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
             return "RegularClass[name=" + getName()
                 + ", in class=" + surroundingClass
                 + ", loadable=" + loadable
-                + ", class=" + classObj + "]";
+                + ", class=" + classObj + ']';
         }
     }
 
@@ -488,7 +488,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
         @Override
         public String toString() {
             return "ClassAlias[alias " + getName()
-                + " for " + classInfo + "]";
+                + " for " + classInfo + ']';
         }
     }
 
@@ -542,8 +542,8 @@ public abstract class AbstractTypeAwareCheck extends Check {
 
         @Override
         public String toString() {
-            return "Token[" + getText() + "(" + getLineNo()
-                + "x" + getColumnNo() + ")]";
+            return "Token[" + getText() + '(' + getLineNo()
+                + 'x' + getColumnNo() + ")]";
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
@@ -76,7 +76,7 @@ public class ClassResolver {
             // when checking for "DataException", it will match on
             // "SecurityDataException". This has been the cause of a very
             // difficult bug to resolve!
-            if (imp.endsWith("." + name)) {
+            if (imp.endsWith('.' + name)) {
                 clazz = resolveQualifiedName(imp);
                 if (clazz != null) {
                     return clazz;
@@ -87,7 +87,7 @@ public class ClassResolver {
 
         // See if in the package
         if (!"".equals(pkg)) {
-            clazz = resolveQualifiedName(pkg + "." + name);
+            clazz = resolveQualifiedName(pkg + '.' + name);
             if (clazz != null) {
                 return clazz;
             }
@@ -120,8 +120,8 @@ public class ClassResolver {
             throws ClassNotFoundException {
         Class<?> clazz = null;
         if (!"".equals(currentClass)) {
-            final String innerClass = (!"".equals(pkg) ? pkg + "." : "")
-                + currentClass + "$" + name;
+            final String innerClass = (!"".equals(pkg) ? pkg + '.' : "")
+                + currentClass + '$' + name;
             if (isLoadable(innerClass)) {
                 clazz = safeLoad(innerClass);
             }
@@ -193,7 +193,7 @@ public class ClassResolver {
             final int dot = name.lastIndexOf('.');
             if (dot != -1) {
                 final String innerName =
-                    name.substring(0, dot) + "$" + name.substring(dot + 1);
+                    name.substring(0, dot) + '$' + name.substring(dot + 1);
                 if (isLoadable(innerName)) {
                     return safeLoad(innerName);
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -405,7 +405,7 @@ public class SuppressWarningsHolder
                 return ast.getText();
             }
             else if (ast.getType() == TokenTypes.DOT) {
-                return getIdentifier(ast.getFirstChild()) + "."
+                return getIdentifier(ast.getFirstChild()) + '.'
                     + getIdentifier(ast.getLastChild());
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -145,7 +145,7 @@ public class UncommentedMainCheck
         // have static methods
         if (classDepth == 0) {
             final DetailAST ident = classDef.findFirstToken(TokenTypes.IDENT);
-            currentClass = packageName.getText() + "." + ident.getText();
+            currentClass = packageName.getText() + '.' + ident.getText();
             classDepth++;
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -97,7 +97,7 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
      */
     protected static int getLineNumber(List<String> lines, String keyName) {
         final String keyPatternString =
-                "^" + keyName.replace(" ", "\\\\ ") + "[\\s:=].*$";
+            '^' + keyName.replace(" ", "\\\\ ") + "[\\s:=].*$";
         final Pattern keyPattern = Pattern.compile(keyPatternString);
         int lineNumber = 1;
         final Matcher matcher = keyPattern.matcher("");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -344,7 +344,7 @@ public class IllegalInstantiationCheck
         try {
             final ClassLoader classLoader = getClassLoader();
             if (classLoader != null) {
-                final String fqName = pkgName + "." + className;
+                final String fqName = pkgName + '.' + className;
                 classLoader.loadClass(fqName);
                 // no ClassNotFoundException, fqName is a known class
                 isSamePackage = true;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -292,11 +292,11 @@ public class MagicNumberCheck extends Check {
         DetailAST reportAST = ast;
         if (parent.getType() == TokenTypes.UNARY_MINUS) {
             reportAST = parent;
-            text = "-" + text;
+            text = '-' + text;
         }
         else if (parent.getType() == TokenTypes.UNARY_PLUS) {
             reportAST = parent;
-            text = "+" + text;
+            text = '+' + text;
         }
         log(reportAST.getLineNo(),
                 reportAST.getColumnNo(),

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -74,7 +74,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck {
      */
     public void setCharset(String charset) throws UnsupportedEncodingException {
         if (!Charset.isSupported(charset)) {
-            final String message = "unsupported charset: '" + charset + "'";
+            final String message = "unsupported charset: '" + charset + '\'';
             throw new UnsupportedEncodingException(message);
         }
         this.charset = charset;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -749,7 +749,7 @@ public class CustomImportOrderCheck extends Check {
             builder.append(tokens.nextToken()).append('.');
             count--;
         }
-        return builder.append("*").toString();
+        return builder.append('*').toString();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/Guard.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/Guard.java
@@ -106,7 +106,7 @@ class Guard {
             }
         }
         else {
-            pkgMatch = forImport.startsWith(pkgName + ".");
+            pkgMatch = forImport.startsWith(pkgName + '.');
             if (pkgMatch && exactMatch) {
                 pkgMatch = forImport.indexOf('.',
                         pkgName.length() + 1) == -1;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
@@ -119,7 +119,7 @@ public class IllegalImportCheck
      */
     private boolean isIllegalImport(String importText) {
         for (String element : illegalPkgs) {
-            if (importText.startsWith(element + ".")) {
+            if (importText.startsWith(element + '.')) {
                 return true;
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -251,7 +251,7 @@ public class ImportOrderCheck
                 if (!Utils.endsWithChar(pkg, '.')) {
                     pkg += ".";
                 }
-                grp = Pattern.compile("^" + Pattern.quote(pkg));
+                grp = Pattern.compile('^' + Pattern.quote(pkg));
             }
 
             groups[i] = grp;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControl.java
@@ -57,7 +57,7 @@ class PkgControl {
      */
     PkgControl(final PkgControl parent, final String subPkg) {
         this.parent = parent;
-        fullPackage = parent.getFullPackage() + "." + subPkg;
+        fullPackage = parent.getFullPackage() + '.' + subPkg;
         parent.children.add(this);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -150,7 +150,7 @@ public abstract class AbstractExpressionHandler {
     protected final void logError(DetailAST ast, String subtypeName,
                                   int actualLevel, IndentLevel expectedLevel) {
         final String typeStr =
-                "".equals(subtypeName) ? "" : " " + subtypeName;
+                "".equals(subtypeName) ? "" : ' ' + subtypeName;
         String messageKey = MSG_ERROR;
         if (expectedLevel.isMultiLevel()) {
             messageKey = MSG_ERROR_MULTI;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineSet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineSet.java
@@ -94,6 +94,6 @@ public class LineSet {
 
     @Override
     public String toString() {
-        return "LineSet[firstLine=" + firstLine() + ", lastLine=" + lastLine() + "]";
+        return "LineSet[firstLine=" + firstLine() + ", lastLine=" + lastLine() + ']';
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -776,8 +776,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
             for (DetailAST typeParam : typeParams) {
                 log(typeParam, MSG_EXCPECTED_TAG,
                     JavadocTagInfo.PARAM.getText(),
-                    "<" + typeParam.findFirstToken(TokenTypes.IDENT).getText()
-                    + ">");
+                    '<' + typeParam.findFirstToken(TokenTypes.IDENT).getText()
+                    + '>');
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
@@ -137,7 +137,7 @@ public class JavadocNodeImpl implements DetailNode {
     @Override
     public String toString() {
         return JavadocUtils.getTokenName(getType())
-                + "[" + getLineNumber() + "x" + getColumnNumber() + "]";
+                + '[' + getLineNumber() + 'x' + getColumnNumber() + ']';
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -267,12 +267,12 @@ public class JavadocTypeCheck
             if (tag.getTagName().equals(tagName)) {
                 tagCount++;
                 if (!formatPattern.matcher(tag.getArg1()).find()) {
-                    log(lineNo, TAG_FORMAT, "@" + tagName, format);
+                    log(lineNo, TAG_FORMAT, '@' + tagName, format);
                 }
             }
         }
         if (tagCount == 0) {
-            log(lineNo, MISSING_TAG, "@" + tagName);
+            log(lineNo, MISSING_TAG, '@' + tagName);
         }
     }
 
@@ -289,13 +289,13 @@ public class JavadocTypeCheck
         for (int i = tags.size() - 1; i >= 0; i--) {
             final JavadocTag tag = tags.get(i);
             if (tag.isParamTag()
-                && tag.getArg1().indexOf("<" + typeParamName + ">") == 0) {
+                && tag.getArg1().indexOf('<' + typeParamName + '>') == 0) {
                 found = true;
             }
         }
         if (!found) {
             log(lineNo, MISSING_TAG,
-                JavadocTagInfo.PARAM.getText() + " <" + typeParamName + ">");
+                JavadocTagInfo.PARAM.getText() + " <" + typeParamName + '>');
         }
     }
 
@@ -319,7 +319,7 @@ public class JavadocTypeCheck
                     log(tag.getLineNo(), tag.getColumnNo(),
                         UNUSED_TAG,
                         JavadocTagInfo.PARAM.getText(),
-                        "<" + typeParamName + ">");
+                        '<' + typeParamName + '>');
                 }
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -269,7 +269,7 @@ public abstract class AbstractClassCouplingCheck extends Check {
         /** Checks if coupling less than allowed or not. */
         public void checkCoupling() {
             referencedClassNames.remove(className);
-            referencedClassNames.remove(packageName + "." + className);
+            referencedClassNames.remove(packageName + '.' + className);
 
             if (referencedClassNames.size() > max) {
                 log(lineNo, columnNo, getLogMessageId(),

--- a/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
@@ -78,7 +78,7 @@ public final class TokenTypesDoclet {
                         final String message = "Should be only one tag.";
                         throw new IllegalArgumentException(message);
                     }
-                    ps.println(field.name() + "="
+                    ps.println(field.name() + '='
                         + field.firstSentenceTags()[0].text());
                 }
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilter.java
@@ -43,7 +43,7 @@ class IntMatchFilter implements IntFilter {
 
     @Override
     public String toString() {
-        return "IntMatchFilter[" + matchValue + "]";
+        return "IntMatchFilter[" + matchValue + ']';
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -181,7 +181,7 @@ public class ParseTreeInfoPanel extends JPanel {
                  // insert the contents of the file to the text area
                  for (String element : sourceLines) {
                    getLines2position().add(jTextArea.getText().length());
-                   jTextArea.append(element + "\n");
+                   jTextArea.append(element + '\n');
                  }
 
                 //clean the text area before inserting the lines of the new file
@@ -192,7 +192,7 @@ public class ParseTreeInfoPanel extends JPanel {
 
                 // insert the contents of the file to the text area
                 for (final String element : sourceLines) {
-                    jTextArea.append(element + "\n");
+                    jTextArea.append(element + '\n');
                 }
 
                 // move back to the top of the file


### PR DESCRIPTION
Fixes `LengthOneStringsInConcatenation` inspection violations.

Description:
>Reports String literals of length one being used in concatenation. These literals may be replaced by equivalent character literals, gaining some performance enhancement.