### PR TITLE
Remove usage of Cloneable from Javadoc. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheck.java
@@ -123,8 +123,6 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
  *
  * @author Travis Schneeberger
  * @see Object#clone()
- * @see Cloneable
- * @see CloneNotSupportedException
  */
 public class NoCloneCheck extends AbstractIllegalMethodCheck {
 


### PR DESCRIPTION
Fixes `UseOfClone` inspection violation.

Description:
>Reports calls to and implementations of the clone() method and uses of java.lang.Cloneable. Some coding standards prohibit clone() usage, and recommend using a copy constructor or static factory method. Calls to clone() on arrays are ignored, because that is a common, correct, efficient and compact way to copy an array.