### PR TITLE
Issue #1566: WhitespaceAfter, DeclarationOrder, ArrayTrailingComma, ParenPad violations fixed

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
@@ -75,12 +75,11 @@ import javax.swing.border.Border;
  */
 class FileDrop {
 
+    /* Default border color */
+    private static final Color DEFAULT_BORDER_COLOR = new Color(0f, 0f, 1f, 0.25f);
+
     private transient Border normalBorder;
     private final transient DropTargetListener dropListener;
-
-    /* Default border color */
-    private static final Color DEFAULT_BORDER_COLOR =
-            new Color(0f, 0f, 1f, 0.25f);
 
     /**
      * Constructs a {@link FileDrop} with a default light-blue border
@@ -96,10 +95,10 @@ class FileDrop {
             final Component component,
             final Listener listener)
             throws TooManyListenersException {
-        this(   component, // Drop target
-                BorderFactory.createMatteBorder(2, 2, 2, 2, DEFAULT_BORDER_COLOR), // Drag border
-                true, // Recursive
-                listener);
+        this(component,
+             BorderFactory.createMatteBorder(2, 2, 2, 2, DEFAULT_BORDER_COLOR),
+             true,
+             listener);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -268,7 +268,7 @@ public class ParseTreeInfoPanel extends JPanel {
         final JScrollPane sp2 = new JScrollPane(jTextArea);
         this.add(sp2, BorderLayout.CENTER);
 
-        final JPanel p = new JPanel(new GridLayout(1,2));
+        final JPanel p = new JPanel(new GridLayout(1, 2));
         this.add(p, BorderLayout.SOUTH);
         p.add(fileSelectionButton);
         p.add(reloadButton);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeModel.java
@@ -35,7 +35,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  */
 public class ParseTreeModel extends AbstractTreeTableModel {
     private static final String[] COLUMN_NAMES = {
-        "Tree", "Type", "Line", "Column", "Text"
+        "Tree", "Type", "Line", "Column", "Text",
     };
 
     public ParseTreeModel(DetailAST parseTree) {
@@ -55,7 +55,7 @@ public class ParseTreeModel extends AbstractTreeTableModel {
         final Object[] path = {root};
         // no need to setup remaining info, as the call results in a
         // table structure changed event anyway - we just pass nulls
-        fireTreeStructureChanged(this, path, null, (Object[])null);
+        fireTreeStructureChanged(this, path, null, (Object[]) null);
     }
 
     @Override


### PR DESCRIPTION
Violations fixed:
- ParenPad '(' is followed by whitespace.
- TrailingComment Don't use trailing comments. (partial)
- ArrayTrailingComma Array should contain trailing comma.
- DeclarationOrder Static variable definition in wrong order.
- WhitespaceAfter ',' is not followed by whitespace.
- WhitespaceAfter 'typecast' is not followed by whitespace.