### PR TITLE
Fix dangling Javadoc comments. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheck.java
@@ -55,7 +55,7 @@ public class InnerTypeLastCheck extends Check {
 
     @Override
     public void visitToken(DetailAST ast) {
-        /** First root class */
+        // First root class
         if (rootClass) {
             rootClass = false;
         }
@@ -75,7 +75,7 @@ public class InnerTypeLastCheck extends Check {
 
     @Override
     public void leaveToken(DetailAST ast) {
-        /** Is this a root class */
+        // Is this a root class
         if (ast.getParent() == null) {
             rootClass = true;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -64,7 +64,6 @@ final class ImportControlLoader extends AbstractLoader {
     /** Used to hold the {@link PkgControl} objects. */
     private final Deque<PkgControl> stack = new ArrayDeque<>();
 
-    /** Initialise the map */
     static {
         DTD_RESOURCE_BY_ID.put(DTD_PUBLIC_ID_1_0, DTD_RESOURCE_NAME_1_0);
         DTD_RESOURCE_BY_ID.put(DTD_PUBLIC_ID_1_1, DTD_RESOURCE_NAME_1_1);


### PR DESCRIPTION
Fixes `DanglingJavadoc` inspection violations.

Description:
>Reports dangling Javadoc comments. Javadoc comment are dangling if they don't belong to any class, method or field. For example a Javadoc comment in between method declarations that have their own javadoc comments.