### PR TITLE
Remove unnecessary Javadoc tags. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -174,7 +174,6 @@ public class SuppressWithNearbyCommentFilter
          * @return a negative number if this tag is before the other tag,
          * 0 if they are at the same position, and a positive number if this
          * tag is after the other tag.
-         * @see Comparable#compareTo(Object)
          */
         @Override
         public int compareTo(Tag other) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -177,7 +177,6 @@ public class SuppressionCommentFilter
          * @return a negative number if this tag is before the other tag,
          * 0 if they are at the same position, and a positive number if this
          * tag is after the other tag.
-         * @see Comparable#compareTo(Object)
          */
         @Override
         public int compareTo(Tag object) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
@@ -83,7 +83,7 @@ class FileDrop {
             new Color(0f, 0f, 1f, 0.25f);
 
     /**
-     * Constructs a {@link FileDrop} with a default light-blue border
+     * Constructs a class with a default light-blue border
      * and, if <var>c</var> is a {@link Container}, recursively
      * sets all elements contained within as drop targets, though only
      * the top level container will change borders.


### PR DESCRIPTION
Fixes `UnnecessaryJavaDocLink` inspection violations.

Description:
>Reports any Javadoc @see, {@link} and {@linkplain} tags which reference the method owning the comment, the super method of the method owning the comment or the class containing the comment. Such links are unnecessary and can be safely removed using this inspections quickfix. The quickfix will remove the entire Javadoc comment if the link is its only content.