### PR TITLE
Remove redundant toString() calls. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
@@ -118,7 +118,7 @@ public class DefaultLogger
                 sb.append(": warning");
             }
             sb.append(": ").append(message);
-            errorWriter.println(sb.toString());
+            errorWriter.println(sb);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -201,7 +201,7 @@ public final class ModifiedControlVariableCheck extends Check {
                 checkIdent(ast);
                 break;
             default:
-                throw new IllegalStateException(ILLEGAL_TYPE_OF_TOKEN + ast.toString());
+                throw new IllegalStateException(ILLEGAL_TYPE_OF_TOKEN + ast);
         }
     }
 
@@ -244,7 +244,7 @@ public final class ModifiedControlVariableCheck extends Check {
                 //we need that Tokens only at visitToken()
                 break;
             default:
-                throw new IllegalStateException(ILLEGAL_TYPE_OF_TOKEN + ast.toString());
+                throw new IllegalStateException(ILLEGAL_TYPE_OF_TOKEN + ast);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -375,7 +375,7 @@ public class ImportOrderCheck
         }
         else {
             throw new IllegalStateException(
-                    "Unexpected option for static imports: " + abstractOption.toString());
+                    "Unexpected option for static imports: " + abstractOption);
         }
 
         lastImportLine = ast.findFirstToken(TokenTypes.SEMI).getLineNo();


### PR DESCRIPTION
Fixes `UnnecessaryToStringCall` inspection violations.

Description:
>Reports on any calls to toString() used in string concatenations and as arguments to the print() and println() methods of java.io.PrintWriter and java.io.PrintStream, the append() method of java.lang.StringBuilder and java.lang.StringBuffer or the trace(), debug(), info(), warn() and error() methods of org.slf4j.Logger. In these cases the conversion to string will be handled by the underlying library methods and an explicit call to toString() is no needed.
 Note that without the toString() call the expression will have slightly different semantics (the string null will be used instead of throwing a NullPointerException).