### PR TITLE
Use short circuit boolean expression. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -219,7 +219,7 @@ public class CommentsIndentationCheck extends Check {
         }
         else {
             result = singleLineComment.getColumnNo() == nextStmt.getColumnNo()
-                | singleLineComment.getColumnNo() == prevStmt.getColumnNo();
+                || singleLineComment.getColumnNo() == prevStmt.getColumnNo();
         }
         return result;
     }


### PR DESCRIPTION
Fixes `NonShortCircuitBoolean` inspection violations.

Description:
>Reports on any uses of the non-short-circuit forms of boolean 'and' and 'or' ( & and | ). The non-short-circuit versions are occasionally useful, but their presence is often due to typos of the short-circuit forms ( && and || ), and may lead to subtle bugs.