### PR TITLE
Use protected constructors in abstract classes. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.java
@@ -49,7 +49,7 @@ public abstract class AbstractFormatCheck
      * @param defaultFormat default format
      * @throws ConversionException unable to parse defaultFormat
      */
-    public AbstractFormatCheck(String defaultFormat) {
+    protected AbstractFormatCheck(String defaultFormat) {
         this(defaultFormat, 0);
     }
 
@@ -60,7 +60,7 @@ public abstract class AbstractFormatCheck
      * See {@link Pattern#compile(String, int)}
      * @throws ConversionException unable to parse defaultFormat
      */
-    public AbstractFormatCheck(String defaultFormat, int compileFlags) {
+    protected AbstractFormatCheck(String defaultFormat, int compileFlags) {
         updateRegexp(defaultFormat, compileFlags);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractOptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractOptionCheck.java
@@ -48,7 +48,7 @@ public abstract class AbstractOptionCheck<T extends Enum<T>>
      * @param optionClass the class for the option. Required due to a quirk
      *        in the Java language.
      */
-    public AbstractOptionCheck(T literalDefault, Class<T> optionClass) {
+    protected AbstractOptionCheck(T literalDefault, Class<T> optionClass) {
         option = literalDefault;
         this.optionClass = optionClass;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalMethodCheck.java
@@ -39,7 +39,7 @@ public abstract class AbstractIllegalMethodCheck extends Check {
      * @param methodName name of the method to disallow.
      * @param errorKey the error key to report with.
      */
-    public AbstractIllegalMethodCheck(String methodName, String errorKey) {
+    protected AbstractIllegalMethodCheck(String methodName, String errorKey) {
         this.methodName = methodName;
         this.errorKey = errorKey;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.java
@@ -37,7 +37,7 @@ public abstract class AbstractNestedDepthCheck extends Check {
      * Creates new instance of checks.
      * @param max default allowed nesting depth.
      */
-    public AbstractNestedDepthCheck(int max) {
+    protected AbstractNestedDepthCheck(int max) {
         setMax(max);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -82,8 +82,8 @@ public abstract class AbstractExpressionHandler {
      * @param expr          the abstract syntax tree
      * @param parent        the parent handler
      */
-    public AbstractExpressionHandler(IndentationCheck indentCheck,
-            String typeName, DetailAST expr, AbstractExpressionHandler parent) {
+    protected AbstractExpressionHandler(IndentationCheck indentCheck, String typeName,
+            DetailAST expr, AbstractExpressionHandler parent) {
         this.indentCheck = indentCheck;
         this.typeName = typeName;
         mainAst = expr;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractAccessControlNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractAccessControlNameCheck.java
@@ -65,7 +65,7 @@ public abstract class AbstractAccessControlNameCheck
      * @param format
      *                format to check with
      */
-    public AbstractAccessControlNameCheck(String format) {
+    protected AbstractAccessControlNameCheck(String format) {
         super(format);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractNameCheck.java
@@ -39,7 +39,7 @@ public abstract class AbstractNameCheck
      * Creates a new <code>AbstractNameCheck</code> instance.
      * @param format format to check with
      */
-    public AbstractNameCheck(String format) {
+    protected AbstractNameCheck(String format) {
         super(format);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.java
@@ -39,7 +39,7 @@ public abstract class AbstractTypeParameterNameCheck
      * Creates a new <code>AbstractTypeParameterNameCheck</code> instance.
      * @param format format to check with
      */
-    public AbstractTypeParameterNameCheck(String format) {
+    protected AbstractTypeParameterNameCheck(String format) {
         super(format);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/AbstractTreeTableModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/AbstractTreeTableModel.java
@@ -76,7 +76,7 @@ public abstract class AbstractTreeTableModel implements TreeTableModel {
     private final Object root;
     private final EventListenerList listenerList = new EventListenerList();
 
-    public AbstractTreeTableModel(Object root) {
+    protected AbstractTreeTableModel(Object root) {
         this.root = root;
     }
 


### PR DESCRIPTION
Fixes `NonProtectedConstructorInAbstractClass` inspection violations.

Description:
>Reports constructors in abstract classes that are not declared protected, package-protected or private.