### PR TITLE
Replace RuntimeException with IllegalStateException. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -268,7 +268,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
                                                     getId(),
                                                     this.getClass(),
                                                     null);
-            throw new RuntimeException(msg.getMessage());
+            throw new IllegalStateException(msg.getMessage());
         }
 
         if (!suppressLoadErrors) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
@@ -202,7 +202,7 @@ public class ClassResolver {
         catch (final ClassNotFoundException ex) {
             // we shouldn't get this exception here,
             // so this is unexpected runtime exception
-            throw new RuntimeException(ex);
+            throw new IllegalStateException(ex);
         }
 
         return null;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -726,7 +726,7 @@ public class CustomImportOrderCheck extends Check {
 
         }
         else {
-            throw new RuntimeException("Unexpected rule: " + ruleStr);
+            throw new IllegalStateException("Unexpected rule: " + ruleStr);
         }
     }
 


### PR DESCRIPTION
Fixes `BadExceptionThrown` inspection violations.

Description:
>Reports throw statements which throw inappropriate exceptions. One use of this inspection would be to warn of throw statements which throw overly generic exceptions (e.g. java.lang.Exception or java.io.IOException).