### PR TITLE
Return unmodifiable collections from methods. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
@@ -103,7 +103,7 @@ public abstract class Check extends AbstractViolationReporter {
      * @return the set of token names
      */
     public final Set<String> getTokenNames() {
-        return tokens;
+        return Collections.unmodifiableSet(tokens);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -230,7 +230,7 @@ public final class FileContents implements CommentListener {
      * @return an object containing the full text of the file
      */
     public FileText getText() {
-        return text;
+        return new FileText(text);
     }
 
     /** @return the lines in the file */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FilterSet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FilterSet.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 
@@ -56,7 +57,7 @@ public class FilterSet
      * @return the Filters of the filter set.
      */
     public Set<Filter> getFilters() {
-        return filters;
+        return Collections.unmodifiableSet(filters);
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -28,6 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multiset.Entry;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
@@ -148,7 +149,7 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
         }
 
         public Multiset<String> getDuplicatedStrings() {
-            return duplicatedStrings;
+            return ImmutableMultiset.copyOf(duplicatedStrings);
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTags.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTags.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
@@ -50,7 +51,7 @@ public final class JavadocTags {
      *  @return validTags field
      */
     public List<JavadocTag> getValidTags() {
-        return validTags;
+        return Collections.unmodifiableList(validTags);
     }
 
     /**
@@ -58,6 +59,6 @@ public final class JavadocTags {
      *  @return invalidTags field
      */
     public List<InvalidJavadocTag> getInvalidTags() {
-        return invalidTags;
+        return Collections.unmodifiableList(invalidTags);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/CSVFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/CSVFilter.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -78,7 +79,7 @@ class CSVFilter implements IntFilter {
      * @return the IntFilters of the filter set.
      */
     protected Set<IntFilter> getFilters() {
-        return filters;
+        return Collections.unmodifiableSet(filters);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -27,6 +27,7 @@ import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.TooManyListenersException;
 
@@ -213,7 +214,7 @@ public class ParseTreeInfoPanel extends JPanel {
     }
 
     public List<Integer> getLines2position() {
-        return lines2position;
+        return Collections.unmodifiableList(lines2position);
     }
 
     /**


### PR DESCRIPTION
Fixes `ReturnOfCollectionField` inspection violations.

Description:
>Reports any attempt to return an array or Collection field from a method. Since the array or Collection may have its contents modified by the calling method, this construct may result in an object having its state modified unexpectedly. While occasionally useful for performance reasons, this construct is inherently bug-prone.