### PR TITLE
Mark methods final if they are used in constructors. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -144,7 +144,7 @@ public class TranslationCheck
      *
      * @param basenameSeparator the basename separator
      */
-    public void setBasenameSeparator(String basenameSeparator) {
+    public final void setBasenameSeparator(String basenameSeparator) {
         this.basenameSeparator = basenameSeparator;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -91,7 +91,7 @@ public class MultipleStringLiteralsCheck extends Check {
      * @throws org.apache.commons.beanutils.ConversionException
      *         if unable to create Pattern object
      */
-    public void setIgnoreStringsRegexp(String ignoreStringsRegexp) {
+    public final void setIgnoreStringsRegexp(String ignoreStringsRegexp) {
         if (ignoreStringsRegexp != null
             && !ignoreStringsRegexp.isEmpty()) {
             pattern = Utils.createPattern(ignoreStringsRegexp);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -823,7 +823,7 @@ public class CustomImportOrderCheck extends Check {
          * @param importFullPath
          *        import full path variable.
          */
-        public void setImportFullPath(String importFullPath) {
+        public final void setImportFullPath(String importFullPath) {
             this.importFullPath = importFullPath;
         }
 
@@ -840,7 +840,7 @@ public class CustomImportOrderCheck extends Check {
          * @param lineNumber
          *        import line number.
          */
-        public void setLineNumber(int lineNumber) {
+        public final void setLineNumber(int lineNumber) {
             this.lineNumber = lineNumber;
         }
 
@@ -857,7 +857,7 @@ public class CustomImportOrderCheck extends Check {
          * @param importGroup
          *        import group.
          */
-        public void setImportGroup(String importGroup) {
+        public final void setImportGroup(String importGroup) {
             this.importGroup = importGroup;
         }
 
@@ -874,7 +874,7 @@ public class CustomImportOrderCheck extends Check {
          * @param isStatic
          *        if import is static.
          */
-        public void setStaticImport(boolean isStatic) {
+        public final void setStaticImport(boolean isStatic) {
             this.staticImport = isStatic;
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
@@ -80,7 +80,7 @@ public class IllegalImportCheck
      * Set the list of illegal packages.
      * @param from array of illegal packages
      */
-    public void setIllegalPkgs(String... from) {
+    public final void setIllegalPkgs(String... from) {
         illegalPkgs = from.clone();
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
@@ -129,7 +129,7 @@ public class LineLengthCheck extends Check {
      * Set the ignore pattern.
      * @param format a <code>String</code> value
      */
-    public void setIgnorePattern(String format) {
+    public final void setIgnorePattern(String format) {
         ignorePattern = Utils.createPattern(format);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/CSVFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/CSVFilter.java
@@ -69,7 +69,7 @@ class CSVFilter implements IntFilter {
      * Adds a IntFilter to the set.
      * @param filter the IntFilter to add.
      */
-    public void addFilter(IntFilter filter) {
+    public final void addFilter(IntFilter filter) {
         filters.add(filter);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -323,7 +323,7 @@ public class SuppressWithNearbyCommentFilter
      * @param format a <code>String</code> value.
      * @throws ConversionException if unable to create Pattern object.
      */
-    public void setCommentFormat(String format) {
+    public final void setCommentFormat(String format) {
         commentRegexp = Utils.createPattern(format);
     }
 
@@ -344,7 +344,7 @@ public class SuppressWithNearbyCommentFilter
      * Set the format for a check.
      * @param format a <code>String</code> value
      */
-    public void setCheckFormat(String format) {
+    public final void setCheckFormat(String format) {
         checkFormat = format;
     }
 
@@ -360,7 +360,7 @@ public class SuppressWithNearbyCommentFilter
      * Set the format for the influence of this check.
      * @param format a <code>String</code> value
      */
-    public void setInfluenceFormat(String format) {
+    public final void setInfluenceFormat(String format) {
         influenceFormat = format;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -316,7 +316,7 @@ public class SuppressionCommentFilter
      * @param format a <code>String</code> value.
      * @throws ConversionException if unable to create Pattern object.
      */
-    public void setOffCommentFormat(String format) {
+    public final void setOffCommentFormat(String format) {
         offRegexp = Utils.createPattern(format);
     }
 
@@ -325,7 +325,7 @@ public class SuppressionCommentFilter
      * @param format a <code>String</code> value
      * @throws ConversionException if unable to create Pattern object.
      */
-    public void setOnCommentFormat(String format) {
+    public final void setOnCommentFormat(String format) {
         onRegexp = Utils.createPattern(format);
     }
 
@@ -346,7 +346,7 @@ public class SuppressionCommentFilter
      * Set the format for a check.
      * @param format a <code>String</code> value
      */
-    public void setCheckFormat(String format) {
+    public final void setCheckFormat(String format) {
         checkFormat = format;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
@@ -202,7 +202,7 @@ public class JTreeTable extends JTable {
      * Overridden to pass the new rowHeight to the tree.
      */
     @Override
-    public void setRowHeight(int newRowHeight) {
+    public final void setRowHeight(int newRowHeight) {
         super.setRowHeight(newRowHeight);
         if (tree != null && tree.getRowHeight() != newRowHeight) {
             tree.setRowHeight(getRowHeight());
@@ -393,7 +393,7 @@ public class JTreeTable extends JTable {
          *
          * @return the list selection model
          */
-        ListSelectionModel getListSelectionModel() {
+        final ListSelectionModel getListSelectionModel() {
             return listSelectionModel;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeModel.java
@@ -49,7 +49,7 @@ public class ParseTreeModel extends AbstractTreeTableModel {
         return (DetailAST) factory.create(TokenTypes.EOF, "ROOT");
     }
 
-    void setParseTree(DetailAST parseTree) {
+    final void setParseTree(DetailAST parseTree) {
         final DetailAST root = (DetailAST) getRoot();
         root.setFirstChild(parseTree);
         final Object[] path = {root};


### PR DESCRIPTION
Fixes `OverridableMethodCallDuringObjectConstruction` inspection violations.

Description:
>Reports any calls to overridable methods of the current class during object construction. A call is during object construction if it is made inside a constructor, in an non-static instance initializer, in a non-static field initializer or inside a clone(), readObject() or readObjectNoData() method. Methods are overridable if they are not declared final, static or private. Such calls may result in subtle bugs, as the object is not guaranteed to be initialized before the method call occurs.