### PR TITLE
Add additional suppression for unchecked operation. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -247,8 +247,9 @@ public class AutomaticBean
      */
     private static class RelaxedStringArrayConverter implements Converter {
         /** {@inheritDoc} */
+        @SuppressWarnings({"unchecked", "rawtypes"})
         @Override
-        public Object convert(@SuppressWarnings("rawtypes") Class type, Object value) {
+        public Object convert(Class type, Object value) {
             // Convert to a String and trim it for the tokenizer.
             final StringTokenizer st = new StringTokenizer(
                 value.toString().trim(), ",");


### PR DESCRIPTION
Fixes `UNCHECKED_WARNING` inspection violations.

Description:
>Unchecked overriding: return type requires unchecked conversion. Found 'java.lang.Object', required 'T' (at line 251).
Signals places where an unchecked warning is issued by the compiler, for example:
```
void f(HashMap map) {
  map.put("key", "value");
  }
```