### PR TITLE
Hide package-visible instance fields. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
@@ -33,7 +33,7 @@ public class Main {
     /**
      * Main frame
      */
-    static JFrame frame;
+    private static JFrame frame;
 
     /**
      * Entry point
@@ -67,6 +67,10 @@ public class Main {
         frame.setVisible(true);
     }
 
+    static JFrame getFrame() {
+        return frame;
+    }
+
     /**
      * http://findbugs.sourceforge.net/bugDescriptions.html#SW_SWING_METHODS_INVOKED_IN_SWING_THREAD
      */
@@ -74,7 +78,7 @@ public class Main {
         /**
          * frame
          */
-        final JFrame frame;
+        private final JFrame frame;
 
         /**
          * contstructor

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -163,7 +163,7 @@ public class ParseTreeInfoPanel extends JPanel {
     public void openFile(File file, final Component parent) {
         if (file != null) {
             try {
-                Main.frame.setTitle("Checkstyle : " + file.getName());
+                Main.getFrame().setTitle("Checkstyle : " + file.getName());
                 final FileText text = new FileText(file.getAbsoluteFile(),
                                                    getEncoding());
                 final DetailAST parseTree = parseFile(text);
@@ -298,12 +298,12 @@ public class ParseTreeInfoPanel extends JPanel {
         /**
          * frame
          */
-        final Component parent;
+        private final Component parent;
 
         /**
          * frame
          */
-        final String msg;
+        private final String msg;
 
         /**
          * contstructor


### PR DESCRIPTION
Fixes `PackageVisibleField` inspection violation.

Description:
>Reports package-visible instance variables. Constants (i.e. variables marked static and final) are not reported.