### PR TITLE
Make methods static. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -173,7 +173,7 @@ public abstract class AbstractSuperCheck
      * @param methodCallDotAst DOT DetailAST
      * @return true if any parameters found
      */
-    private boolean hasArguments(DetailAST methodCallDotAst) {
+    private static boolean hasArguments(DetailAST methodCallDotAst) {
         final DetailAST argumentsList = methodCallDotAst.getNextSibling();
         return argumentsList.getChildCount() > 0;
     }


### PR DESCRIPTION
Fixes `MethodMayBeStatic` inspection violations.

Description:
>Reports any methods which may safely be made static. A method may be static if it is not synchronized, it does not reference any of its class' non static methods and non static fields and is not overridden in a sub class.