### PR TITLE
Remove unnecessary calls to superclass constructors. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -182,7 +182,6 @@ public class MagicNumberCheck extends Check {
      * Sort the allowedTokensBetweenMagicNumberAndConstDef array for binary search.
      */
     public MagicNumberCheck() {
-        super();
         Arrays.sort(constantWaiverParentToken);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
@@ -110,7 +110,6 @@ public class JTreeTable extends JTable {
     private List<Integer> lines2position;
 
     public JTreeTable(TreeTableModel treeTableModel) {
-        super();
 
         // Create the tree. It will be used as a renderer and editor.
         tree = new TreeTableCellRenderer(treeTableModel);


### PR DESCRIPTION
Fixes `UnnecessarySuperConstructor` inspection violations.

Description:
>Reports any no-argument calls to a superclass constructor as the first call of a constructor. Such calls are unnecessary, and may be removed.