### PR TITLE
Remove unnecessary enum modifiers. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -68,7 +68,7 @@ public final class TreeWalker
      * State of AST.
      * Indicates whether tree contains certain nodes.
      */
-    private static enum AstState {
+    private enum AstState {
         /**
          * Ordinary tree.
          */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -436,7 +436,7 @@ public final class AnnotationUseStyleCheck extends Check {
      * Defines the styles for defining elements in an annotation.
      * @author Travis Schneeberger
      */
-    public static enum ElementStyle {
+    public enum ElementStyle {
 
         /**
          * expanded example
@@ -473,7 +473,7 @@ public final class AnnotationUseStyleCheck extends Check {
      *
      * @author Travis Schneeberger
      */
-    public static enum TrailingArrayComma {
+    public enum TrailingArrayComma {
 
         /**
          * with comma example
@@ -501,7 +501,7 @@ public final class AnnotationUseStyleCheck extends Check {
      *
      * @author Travis Schneeberger
      */
-    public static enum ClosingParens {
+    public enum ClosingParens {
 
         /**
          * with parens example


### PR DESCRIPTION
Fixes `UnnecessaryEnumModifier` inspection violations.

Description:
>Reports on any redundant modifiers on enumerated classes or components of enumerated classes.