### PR TITLE
Fix Javadoc problems. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
@@ -411,11 +411,6 @@ public enum JavadocTagInfo {
      * given AST.
      *
      * <p>
-     * For example: Given a call to
-     * <code>JavadocTag.RETURN{@link #isValidOn(DetailAST)}</code>.
-     * </p>
-     *
-     * <p>
      * If passing in a DetailAST representing a non-void METHOD_DEF
      * <code> true </code> would be returned. If passing in a DetailAST
      * representing a CLASS_DEF <code> false </code> would be returned because

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -430,8 +430,6 @@ public abstract class AbstractJavadocCheck extends Check {
      * @param blockComment
      *        block comment content.
      * @return parse tree
-     * @throws IOException
-     *         errors in ANTLRInputStream
      */
     private ParseTree parseJavadocAsParseTree(String blockComment) {
         final ANTLRInputStream input = new ANTLRInputStream(blockComment);


### PR DESCRIPTION
Fixes `JavaDoc` inspection violations.

Description:
>This inspection points out the following javadoc comment flaws:
- no javadoc where it is required
- required tag is missing
- invalid or incomplete tag
- javadoc description is missing or incomplete