### PR TITLE
Remove redundant empty method. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -149,11 +149,6 @@ public abstract class AbstractJavadocCheck extends Check {
     }
 
     @Override
-    public final void leaveToken(DetailAST ast) {
-        // No code by default, should be overridden only by demand at subclasses
-    }
-
-    @Override
     public final void visitToken(DetailAST blockCommentAst) {
         if (JavadocUtils.isJavadocComment(blockCommentAst)) {
             this.blockCommentAst = blockCommentAst;


### PR DESCRIPTION
Fixes `RedundantMethodOverride` inspection violation.

Description:
>Reports any method that has a body and signature that are identical to its super method. Such a method is redundant and probably a coding error.