### PR TITLE
Set parameter 'failOnError' of maven javadoc plugin to true, issue #291.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -789,7 +789,7 @@
         <version>2.10.3</version>
         <configuration>
           <source>1.7</source>
-          <failOnError>false</failOnError>
+          <failOnError>true</failOnError>
           <linksource>true</linksource>
         </configuration>
         <reportSets>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -37,7 +37,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <p>
  * To configure the Check:
  * </p>
- * <p>
+ *
  * <pre>
  * <code>
  * &lt;module name=&quot;CommentsIndentation&quot;/module&gt;
@@ -59,7 +59,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * String str1 = "";
  * </code>
  * </pre>
- * </p>
+ *
  *
  * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
  * @author <a href="mailto:andreyselkin@gmail.com">Andrei Selkin</a>


### PR DESCRIPTION
@romani 
A bit confusing situation happened after we added CommentsIndentationCheck at master branch. I did not pay attention at javadoc formatting problems at the Check.
So I resolved javadoc problems at CommentsIndentationCheck and set failOnError to true.