### PR TITLE
Corrected links on website, issue #751

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Contributors chat: [![https://gitter.im/checkstyle/checkstyle](https://badges.gi
 Checkstyle is a tool for
 checking Java source code for adherence to a Code Standard or set of validation rules (best practices).
 
-The latest version can be found at [SourceForge downloads](https://sourceforge.net/projects/checkstyle/files/checkstyle/) or at [Maven repo](http://repo1.maven.org/maven2/com/puppycrawl/tools/checkstyle/).
+The latest version can be found at [SourceForge downloads](http://sourceforge.net/projects/checkstyle/files/checkstyle/) or at [Maven repo](http://repo1.maven.org/maven2/com/puppycrawl/tools/checkstyle/).
 
 Documentation is available in HTML format, see http://checkstyle.sourceforge.net/checks.html.
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Configurable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Configurable.java
@@ -26,7 +26,7 @@ package com.puppycrawl.tools.checkstyle.api;
  * to parent object or created by parent object.
  * The general idea of
  * Configuration/Configurable was taken from <a target="_top"
- * href="http://jakarta.apache.org/avalon/">Jakarta's Avalon framework</a>.
+ * href="http://avalon.apache.org/closed.html">Jakarta's Avalon framework</a>.
  * @author lkuehne
  */
 public interface Configurable {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Configuration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Configuration.java
@@ -26,7 +26,7 @@ import com.google.common.collect.ImmutableMap;
 /**
  * A Configuration is used to configure a Configurable component.  The general
  * idea of Configuration/Configurable was taken from <a target="_top"
- * href="http://jakarta.apache.org/avalon/">Jakarta's Avalon framework</a>.
+ * href="http://avalon.apache.org/closed.html">Jakarta's Avalon framework</a>.
  * @author lkuehne
  */
 public interface Configuration extends Serializable {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Context.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Context.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableCollection;
 /**
  * A context to be used in subcomponents. The general idea of
  * Context/Contextualizable was taken from <a target="_top"
- * href="http://jakarta.apache.org/avalon/">Jakarta's Avalon framework</a>.
+ * href="http://avalon.apache.org/closed.html">Jakarta's Avalon framework</a>.
  * @author lkuehne
  * @see Contextualizable
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Contextualizable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Contextualizable.java
@@ -27,7 +27,7 @@ package com.puppycrawl.tools.checkstyle.api;
  * Contextualizing is inheriting some properties from parent that are provided by user
  * to parent object or created by parent object.
  * The general idea of Context/Contextualizable was taken from <a target="_top"
- * href="http://jakarta.apache.org/avalon/">Jakarta's Avalon framework</a>.
+ * href="http://avalon.apache.org/closed.html">Jakarta's Avalon framework</a>.
  * @author lkuehne
  */
 public interface Contextualizable {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -29,7 +29,7 @@ import com.puppycrawl.tools.checkstyle.Utils;
 /**
  * An extension of the CommonAST that records the line and column
  * number.  The idea was taken from <a target="_top"
- * href="http://www.jguru.com/jguru/faq/view.jsp?EID=62654">Java Guru
+ * href="http://www.jguru.com/faq/view.jsp?EID=62654">Java Guru
  * FAQ: How can I include line numbers in automatically generated
  * ASTs?</a>.
  * @author Oliver Burn

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -2797,7 +2797,7 @@ public final class TokenTypes {
      *     +--SEMI (;)
      * </pre>
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=201">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">
      * JSR201</a>
      * @see #LITERAL_STATIC
      * @see #DOT
@@ -2869,7 +2869,7 @@ public final class TokenTypes {
      *         +--RCURLY (})
      * </pre>
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=201">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">
      * JSR201</a>
      * @see #MODIFIERS
      * @see #ENUM
@@ -2939,7 +2939,7 @@ public final class TokenTypes {
      *         +--RCURLY (})
      * </pre>
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=201">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">
      * JSR201</a>
      * @see #ANNOTATIONS
      * @see #MODIFIERS
@@ -2999,7 +2999,7 @@ public final class TokenTypes {
      *         +--RCURLY (})
      * </pre>
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=201">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">
      * JSR201</a>
      * @see #MODIFIERS
      * @see #LITERAL_INTERFACE
@@ -3039,7 +3039,7 @@ public final class TokenTypes {
      *     +--SEMI (;)
      * </pre>
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=201">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">
      * JSR201</a>
      * @see #MODIFIERS
      * @see #TYPE
@@ -3078,7 +3078,7 @@ public final class TokenTypes {
      *     +--SEMI (;)
      * </pre>
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=201">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">
      * JSR201</a>
      * @see #ANNOTATION
      * @see #AT
@@ -3128,7 +3128,7 @@ public final class TokenTypes {
      *     +--RPAREN ())
      * </pre>
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=201">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">
      * JSR201</a>
      * @see #MODIFIERS
      * @see #IDENT
@@ -3142,7 +3142,7 @@ public final class TokenTypes {
      * Its children are the name of the member, the assignment literal
      * and the (compile-time constant conditional expression) value.
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=201">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">
      * JSR201</a>
      * @see #ANNOTATION
      * @see #IDENT
@@ -3175,7 +3175,7 @@ public final class TokenTypes {
      *     +--RCURLY (})
      * </pre>
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=201">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">
      * JSR201</a>
      * @see #ANNOTATION
      * @see #IDENT
@@ -3228,7 +3228,7 @@ public final class TokenTypes {
      *     +--RCURLY (})
      * </pre>
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=14">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=14">
      * JSR14</a>
      * @see #GENERIC_START
      * @see #GENERIC_END
@@ -3259,7 +3259,7 @@ public final class TokenTypes {
      *         +--IDENT (Collection)
      * </pre>
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=14">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=14">
      * JSR14</a>
      * @see #IDENT
      * @see #WILDCARD_TYPE
@@ -3333,7 +3333,7 @@ public final class TokenTypes {
      *         +--IDENT (List)
      * </pre>
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=14">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=14">
      * JSR14</a>
      * @see #WILDCARD_TYPE
      * @see #TYPE_UPPER_BOUNDS
@@ -3345,7 +3345,7 @@ public final class TokenTypes {
     /**
      * The type that refers to all types. This node has no children.
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=14">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=14">
      * JSR14</a>
      * @see #TYPE_ARGUMENT
      * @see #TYPE_UPPER_BOUNDS
@@ -3359,7 +3359,7 @@ public final class TokenTypes {
      * This node has one child - the type that is being used for
      * the bounding.
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=14">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=14">
      * JSR14</a>
      * @see #TYPE_PARAMETER
      * @see #TYPE_ARGUMENT
@@ -3372,7 +3372,7 @@ public final class TokenTypes {
      * A lower bounds on a wildcard type argument. This node has one child
      *  - the type that is being used for the bounding.
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=14">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=14">
      * JSR14</a>
      * @see #TYPE_ARGUMENT
      * @see #WILDCARD_TYPE
@@ -3385,7 +3385,7 @@ public final class TokenTypes {
      * to the interface literal signifying the definition of an annotation
      * declaration.
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=201">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">
      * JSR201</a>
      */
     public static final int AT = GeneratedJavaTokenTypes.AT;
@@ -3394,7 +3394,7 @@ public final class TokenTypes {
      * A triple dot for variable-length parameters. This token only ever occurs
      * in a parameter declaration immediately after the type of the parameter.
      *
-     * @see <a href="http://www.jcp.org/en/jsr/detail?id=201">
+     * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">
      * JSR201</a>
      */
     public static final int ELLIPSIS = GeneratedJavaTokenTypes.ELLIPSIS;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -32,7 +32,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * "http://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.3">
  * Unicode escapes</a> (e.g. \u221e).
  * It is possible to allow using escapes for
- * <a href="http://en.wiktionary.org/wiki/Appendix:Control_characters">
+ * <a href="https://en.wiktionary.org/wiki/Appendix:Control_characters">
  * non-printable(control) characters</a>.
  * Also, this check can be configured to allow using escapes
  * if trail comment is present. By the option it is possible to

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.checks.CheckUtils;
 
 /**
  * <p>
- * Checks that there are no <a href="http://en.wikipedia.org/wiki/Magic_number_%28programming%29">
+ * Checks that there are no <a href="https://en.wikipedia.org/wiki/Magic_number_%28programming%29">
  * &quot;magic numbers&quot;</a> where a magic
  * number is a numeric literal that is not defined as a constant.
  * By default, -1, 0, 1, and 2 are not considered to be magic numbers.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -210,7 +210,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </code>
  * </pre>
  * <p>
- * It is possible to enforce <a href="http://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>
+ * It is possible to enforce
+ * <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>
  * of imports in groups using the following configuration:
  * </p>
  * <pre>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -29,7 +29,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 /**
  * This check calculates the Non Commenting Source Statements (NCSS) metric for
  * java source files and methods. The check adheres to the <a
- * href="http://www.kclee.com/clemens/java/javancss/">JavaNCSS specification
+ * href="http://kclee.com/clemens/java/javancss/">JavaNCSS specification
  * </a> and gives the same results as the JavaNCSS tool.
  *
  * The NCSS-metric tries to determine complexity of methods, classes and files

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -33,7 +33,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <p>
  * The Check validate abbreviations(consecutive capital letters) length in
  * identifier name, it also allows to enforce camel case naming. Please read more at
- * <a href="http://google-styleguide.googlecode.com/svn/trunk/javaguide.html#s5.3-camel-case">
+ * <a href="http://checkstyle.sourceforge.net/reports/google-java-style.html#s5.3-camel-case">
  * Google Style Guide</a> to get to know how to avoid long abbreviations in names.
  * </p>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModel.java
@@ -50,7 +50,7 @@ import javax.swing.tree.TreeModel;
  * the TreeTableModel can return a value for each of the columns and
  * set that value if isCellEditable() returns true.
  *
- * <a href="http://java.sun.com/products/jfc/tsc/articles/treetable1/index.html">Original&nbsp;Source&nbsp;Location</a>
+ * <a href="http://docs.oracle.com/cd/E16162_01/apirefs.1112/e17493/oracle/ide/controls/TreeTableModel.html">Original&nbsp;Source&nbsp;Location</a>
  *
  * @author Philip Milne
  * @author Scott Violet

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -24,11 +24,11 @@
           />
     <logo name="SourceForge"
           img="images/sflogo.gif"
-          href="http://sourceforge.net/projects/checkstyle"
+          href="http://sourceforge.net/projects/checkstyle/"
           />
     <logo name="Twitter"
           img="images/twitter_button.png"
-          href="https://twitter.com/checkstyle_java"
+          href="https://twitter.com/checkstyle_java/"
           />
     <logo name="Stackoverflow"
           img="images/stackoverflow.jpeg"
@@ -44,7 +44,7 @@
           />
     <logo name="Google+"
           img="images/Google-Plus-Logo-120x38.png"
-          href="https://plus.google.com/u/0/108692338295483568100/posts"
+          href="https://plus.google.com/108692338295483568100/posts"
           />
   </poweredBy>
   

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -145,7 +145,7 @@
         <td>
           Checks that the parts of a class or interface declaration
           appear in the order suggested by the <a
-          href="http://java.sun.com/docs/codeconv/html/CodeConventions.doc2.html#1852"
+          href="http://www.oracle.com/technetwork/java/javase/documentation/codeconventions-141855.html#1852"
           >Code Conventions for the Java Programming Language</a>.
         </td>
       </tr>
@@ -471,7 +471,7 @@
         <td>
           Checks that the order of modifiers conforms to the suggestions in the
           <a
-              href="http://java.sun.com/docs/books/jls/second_edition/html/classes.doc.html">
+              href="http://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html">
         Java Language specification, sections 8.1.1, 8.3.1 and 8.4.3</a>.</td>
       </tr>
       <tr>

--- a/src/xdocs/cmdline.xml.vm
+++ b/src/xdocs/cmdline.xml.vm
@@ -98,7 +98,7 @@ java -D&lt;property&gt;=&lt;value&gt;  \
     <section name="Download and Run">
       <p>
           It is possible to run Checkstyle directly from the JAR file using
-          the <code>-jar</code> option. Download latest <a href="http://sourceforge.net/projects/checkstyle/files/checkstyle/${projectVersion}/checkstyle-${projectVersion}-all.jar/download">
+          the <code>-jar</code> option. Download latest <a href="http://iweb.dl.sourceforge.net/project/checkstyle/checkstyle/${projectVersion}/checkstyle-${projectVersion}-all.jar">
           checkstyle-${projectVersion}-all.jar</a>.
           An example of run would be:
         <source>
@@ -111,7 +111,7 @@ java -jar checkstyle-${projectVersion}-all.jar -c /google_checks.xml MyClass.jav
       </p>
       <p>
           To run Checkstyle UI viewer for AST tree directly from the JAR file using
-          the <code>-jar</code> option. Download latest <a href="http://sourceforge.net/projects/checkstyle/files/checkstyle/${projectVersion}/checkstyle-${projectVersion}-all.jar/download">
+          the <code>-jar</code> option. Download latest <a href="http://iweb.dl.sourceforge.net/project/checkstyle/checkstyle/${projectVersion}/checkstyle-${projectVersion}-all.jar">
           checkstyle-${projectVersion}-all.jar</a>.
           An example of run would be (path to java file is optional):
         <source>
@@ -150,7 +150,7 @@ java -jar target/checkstyle-X.X-SNAPSHOT-all.jar -c /sun_checks.xml MyClass.java
     <section name="Usage by Classpath update">
       <p>
         The easiest way is to include
-        <a href="http://sourceforge.net/projects/checkstyle/files/checkstyle/${projectVersion}/checkstyle-${projectVersion}-all.jar/download">checkstyle-${projectVersion}-all.jar</a> in the
+        <a href="http://iweb.dl.sourceforge.net/project/checkstyle/checkstyle/${projectVersion}/checkstyle-${projectVersion}-all.jar">checkstyle-${projectVersion}-all.jar</a> in the
         <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html#sthref10">classpath</a>. Alternatively, you must include the
         <code>compile</code> third party dependencies listed in
 

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -935,7 +935,7 @@ class SomeClass
     <section name="MagicNumber">
       <subsection name="Description">
         <p>
-          Checks that there are no <a href="http://en.wikipedia.org/wiki/Magic_number_%28programming%29">
+          Checks that there are no <a href="https://en.wikipedia.org/wiki/Magic_number_%28programming%29">
           &quot;magic numbers&quot;</a> where a magic
           number is a numeric literal that is not defined as a constant.
           By default, -1, 0, 1, and 2 are not considered to be magic numbers.
@@ -2508,7 +2508,7 @@ case 5:
 
         <p>
           Rationale: <a
-          href="http://java.sun.com/docs/codeconv/html/CodeConventions.doc5.html#2991">
+          href="http://www.oracle.com/technetwork/java/javase/documentation/codeconventions-141270.html#2992">
           the Java code conventions chapter 6.1</a> recommends that
           declarations should be one per line/statement.
         </p>

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -346,7 +346,7 @@ class SomeClass
           According to Bloch, an interface should describe a <em>type</em>.
           It is therefore inappropriate to define an interface that does not
           contain any methods but only constants. The Standard class <a
-          href="http://java.sun.com/j2se/1.4.1/docs/api/javax/swing/SwingConstants.html">javax.swing.SwingConstants</a>
+          href="http://docs.oracle.com/javase/8/docs/api/javax/swing/SwingConstants.html">javax.swing.SwingConstants</a>
           is an example of a class that would be flagged by this check.
         </p>
 

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -181,7 +181,7 @@
           Checks for imports from a set of illegal packages. By default, the
           check rejects all <code>sun.*</code> packages since
           programs that contain direct calls to the <code>sun.*</code> packages are <a
-          href="http://java.sun.com/products/jdk/faq/faq-sun-packages.html">"not guaranteed
+          href="http://www.oracle.com/technetwork/java/faq-sun-packages-142232.html">"not guaranteed
           to work on all Java-compatible platforms"</a>. To reject other packages, set property <code> illegalPkgs</code> to a list of the illegal packages.
         </p>
       </subsection>
@@ -388,7 +388,7 @@ class FooBar {
           within each group are in lexicographic order</li>
           <li>sorts according to case: ensures that the comparison
           between imports is case sensitive, in
-          <a href="http://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a></li>
+          <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a></li>
           <li>groups static imports: ensures the relative order between
           regular imports and static imports (see
           <a href="property_types.html#importOrder">import orders</a>)</li>
@@ -442,7 +442,7 @@ class FooBar {
             <td>caseSensitive</td>
             <td>whether string comparison should be case sensitive or not.
               Case sensitive sorting is in
-              <a href="http://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>
+              <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>true</td>
@@ -792,7 +792,7 @@ import java.util.regex.Matcher; //#8
           <tr>
             <td>sortImportsInGroupAlphabetically</td>
             <td>Force grouping alphabetically, in
-                <a href="http://en.wikipedia.org/wiki/ASCII#Order">
+                <a href="https://en.wikipedia.org/wiki/ASCII#Order">
                    ASCII sort order</a>.</td>
             <td><a href="property_types.html#boolean">boolean</a></td>
             <td><code>false</code></td>
@@ -908,7 +908,7 @@ import java.util.regex.Matcher; //#8
 &lt;/module&gt;
         </source>
         <p>
-          It is possible to enforce <a href="http://en.wikipedia.org/wiki/ASCII#Order">
+          It is possible to enforce <a href="https://en.wikipedia.org/wiki/ASCII#Order">
           ASCII sort order</a>
           of imports in groups using the following configuration:
         </p>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -655,8 +655,8 @@ public boolean isSomething()
 
         <p>
           These checks were patterned after the checks made by the <a
-          href="http://java.sun.com/j2se/javadoc/doccheck/index.html">DocCheck</a>
-          doclet available from Sun.
+          href="http://maven-doccheck.sourceforge.net/">DocCheck</a>
+          doclet available from Sun. Note: Original Sun's DocCheck tool does not exist anymore.
         </p>
       </subsection>
 

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -42,7 +42,7 @@
         <p>
           Note that the operators <code>&#x26;</code> and
           <code>|</code> are not only integer bitwise operators, they are also the
-          <a href="http://java.sun.com/docs/books/jls/third_edition/html/expressions.html#15.22.2">
+          <a href="http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.22.2">
           non-shortcut versions</a> of the boolean operators.
           <code>&#x26;&#x26;</code> and <code>||</code>.
         </p>

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -395,7 +395,7 @@ messages.properties: Key 'ok' missing.
           Checks that long constants are defined with an upper ell. That
           is <code>' L'</code> and not <code>'l'</code>. This is in accordance with the Java
           Language Specification, <a
-          href="http://java.sun.com/docs/books/jls/second_edition/html/lexical.doc.html#48282">
+          href="http://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.1">
           Section 3.10.1</a>.
         </p>
 
@@ -1201,7 +1201,7 @@ d = e / f;        // Another comment for this line
           Restrict using <a href = "http://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.3">
           Unicode escapes</a> (e.g. \u221e).
           It is possible to allow using escapes for
-          <a href="http://en.wiktionary.org/wiki/Appendix:Control_characters"> non-printable(control) characters</a>.
+          <a href="https://en.wiktionary.org/wiki/Appendix:Control_characters"> non-printable(control) characters</a>.
           Also, this check can be configured to allow using escapes
           if trail comment is present. By the option it is possible to
           allow using escapes if literal contains only them.

--- a/src/xdocs/config_modifier.xml
+++ b/src/xdocs/config_modifier.xml
@@ -31,7 +31,7 @@
         <p>
           Checks that the order of modifiers conforms to the suggestions in
           the <a
-          href="http://java.sun.com/docs/books/jls/second_edition/html/classes.doc.html">Java
+          href="http://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html">Java
           Language specification, sections 8.1.1, 8.3.1 and 8.4.3</a>. The
           correct order is:
         </p>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -31,7 +31,7 @@
         Each of these naming modules validates identifiers for particular code
         elements. Valid identifiers for a naming module are specified by its
         <code> format</code> property. The value of <code>format</code> is a <a
-        href="http://java.sun.com/j2se/1.5.0/docs/api/java/util/regex/Pattern.html">
+        href="http://docs.oracle.com/javase/1.5.0/docs/api/java/util/regex/Pattern.html">
         regular expression</a> for valid identifiers.  This is an example of a
         configuration of the <code>MemberName</code> module to
         ensure that member identifiers begin with
@@ -357,7 +357,7 @@ class MyClass {
       <p>
         The default value of <code>format</code> for module <code>PackageName</code> has been chosen to match the
         requirements in the <a
-        href="http://java.sun.com/docs/books/jls/second_edition/html/packages.doc.html#40169">Java
+        href="http://docs.oracle.com/javase/specs/jls/se8/html/jls-6.html#jls-6.5.3">Java
         Language specification</a> and the Sun coding conventions. However
         both underscores and uppercase letters are rather uncommon, so most
         configurations should probably assign value <code>^[a-z]+(\.[a-z][a-z0-9]*)*$</code> to <code>format</code> for module <code>PackageName</code>, as in
@@ -376,7 +376,7 @@ class MyClass {
         <p>
          The Check validate abbreviations(consecutive capital letters)
          length in identifier name, it also allows to enforce camel case naming. Please read more at
-         <a href="http://google-styleguide.googlecode.com/svn/trunk/javaguide.html#s5.3-camel-case">
+         <a href="http://checkstyle.sourceforge.net/reports/google-java-style.html#s5.3-camel-case">
          Google Style Guide</a>
          to get to know how to avoid long abbreviations in names.
         </p>

--- a/src/xdocs/consulting.xml
+++ b/src/xdocs/consulting.xml
@@ -33,7 +33,7 @@
           - personal consulting on how to introduce Checkstyle into your company process,<br/>
           - help in introducing Checkstyle to legacy projects,<br/>
           - help in developing company's personal code convention/style,<br/>
-          - help in eliminating <a href="http://en.wikipedia.org/wiki/Job_security">Job security</a>
+          - help in eliminating <a href="https://en.wikipedia.org/wiki/Job_security">Job security</a>
             by enforcing code standards/style and static code analysis,<br/>
           - prioritized handling of bugs/issues,<br/>
           - prioritized handling of enhancement requests,<br/>

--- a/src/xdocs/contributing.xml
+++ b/src/xdocs/contributing.xml
@@ -81,7 +81,7 @@
         do take this one step further and measure the coverage of our
         unit tests using
 
-        <a href="http://cobertura.sourceforge.net/">Cobertura</a>.
+        <a href="http://cobertura.github.io/cobertura/">Cobertura</a>.
 
         This means it is not sufficient to pass all tests, but the tests
         should ideally execute each line in the code, code coverage should be 100%. To generate the
@@ -125,8 +125,8 @@
       </p>
 
       <p>
-        Please use <a href="http://help.github.com/articles/using-pull-requests">Pull Request</a>
-        feature of <a href="http://github.com/">Github</a>.<br/>
+        Please use <a href="https://help.github.com/articles/using-pull-requests/">Pull Request</a>
+        feature of <a href="https://github.com/">Github</a>.<br/>
         Please provide wide description of update with detailed explanation of problem
         and how you propose to resolve it.
         <b>ATTENTION:</b> Please recheck that in your Pull Request there is ONLY your changes and all of them are rebased from most recent HEAD of our master branch.

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -556,7 +556,7 @@
                                 <br />
                                 We can detect URL with protocol type as http://, https:// etc.
                                 <br />
-                                <a href="https://developers.google.com/eclipse/docs/gwt_jsni">JSNI</a>
+                                <a href="http://googlewebtoolkit.blogspot.com/2008/07/getting-to-really-know-gwt-part-1-jsni.html">JSNI</a>
                                 could not be detected right now, but might be possible after comments and
                                 javadoc support appear in Checkstyle
                             </td>

--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -34,7 +34,7 @@
         any coding standard. An example configuration files are supplied
         supporting the <a href="http://www.oracle.com/technetwork/java/javase/documentation/codeconvtoc-136057.html">
         Sun Code Conventions</a>,
-        <a href="https://google-styleguide.googlecode.com/svn/trunk/javaguide.html">Google Java Style</a>.
+        <a href="http://checkstyle.sourceforge.net/reports/google-java-style.html">Google Java Style</a>.
       </p>
 
       <p>
@@ -91,7 +91,7 @@
     <section name="Download">
       <p>
         The latest release of Checkstyle can be downloaded from <a
-        href="https://sourceforge.net/projects/checkstyle/files/checkstyle/">the
+        href="http://sourceforge.net/projects/checkstyle/files/checkstyle/">the
         SourceForge download page</a>, or <a href="http://search.maven.org/#search|gav|1|g%3A%22com.puppycrawl.tools%22%20AND%20a%3A%22checkstyle%22">Maven central</a>.
       </p>
 
@@ -129,7 +129,7 @@
           <th>Remarks</th>
         </tr>
         <tr>
-          <td><a href="http://www.scm-manager.org/">SCM-Manager</a></td>
+          <td><a href="https://www.scm-manager.org/">SCM-Manager</a></td>
           <td></td>
           <td><a href="http://plugins.scm-manager.org/scm-plugin-backend/page/index.html">SCM-Manager Plugin Page</a></td>
           <td></td>
@@ -172,7 +172,7 @@
             Checkstyle. See the
             <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki">Wiki</a>
             and
-            <a href="http://sevntu-checkstyle.github.com/sevntu.checkstyle/">Blog</a>
+            <a href="http://sevntu-checkstyle.github.io/sevntu.checkstyle/">Blog</a>
             .
           </td>
         </tr>
@@ -187,16 +187,16 @@
           <td></td>
         </tr>
         <tr>
-          <td><a href="http://www.intellij.com/idea/">IntelliJ IDEA</a></td>
+          <td><a href="http://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
           <td>Jakub Slawinski</td>
           <td>
-            <a href="http://www.qaplug.com/">QAPlug</a>
+            <a href="http://qaplug.com/">QAPlug</a>
           </td>
           <td>Provides quality assurance features.</td>
         </tr>
 
         <tr>
-          <td><a href="http://www.intellij.com/idea/">IntelliJ IDEA</a></td>
+          <td><a href="http://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
           <td>James Shiell</td>
           <td>
             <a href="https://github.com/jshiell/checkstyle-idea">Checkstyle-idea Project Page</a>
@@ -204,7 +204,7 @@
           <td>Provides real-time and on-demand scanning.</td>
         </tr>
         <tr>
-          <td><a href="http://www.intellij.com/idea/">IntelliJ IDEA</a></td>
+          <td><a href="http://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
           <td>Mark Lussier</td>
           <td>
             <a href="http://jetstyle.sourceforge.net/">JetStyle
@@ -213,7 +213,7 @@
           <td></td>
         </tr>
         <tr>
-          <td><a href="http://netbeans.org">NetBeans</a></td>
+          <td><a href="https://netbeans.org/">NetBeans</a></td>
           <td>Petr Hejl</td>
           <td>
             <a href="http://www.sickboy.cz/checkstyle/">Checkstyle Beans</a>
@@ -224,7 +224,7 @@
           </td>
         </tr>
         <tr>
-          <td><a href="http://netbeans.org">NetBeans</a></td>
+          <td><a href="https://netbeans.org/">NetBeans</a></td>
           <td>Paul Goulbourn</td>
           <td>
             <a href="http://nbcheckstyle.sourceforge.net">nbCheckStyle</a>
@@ -232,18 +232,18 @@
           <td></td>
         </tr>
         <tr>
-          <td><a href="http://netbeans.org">NetBeans</a></td>
+          <td><a href="https://netbeans.org/">NetBeans</a></td>
           <td></td>
           <td>
-            <a href="http://java.net/projects/sqe/">Software Quality Environment (SQE)</a>
+            <a href="https://java.net/projects/sqe/">Software Quality Environment (SQE)</a>
           </td>
           <td></td>
         </tr>
         <tr>
           <td></td>
-          <td><a href="http://www.jcoderz.org/">jCoderZ</a></td>
+          <td><a href="http://jcoderz.github.io/">jCoderZ</a></td>
           <td>
-            <a href="http://www.jcoderz.org/fawkez/">fawkeZ</a>
+            <a href="http://jcoderz.github.io/">fawkeZ</a>
           </td>
           <td>Combines multiple tools (CheckStyle, findbugs, PMD, Cobertura, etc.)</td>
         </tr>
@@ -277,7 +277,7 @@
           <td><a href="http://www.vim.org">Vim editor</a></td>
           <td>Xandy Johnson</td>
           <td><a
-              href="http://vim.sourceforge.net/script.php?script_id=448">Plugin Homepage</a></td>
+              href="http://vim.sourceforge.net/scripts/script.php?script_id=448">Plugin Homepage</a></td>
           <td>Vim file-type plug-in</td>
         </tr>
         <tr>

--- a/src/xdocs/releasenotes.xml
+++ b/src/xdocs/releasenotes.xml
@@ -37,16 +37,16 @@
       <p>Bug fixes:</p>
       <ul>
         <li>
-          Fixed NPE in MultipleVariableDeclarationsCheck Issue. Author:  Baratali Izmailov <a href="https://github.com/checkstyle/checkstyle/issues/1539: Fixed NPE in MultipleVariableDeclarationsCheck">#1539</a>
+          Fixed NPE in MultipleVariableDeclarationsCheck Issue. Author:  Baratali Izmailov <a href="https://github.com/checkstyle/checkstyle/issues/1539">#1539</a>
         </li>
         <li>
-          Added column number into violation messages for RightCurlyCheck and LeftCurlyCheck. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1511.">#1511.</a>
+          Added column number into violation messages for RightCurlyCheck and LeftCurlyCheck. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1511">#1511</a>
         </li>
         <li>
           Fix BooleanExpressionComplexity check violations in Checkstyle code. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1052">#1052</a>
         </li>
         <li>
-          Add new option for RightCurlyCheck. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1019.">#1019.</a>
+          Add new option for RightCurlyCheck. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1019">#1019</a>
         </li>
         <li>
           Updated configuration for Eclipse Mars in xdoc. Author:  Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1464">#1464</a>
@@ -61,10 +61,10 @@
           RedundantModifier for inner classes and enum constructors. Author:  liscju <a href="https://github.com/checkstyle/checkstyle/issues/1242">#1242</a>
         </li>
         <li>
-          Add missing xdocs for allowMultipleEmptyLines property of EmptyLineSeparatorCheck. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/881.">#881.</a>
+          Add missing xdocs for allowMultipleEmptyLines property of EmptyLineSeparatorCheck. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/881">#881</a>
         </li>
         <li>
-          Add setter for 'ignoreEnums' in LeftCurlyCheck. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/975.">#975.</a>
+          Add setter for 'ignoreEnums' in LeftCurlyCheck. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/975">#975</a>
         </li>
         <li>
           JavadocType does not check parameters in inner classes. Author:  Pavel Baranchikov <a href="https://github.com/checkstyle/checkstyle/issues/1421">#1421</a>
@@ -76,16 +76,16 @@
           Fix for SuperClone and SuperFinalize checks reporting violations on native methods. Author:  Vladislav Lisetskiy <a href="https://github.com/checkstyle/checkstyle/issues/1367">#1367</a>
         </li>
         <li>
-          Fix FallThroughCheck fails on if with no else. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1395.">#1395.</a>
+          Fix FallThroughCheck fails on if with no else. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1395">#1395</a>
         </li>
         <li>
           fix JavadocParagraph allows new line before the next paragraph. Author:  Vladislav Lisetskiy <a href="https://github.com/checkstyle/checkstyle/issues/1332">#1332</a>
         </li>
         <li>
-          Fix RegexpHeader causing exception with default config. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1129.">#1129.</a>
+          Fix RegexpHeader causing exception with default config. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1129">#1129</a>
         </li>
         <li>
-          Fix OneStatementPerLine on multiple field initialization bug. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1237.">#1237.</a>
+          Fix OneStatementPerLine on multiple field initialization bug. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1237">#1237</a>
         </li>
         <li>
           extend target list fo SuppressWarningsHolder. Author:  Vladislav Lisetskiy <a href="https://github.com/checkstyle/checkstyle/issues/1158">#1158</a>
@@ -94,26 +94,26 @@
           provide human message for SuppressWarningsHolder. Author:  Vladislav Lisetskiy <a href="https://github.com/checkstyle/checkstyle/issues/1158">#1158</a>
         </li>
         <li>
-          Raising exception for CustomImportOrder.SAME_PACKAGE. Author:  Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1282">#1282</a>
+          Raising exception for CustomImportOrder.SAME_PACKAGE. Author:  Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/pull/1282">#1282</a>
         </li>
       </ul>
 
       <p>Notes:</p>
       <ul>
         <li>
-          Enable CustomImportOrder. Author:  Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1459">#1459</a>
+          Enable CustomImportOrder. Author:  Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/pull/1459">#1459</a>
         </li>
         <li>
-          Add UniquePropertiesCheck into checkstyle_checks.xml. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1129.">#1129.</a>
+          Add UniquePropertiesCheck into checkstyle_checks.xml. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1129">#1129</a>
         </li>
         <li>
-          Refactoring of FinalLocalVariableCheck to avoid 'fall through' violation. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1395.">#1395.</a>
+          Refactoring of FinalLocalVariableCheck to avoid 'fall through' violation. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1395">#1395</a>
         </li>
         <li>
           Add Organize Imports instructions to site. Author:  Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1448">#1448</a>
         </li>
         <li>
-          Fixed compilation error for CustomImportOrder input file. Author:  Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1470">#1470</a>
+          Fixed compilation error for CustomImportOrder input file. Author:  Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/pull/1470">#1470</a>
         </li>
         <li>
           ImportOrder enabled in configuration. Author:  Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1448">#1448</a>
@@ -122,16 +122,16 @@
           Number of updates for. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1555">#1555</a>
         </li>
         <li>
-          Fixed incorrect Google Java Style links. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/751.">#751.</a>
+          Fixed incorrect Google Java Style links. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/751">#751</a>
         </li>
         <li>
-          Refactoring of RightCurlyCheck. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1511.">#1511.</a>
+          Refactoring of RightCurlyCheck. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1511">#1511</a>
         </li>
         <li>
-          Apply various improvements over Checkstyle test code. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1542">#1542</a>
+          Apply various improvements over Checkstyle test code. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/pull/1542">#1542</a>
         </li>
         <li>
-          Apply various improvements over Checkstyle code. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1538">#1538</a>
+          Apply various improvements over Checkstyle code. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/pull/1538">#1538</a>
         </li>
         <li>
           Remove unnecessary consecutive lines in Checkstyle code. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1534">#1534</a>
@@ -212,13 +212,13 @@
           new images were provided by our artist, new header for web site . Author:  Roman Ivanov
         </li>
         <li>
-          BaseCheckTestSupport.verify fails on Windows. Author:  WonderCsabo <a href="https://github.com/checkstyle/checkstyle/issues/1388: BaseCheckTestSupport.verify fails on Windows">#1388</a>
+          BaseCheckTestSupport.verify fails on Windows. Author:  WonderCsabo <a href="https://github.com/checkstyle/checkstyle/issues/1388">#1388</a>
         </li>
         <li>
           check for connection is done by our website URL, as resource file is there. That let pass test when sourceforge web site is down . Author:  Roman Ivanov
         </li>
         <li>
-          Switch options reoganized for easier reading. Author:  Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1376">#1376</a>
+          Switch options reoganized for easier reading. Author:  Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/pull/1376">#1376</a>
         </li>
         <li>
           add example for ConstantName in xdoc. Author:  Vladislav Lisetskiy <a href="https://github.com/checkstyle/checkstyle/issues/1106">#1106</a>
@@ -236,13 +236,13 @@
           fix structure of site.xml. Author:  Vladislav Lisetskiy <a href="https://github.com/checkstyle/checkstyle/issues/1341">#1341</a>
         </li>
         <li>
-          Move tests which cause compilation problem in Eclipse 4.2.2 to non-compilable folder. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1351.">#1351.</a>
+          Move tests which cause compilation problem in Eclipse 4.2.2 to non-compilable folder. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1351">#1351</a>
         </li>
         <li>
           Fix integration test compilation error for Windows environment. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1342">#1342</a>
         </li>
         <li>
-          Fix failing of ITs for OneStatementPerLineCheck. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1348.">#1348.</a>
+          Fix failing of ITs for OneStatementPerLineCheck. Author:  Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1348">#1348</a>
         </li>
         <li>
           surefire and failsafe plugins are moved above checkstyle validation to run before long checkstyle execution . Author:  Roman Ivanov
@@ -272,7 +272,7 @@
           system-rules, ant were updated to latest version . Author:  Roman Ivanov
         </li>
         <li>
-          Removed all assert statements. Author:  Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1298">#1298</a>
+          Removed all assert statements. Author:  Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/pull/1298">#1298</a>
         </li>
         <li>
           Fix AbstractClassName Check on checkstyle code. Author:  Bhavik Patel <a href="https://github.com/checkstyle/checkstyle/issues/945">#945</a>
@@ -437,7 +437,7 @@
           Content section was added to ease navigation in Checks descriptions pages, favicon images (png,ico) were introduced . Author:  Roman Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1208">#1208</a>
         </li>
         <li>
-          till MECLIPSE-735 we will keep Eclipse project files in repository. Author:  Roman Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1219">#1219</a>
+          till MECLIPSE-735 we will keep Eclipse project files in repository. Author:  Roman Ivanov <a href="https://github.com/checkstyle/checkstyle/pull/1219">#1219</a>
         </li>
         <li>
           Ordering issue with nested classes in static imports - xdoc was extended. Author:  Roman Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1239">#1239</a>
@@ -473,13 +473,13 @@
           Remove unused MethodCallLineWrapHandler class. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1178">#1178</a>
         </li>
         <li>
-          Make cobertura and coveralls build faster, Provide workaround for incorrect coverage shown by Cobertura. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1176">#1176</a>
+          Make cobertura and coveralls build faster, Provide workaround for incorrect coverage shown by Cobertura. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/pull/1176">#1176</a>
         </li>
         <li>
-          Generate HTML report on Maven cobertura:cobertura goal. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1169">#1169</a>
+          Generate HTML report on Maven cobertura:cobertura goal. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/pull/1169">#1169</a>
         </li>
         <li>
-           Add virtual machine crash log files to .gitingore. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1168">#1168</a>
+           Add virtual machine crash log files to .gitingore. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/pull/1168">#1168</a>
         </li>
         <li>
           Configure RegexpSinglelineJava to detect non-ASCII characters. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1165">#1165</a>
@@ -488,7 +488,7 @@
           Verify that classes with constants have private constructors. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/840">#840</a>
         </li>
         <li>
-          Update system-rules to 1.10.0, maven-assembly-plugin to 2.5.5, maven-failsafe-plugin to 2.18.1, Maven Shade Plugin to 2.4. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1156">#1156</a>, <a href="https://github.com/checkstyle/checkstyle/issues/1175">#1175</a>, <a href="https://github.com/checkstyle/checkstyle/issues/1193">#1193</a>, <a href="https://github.com/checkstyle/checkstyle/issues/1204">#1204</a>
+          Update system-rules to 1.10.0, maven-assembly-plugin to 2.5.5, maven-failsafe-plugin to 2.18.1, Maven Shade Plugin to 2.4. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/pull/1156">#1156</a>, <a href="https://github.com/checkstyle/checkstyle/pull/1175">#1175</a>, <a href="https://github.com/checkstyle/checkstyle/pull/1193">#1193</a>, <a href="https://github.com/checkstyle/checkstyle/pull/1204">#1204</a>
         </li>
       </ul>
     </section>
@@ -513,14 +513,14 @@
           New "ignorePrivateMethods" property for <a href="http://checkstyle.sourceforge.net/config_design.html#ThrowsCount">ThrowsCount</a> check to skip private methods. Author:  Vladislav Lisetskiy <a href="https://github.com/checkstyle/checkstyle/issues/1136">#1136</a>
         </li>
         <li>
-          New "crlf" option for lineSeparator property in <a href="http://checkstyle.sourceforge.net/config_misc.html#NewlineAtEndOfFile">NewlineAtEndOfFile</a> check. Author:  Martin Steiger <a href="https://github.com/checkstyle/checkstyle/issues/1045">#1045</a>
+          New "crlf" option for lineSeparator property in <a href="http://checkstyle.sourceforge.net/config_misc.html#NewlineAtEndOfFile">NewlineAtEndOfFile</a> check. Author:  Martin Steiger <a href="https://github.com/checkstyle/checkstyle/pull/1045">#1045</a>
         </li>
       </ul>
 
       <p>Bug fixes:</p>
       <ul>
         <li>
-          Make message-based checks invariant to Locale. Author:  Martin Steiger <a href="https://github.com/checkstyle/checkstyle/issues/1044">#1044</a>
+          Make message-based checks invariant to Locale. Author:  Martin Steiger <a href="https://github.com/checkstyle/checkstyle/pull/1044">#1044</a>
         </li>
         <li>
           Fix no possibility to set English language explicitly in config. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/152">#152</a>
@@ -597,7 +597,7 @@
           remove dead code from <a href="http://checkstyle.sourceforge.net/config_design.html#FinalClass">FinalClass</a> check. Author:  Vladislav Lisetskiy <a href="https://github.com/checkstyle/checkstyle/issues/1100">#1100</a>
         </li>
         <li>
-          Make tests of Main class platform independent. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1086">#1086</a>
+          Make tests of Main class platform independent. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/pull/1086">#1086</a>
         </li>
         <li>
           removing abandoned test input files. Author:  Ivan Sopov
@@ -612,10 +612,10 @@
           Enable multiple Checkstyle checks on Checkstyle codebase. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/945">#945</a>, <a href="https://github.com/checkstyle/checkstyle/issues/1049">#1049</a>, <a href="https://github.com/checkstyle/checkstyle/issues/1040">#1040</a>
         </li>
         <li>
-          Update commons-cli to 1.3. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1067">#1067</a>
+          Update commons-cli to 1.3. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/pull/1067">#1067</a>
         </li>
         <li>
-          Update wagon-ssh to 2.9. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1060">#1060</a>
+          Update wagon-ssh to 2.9. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/pull/1060">#1060</a>
         </li>
         <li>
           Update maven-assembly-plugin to 2.5.4. Author:  Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1055">#1055</a>
@@ -682,7 +682,7 @@
           Introduce new handler SynchronizedHandler for checking indentation. Author: liscju <a href="https://github.com/checkstyle/checkstyle/issues/580">#580</a>
         </li>
         <li>
-          added validation for header in setHeader in RegexpHeaderCheck.java to provide better feedback when an invalid Pattern is specified. Author: richter722 and Roman Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/897">#897</a>
+          added validation for header in setHeader in RegexpHeaderCheck.java to provide better feedback when an invalid Pattern is specified. Author: richter722 and Roman Ivanov <a href="https://github.com/checkstyle/checkstyle/pull/897">#897</a>
         </li>
       </ul>
 
@@ -785,7 +785,7 @@
           New allowSingleLineStatement property for NeedBraces check to allow one-line statements. Author: Alex Kravin <a href="https://github.com/checkstyle/checkstyle/issues/300">#300</a>
         </li>
         <li>
-          New ignoreAnnotationCanonicalNames property for VisibilityModifier check, to ignore fields with particular annotations. Author: Alex Kravin <a href="https://github.com/checkstyle/checkstyle/issues/584">#584</a>
+          New ignoreAnnotationCanonicalNames property for VisibilityModifier check, to ignore fields with particular annotations. Author: Alex Kravin <a href="https://github.com/checkstyle/checkstyle/pull/584">#584</a>
         </li>
         <li>
           New validateEnhancedForLoopVariable property for FinalLocalVariable check to enforce final variables in for each clause. Author: Bhavik Patel <a href="https://github.com/checkstyle/checkstyle/issues/20">#20</a>
@@ -816,7 +816,7 @@
           Fix bug with lambda params in FinalLocalVariable check. Author: Alex Kravin <a href="https://github.com/checkstyle/checkstyle/issues/747">#747</a>
         </li>
         <li>
-          Final Local Variable Check, extended acceptable tokens. Author: Alex Kravin <a href="https://github.com/checkstyle/checkstyle/issues/762">#762</a>
+          Final Local Variable Check, extended acceptable tokens. Author: Alex Kravin <a href="https://github.com/checkstyle/checkstyle/pull/762">#762</a>
         </li>
         <li>
           Add support of logging severity for all audit events. Author: Alex Kravin <a href="https://github.com/checkstyle/checkstyle/issues/67">#67</a>
@@ -1292,7 +1292,7 @@
       <p>Bug fixes:</p>
       <ul>
         <li>
-          Huge performance optimization for JavaDoc parsing. In scope of issue <a href="https://github.com/checkstyle/checkstyle/pull/49">#49</a>. Caching DetailNode trees in AbstractJavadocCheck . Author: Baratali Izmailov <a href="https://github.com/checkstyle/checkstyle/pull/355">#355</a>
+          Huge performance optimization for JavaDoc parsing. In scope of issue <a href="https://github.com/checkstyle/checkstyle/issues/49">#49</a>. Caching DetailNode trees in AbstractJavadocCheck . Author: Baratali Izmailov <a href="https://github.com/checkstyle/checkstyle/pull/355">#355</a>
         </li>
         <li>
           "FileContents.getLines()" performance fix. Author: Vladimir Sitnikov, Ivan Sopov. <a href="https://github.com/checkstyle/checkstyle/pull/351">#351</a>
@@ -1310,7 +1310,7 @@
           Using BitSet for indent levels for performance. Author: Vladimir Sitnikov, Ivan Sopov. <a href="https://github.com/checkstyle/checkstyle/pull/349">#349</a>
         </li>
         <li>
-          Various documentation/spelling issues with AnnotationLocationCheck. Author: Roman Ivanov. <a href="https://github.com/checkstyle/checkstyle/pull/356">#356</a>
+          Various documentation/spelling issues with AnnotationLocationCheck. Author: Roman Ivanov. <a href="https://github.com/checkstyle/checkstyle/issues/356">#356</a>
         </li>
         <li>
           Multidimensional arrays can be parsed now. Author: Ilja Dubinin. <a href="https://github.com/checkstyle/checkstyle/pull/304">#304</a>
@@ -1319,7 +1319,7 @@
       <p>Breaking backward compatibility:</p>
       <ul>
         <li>
-          AnnotationLocationCheck, package location was changed, one option was renamed. Author: Roman Ivanov. <a href="https://github.com/checkstyle/checkstyle/pull/356">#356</a>
+          AnnotationLocationCheck, package location was changed, one option was renamed. Author: Roman Ivanov. <a href="https://github.com/checkstyle/checkstyle/issues/356">#356</a>
         </li>
       </ul>
     </section>
@@ -1360,7 +1360,7 @@
       <p>Notes:</p>
       <ul>
         <li>
-          <a href="https://google-styleguide.googlecode.com/svn-history/r130/trunk/javaguide.html">Google style</a>
+          <a href="http://checkstyle.sourceforge.net/reports/google-java-style.html">Google style</a>
           is now covered to maximum of Checkstyle ability. See detailed report <a href="google_style.html">here</a>. Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
         </li>
         <li>
@@ -1507,7 +1507,7 @@
         </li>
         <li>
           Fixed RedundantModifier. Abstract Interface Should not be Allowed.
-          Author: Yuriy Chulovskyy. <a href="https://github.com/checkstyle/checkstyle/issues/209">#209</a>
+          Author: Yuriy Chulovskyy. <a href="https://github.com/checkstyle/checkstyle/pull/209">#209</a>
         </li>
         <li>
           Fixed EmptyBlock. need to handle switch block.
@@ -1592,7 +1592,7 @@
           violations. Thanks to Trevor Robinson for patch #156.
         </li>
         <li>
-          New: UniqueProperties check. Thanks to Pavel Baranchikov. <a href="https://github.com/checkstyle/checkstyle/issues/19">#19</a>
+          New: UniqueProperties check. Thanks to Pavel Baranchikov. <a href="https://github.com/checkstyle/checkstyle/pull/19">#19</a>
         </li>
         <li>
           Support for '&amp;' in nested generics. Thanks to <a
@@ -1625,10 +1625,10 @@
           RequireThisCheck doesn't check methods. Thanks to krzyk.<a href="https://github.com/checkstyle/checkstyle/issues/41">#41</a>
         </li>
         <li>
-          Document WhitespaceAround for-each property. Thanks to Andrew Gaul.<a href="https://github.com/checkstyle/checkstyle/issues/15">#15</a>
+          Document WhitespaceAround for-each property. Thanks to Andrew Gaul.<a href="https://github.com/checkstyle/checkstyle/pull/15">#15</a>
         </li>
         <li>
-          Other corrections for typos. Thanks to Andrew Gaul.<a href="https://github.com/checkstyle/checkstyle/issues/16">#16</a>
+          Other corrections for typos. Thanks to Andrew Gaul.<a href="https://github.com/checkstyle/checkstyle/pull/16">#16</a>
         </li>
         <li>
           Remnants of DoubleCheckedLocking were removed. Thanks to Antonio Ospite.
@@ -2380,7 +2380,7 @@
         <li>
           <i>Retired</i> the J2EE Checks. If you are using Java 5, then you
           really should be using
-          <a href="http://java.sun.com/javaee/">Java EE</a>. If you need
+          <a href="http://www.oracle.com/technetwork/java/javaee/overview/index.html">Java EE</a>. If you need
           these checks, then use a Checkstyle 4.x release.
         </li>
         <li>
@@ -2636,7 +2636,7 @@
       <ul>
         <li>
           Applied patch 1344344 by sjq to provide the new
-          <a href="config_misc.html#Regexp">Regexp</a> check that can
+          <a href="http://checkstyle.sourceforge.net/config_misc.html#Regexp">Regexp</a> check that can
           provide the functionality of the following
           checks: <a
           href="config_header.html#RegexpHeader">RegexpHeader</a>

--- a/src/xdocs/writingchecks.xml.vm
+++ b/src/xdocs/writingchecks.xml.vm
@@ -171,11 +171,11 @@ java -cp checkstyle-${projectVersion}-all.jar com.puppycrawl.tools.checkstyle.gu
       <p>
         Ready for a bit more theory? The last bit
         that is missing before you can start writing Checks is understanding
-        the <a href="http://en.wikipedia.org/wiki/Visitor_pattern">Visitor pattern</a>.
+        the <a href="https://en.wikipedia.org/wiki/Visitor_pattern">Visitor pattern</a>.
       </p>
 
       <p>
-        When working with <a href="http://en.wikipedia.org/wiki/Abstract_syntax_tree">
+        When working with <a href="https://en.wikipedia.org/wiki/Abstract_syntax_tree">
         Abstract Syntax Tree (AST)</a>, a simple approach to define check operations
         on them would be to add a <code>check()</code> method to the Class that defines
         the AST nodes. For example, our AST type could have a method
@@ -202,7 +202,7 @@ java -cp checkstyle-${projectVersion}-all.jar com.puppycrawl.tools.checkstyle.gu
       Instead, the TreeWalker initiates
       a recursive descend from the root of the AST to the leaf nodes and calls
       the Check methods. The traversal is done using a <a
-      href="http://en.wikipedia.org/wiki/Tree_traversal">tree traversal (depth-first)</a>
+      href="https://en.wikipedia.org/wiki/Tree_traversal">tree traversal (depth-first)</a>
       algorithm.  </p>
 
       <p> Before any visitor method is called, the TreeWalker
@@ -376,7 +376,7 @@ public class MethodLimitCheck extends Check
         methods to provide the dynamic part of the message (mMax in this
         case): <code>log(&quot;too.many.methods&quot;,
         mMax);</code>. Please consult the documentation of Java&#39;s <a
-        href="http://java.sun.com/j2se/1.4.1/docs/api/java/text/MessageFormat.html">MessageFormat</a>
+        href="http://docs.oracle.com/javase/8/docs/api/java/text/MessageFormat.html">MessageFormat</a>
         to learn about the syntax of format strings (especially about
         those funny numbers in the translated text).
       </p>
@@ -472,7 +472,7 @@ java -classpath mycompanychecks.jar;checkstyle-${projectVersion}-all.jar \
         There are basically only few of them:
       </p>
       <ul>
-        <li>Java code should be written with <a href="http://en.wikipedia.org/wiki/ASCII">ASCII</a> characters only, no UTF-8 support.</li>
+        <li>Java code should be written with <a href="https://en.wikipedia.org/wiki/ASCII">ASCII</a> characters only, no UTF-8 support.</li>
         <li>To get valid violations, code have to be compilable, in other case you can get not easy to understand parse errors.</li>
         <li>You cannot determine the type of an expression. Example: "getValue() + getValue2()"</li>
         <li>You cannot determine the full inheritance hierarchy of type.</li>
@@ -481,7 +481,7 @@ java -classpath mycompanychecks.jar;checkstyle-${projectVersion}-all.jar \
       <p>
         This means that you cannot implement some of the code inspection
         features that are available in advanced IDEs like <a
-        href="http://www.intellij.com/idea/">IntelliJ IDEA</a>,
+        href="http://www.jetbrains.com/idea/">IntelliJ IDEA</a>,
         <a href="http://findbugs.sourceforge.net/">Findbug</a>,
         <a href="http://pmd.sourceforge.net/">PMD</a>,
         <a href="http://www.sonarqube.org/">Sonarqube</a>. 

--- a/src/xdocs/writinglisteners.xml.vm
+++ b/src/xdocs/writinglisteners.xml.vm
@@ -235,11 +235,11 @@ Audit finished. Total errors: 1
         href="http://ant.apache.org/">ANT</a> listeners. The first
         listener, <code> CommonsLoggingListener</code>,
         hands off events to the <a
-        href="http://commons.apache.org/logging/">Apache
+        href="http://commons.apache.org/proper/commons-logging/">Apache
         Commons Logging</a> facade and the second, <code>MailLogger</code>, sends a report of an audit via
         e-mail. The discussion of these examples and how to use them is
         derived from material in <a
-        href="http://www.manning.com/hatcher/">&quot;Java Development
+        href="http://manning.com/hatcher/">&quot;Java Development
         with Ant&quot;</a> by Eric Hatcher and Steve Loughran, an
         excellent ANT book.
       </p>
@@ -249,7 +249,7 @@ Audit finished. Total errors: 1
 
       <p>
         <a
-        href="http://commons.apache.org/logging/">Apache
+        href="http://commons.apache.org/proper/commons-logging/">Apache
         Commons Logging</a> provides a facade for logging tools
         <a
         href="http://logging.apache.org/log4j/2.x/index.html">log4j</a>,
@@ -271,10 +271,10 @@ Audit finished. Total errors: 1
         in the classpath because that jar file contains all the Commons
         Logging classes.  The default Log under J2SE 1.4 is wrapper
         class <a
-        href="http://commons.apache.org/logging/apidocs/org/apache/commons/logging/impl/Jdk14Logger.html">Jdk14Logger</a>.
+        href="http://commons.apache.org/proper/commons-logging/apidocs/org/apache/commons/logging/impl/Jdk14Logger.html">Jdk14Logger</a>.
         Under earlier Java versions, the default Log is a simple wrapper
         class, <a
-        href="http://commons.apache.org/logging/apidocs/org/apache/commons/logging/impl/SimpleLog.html">SimpleLog</a>.
+        href="http://commons.apache.org/proper/commons-logging/apidocs/org/apache/commons/logging/impl/SimpleLog.html">SimpleLog</a>.
         Both default logging tools can be used directly from Commons
         Logging; if you need to use other tools such as log4j, then you
         must include the appropriate jar file(s) in the classpath.
@@ -283,7 +283,7 @@ Audit finished. Total errors: 1
       <p>
         Logging configuration details for Jakarta Commons Logging are in
         the <a
-        href="http://commons.apache.org/logging/">documentation</a>.
+        href="http://commons.apache.org/proper/commons-logging/">documentation</a>.
         As a simple example, assume that <code>log4j.jar</code> is in the classpath and the
         following <code>log4j.properties</code> file is
         in the current directory:
@@ -332,7 +332,7 @@ INFO  com.puppycrawl...Checker  - Audit finished.
         The source code for <code>CommonsLoggingListener</code> is in distribution
         directory <code>https://github.com/checkstyle/contribution/examples/listeners</code>.  This
         implementation uses the <a
-        href="http://java.sun.com/products/javamail">JavaMail API</a> as
+        href="http://www.oracle.com/technetwork/java/javamail/index.html">JavaMail API</a> as
         the mail system, and you must include appropriate jar files in
         the classpath.
       </p>


### PR DESCRIPTION
@romani 
Corrected all links that were reported as problematic by [linkcheck](http://checkstyle.sourceforge.net/linkcheck.html) on website and at javadoc. 

Corrected all links that were mentioned by @mkordas [here](https://github.com/checkstyle/checkstyle/issues/751#issuecomment-84383870).

No longer available:
1) JSNI
https://developers.google.com/eclipse/docs/gwt_jsni
2) DocCheck
http://www.oracle.com/technetwork/java/javase/documentation/javadoc-137458.html

Redirect tracer:
http://www.wheregoes.com/
