### PR TITLE
Use isEmpty() instead of "".equals() on strings. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -269,7 +269,7 @@ public final class FileContents implements CommentListener {
      **/
     public boolean lineIsBlank(int lineNo) {
         // possible improvement: avoid garbage creation in trim()
-        return "".equals(line(lineNo).trim());
+        return line(lineNo).trim().isEmpty();
     }
 
     /**


### PR DESCRIPTION
Fixes `StringEqualsEmptyString` inspection violations.

Description:
>Reports .equals() being called to compare a String with an empty string. It is normally more performant to test a String for emptiness by comparing its .length() to zero instead.