### PR TITLE
Do not ignore stacktrace of previous exception. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -158,7 +158,7 @@ public final class ConfigurationLoader {
                         overridePropsResolver, atts.getValue(DEFAULT));
                 }
                 catch (final CheckstyleException ex) {
-                    throw new SAXException(ex.getMessage());
+                    throw new SAXException(ex);
                 }
                 final String name = atts.getValue(NAME);
 


### PR DESCRIPTION
Fixes `ExceptionFromCatchWhichDoesntWrap` inspection violation.

Description:
>Reports exceptions constructed and thrown from inside catch blocks, which do not "wrap" the caught exception. It is considered good practice when throwing an exception in response to an exception to wrap the initial exception, so that valuable context information such as stack frames and line numbers are not lost.