### PR TITLE
Remove redundant throws declarations. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -113,10 +113,8 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
     /**
      * Creates a new <code>Checker</code> instance.
      * The instance needs to be contextualized and configured.
-     *
-     * @throws CheckstyleException if an error occurs
      */
-    public Checker() throws CheckstyleException {
+    public Checker() {
         addListener(counter);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyResolver.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyResolver.java
@@ -19,8 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
-
 /**
  * Resolves properties in module configurations.
  *
@@ -36,8 +34,6 @@ public interface PropertyResolver {
      * Resolves a property name to it's value.
      * @param name the name of the property.
      * @return the value that is associated with <code>propertyName</code>.
-     * @throws CheckstyleException if the propertyName cannot be reolved
      */
-    String resolve(String name)
-        throws CheckstyleException;
+    String resolve(String name);
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -417,13 +417,9 @@ public class CheckstyleAntTask extends Task {
     /**
      * Return the list of listeners set in this task.
      * @return the list of listeners.
-     * @throws ClassNotFoundException if an error occurs
-     * @throws InstantiationException if an error occurs
-     * @throws IllegalAccessException if an error occurs
      * @throws IOException if an error occurs
      */
-    private AuditListener[] getListeners() throws ClassNotFoundException,
-            InstantiationException, IllegalAccessException, IOException {
+    private AuditListener[] getListeners() throws IOException {
         final int formatterCount = Math.max(1, formatters.size());
 
         final AuditListener[] listeners = new AuditListener[formatterCount];


### PR DESCRIPTION
Fixes `RedundantThrows` inspection violations.

Description:
>This inspection reports exceptions that are declared in a method's signature but never thrown by the method itself or its implementations/derivatives.