### PR TITLE
Use adapter instead of listener. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
@@ -27,6 +27,7 @@ import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.dnd.DnDConstants;
 import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetAdapter;
 import java.awt.dnd.DropTargetDragEvent;
 import java.awt.dnd.DropTargetDropEvent;
 import java.awt.dnd.DropTargetEvent;
@@ -234,7 +235,7 @@ class FileDrop {
         void filesDropped(File... files);
     }
 
-    private class FileDropTargetListener implements DropTargetListener {
+    private class FileDropTargetListener extends DropTargetAdapter {
         private final Component component;
         private final Border dragBorder;
         private final Listener listener;
@@ -305,11 +306,6 @@ class FileDrop {
             else {
                 evt.rejectDrag();
             }
-        }
-
-        @Override
-        public void dragOver(DropTargetDragEvent dtde) {
-            // No code, tree is read-only
         }
 
         public FileDropTargetListener(Component component, Border dragBorder, Listener listener) {


### PR DESCRIPTION
Fixes `ListenerMayUseAdapter` inspection violations.

Description:
>Reports any classes which implement a listener, but may extend the corresponding adapter instead. The quickfix for this inspection will also remove any redundant empty methods left over after replacing the implementation of the listener with an extension of the corresponding adapter.