### PR TITLE
Issue #1566: Line cannot start with this symbol violations fixed

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -365,10 +365,8 @@ public final class AnnotationUseStyleCheck extends Check {
         while (child != null) {
             DetailAST arrayInit = null;
 
-            if (child.getType()
-                == TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {
-                arrayInit =
-                    child.findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
+            if (child.getType() == TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {
+                arrayInit = child.findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
             }
             else if (child.getType() == TokenTypes.ANNOTATION_ARRAY_INIT) {
                 arrayInit = child;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -259,8 +259,7 @@ public class LeftCurlyCheck
         }
         final int lastAnnotLineNumber = lastAnnot.getLineNo();
         while (lastAnnot.getPreviousSibling() != null
-               && lastAnnot.getPreviousSibling().getLineNo()
-                    == lastAnnotLineNumber) {
+               && lastAnnot.getPreviousSibling().getLineNo() == lastAnnotLineNumber) {
             lastAnnot = lastAnnot.getPreviousSibling();
         }
         return lastAnnot;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -380,8 +380,7 @@ public class MagicNumberCheck extends Check {
         // contains variable declaration
         // and it is directly inside class declaration
         return varDefAST != null
-                && varDefAST.getParent().getParent().getType()
-                    == TokenTypes.CLASS_DEF;
+                && varDefAST.getParent().getParent().getType() == TokenTypes.CLASS_DEF;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -253,8 +253,7 @@ public class UnnecessaryParenthesesCheck extends Check {
                 if (assignDepth >= 1) {
                     log(ast, MSG_ASSIGN);
                 }
-                else if (ast.getParent().getType()
-                    == TokenTypes.LITERAL_RETURN) {
+                else if (ast.getParent().getType() == TokenTypes.LITERAL_RETURN) {
                     log(ast, MSG_RETURN);
                 }
                 else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -791,8 +791,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
                             final DetailAST firstNodeInsideElseBlock = elseBlock
                                 .getFirstChild();
 
-                            if (firstNodeInsideElseBlock.getType()
-                                == TokenTypes.LITERAL_IF) {
+                            if (firstNodeInsideElseBlock.getType() == TokenTypes.LITERAL_IF) {
                                 isVarInOperatorDeclr |=
                                     isVariableInOperatorExpr(
                                         firstNodeInsideElseBlock,
@@ -806,8 +805,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
                             .findFirstToken(TokenTypes.CASE_GROUP);
 
                         while (currentCaseBlock != null
-                            && currentCaseBlock.getType()
-                            == TokenTypes.CASE_GROUP) {
+                            && currentCaseBlock.getType() == TokenTypes.CASE_GROUP) {
                             final DetailAST firstNodeInsideCaseBlock =
                                 currentCaseBlock.getFirstChild();
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -177,8 +177,8 @@ public class CommentsIndentationCheck extends Check {
 
                 if (parentBlock != null && parentBlock.getParent() != null
                     && parentBlock.getParent().getPreviousSibling() != null
-                    && parentBlock.getParent().getPreviousSibling().getType()
-                        == TokenTypes.LITERAL_CASE) {
+                    && parentBlock.getParent().getPreviousSibling()
+                        .getType() == TokenTypes.LITERAL_CASE) {
 
                     prevBlock = parentBlock.getParent().getPreviousSibling();
                     prevStmt = prevBlock;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -219,10 +219,8 @@ public class GenericWhitespaceCheck extends Check {
      */
     private static boolean isGenericBeforeMethod(DetailAST ast) {
         return ast.getParent().getType() == TokenTypes.TYPE_ARGUMENTS
-                && ast.getParent().getParent().getType()
-                    == TokenTypes.DOT
-                && ast.getParent().getParent().getParent().getType()
-                    == TokenTypes.METHOD_CALL
+                && ast.getParent().getParent().getType() == TokenTypes.DOT
+                && ast.getParent().getParent().getParent().getType() == TokenTypes.METHOD_CALL
                 || isAfterMethodReference(ast);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheck.java
@@ -72,8 +72,7 @@ public class TypecastParenPadCheck extends AbstractParenPadCheck {
             processLeft(ast);
         }
         else if (ast.getParent().getType() == TokenTypes.TYPECAST
-                 && ast.getParent().findFirstToken(TokenTypes.RPAREN)
-                     == ast) {
+                 && ast.getParent().findFirstToken(TokenTypes.RPAREN) == ast) {
             processRight(ast);
         }
     }


### PR DESCRIPTION
Violations fixed:
- RegexpSingleline Line cannot start with this symbol, move it to the previous line

**NOTE:**

This Qulice's configuration:
```
<module name="OperatorWrap"/>
```

contradicts with this one:
```
<module name="RegexpSingleline">
    <property name="format" value="^ *="/>
    <property name="fileExtensions" value="java"/>
    <property name="message" value="Line cannot start with this symbol, move it to the previous     line"/>
</module>
```

for ```==``` operator.

I managed to fix all such violations by moving ```==``` into one line with its operands.