### PR TITLE
Rename ignored catch parameters. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -307,7 +307,7 @@ public final class ConfigurationLoader {
             final URL url = new URL(config);
             uri = url.toURI();
         }
-        catch (final URISyntaxException | MalformedURLException ex) {
+        catch (final URISyntaxException | MalformedURLException ignored) {
             uri = null;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -135,7 +135,7 @@ class PackageObjectFactory implements ModuleFactory {
         try {
             return doMakeObject(name);
         }
-        catch (final CheckstyleException ex) {
+        catch (final CheckstyleException ignored) {
             //try again with suffix "Check"
             try {
                 return doMakeObject(name + "Check");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
@@ -199,7 +199,7 @@ public final class Utils {
         try {
             Pattern.compile(pattern);
         }
-        catch (final PatternSyntaxException e) {
+        catch (final PatternSyntaxException ignored) {
             return false;
         }
         return true;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -212,7 +212,7 @@ public class XMLLogger
                     ent.substring(prefixLength, ent.length() - 1), radix);
                 return true;
             }
-            catch (final NumberFormatException nfe) {
+            catch (final NumberFormatException ignored) {
                 return false;
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -252,7 +252,7 @@ public final class LocalizedMessage
             final String pattern = bundle.getString(key);
             return MessageFormat.format(pattern, args);
         }
-        catch (final MissingResourceException ex) {
+        catch (final MissingResourceException ignored) {
             // If the Check author didn't provide i18n resource bundles
             // and logs error messages directly, this will return
             // the author's original message

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -223,7 +223,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
         try {
             return getClassResolver().resolve(className, currentClass);
         }
-        catch (final ClassNotFoundException e) {
+        catch (final ClassNotFoundException ignored) {
             return null;
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
@@ -158,7 +158,7 @@ public class ClassResolver {
             safeLoad(name);
             return true;
         }
-        catch (final ClassNotFoundException | NoClassDefFoundError e) {
+        catch (final ClassNotFoundException | NoClassDefFoundError ignored) {
             return false;
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
@@ -92,7 +92,7 @@ public class NewlineAtEndOfFileCheck
                 Closeables.close(randomAccessFile, threw);
             }
         }
-        catch (final IOException e) {
+        catch (final IOException ignored) {
             log(0, MSG_KEY_UNABLE_OPEN, file.getPath());
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -350,7 +350,7 @@ public class IllegalInstantiationCheck
                 isSamePackage = true;
             }
         }
-        catch (final ClassNotFoundException ex) {
+        catch (final ClassNotFoundException ignored) {
             // not a class from the same package
             isSamePackage = false;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -129,7 +129,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck {
             final URL url = new URL(filename);
             uri = url.toURI();
         }
-        catch (final MalformedURLException | URISyntaxException ex) {
+        catch (final MalformedURLException | URISyntaxException ignored) {
             // URL violating RFC 2396
             uri = null;
         }
@@ -148,7 +148,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck {
                     }
                     uri = configUrl.toURI();
                 }
-                catch (final URISyntaxException e) {
+                catch (final URISyntaxException ignored) {
                     throw new FileNotFoundException(filename);
                 }
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -133,7 +133,7 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck {
             try {
                 headerRegexps.add(Pattern.compile(line));
             }
-            catch (final PatternSyntaxException ex) {
+            catch (final PatternSyntaxException ignored) {
                 throw new ConversionException("line "
                         + (headerRegexps.size() + 1)
                         + " in header specification"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
@@ -116,7 +116,7 @@ class MultilineDetector {
             }
         }
         // see http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6337993 et al.
-        catch (StackOverflowError e) {
+        catch (StackOverflowError ignored) {
             // OK http://blog.igorminar.com/2008/05/catching-stackoverflowerror-and-bug-in.html
             // http://programmers.stackexchange.com/questions/
             //        209099/is-it-ever-okay-to-catch-stackoverflowerror-in-java

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -107,7 +107,7 @@ public final class SuppressionsLoader
                     suppress.setChecks(checks);
                 }
             }
-            catch (final PatternSyntaxException e) {
+            catch (final PatternSyntaxException ignored) {
                 throw new SAXException("invalid files or checks format");
             }
             final String lines = atts.getValue("lines");
@@ -136,7 +136,7 @@ public final class SuppressionsLoader
             final URL url = new URL(filename);
             uri = url.toURI();
         }
-        catch (final MalformedURLException | URISyntaxException ex) {
+        catch (final MalformedURLException | URISyntaxException ignored) {
             // URL violating RFC 2396
             uri = null;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
@@ -278,7 +278,7 @@ class FileDrop {
                     evt.rejectDrop();
                 }
             }
-            catch (final IOException | UnsupportedFlavorException io) {
+            catch (final IOException | UnsupportedFlavorException ignored) {
                 evt.rejectDrop();
             }
             finally {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -276,7 +276,7 @@ public class ParseTreeInfoPanel extends JPanel {
         try {
             new FileDrop(sp, new FileDropListener(sp));
         }
-        catch (final TooManyListenersException ex) {
+        catch (final TooManyListenersException ignored) {
            showErrorDialog(null, "Cannot initialize Drag and Drop support");
         }
 


### PR DESCRIPTION
Fixes `UnusedCatchParameter` inspection violations.

Description:
>Reports any catch parameters that are unused in their corresponding blocks. This inspection will not report any catch parameters named "ignore" or "ignored". Conversely this inspection will warn on any catch parameters named "ignore" or "ignored" that are actually used.