### PR TITLE
Make class final. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
@@ -29,7 +29,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 /**
  * Entry point for starting the checkstyle GUI.
  */
-public class Main {
+public final class Main {
     /**
      * Main frame
      */


### PR DESCRIPTION
Fixes `NonFinalUtilityClass` inspection violation.

Description:
>Reports utility classes which are not final. Utility classes have all fields and methods declared static. Giving such classes making them final prevents them from being inadvertently subclassed.