### PR TITLE
Fix confusing floating point literals. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
@@ -77,7 +77,7 @@ import javax.swing.border.Border;
 class FileDrop {
 
     /* Default border color */
-    private static final Color DEFAULT_BORDER_COLOR = new Color(0f, 0f, 1f, 0.25f);
+    private static final Color DEFAULT_BORDER_COLOR = new Color(0.0f, 0.0f, 1.0f, 0.25f);
 
     private transient Border normalBorder;
     private final transient DropTargetListener dropListener;


### PR DESCRIPTION
Fixes `ConfusingFloatingPointLiteral` inspection violations.

Description:
>Reports any floating point numbers which do not have a decimal point, numbers before the decimal point, and numbers after the decimal point. Such literals may be confusing, and violate several coding standards.