### PR TITLE
Inline calls to simple setters. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -433,7 +433,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
      */
     @Deprecated
     public final void setClassloader(ClassLoader loader) {
-        setClassLoader(loader);
+        this.loader = loader;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -604,7 +604,7 @@ public class CheckstyleAntTask extends Task {
 
         /** @param value set the property value from a File */
         public void setFile(File value) {
-            setValue(value.getAbsolutePath());
+            this.value = value.getAbsolutePath();
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -96,7 +96,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
             ((DetailAST) ast).setParent(parent);
         }
         if (ast != null) {
-            ((DetailAST) ast).setPreviousSibling(this);
+            ((DetailAST) ast).previousSibling = this;
         }
     }
 
@@ -111,7 +111,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
             final DetailAST previousSibling = this.getPreviousSibling();
 
             if (previousSibling != null) {
-                ast.setPreviousSibling(previousSibling);
+                ast.previousSibling = previousSibling;
                 previousSibling.setNextSibling(ast);
             }
             else if (parent != null) {
@@ -119,7 +119,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
             }
 
             ast.setNextSibling(this);
-            this.setPreviousSibling(ast);
+            this.previousSibling = ast;
         }
     }
 
@@ -135,10 +135,10 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
 
             if (nextSibling != null) {
                 ast.setNextSibling(nextSibling);
-                nextSibling.setPreviousSibling(ast);
+                nextSibling.previousSibling = ast;
             }
 
-            ast.setPreviousSibling(this);
+            ast.previousSibling = this;
             this.setNextSibling(ast);
         }
     }
@@ -188,7 +188,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
         final DetailAST nextSibling = getNextSibling();
         if (nextSibling != null) {
             nextSibling.setParent(parent);
-            nextSibling.setPreviousSibling(this);
+            nextSibling.previousSibling = this;
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -95,7 +95,7 @@ public class TranslationCheck
      */
     public TranslationCheck() {
         setFileExtensions("properties");
-        setBasenameSeparator("_");
+        this.basenameSeparator = "_";
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.java
@@ -38,7 +38,7 @@ public abstract class AbstractNestedDepthCheck extends Check {
      * @param max default allowed nesting depth.
      */
     public AbstractNestedDepthCheck(int max) {
-        setMax(max);
+        this.max = max;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
@@ -59,7 +59,7 @@ public final class ReturnCountCheck extends AbstractFormatCheck {
     /** Creates new instance of the checks. */
     public ReturnCountCheck() {
         super("^equals$");
-        setMax(DEFAULT_MAX);
+        this.max = DEFAULT_MAX;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
@@ -59,7 +59,7 @@ public final class MutableExceptionCheck extends AbstractFormatCheck {
     /** Creates new instance of the check. */
     public MutableExceptionCheck() {
         super(DEFAULT_FORMAT);
-        setExtendedClassNameFormat(DEFAULT_FORMAT);
+        this.extendedClassNameFormat = DEFAULT_FORMAT;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
@@ -71,7 +71,7 @@ public final class ThrowsCountCheck extends Check {
 
     /** Creates new instance of the check. */
     public ThrowsCountCheck() {
-        setMax(DEFAULT_MAX);
+        this.max = DEFAULT_MAX;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -782,10 +782,10 @@ public class CustomImportOrderCheck extends Check {
          */
         public ImportDetails(String importFullPath,
                 int lineNumber, String importGroup, boolean staticImport) {
-            setImportFullPath(importFullPath);
-            setLineNumber(lineNumber);
-            setImportGroup(importGroup);
-            setStaticImport(staticImport);
+            this.importFullPath = importFullPath;
+            this.lineNumber = lineNumber;
+            this.importGroup = importGroup;
+            this.staticImport = staticImport;
         }
 
         /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -78,7 +78,7 @@ public abstract class AbstractClassCouplingCheck extends Check {
      * @param defaultMax default value for allowed complexity.
      */
     protected AbstractClassCouplingCheck(int defaultMax) {
-        setMax(defaultMax);
+        this.max = defaultMax;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.java
@@ -153,7 +153,7 @@ public abstract class AbstractComplexityCheck
      * @param by the amount to increment by
      */
     protected final void incrementCurrentValue(BigInteger by) {
-        setCurrentValue(getCurrentValue().add(by));
+        currentValue = getCurrentValue().add(by);
     }
 
     /** Push the current value on the stack */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
@@ -57,7 +57,7 @@ public final class BooleanExpressionComplexityCheck extends Check {
 
     /** Creates new instance of the check. */
     public BooleanExpressionComplexityCheck() {
-        setMax(DEFAULT_MAX);
+        this.max = DEFAULT_MAX;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
@@ -54,7 +54,7 @@ public final class ExecutableStatementCountCheck
 
     /** Constructs a <code>ExecutableStatementCountCheck</code>. */
     public ExecutableStatementCountCheck() {
-        setMax(DEFAULT_MAX);
+        this.max = DEFAULT_MAX;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -314,8 +314,8 @@ public class SuppressWithNearbyCommentFilter
      */
     public SuppressWithNearbyCommentFilter() {
         setCommentFormat(DEFAULT_COMMENT_FORMAT);
-        setCheckFormat(DEFAULT_CHECK_FORMAT);
-        setInfluenceFormat(DEFAULT_INFLUENCE_FORMAT);
+        checkFormat = DEFAULT_CHECK_FORMAT;
+        influenceFormat = DEFAULT_INFLUENCE_FORMAT;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -308,7 +308,7 @@ public class SuppressionCommentFilter
     public SuppressionCommentFilter() {
         setOnCommentFormat(DEFAULT_ON_FORMAT);
         setOffCommentFormat(DEFAULT_OFF_FORMAT);
-        setCheckFormat(DEFAULT_CHECK_FORMAT);
+        checkFormat = DEFAULT_CHECK_FORMAT;
     }
 
     /**


### PR DESCRIPTION
Fixes `CallToSimpleSetterInClass` inspection violations.

Description:
Reports any calls to a simple property setter from within the property's class. A simple property setter is defined as one which simply assigns the value of its parameter to a field, and does no other calculation. Such simple setter calls may be safely inlined, at a small performance improvement. Some coding standards also suggest against the use of simple setters for code clarity reasons.