### PR TITLE
Remove unchecked exception from throws. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/CSVFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/CSVFilter.java
@@ -46,8 +46,7 @@ class CSVFilter implements IntFilter {
      * @throws NumberFormatException if a component substring does not
      * contain a parsable integer.
      */
-    public CSVFilter(String pattern)
-        throws NumberFormatException {
+    public CSVFilter(String pattern) {
         final StringTokenizer tokenizer = new StringTokenizer(pattern, ",");
         while (tokenizer.hasMoreTokens()) {
             final String token = tokenizer.nextToken().trim();


### PR DESCRIPTION
Fixes `ThrowsRuntimeException` inspection violation.

Description:
>Reports declarations of unchecked exceptions (RuntimeException and its subclasses) in the throws clause of a method. Declaration of unchecked exceptions are not required and may be removed or moved to a Javadoc @throws tag.