### PR TITLE
Inline calls to simple getters. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -381,7 +381,7 @@ public final class ConfigurationLoader {
                 new ConfigurationLoader(overridePropsResolver,
                                         omitIgnoredModules);
             loader.parseInputSource(configSource);
-            return loader.getConfiguration();
+            return loader.configuration;
         }
         catch (final SAXParseException e) {
             throw new CheckstyleException("unable to parse configuration stream"
@@ -391,14 +391,6 @@ public final class ConfigurationLoader {
         catch (final ParserConfigurationException | IOException | SAXException e) {
             throw new CheckstyleException("unable to parse configuration stream", e);
         }
-    }
-
-    /**
-     * Returns the configuration in the last file parsed.
-     * @return Configuration object
-     */
-    private Configuration getConfiguration() {
-        return configuration;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -69,7 +69,7 @@ public final class DefaultConfiguration implements Configuration {
     public String getAttribute(String name) throws CheckstyleException {
         if (!attributeMap.containsKey(name)) {
             throw new CheckstyleException(
-                    "missing key '" + name + "' in " + getName());
+                    "missing key '" + name + "' in " + this.name);
         }
         return attributeMap.get(name);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -76,15 +76,6 @@ public final class PackageNamesLoader
         super(DTD_PUBLIC_ID, DTD_RESOURCE_NAME);
     }
 
-    /**
-     * Returns the set of fully qualified package names this
-     * this loader processed.
-     * @return the set of package names
-     */
-    private Set<String> getPackageNames() {
-        return packageNames;
-    }
-
     @Override
     public void startElement(String namespaceURI,
                              String localName,
@@ -163,7 +154,7 @@ public final class PackageNamesLoader
                 }
             }
 
-            result = namesLoader.getPackageNames();
+            result = namesLoader.packageNames;
 
         }
         catch (IOException e) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -73,12 +73,12 @@ public abstract class AbstractFileSetCheck
     @Override
     public final SortedSet<LocalizedMessage> process(File file,
                                                    List<String> lines) {
-        getMessageCollector().reset();
+        messages.reset();
         // Process only what interested in
         if (Utils.fileExtensionMatches(file, fileExtensions)) {
             processFiltered(file, lines);
         }
-        return getMessageCollector().getMessages();
+        return messages.getMessages();
     }
 
     /** {@inheritDoc} */
@@ -154,16 +154,16 @@ public abstract class AbstractFileSetCheck
     @Override
     public final void log(int lineNo, int colNo, String key,
             Object... args) {
-        getMessageCollector().add(
+        messages.add(
             new LocalizedMessage(lineNo,
-                                 colNo,
-                                 getMessageBundle(),
-                                 key,
-                                 args,
-                                 getSeverityLevel(),
-                                 getId(),
-                                 this.getClass(),
-                                 this.getCustomMessages().get(key)));
+                colNo,
+                getMessageBundle(),
+                key,
+                args,
+                getSeverityLevel(),
+                getId(),
+                this.getClass(),
+                this.getCustomMessages().get(key)));
     }
 
     /**
@@ -173,9 +173,9 @@ public abstract class AbstractFileSetCheck
      * @param fileName the audited file
      */
     protected final void fireErrors(String fileName) {
-        final SortedSet<LocalizedMessage> errors = getMessageCollector()
+        final SortedSet<LocalizedMessage> errors = messages
                 .getMessages();
-        getMessageCollector().reset();
+        messages.reset();
         getMessageDispatcher().fireErrors(fileName, errors);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
@@ -168,7 +168,7 @@ public abstract class Check extends AbstractViolationReporter {
      * @return the file contents
      */
     public final String[] getLines() {
-        return getFileContents().getLines();
+        return fileContents.getLines();
     }
 
     /**
@@ -177,7 +177,7 @@ public abstract class Check extends AbstractViolationReporter {
      * @return the line from the file contents
      */
     public final String getLine(int index) {
-        return getFileContents().getLine(index);
+        return fileContents.getLine(index);
     }
 
     /**
@@ -243,7 +243,7 @@ public abstract class Check extends AbstractViolationReporter {
     public final void log(int lineNo, int colNo, String key,
             Object... args) {
         final int col = 1 + Utils.lengthExpandedTabs(
-            getLines()[lineNo - 1], colNo, getTabWidth());
+            getLines()[lineNo - 1], colNo, tabWidth);
         messages.add(
             new LocalizedMessage(
                 lineNo,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -108,7 +108,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
     public void addPreviousSibling(DetailAST ast) {
         if (ast != null) {
             ast.setParent(parent);
-            final DetailAST previousSibling = this.getPreviousSibling();
+            final DetailAST previousSibling = this.previousSibling;
 
             if (previousSibling != null) {
                 ast.setPreviousSibling(previousSibling);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
@@ -139,7 +139,7 @@ public final class FullIdent {
 
     @Override
     public String toString() {
-        return getText() + "[" + getLineNo() + "x" + getColumnNo() + "]";
+        return getText() + "[" + lineNo + "x" + colNo + "]";
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
@@ -373,8 +373,8 @@ public enum JavadocTagInfo {
             new ImmutableMap.Builder<>();
 
         for (final JavadocTagInfo tag : JavadocTagInfo.values()) {
-            textToTagBuilder.put(tag.getText(), tag);
-            nameToTagBuilder.put(tag.getName(), tag);
+            textToTagBuilder.put(tag.text, tag);
+            nameToTagBuilder.put(tag.name, tag);
         }
 
         TEXT_TO_TAG = textToTagBuilder.build();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
@@ -57,9 +57,9 @@ public class LineColumn implements Comparable<LineColumn> {
     /** {@inheritDoc} */
     @Override
     public int compareTo(LineColumn lineColumn) {
-        return this.getLine() != lineColumn.getLine()
-            ? this.getLine() - lineColumn.getLine()
-            : this.getColumn() - lineColumn.getColumn();
+        return line != lineColumn.line
+            ? line - lineColumn.line
+            : col - lineColumn.col;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -346,14 +346,14 @@ public final class LocalizedMessage
     /** {@inheritDoc} */
     @Override
     public int compareTo(LocalizedMessage other) {
-        if (getLineNo() == other.getLineNo()) {
-            if (getColumnNo() == other.getColumnNo()) {
+        if (lineNo == other.lineNo) {
+            if (colNo == other.colNo) {
                 return getMessage().compareTo(other.getMessage());
             }
-            return getColumnNo() < other.getColumnNo() ? -1 : 1;
+            return colNo < other.colNo ? -1 : 1;
         }
 
-        return getLineNo() < other.getLineNo() ? -1 : 1;
+        return lineNo < other.lineNo ? -1 : 1;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -322,7 +322,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
                     final FullIdent name =
                         FullIdent.createFullIdentBelow(bounds);
                     final AbstractClassInfo ci =
-                        createClassInfo(new Token(name), getCurrentClassName());
+                        createClassInfo(new Token(name), currentClass);
                     paramsMap.put(alias, ci);
                 }
             }
@@ -434,14 +434,10 @@ public abstract class AbstractTypeAwareCheck extends Check {
             this.surroundingClass = surroundingClass;
             this.check = check;
         }
-        /** @return if class is loadable ot not. */
-        private boolean isLoadable() {
-            return loadable;
-        }
 
         @Override
         public Class<?> getClazz() {
-            if (isLoadable() && classObj == null) {
+            if (loadable && classObj == null) {
                 setClazz(check.tryLoadClass(getName(), surroundingClass));
             }
             return classObj;
@@ -542,8 +538,8 @@ public abstract class AbstractTypeAwareCheck extends Check {
 
         @Override
         public String toString() {
-            return "Token[" + getText() + "(" + getLineNo()
-                + "x" + getColumnNo() + ")]";
+            return "Token[" + text + "(" + line
+                + "x" + column + ")]";
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -575,7 +575,7 @@ public class HiddenFieldCheck
         public boolean containsInstanceField(String field) {
             return instanceFields.contains(field)
                     || parent != null
-                    && !isStaticType()
+                    && !staticType
                     && parent.containsInstanceField(field);
 
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -91,7 +91,7 @@ public class IllegalTokenTextCheck
     public void visitToken(DetailAST ast) {
         final String text = ast.getText();
         if (getRegexp().matcher(text).find()) {
-            String message = getMessage();
+            String message = this.message;
             if ("".equals(message)) {
                 message = MSG_KEY;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
@@ -136,9 +136,9 @@ public final class ThrowsCountCheck extends Check {
                 && !isOverriding(ast)) {
             // Account for all the commas!
             final int count = (ast.getChildCount() + 1) / 2;
-            if (count > getMax()) {
+            if (count > max) {
                 log(ast.getLineNo(),  ast.getColumnNo(), MSG_KEY,
-                    count, getMax());
+                    count, max);
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -352,13 +352,6 @@ public class VisibilityModifierCheck
     }
 
     /**
-     * @return the regexp for public members to ignore.
-     */
-    private Pattern getPublicMemberRegexp() {
-        return publicMemberPattern;
-    }
-
-    /**
      * Sets whether public immutable are allowed.
      * @param allow user's value.
      */
@@ -524,8 +517,8 @@ public class VisibilityModifierCheck
         if (!"private".equals(variableScope)) {
             result =
                 isStaticFinalVariable(variableDef)
-                || isPackageAllowed() && "package".equals(variableScope)
-                || isProtectedAllowed() && "protected".equals(variableScope)
+                || packageAllowed && "package".equals(variableScope)
+                || protectedAllowed && "protected".equals(variableScope)
                 || isIgnoredPublicMember(variableName, variableScope)
                    || allowPublicImmutableFields
                       && isImmutableFieldDefinedInFinalClass(variableDef);
@@ -552,7 +545,7 @@ public class VisibilityModifierCheck
      */
     private boolean isIgnoredPublicMember(String variableName, String variableScope) {
         return "public".equals(variableScope)
-            && getPublicMemberRegexp().matcher(variableName).find();
+            && publicMemberPattern.matcher(variableName).find();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControl.java
@@ -57,7 +57,7 @@ class PkgControl {
      */
     PkgControl(final PkgControl parent, final String subPkg) {
         this.parent = parent;
-        fullPackage = parent.getFullPackage() + "." + subPkg;
+        fullPackage = parent.fullPackage + "." + subPkg;
         parent.children.add(this);
     }
 
@@ -85,7 +85,7 @@ class PkgControl {
         // Check if we are a match.
         // This algormithm should be improved to check for a trailing "."
         // or nothing following.
-        if (!forPkg.startsWith(getFullPackage())) {
+        if (!forPkg.startsWith(fullPackage)) {
             return null;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -471,7 +471,7 @@ public abstract class AbstractExpressionHandler {
      */
     protected final void findSubtreeLines(LineSet lines, DetailAST tree,
         boolean allowNesting) {
-        if (getIndentCheck().getHandlerFactory().isHandledType(tree.getType())) {
+        if (indentCheck.getHandlerFactory().isHandledType(tree.getType())) {
             return;
         }
 
@@ -545,7 +545,7 @@ public abstract class AbstractExpressionHandler {
      * @return value of basicOffset property of <code>IndentationCheck</code>
      */
     protected final int getBasicOffset() {
-        return getIndentCheck().getBasicOffset();
+        return indentCheck.getBasicOffset();
     }
 
     /**
@@ -554,7 +554,7 @@ public abstract class AbstractExpressionHandler {
      *         of <code>IndentationCheck</code>
      */
     protected final int getBraceAdjustment() {
-        return getIndentCheck().getBraceAdjustment();
+        return indentCheck.getBraceAdjustment();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
@@ -136,8 +136,8 @@ public class JavadocNodeImpl implements DetailNode {
 
     @Override
     public String toString() {
-        return JavadocUtils.getTokenName(getType())
-                + "[" + getLineNumber() + "x" + getColumnNumber() + "]";
+        return JavadocUtils.getTokenName(type)
+                + "[" + lineNumber + "x" + columnNumber + "]";
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.java
@@ -181,7 +181,7 @@ public abstract class AbstractComplexityCheck
      * @param ast the token representing the method definition
      */
     private void leaveMethodDef(DetailAST ast) {
-        final BigInteger bigIntegerMax = BigInteger.valueOf(getMax());
+        final BigInteger bigIntegerMax = BigInteger.valueOf(max);
         if (currentValue.compareTo(bigIntegerMax) > 0) {
             log(ast, getMessageID(), currentValue, bigIntegerMax);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
@@ -156,9 +156,9 @@ public final class ExecutableStatementCountCheck
      */
     private void leaveMemberDef(DetailAST ast) {
         final int count = context.getCount();
-        if (count > getMax()) {
+        if (count > max) {
             log(ast.getLineNo(), ast.getColumnNo(),
-                    MSG_KEY, count, getMax());
+                    MSG_KEY, count, max);
         }
         context = contextStack.pop();
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/CSVFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/CSVFilter.java
@@ -89,7 +89,7 @@ class CSVFilter implements IntFilter {
      */
     @Override
     public boolean accept(int intValue) {
-        for (IntFilter filter : getFilters()) {
+        for (IntFilter filter : filters) {
             if (filter.accept(intValue)) {
                 return true;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -262,8 +262,8 @@ public class SuppressWithNearbyCommentFilter
         /** {@inheritDoc} */
         @Override
         public final String toString() {
-            return "Tag[lines=[" + getFirstLine() + " to " + getLastLine()
-                + "]; text='" + getText() + "']";
+            return "Tag[lines=[" + firstLine + " to " + lastLine
+                + "]; text='" + text + "']";
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -256,8 +256,8 @@ public class SuppressionCommentFilter
 
         @Override
         public final String toString() {
-            return "Tag[line=" + getLine() + "; col=" + getColumn()
-                + "; on=" + isOn() + "; text='" + getText() + "']";
+            return "Tag[line=" + line + "; col=" + column
+                + "; on=" + on + "; text='" + text + "']";
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -178,7 +178,7 @@ public final class SuppressionsLoader
             final SuppressionsLoader suppressionsLoader =
                 new SuppressionsLoader();
             suppressionsLoader.parseInputSource(source);
-            return suppressionsLoader.getFilterChain();
+            return suppressionsLoader.filterChain;
         }
         catch (final FileNotFoundException e) {
             throw new CheckstyleException("unable to find " + sourceName, e);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -86,9 +86,9 @@ public class ParseTreeInfoPanel extends JPanel {
         reloadAction.setEnabled(true);
 
         // clear for each new file
-        getLines2position().clear();
+        lines2position.clear();
         // starts line counting at 1
-        getLines2position().add(0);
+        lines2position.add(0);
         // insert the contents of the file to the text area
 
         // clean the text area before inserting the lines of the new file
@@ -175,12 +175,12 @@ public class ParseTreeInfoPanel extends JPanel {
                 final String[] sourceLines = text.toLinesArray();
 
                 // clear for each new file
-                 getLines2position().clear();
+                lines2position.clear();
                  // starts line counting at 1
-                 getLines2position().add(0);
+                lines2position.add(0);
                  // insert the contents of the file to the text area
                  for (String element : sourceLines) {
-                   getLines2position().add(jTextArea.getText().length());
+                     lines2position.add(jTextArea.getText().length());
                    jTextArea.append(element + "\n");
                  }
 


### PR DESCRIPTION
Fixes `CallToSimpleGetterInClass` inspection violations.

Description:
Reports any calls to a simple property getter from within the property's class. A simple property getter is defined as one which simply returns the value of a field, and does no other calculation. Such simple getter calls may be safely inlined, at a small performance improvement. Some coding standards also suggest against the use of simple getters for code clarity reasons.