### PR TITLE
Fix incorrect references in Javadoc. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -208,8 +208,8 @@ public class HiddenFieldCheck
     }
 
     /**
-     * Called to process tokens other than {@link TokenTypes.VARIABLE_DEF}
-     * and {@link TokenTypes.PARAMETER_DEF}
+     * Called to process tokens other than {@link TokenTypes#VARIABLE_DEF}
+     * and {@link TokenTypes#PARAMETER_DEF}
      *
      * @param ast token to process
      * @param type type of the token

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
@@ -147,7 +147,7 @@ public class ParenPadCheck extends AbstractParenPadCheck {
     }
 
     /**
-     * Checks parens in {@link TokenTypes#FOR_LITERAL}.
+     * Checks parens in {@link TokenTypes#LITERAL_FOR}.
      * @param ast the token to check.
      */
     private void visitLiteralFor(DetailAST ast) {


### PR DESCRIPTION
Fixes `JavadocReference` inspection violations.

Description:
>This inspection points out unresolved references inside javadoc