### PR TITLE
Issue #1566: First sentence should end with a period violations fixed

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -724,7 +724,7 @@ public final class JavadocTokenTypes {
     public static final int VALUE_LITERAL = JavadocParser.VALUE_LITERAL;
 
     /**
-     * Parameter of these Javadoc tags:
+     * Parameter of the Javadoc tags listed below.
      * <ul>
      * <li>{@link #SEE_LITERAL @see}</li>
      * <li>{@link #LINK_LITERAL &#123;&#64;link&#125;}</li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java
@@ -39,7 +39,7 @@ public class CodeSelector {
     private final List<Integer> lines2position;
 
     /**
-     * Constructor
+     * Constructor.
      * @param ast ast node.
      * @param editor text area editor.
      * @param lines2position list to map lines.
@@ -52,7 +52,7 @@ public class CodeSelector {
     }
 
     /**
-     * Set a selection position from AST line and Column
+     * Set a selection position from AST line and Column.
      */
     public void select() {
         final int start = lines2position.get(ast.getLineNo()) + ast.getColumnNo();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
@@ -36,7 +36,7 @@ public class Main {
     static JFrame frame;
 
     /**
-     * Entry point
+     * Entry point.
      * @param args the command line arguments.
      */
     public static void main(String... args) {
@@ -54,7 +54,7 @@ public class Main {
     }
 
     /**
-     * Method is used for testing inthe past
+     * Method is used for testing in the past.
      * @param ast tree to display
      */
     public static void displayAst(DetailAST ast) {


### PR DESCRIPTION
Violations fixed:
- JavadocStyle First sentence should end with a period.