### PR TITLE
Remove unnecessary this keyword. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -263,7 +263,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
                 LOG.debug("IOException occured.", ioe);
                 fileMessages.add(new LocalizedMessage(0,
                         Definitions.CHECKSTYLE_BUNDLE, "general.exception",
-                        new String[] {ioe.getMessage()}, null, this.getClass(),
+                        new String[] {ioe.getMessage()}, null, getClass(),
                         null));
             }
             fireErrors(fileName, fileMessages);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -238,7 +238,7 @@ public final class TreeWalker
                 "general.exception",
                 new String[] {message },
                 getId(),
-                this.getClass(), null);
+                getClass(), null);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -400,7 +400,7 @@ public class CheckstyleAntTask extends Task {
         }
 
         // override with Ant properties like ${basedir}
-        final Map<String, Object> antProps = this.getProject().getProperties();
+        final Map<String, Object> antProps = getProject().getProperties();
         for (Map.Entry<String, Object> entry : antProps.entrySet()) {
             final String value = String.valueOf(entry.getValue());
             retVal.setProperty(entry.getKey(), value);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -162,8 +162,8 @@ public abstract class AbstractFileSetCheck
                                  args,
                                  getSeverityLevel(),
                                  getId(),
-                                 this.getClass(),
-                                 this.getCustomMessages().get(key)));
+                                 getClass(),
+                                 getCustomMessages().get(key)));
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractLoader.java
@@ -106,7 +106,7 @@ public abstract class AbstractLoader
             final String dtdResourceName =
                     publicIdToResourceNameMap.get(publicId);
             final ClassLoader loader =
-                this.getClass().getClassLoader();
+                getClass().getClassLoader();
             final InputStream dtdIS =
                 loader.getResourceAsStream(dtdResourceName);
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
@@ -111,7 +111,7 @@ public abstract class AbstractViolationReporter
      * used by this module.
      */
     protected String getMessageBundle() {
-        final String className = this.getClass().getName();
+        final String className = getClass().getName();
         return getMessageBundle(className);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -202,7 +202,7 @@ public class AutomaticBean
         for (final String key : attributes) {
             final Object value = context.get(key);
 
-            tryCopyProperty(this.getClass().getName(), key, value, false);
+            tryCopyProperty(getClass().getName(), key, value, false);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
@@ -235,8 +235,8 @@ public abstract class Check extends AbstractViolationReporter {
                 args,
                 getSeverityLevel(),
                 getId(),
-                this.getClass(),
-                this.getCustomMessages().get(key)));
+                getClass(),
+                getCustomMessages().get(key)));
     }
 
     @Override
@@ -253,7 +253,7 @@ public abstract class Check extends AbstractViolationReporter {
                 args,
                 getSeverityLevel(),
                 getId(),
-                this.getClass(),
-                this.getCustomMessages().get(key)));
+                getClass(),
+                getCustomMessages().get(key)));
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -108,7 +108,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
     public void addPreviousSibling(DetailAST ast) {
         if (ast != null) {
             ast.setParent(parent);
-            final DetailAST previousSibling = this.getPreviousSibling();
+            final DetailAST previousSibling = getPreviousSibling();
 
             if (previousSibling != null) {
                 ast.setPreviousSibling(previousSibling);
@@ -119,7 +119,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
             }
 
             ast.setNextSibling(this);
-            this.setPreviousSibling(ast);
+            setPreviousSibling(ast);
         }
     }
 
@@ -131,7 +131,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
     public void addNextSibling(DetailAST ast) {
         if (ast != null) {
             ast.setParent(parent);
-            final DetailAST nextSibling = this.getNextSibling();
+            final DetailAST nextSibling = getNextSibling();
 
             if (nextSibling != null) {
                 ast.setNextSibling(nextSibling);
@@ -139,7 +139,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
             }
 
             ast.setPreviousSibling(this);
-            this.setNextSibling(ast);
+            setNextSibling(ast);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -76,7 +76,7 @@ public final class FileContents implements CommentListener {
      */
     @Deprecated
     public FileContents(String filename, String... lines) {
-        this.fileName = filename;
+        fileName = filename;
         text = FileText.fromLines(new File(filename), Arrays.asList(lines));
     }
 
@@ -321,6 +321,6 @@ public final class FileContents implements CommentListener {
      * @return true if the package file.
      */
     public boolean inPackageInfo() {
-        return this.getFileName().endsWith("package-info.java");
+        return getFileName().endsWith("package-info.java");
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -193,11 +193,11 @@ public final class FileText extends AbstractList<String> {
      * @param fileText to make copy of
      */
     public FileText(FileText fileText) {
-        this.file = fileText.file;
-        this.charset = fileText.charset;
-        this.fullText = fileText.fullText;
-        this.lines = fileText.lines.clone();
-        this.lineBreaks = ArrayUtils.clone(fileText.lineBreaks);
+        file = fileText.file;
+        charset = fileText.charset;
+        fullText = fileText.fullText;
+        lines = fileText.lines.clone();
+        lineBreaks = ArrayUtils.clone(fileText.lineBreaks);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
@@ -427,7 +427,7 @@ public enum JavadocTagInfo {
      * @return the tag text
      */
     public String getText() {
-        return this.text;
+        return text;
     }
 
     /**
@@ -435,7 +435,7 @@ public enum JavadocTagInfo {
      * @return the tag name
      */
     public String getName() {
-        return this.name;
+        return name;
     }
 
     /**
@@ -443,7 +443,7 @@ public enum JavadocTagInfo {
      * @return the Tag type
      */
     public Type getType() {
-        return this.type;
+        return type;
     }
 
     /**
@@ -505,8 +505,8 @@ public enum JavadocTagInfo {
      */
     @Override
     public String toString() {
-        return "text [" + this.text + "] name [" + this.name
-            + "] type [" + this.type + "]";
+        return "text [" + text + "] name [" + name
+            + "] type [" + type + "]";
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
@@ -57,9 +57,9 @@ public class LineColumn implements Comparable<LineColumn> {
     /** {@inheritDoc} */
     @Override
     public int compareTo(LineColumn lineColumn) {
-        return this.getLine() != lineColumn.getLine()
-            ? Integer.compare(this.getLine(), lineColumn.getLine())
-            : Integer.compare(this.getColumn(), lineColumn.getColumn());
+        return getLine() != lineColumn.getLine()
+            ? Integer.compare(getLine(), lineColumn.getLine())
+            : Integer.compare(getColumn(), lineColumn.getColumn());
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
@@ -81,7 +81,7 @@ public abstract class AbstractDeclarationCollector extends Check {
             case TokenTypes.SLIST :
             case TokenTypes.METHOD_DEF :
             case TokenTypes.CTOR_DEF :
-                this.current = this.frames.get(ast);
+                current = frames.get(ast);
                 break;
             default :
                 // do nothing
@@ -178,7 +178,7 @@ public abstract class AbstractDeclarationCollector extends Check {
             case TokenTypes.SLIST :
             case TokenTypes.METHOD_DEF :
             case TokenTypes.CTOR_DEF :
-                this.frames.put(ast, frameStack.poll());
+                frames.put(ast, frameStack.poll());
                 break;
             default :
                 // do nothing

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -266,7 +266,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
                                                     values,
                                                     getSeverityLevel(),
                                                     getId(),
-                                                    this.getClass(),
+                                                    getClass(),
                                                     null);
             throw new IllegalStateException(msg.getMessage());
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -223,7 +223,7 @@ public class TranslationCheck
                 key,
                 args,
                 getId(),
-                this.getClass(), null);
+                getClass(), null);
         final SortedSet<LocalizedMessage> messages = Sets.newTreeSet();
         messages.add(message);
         getMessageDispatcher().fireErrors(file.getPath(), messages);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -225,7 +225,7 @@ public final class AnnotationUseStyleCheck extends Check {
     /** {@inheritDoc} */
     @Override
     public int[] getDefaultTokens() {
-        return this.getRequiredTokens();
+        return getRequiredTokens();
     }
 
     /** {@inheritDoc} */
@@ -239,15 +239,15 @@ public final class AnnotationUseStyleCheck extends Check {
     /** {@inheritDoc} */
     @Override
     public int[] getAcceptableTokens() {
-        return this.getRequiredTokens();
+        return getRequiredTokens();
     }
 
     /** {@inheritDoc} */
     @Override
     public void visitToken(final DetailAST ast) {
-        this.checkStyleType(ast);
-        this.checkCheckClosingParens(ast);
-        this.checkTrailingComma(ast);
+        checkStyleType(ast);
+        checkCheckClosingParens(ast);
+        checkTrailingComma(ast);
     }
 
     /**
@@ -259,7 +259,7 @@ public final class AnnotationUseStyleCheck extends Check {
      */
     private void checkStyleType(final DetailAST annotation) {
 
-        switch (this.style) {
+        switch (style) {
             case COMPACT_NO_ARRAY:
                 checkCompactNoArrayStyle(annotation);
                 break;
@@ -285,7 +285,7 @@ public final class AnnotationUseStyleCheck extends Check {
 
         if (valuePairCount == 0
             && annotation.branchContains(TokenTypes.EXPR)) {
-            this.log(annotation.getLineNo(), MSG_KEY_ANNOTATION_INCORRECT_STYLE,
+            log(annotation.getLineNo(), MSG_KEY_ANNOTATION_INCORRECT_STYLE,
                 ElementStyle.EXPANDED);
         }
     }
@@ -307,7 +307,7 @@ public final class AnnotationUseStyleCheck extends Check {
         if (valuePairCount == 1
             && AnnotationUseStyleCheck.ANNOTATION_ELEMENT_SINGLE_NAME.equals(
                 valuePair.getFirstChild().getText())) {
-            this.log(annotation.getLineNo(), MSG_KEY_ANNOTATION_INCORRECT_STYLE,
+            log(annotation.getLineNo(), MSG_KEY_ANNOTATION_INCORRECT_STYLE,
                 ElementStyle.COMPACT);
         }
     }
@@ -330,7 +330,7 @@ public final class AnnotationUseStyleCheck extends Check {
         //in compact style with one value
         if (arrayInit != null
             && arrayInit.getChildCount(TokenTypes.EXPR) == 1) {
-            this.log(annotation.getLineNo(), MSG_KEY_ANNOTATION_INCORRECT_STYLE,
+            log(annotation.getLineNo(), MSG_KEY_ANNOTATION_INCORRECT_STYLE,
                 ElementStyle.COMPACT_NO_ARRAY);
         }
         //in expanded style with one value and the correct element name
@@ -343,7 +343,7 @@ public final class AnnotationUseStyleCheck extends Check {
                     .ANNOTATION_ELEMENT_SINGLE_NAME.equals(
                     valuePair.getFirstChild().getText())
                     && nestedArrayInit.getChildCount(TokenTypes.EXPR) == 1) {
-                this.log(annotation.getLineNo(), MSG_KEY_ANNOTATION_INCORRECT_STYLE,
+                log(annotation.getLineNo(), MSG_KEY_ANNOTATION_INCORRECT_STYLE,
                     ElementStyle.COMPACT_NO_ARRAY);
             }
         }
@@ -356,7 +356,7 @@ public final class AnnotationUseStyleCheck extends Check {
      * @param annotation the annotation token
      */
     private void checkTrailingComma(final DetailAST annotation) {
-        if (TrailingArrayComma.IGNORE == this.comma) {
+        if (TrailingArrayComma.IGNORE == comma) {
             return;
         }
 
@@ -373,7 +373,7 @@ public final class AnnotationUseStyleCheck extends Check {
             }
 
             if (arrayInit != null) {
-                this.logCommaViolation(arrayInit);
+                logCommaViolation(arrayInit);
             }
             child = child.getNextSibling();
         }
@@ -393,12 +393,12 @@ public final class AnnotationUseStyleCheck extends Check {
 
         if (this.comma == TrailingArrayComma.ALWAYS
             && (comma == null || comma.getType() != TokenTypes.COMMA)) {
-            this.log(rCurly.getLineNo(),
+            log(rCurly.getLineNo(),
                 rCurly.getColumnNo(), MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING);
         }
         else if (this.comma == TrailingArrayComma.NEVER
             && comma != null && comma.getType() == TokenTypes.COMMA) {
-            this.log(comma.getLineNo(),
+            log(comma.getLineNo(),
                 comma.getColumnNo(), MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT);
         }
     }
@@ -410,23 +410,23 @@ public final class AnnotationUseStyleCheck extends Check {
      * @param ast the annotation token
      */
     private void checkCheckClosingParens(final DetailAST ast) {
-        if (ClosingParens.IGNORE == this.parens) {
+        if (ClosingParens.IGNORE == parens) {
             return;
         }
 
         final DetailAST paren = ast.getLastChild();
         final boolean parenExists = paren.getType() == TokenTypes.RPAREN;
 
-        if (ClosingParens.ALWAYS == this.parens
+        if (ClosingParens.ALWAYS == parens
             && !parenExists) {
-            this.log(ast.getLineNo(), MSG_KEY_ANNOTATION_PARENS_MISSING);
+            log(ast.getLineNo(), MSG_KEY_ANNOTATION_PARENS_MISSING);
         }
-        else if (ClosingParens.NEVER == this.parens
+        else if (ClosingParens.NEVER == parens
             && !ast.branchContains(TokenTypes.EXPR)
             && !ast.branchContains(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR)
             && !ast.branchContains(TokenTypes.ANNOTATION_ARRAY_INIT)
             && parenExists) {
-            this.log(ast.getLineNo(), MSG_KEY_ANNOTATION_PARENS_PRESENT);
+            log(ast.getLineNo(), MSG_KEY_ANNOTATION_PARENS_PRESENT);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
@@ -119,7 +119,7 @@ public final class MissingDeprecatedCheck extends Check {
     /** {@inheritDoc} */
     @Override
     public int[] getDefaultTokens() {
-        return this.getAcceptableTokens();
+        return getAcceptableTokens();
     }
 
     /** {@inheritDoc} */
@@ -142,16 +142,16 @@ public final class MissingDeprecatedCheck extends Check {
     @Override
     public void visitToken(final DetailAST ast) {
         final TextBlock javadoc =
-            this.getFileContents().getJavadocBefore(ast.getLineNo());
+            getFileContents().getJavadocBefore(ast.getLineNo());
 
         final boolean containsAnnotation =
             AnnotationUtility.containsAnnotation(ast, DEPRECATED)
             || AnnotationUtility.containsAnnotation(ast, FQ_DEPRECATED);
 
-        final boolean containsJavadocTag = this.containsJavadocTag(javadoc);
+        final boolean containsJavadocTag = containsJavadocTag(javadoc);
 
         if (containsAnnotation ^ containsJavadocTag) {
-            this.log(ast.getLineNo(), MSG_KEY_ANNOTATION_MISSING_DEPRECATED);
+            log(ast.getLineNo(), MSG_KEY_ANNOTATION_MISSING_DEPRECATED);
         }
     }
 
@@ -184,7 +184,7 @@ public final class MissingDeprecatedCheck extends Check {
 
             if (javadocNoargMatcher.find()) {
                 if (found) {
-                    this.log(currentLine, MSG_KEY_JAVADOC_DUPLICATE_TAG,
+                    log(currentLine, MSG_KEY_JAVADOC_DUPLICATE_TAG,
                         JavadocTagInfo.DEPRECATED.getText());
                 }
                 found = true;
@@ -224,15 +224,15 @@ public final class MissingDeprecatedCheck extends Check {
                 if (!lFin.equals(MissingDeprecatedCheck.NEXT_TAG)
                     && !lFin.equals(MissingDeprecatedCheck.END_JAVADOC)) {
                     if (foundBefore) {
-                        this.log(currentLine, MSG_KEY_JAVADOC_DUPLICATE_TAG,
+                        log(currentLine, MSG_KEY_JAVADOC_DUPLICATE_TAG,
                             JavadocTagInfo.DEPRECATED.getText());
                     }
                     found = true;
                 }
                 else {
-                    this.log(currentLine, MSG_KEY_JAVADOC_MISSING);
+                    log(currentLine, MSG_KEY_JAVADOC_MISSING);
                     if (foundBefore) {
-                        this.log(currentLine, MSG_KEY_JAVADOC_DUPLICATE_TAG,
+                        log(currentLine, MSG_KEY_JAVADOC_DUPLICATE_TAG,
                             JavadocTagInfo.DEPRECATED.getText());
                     }
                     found = true;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
@@ -119,19 +119,19 @@ public final class MissingOverrideCheck extends Check {
      * @param compatibility compatibility or not
      */
     public void setJavaFiveCompatibility(final boolean compatibility) {
-        this.javaFiveCompatibility = compatibility;
+        javaFiveCompatibility = compatibility;
     }
 
     /** {@inheritDoc} */
     @Override
     public int[] getDefaultTokens() {
-        return this.getRequiredTokens();
+        return getRequiredTokens();
     }
 
     /** {@inheritDoc} */
     @Override
     public int[] getAcceptableTokens() {
-        return this.getRequiredTokens();
+        return getRequiredTokens();
     }
 
     /** {@inheritDoc} */
@@ -145,16 +145,16 @@ public final class MissingOverrideCheck extends Check {
     @Override
     public void visitToken(final DetailAST ast) {
         final TextBlock javadoc =
-            this.getFileContents().getJavadocBefore(ast.getLineNo());
+            getFileContents().getJavadocBefore(ast.getLineNo());
 
         final boolean containastag = containsJavadocTag(javadoc);
         if (containastag && !JavadocTagInfo.INHERIT_DOC.isValidOn(ast)) {
-            this.log(ast.getLineNo(), MSG_KEY_TAG_NOT_VALID_ON,
+            log(ast.getLineNo(), MSG_KEY_TAG_NOT_VALID_ON,
                 JavadocTagInfo.INHERIT_DOC.getText());
             return;
         }
 
-        if (this.javaFiveCompatibility) {
+        if (javaFiveCompatibility) {
             final DetailAST defOrNew = ast.getParent().getParent();
 
             if (defOrNew.branchContains(TokenTypes.EXTENDS_CLAUSE)
@@ -167,7 +167,7 @@ public final class MissingOverrideCheck extends Check {
         if (containastag
             && !AnnotationUtility.containsAnnotation(ast, OVERRIDE)
             && !AnnotationUtility.containsAnnotation(ast, FQ_OVERRIDE)) {
-            this.log(ast.getLineNo(), MSG_KEY_ANNOTATION_MISSING_OVERRIDE);
+            log(ast.getLineNo(), MSG_KEY_ANNOTATION_MISSING_OVERRIDE);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheck.java
@@ -49,7 +49,7 @@ public class PackageAnnotationCheck extends Check {
     /** {@inheritDoc} */
     @Override
     public int[] getDefaultTokens() {
-        return this.getRequiredTokens();
+        return getRequiredTokens();
     }
 
     /** {@inheritDoc} */
@@ -63,7 +63,7 @@ public class PackageAnnotationCheck extends Check {
     /** {@inheritDoc} */
     @Override
     public int[] getAcceptableTokens() {
-        return this.getRequiredTokens();
+        return getRequiredTokens();
     }
 
     /** {@inheritDoc} */
@@ -72,10 +72,10 @@ public class PackageAnnotationCheck extends Check {
         final boolean containsAnnotation =
             AnnotationUtility.containsAnnotation(ast);
         final boolean inPackageInfo =
-            this.getFileContents().inPackageInfo();
+            getFileContents().inPackageInfo();
 
         if (containsAnnotation && !inPackageInfo) {
-            this.log(ast.getLine(), "annotation.package.location");
+            log(ast.getLine(), "annotation.package.location");
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -118,7 +118,7 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
     /** {@inheritDoc} */
     @Override
     public final int[] getDefaultTokens() {
-        return this.getAcceptableTokens();
+        return getAcceptableTokens();
     }
 
     /** {@inheritDoc} */
@@ -165,7 +165,7 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
         //rare case with empty array ex: @SuppressWarnings({})
         if (warning == null) {
             //check to see if empty warnings are forbidden -- are by default
-            this.logMatch(warningHolder.getLineNo(),
+            logMatch(warningHolder.getLineNo(),
                 warningHolder.getColumnNo(), "");
             return;
         }
@@ -178,13 +178,13 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
                     case TokenTypes.STRING_LITERAL:
                         final String warningText =
                             removeQuotes(warning.getFirstChild().getText());
-                        this.logMatch(warning.getLineNo(),
+                        logMatch(warning.getLineNo(),
                                 warning.getColumnNo(), warningText);
                         break;
                     // conditional case
                     // ex: @SuppressWarnings((false) ? (true) ? "unchecked" : "foo" : "unused")
                     case TokenTypes.QUESTION:
-                        this.walkConditional(fChild);
+                        walkConditional(fChild);
                         break;
                     // param in constant case
                     // ex: public static final String UNCHECKED = "unchecked";
@@ -229,9 +229,9 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
      */
     private void logMatch(final int lineNo,
         final int colNum, final String warningText) {
-        final Matcher matcher = this.getRegexp().matcher(warningText);
+        final Matcher matcher = getRegexp().matcher(warningText);
         if (matcher.matches()) {
-            this.log(lineNo, colNum,
+            log(lineNo, colNum,
                     MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, warningText);
         }
     }
@@ -291,12 +291,12 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
         if (cond.getType() != TokenTypes.QUESTION) {
             final String warningText =
                 removeQuotes(cond.getText());
-            this.logMatch(cond.getLineNo(), cond.getColumnNo(), warningText);
+            logMatch(cond.getLineNo(), cond.getColumnNo(), warningText);
             return;
         }
 
-        this.walkConditional(getCondLeft(cond));
-        this.walkConditional(getCondRight(cond));
+        walkConditional(getCondLeft(cond));
+        walkConditional(getCondRight(cond));
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -417,6 +417,6 @@ public final class IllegalTypeCheck extends AbstractFormatCheck {
         for (String modifier : modifiers.split(",")) {
             modifiersList.add(Utils.getTokenId(modifier.trim()));
         }
-        this.memberModifiers = modifiersList;
+        memberModifiers = modifiersList;
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -221,7 +221,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
      *         if unable to create Pattern object.
      */
     public void setIgnoreVariablePattern(String ignorePattern) {
-        this.ignoreVariablePattern = Utils.createPattern(ignorePattern);
+        ignoreVariablePattern = Utils.createPattern(ignorePattern);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -367,7 +367,7 @@ public class VisibilityModifierCheck
      * @param allow user's value.
      */
     public void setAllowPublicImmutableFields(boolean allow) {
-        this.allowPublicImmutableFields = allow;
+        allowPublicImmutableFields = allow;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -601,7 +601,7 @@ public class CustomImportOrderCheck extends Check {
     private boolean matchesSamePackageImportGroup(boolean isStatic,
         String importFullPath, String currentGroup) {
         final String importPathTrimmedToSamePackageDepth =
-                getFirstNDomainsFromIdent(this.samePackageMatchingDepth, importFullPath);
+                getFirstNDomainsFromIdent(samePackageMatchingDepth, importFullPath);
         return !isStatic && SAME_PACKAGE_RULE_GROUP.equals(currentGroup)
                 && samePackageDomainsRegExp.equals(importPathTrimmedToSamePackageDepth);
     }
@@ -875,7 +875,7 @@ public class CustomImportOrderCheck extends Check {
          *        if import is static.
          */
         public final void setStaticImport(boolean isStatic) {
-            this.staticImport = isStatic;
+            staticImport = isStatic;
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -298,7 +298,7 @@ public class ImportOrderCheck
      * @param sortAlphabetically true or false.
      */
     public void setSortStaticImportsAlphabetically(boolean sortAlphabetically) {
-        this.sortStaticImportsAlphabetically = sortAlphabetically;
+        sortStaticImportsAlphabetically = sortAlphabetically;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
@@ -199,7 +199,7 @@ public class IndentationCheck extends Check {
      * @return the throws indentation level
      */
     public int getThrowsIndent() {
-        return this.throwsIndentationAmount;
+        return throwsIndentationAmount;
     }
 
     /**
@@ -217,7 +217,7 @@ public class IndentationCheck extends Check {
      * @return the initialisation indentation level
      */
     public int getArrayInitIndent() {
-        return this.arrayInitIndentationAmount;
+        return arrayInitIndentationAmount;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -121,7 +121,7 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
         for (String aSOrder : sOrder) {
             customOrder.add(aSOrder.trim());
         }
-        this.tagOrder = customOrder;
+        tagOrder = customOrder;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -110,7 +110,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * @param value value to set.
      */
     public void setAllowNewlineParagraph(boolean value) {
-        this.tagImmediatelyBeforeFirstWord = value;
+        tagImmediatelyBeforeFirstWord = value;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -445,7 +445,7 @@ public class WhitespaceAroundCheck extends Check {
                 return true;
             }
             else if (parentType == TokenTypes.FOR_EACH_CLAUSE
-                && this.ignoreEnhancedForColon) {
+                && ignoreEnhancedForColon) {
                 return true;
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilter.java
@@ -55,7 +55,7 @@ class IntMatchFilter implements IntFilter {
     public boolean equals(Object object) {
         if (object instanceof IntMatchFilter) {
             final IntMatchFilter other = (IntMatchFilter) object;
-            return this.matchValue == other.matchValue;
+            return matchValue == other.matchValue;
         }
         return false;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
@@ -213,7 +213,7 @@ public class JTreeTable extends JTable {
     }
 
     public void setEditor(JTextArea mJTextArea) {
-        this.editor = mJTextArea;
+        editor = mJTextArea;
     }
 
     public void setLinePositionMap(List<Integer> lines2position) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -75,7 +75,7 @@ public class ParseTreeInfoPanel extends JPanel {
         parseTreeModel = new ParseTreeModel(null);
         final JTreeTable treeTable = new JTreeTable(parseTreeModel);
         final JScrollPane sp = new JScrollPane(treeTable);
-        this.add(sp, BorderLayout.NORTH);
+        add(sp, BorderLayout.NORTH);
 
         final JButton fileSelectionButton =
             new JButton(new FileSelectionAction());
@@ -90,10 +90,10 @@ public class ParseTreeInfoPanel extends JPanel {
         treeTable.setLinePositionMap(lines2position);
 
         final JScrollPane sp2 = new JScrollPane(jTextArea);
-        this.add(sp2, BorderLayout.CENTER);
+        add(sp2, BorderLayout.CENTER);
 
         final JPanel p = new JPanel(new GridLayout(1, 2));
-        this.add(p, BorderLayout.SOUTH);
+        add(p, BorderLayout.SOUTH);
         p.add(fileSelectionButton);
         p.add(reloadButton);
 


### PR DESCRIPTION
Fixes `UnnecessaryThis` inspection violations.

Description:
>Reports on any unnecessary uses of this in the code. Using this to disambiguate a code reference may easily become unnecessary via automatic refactorings, and is discouraged by many coding styles.
 For example:
 ```
 this.a = 3;
 ```