### PR TITLE
Remove unnecessary qualifiers. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/AnnotationUtility.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AnnotationUtility.java
@@ -71,7 +71,7 @@ public final class AnnotationUtility {
         if (ast == null) {
             throw new IllegalArgumentException(THE_AST_IS_NULL);
         }
-        return AnnotationUtility.getAnnotation(ast, annotation) != null;
+        return getAnnotation(ast, annotation) != null;
     }
 
     /**
@@ -85,7 +85,7 @@ public final class AnnotationUtility {
         if (ast == null) {
             throw new IllegalArgumentException(THE_AST_IS_NULL);
         }
-        final DetailAST holder = AnnotationUtility.getAnnotationHolder(ast);
+        final DetailAST holder = getAnnotationHolder(ast);
         return holder != null && holder.branchContains(TokenTypes.ANNOTATION);
     }
 
@@ -152,7 +152,7 @@ public final class AnnotationUtility {
                     "the annotation is empty or spaces");
         }
 
-        final DetailAST holder = AnnotationUtility.getAnnotationHolder(ast);
+        final DetailAST holder = getAnnotationHolder(ast);
 
         for (DetailAST child = holder.getFirstChild();
             child != null; child = child.getNextSibling()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ScopeUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ScopeUtils.java
@@ -79,7 +79,7 @@ public final class ScopeUtils {
                 || type == TokenTypes.ENUM_DEF) {
                 final DetailAST mods =
                     token.findFirstToken(TokenTypes.MODIFIERS);
-                final Scope modScope = ScopeUtils.getScopeFromMods(mods);
+                final Scope modScope = getScopeFromMods(mods);
                 if (retVal == null || retVal.isIn(modScope)) {
                     retVal = modScope;
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -194,7 +194,7 @@ public final class TreeWalker
         try {
             final FileText text = FileText.fromLines(file, lines);
             final FileContents contents = new FileContents(text);
-            final DetailAST rootAST = TreeWalker.parse(contents);
+            final DetailAST rootAST = parse(contents);
 
             getMessageCollector().reset();
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -305,7 +305,7 @@ public final class AnnotationUseStyleCheck extends Check {
                 TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
 
         if (valuePairCount == 1
-            && AnnotationUseStyleCheck.ANNOTATION_ELEMENT_SINGLE_NAME.equals(
+            && ANNOTATION_ELEMENT_SINGLE_NAME.equals(
                 valuePair.getFirstChild().getText())) {
             this.log(annotation.getLineNo(), MSG_KEY_ANNOTATION_INCORRECT_STYLE,
                 ElementStyle.COMPACT);
@@ -339,8 +339,7 @@ public final class AnnotationUseStyleCheck extends Check {
                 valuePair.findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
 
             if (nestedArrayInit != null
-                && AnnotationUseStyleCheck
-                    .ANNOTATION_ELEMENT_SINGLE_NAME.equals(
+                && ANNOTATION_ELEMENT_SINGLE_NAME.equals(
                     valuePair.getFirstChild().getText())
                     && nestedArrayInit.getChildCount(TokenTypes.EXPR) == 1) {
                 this.log(annotation.getLineNo(), MSG_KEY_ANNOTATION_INCORRECT_STYLE,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
@@ -177,10 +177,8 @@ public final class MissingDeprecatedCheck extends Check {
             final String line = lines[i];
 
             final Matcher javadocNoargMatcher =
-                MissingDeprecatedCheck.MATCH_DEPRECATED.matcher(line);
-            final Matcher noargMultilineStart =
-                MissingDeprecatedCheck
-                    .MATCH_DEPRECATED_MULTILINE_START.matcher(line);
+                MATCH_DEPRECATED.matcher(line);
+            final Matcher noargMultilineStart = MATCH_DEPRECATED_MULTILINE_START.matcher(line);
 
             if (javadocNoargMatcher.find()) {
                 if (found) {
@@ -214,15 +212,13 @@ public final class MissingDeprecatedCheck extends Check {
         boolean found = false;
         for (int reindex = i + 1;
             reindex < lines.length; reindex++) {
-            final Matcher multilineCont =
-                MissingDeprecatedCheck.MATCH_DEPRECATED_MULTILINE_CONT
-                .matcher(lines[reindex]);
+            final Matcher multilineCont = MATCH_DEPRECATED_MULTILINE_CONT.matcher(lines[reindex]);
 
             if (multilineCont.find()) {
                 reindex = lines.length;
                 final String lFin = multilineCont.group(1);
-                if (!lFin.equals(MissingDeprecatedCheck.NEXT_TAG)
-                    && !lFin.equals(MissingDeprecatedCheck.END_JAVADOC)) {
+                if (!lFin.equals(NEXT_TAG)
+                    && !lFin.equals(END_JAVADOC)) {
                     if (foundBefore) {
                         this.log(currentLine, MSG_KEY_JAVADOC_DUPLICATE_TAG,
                             JavadocTagInfo.DEPRECATED.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
@@ -186,7 +186,7 @@ public final class MissingOverrideCheck extends Check {
 
         for (final String line : lines) {
             final Matcher matchInheritDoc =
-                MissingOverrideCheck.MATCH_INHERITDOC.matcher(line);
+                MATCH_INHERITDOC.matcher(line);
 
             if (matchInheritDoc.find()) {
                 return true;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -212,11 +212,11 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
      */
     private static DetailAST getSuppressWarnings(DetailAST ast) {
         final DetailAST annotation = AnnotationUtility.getAnnotation(
-            ast, SuppressWarningsCheck.SUPPRESS_WARNINGS);
+            ast, SUPPRESS_WARNINGS);
 
         return annotation != null ? annotation
             : AnnotationUtility.getAnnotation(
-                ast, SuppressWarningsCheck.FQ_SUPPRESS_WARNINGS);
+                ast, FQ_SUPPRESS_WARNINGS);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java
@@ -119,7 +119,7 @@ class HtmlTag {
     public String toString() {
         final int startOfText = position;
         final int endOfText =
-            Math.min(startOfText + HtmlTag.MAX_TEXT_LEN, text.length());
+            Math.min(startOfText + MAX_TEXT_LEN, text.length());
         return text.substring(startOfText, endOfText);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
@@ -319,9 +319,9 @@ public final class JavadocUtils {
      * @return next sibling.
      */
     public static DetailNode getNextSibling(DetailNode node, int tokenType) {
-        DetailNode nextSibling = JavadocUtils.getNextSibling(node);
+        DetailNode nextSibling = getNextSibling(node);
         while (nextSibling != null && nextSibling.getType() != tokenType) {
-            nextSibling = JavadocUtils.getNextSibling(nextSibling);
+            nextSibling = getNextSibling(nextSibling);
         }
         return nextSibling;
     }
@@ -384,11 +384,11 @@ public final class JavadocUtils {
     public static String getTagName(DetailNode javadocTagSection) {
         String javadocTagName;
         if (javadocTagSection.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG) {
-            javadocTagName = JavadocUtils.getNextSibling(
-                    JavadocUtils.getFirstChild(javadocTagSection)).getText();
+            javadocTagName = getNextSibling(
+                    getFirstChild(javadocTagSection)).getText();
         }
         else {
-            javadocTagName = JavadocUtils.getFirstChild(javadocTagSection).getText();
+            javadocTagName = getFirstChild(javadocTagSection).getText();
         }
         return javadocTagName;
     }


### PR DESCRIPTION
Fixes `UnnecessarilyQualifiedStaticUsage` inspection violations.

Description:
>Reports calls to static methods or accesses of static fields on the current class which are qualified with the class name. Such qualification is unnecessary, and may be safely removed.