### PR TITLE
Remove redundant and confusing else. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -579,12 +579,7 @@ public final class TreeWalker
         if (ast1.getLineNo() < ast2.getLineNo()) {
             return false;
         }
-        else {
-            if (ast1.getColumnNo() > ast2.getColumnNo()) {
-                return true;
-            }
-        }
-        return false;
+        return ast1.getColumnNo() > ast2.getColumnNo();
     }
 
     /**


### PR DESCRIPTION
Fixes `ConfusingElse` inspection violation.

Description:
>Reports confusing else branches. else branches are confusing when the if statement is followed by other statements and the if branch cannot complete normally, for example because it ends with a return statement. In these cases the statements in the else can be moved after the if statement and the else branch removed.