### PR TITLE
Replace <code> tags with {@code ...} constructs. #1555

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1090,7 +1090,6 @@
                   <regex><pattern>.*.checks.UniquePropertiesCheck\$.*</pattern><branchRate>75</branchRate><lineRate>90</lineRate></regex>
 
                   <regex><pattern>.*.checks.coding.DeclarationOrderCheck</pattern><branchRate>82</branchRate><lineRate>93</lineRate></regex>
-                  <regex><pattern>.*.checks.coding.VariableDeclarationUsageDistanceCheck</pattern><branchRate>90</branchRate><lineRate>98</lineRate></regex>
 
                   <regex><pattern>.*.checks.header.AbstractHeaderCheck</pattern><branchRate>90</branchRate><lineRate>87</lineRate></regex>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AnnotationUtility.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AnnotationUtility.java
@@ -91,7 +91,7 @@ public final class AnnotationUtility {
 
     /**
      * Gets the AST that holds a series of annotations for the
-     * potentially annotated AST.  Returns <code>null</code>
+     * potentially annotated AST.  Returns {@code null}
      * the passed in AST is not have an Annotation Holder.
      *
      * @param ast the current node

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -111,7 +111,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
     private String charset = System.getProperty("file.encoding", "UTF-8");
 
     /**
-     * Creates a new <code>Checker</code> instance.
+     * Creates a new {@code Checker} instance.
      * The instance needs to be contextualized and configured.
      */
     public Checker() {
@@ -401,7 +401,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
 
     /**
      * Sets the severity level.  The string should be one of the names
-     * defined in the <code>SeverityLevel</code> class.
+     * defined in the {@code SeverityLevel} class.
      *
      * @param severity  The new severity level
      * @see SeverityLevel

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -103,9 +103,9 @@ public final class ConfigurationLoader {
     private final boolean omitIgnoredModules;
 
     /**
-     * Creates a new <code>ConfigurationLoader</code> instance.
+     * Creates a new {@code ConfigurationLoader} instance.
      * @param overrideProps resolver for overriding properties
-     * @param omitIgnoredModules <code>true</code> if ignored modules should be
+     * @param omitIgnoredModules {@code true} if ignored modules should be
      *         omitted
      * @throws ParserConfigurationException if an error occurs
      * @throws SAXException if an error occurs
@@ -163,8 +163,8 @@ public final class ConfigurationLoader {
      *
      * @param config location of config file, can be either a URL or a filename
      * @param overridePropsResolver overriding properties
-     * @param omitIgnoredModules <code>true</code> if modules with severity
-     *            'ignore' should be omitted, <code>false</code> otherwise
+     * @param omitIgnoredModules {@code true} if modules with severity
+     *            'ignore' should be omitted, {@code false} otherwise
      * @return the check configurations
      * @throws CheckstyleException if an error occurs
      */
@@ -212,8 +212,8 @@ public final class ConfigurationLoader {
      *
      * @param configStream the input stream to the Checkstyle configuration
      * @param overridePropsResolver overriding properties
-     * @param omitIgnoredModules <code>true</code> if modules with severity
-     *            'ignore' should be omitted, <code>false</code> otherwise
+     * @param omitIgnoredModules {@code true} if modules with severity
+     *            'ignore' should be omitted, {@code false} otherwise
      * @return the check configurations
      * @throws CheckstyleException if an error occurs
      *
@@ -238,8 +238,8 @@ public final class ConfigurationLoader {
      *
      * @param configSource the input stream to the Checkstyle configuration
      * @param overridePropsResolver overriding properties
-     * @param omitIgnoredModules <code>true</code> if modules with severity
-     *            'ignore' should be omitted, <code>false</code> otherwise
+     * @param omitIgnoredModules {@code true} if modules with severity
+     *            'ignore' should be omitted, {@code false} otherwise
      * @return the check configurations
      * @throws CheckstyleException if an error occurs
      */
@@ -272,24 +272,24 @@ public final class ConfigurationLoader {
     }
 
     /**
-     * Replaces <code>${xxx}</code> style constructions in the given value
+     * Replaces {@code ${xxx}} style constructions in the given value
      * with the string value of the corresponding data types.
      *
      * The method is package visible to facilitate testing.
      *
      * @param value The string to be scanned for property references.
-     *              May be <code>null</code>, in which case this
+     *              May be {@code null}, in which case this
      *              method returns immediately with no effect.
      * @param props Mapping (String to String) of property names to their
-     *              values. Must not be <code>null</code>.
+     *              values. Must not be {@code null}.
      * @param defaultValue default to use if one of the properties in value
      *              cannot be resolved from props.
      *
      * @return the original string with the properties replaced, or
-     *         <code>null</code> if the original string is <code>null</code>.
+     *         {@code null} if the original string is {@code null}.
      * @throws CheckstyleException if the string contains an opening
-     *                           <code>${</code> without a closing
-     *                           <code>}</code>
+     *                           {@code ${} without a closing
+     *                           {@code }}
      *
      * Code copied from ant -
      * http://cvs.apache.org/viewcvs/jakarta-ant/src/main/org/apache/tools/ant/ProjectHelper.java
@@ -329,21 +329,21 @@ public final class ConfigurationLoader {
     }
 
     /**
-     * Parses a string containing <code>${xxx}</code> style property
+     * Parses a string containing {@code ${xxx}} style property
      * references into two lists. The first list is a collection
      * of text fragments, while the other is a set of string property names.
-     * <code>null</code> entries in the first list indicate a property
+     * {@code null} entries in the first list indicate a property
      * reference from the second list.
      *
-     * @param value     Text to parse. Must not be <code>null</code>.
+     * @param value     Text to parse. Must not be {@code null}.
      * @param fragments List to add text fragments to.
-     *                  Must not be <code>null</code>.
+     *                  Must not be {@code null}.
      * @param propertyRefs List to add property names to.
-     *                     Must not be <code>null</code>.
+     *                     Must not be {@code null}.
      *
      * @throws CheckstyleException if the string contains an opening
-     *                           <code>${</code> without a closing
-     *                           <code>}</code>
+     *                           {@code ${} without a closing
+     *                           {@code }}
      * Code copied from ant -
      * http://cvs.apache.org/viewcvs/jakarta-ant/src/main/org/apache/tools/ant/ProjectHelper.java
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
@@ -57,7 +57,7 @@ public class DefaultLogger
     private final boolean closeError;
 
     /**
-     * Creates a new <code>DefaultLogger</code> instance.
+     * Creates a new {@code DefaultLogger} instance.
      * @param os where to log infos and errors
      * @param closeStreamsAfterUse if oS should be closed in auditFinished()
      * @exception UnsupportedEncodingException if there is a problem to use UTF-8 encoding
@@ -69,11 +69,11 @@ public class DefaultLogger
     }
 
     /**
-     * Creates a new <code>DefaultLogger</code> instance.
+     * Creates a new {@code DefaultLogger} instance.
      *
-     * @param infoStream the <code>OutputStream</code> for info messages
+     * @param infoStream the {@code OutputStream} for info messages
      * @param closeInfoAfterUse auditFinished should close infoStream
-     * @param errorStream the <code>OutputStream</code> for error messages
+     * @param errorStream the {@code OutputStream} for error messages
      * @param closeErrorAfterUse auditFinished should close errorStream
      * @exception UnsupportedEncodingException if there is a problem to use UTF-8 encoding
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Definitions.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Definitions.java
@@ -29,7 +29,7 @@ public final class Definitions {
             "com.puppycrawl.tools.checkstyle.messages";
 
     /**
-     * Do no allow <code>Definitions</code> instances to be created.
+     * Do no allow {@code Definitions} instances to be created.
      **/
     private Definitions() {
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -282,7 +282,7 @@ public final class Main {
      *
      * @param format format of the audit listener
      * @param outputLocation the location of output
-     * @return a fresh new <code>AuditListener</code>
+     * @return a fresh new {@code AuditListener}
      * @exception UnsupportedEncodingException if there is problem to use UTf-8
      * @exception FileNotFoundException when provided output location is not found
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ModuleFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ModuleFactory.java
@@ -24,8 +24,8 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 /**
  * A module factory creates Objects from a given name.
  * It's purpose is to map the shortnames like
- * <code>AvoidStarImport</code> to full classnames like
- * <code>com.puppycrawl.tools.checkstyle.checks.AvoidStarImportCheck</code>.
+ * {@code AvoidStarImport} to full classnames like
+ * {@code com.puppycrawl.tools.checkstyle.checks.AvoidStarImportCheck}.
  * A ModuleFactory can implement this name resolution by using naming
  * conventions, fallback strategies, etc.
  *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -67,7 +67,7 @@ public final class PackageNamesLoader
     private final Set<String> packageNames = Sets.newLinkedHashSet();
 
     /**
-     * Creates a new <code>PackageNamesLoader</code> instance.
+     * Creates a new {@code PackageNamesLoader} instance.
      * @throws ParserConfigurationException if an error occurs
      * @throws SAXException if an error occurs
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -43,7 +43,7 @@ class PackageObjectFactory implements ModuleFactory {
     private final ClassLoader moduleClassLoader;
 
     /**
-     * Creates a new <code>PackageObjectFactory</code> instance.
+     * Creates a new {@code PackageObjectFactory} instance.
      * @param packageNames the list of package names to use
      * @param moduleClassLoader class loader used to load Checkstyle
      *          core and custom modules
@@ -74,7 +74,7 @@ class PackageObjectFactory implements ModuleFactory {
      * an instance of a classname obtained by concatenating the given
      * to a package name from a given list of package names.
      * @param name the name of a class.
-     * @return the <code>Object</code>
+     * @return the {@code Object}
      * @throws CheckstyleException if an error occurs.
      */
     private Object doMakeObject(String name)
@@ -105,7 +105,7 @@ class PackageObjectFactory implements ModuleFactory {
     /**
      * Creates a new instance of a named class.
      * @param className the name of the class to instantiate.
-     * @return the <code>Object</code> created by loader.
+     * @return the {@code Object} created by loader.
      * @throws CheckstyleException if an error occurs.
      */
     private Object createObject(String className)
@@ -126,7 +126,7 @@ class PackageObjectFactory implements ModuleFactory {
      * an instance of a classname obtained by concatenating the given name
      * to a package name from a given list of package names.
      * @param name the name of a class.
-     * @return the <code>Object</code> created by loader.
+     * @return the {@code Object} created by loader.
      * @throws CheckstyleException if an error occurs.
      */
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
@@ -23,7 +23,7 @@ import java.util.Properties;
 
 /**
  * Resolves external properties from an
- * underlying <code>Properties</code> object.
+ * underlying {@code Properties} object.
  *
  * @author lkuehne
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -79,7 +79,7 @@ final class PropertyCacheFile {
     private final String fileName;
 
     /**
-     * Creates a new <code>PropertyCacheFile</code> instance.
+     * Creates a new {@code PropertyCacheFile} instance.
      *
      * @param config the current configuration, not null
      * @param fileName the cache file
@@ -176,7 +176,7 @@ final class PropertyCacheFile {
      * Calculates the hashcode for a GlobalProperties.
      *
      * @param object the GlobalProperties
-     * @return the hashcode for <code>object</code>
+     * @return the hashcode for {@code object}
      */
     private static String getConfigHashCode(Serializable object) {
         try {
@@ -210,7 +210,7 @@ final class PropertyCacheFile {
     /**
      * Hex-encodes a byte array.
      * @param byteArray the byte array
-     * @return hex encoding of <code>byteArray</code>
+     * @return hex encoding of {@code byteArray}
      */
     private static String hexEncode(byte... byteArray) {
         final StringBuilder buf = new StringBuilder(2 * byteArray.length);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyResolver.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyResolver.java
@@ -23,7 +23,7 @@ package com.puppycrawl.tools.checkstyle;
  * Resolves properties in module configurations.
  *
  * The {@link ConfigurationLoader} uses a PropertyResolver to
- * resolve the values of external properties like <code>${basename}</code>
+ * resolve the values of external properties like {@code ${basename}}
  * that occur in the configuration file.
  *
  * @author lkuehne
@@ -33,7 +33,7 @@ public interface PropertyResolver {
     /**
      * Resolves a property name to it's value.
      * @param name the name of the property.
-     * @return the value that is associated with <code>propertyName</code>.
+     * @return the value that is associated with {@code propertyName}.
      */
     String resolve(String name);
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ScopeUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ScopeUtils.java
@@ -39,7 +39,7 @@ public final class ScopeUtils {
      * Returns the Scope specified by the modifier set.
      *
      * @param aMods root node of a modifier set
-     * @return a <code>Scope</code> value
+     * @return a {@code Scope} value
      */
     public static Scope getScopeFromMods(DetailAST aMods) {
         Scope retVal = Scope.PACKAGE; // default scope
@@ -98,7 +98,7 @@ public final class ScopeUtils {
      *
      * @param aAST the node to check if directly contained within an interface
      * block
-     * @return a <code>boolean</code> value
+     * @return a {@code boolean} value
      */
     public static boolean inInterfaceBlock(DetailAST aAST) {
         boolean retVal = false;
@@ -130,7 +130,7 @@ public final class ScopeUtils {
      *
      * @param aAST the node to check if directly contained within an annotation
      * block
-     * @return a <code>boolean</code> value
+     * @return a {@code boolean} value
      */
     public static boolean inAnnotationBlock(DetailAST aAST) {
         boolean retVal = false;
@@ -163,7 +163,7 @@ public final class ScopeUtils {
      *
      * @param aAST the node to check if directly contained within an interface
      * or annotation block
-     * @return a <code>boolean</code> value
+     * @return a {@code boolean} value
      */
     public static boolean inInterfaceOrAnnotationBlock(DetailAST aAST) {
         return inInterfaceBlock(aAST) || inAnnotationBlock(aAST);
@@ -174,7 +174,7 @@ public final class ScopeUtils {
      *
      * @param aAST the node to check if directly contained within an enum
      * block
-     * @return a <code>boolean</code> value
+     * @return a {@code boolean} value
      */
     public static boolean inEnumBlock(DetailAST aAST) {
         boolean retVal = false;
@@ -206,7 +206,7 @@ public final class ScopeUtils {
      * A code block is a method or constructor body, or a initialiser block.
      *
      * @param aAST the node to check
-     * @return a <code>boolean</code> value
+     * @return a {@code boolean} value
      */
     public static boolean inCodeBlock(DetailAST aAST) {
         boolean retVal = false;
@@ -232,7 +232,7 @@ public final class ScopeUtils {
      * Returns whether a node is contained in the outer most type block.
      *
      * @param aAST the node to check
-     * @return a <code>boolean</code> value
+     * @return a {@code boolean} value
      */
     public static boolean isOuterMostType(DetailAST aAST) {
         boolean retVal = true;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -116,7 +116,7 @@ public final class TreeWalker
     private ModuleFactory moduleFactory;
 
     /**
-     * Creates a new <code>TreeWalker</code> instance.
+     * Creates a new {@code TreeWalker} instance.
      */
     public TreeWalker() {
         setFileExtensions("java");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
@@ -256,10 +256,10 @@ public final class Utils {
      * http://pmd.sourceforge.net/pmd-5.3.1/pmd-java/rules/java/optimizations.html#SimplifyStartsWith
      * </p>
      *
-     * @param value the <code>String</code> to check
+     * @param value the {@code String} to check
      * @param prefix the prefix to find
-     * @return <code>true</code> if the <code>char</code> is a prefix of the given
-     * <code>String</code>; <code>false</code> otherwise.
+     * @return {@code true} if the {@code char} is a prefix of the given
+     * {@code String}; {@code false} otherwise.
      */
     public static boolean startsWithChar(String value, char prefix) {
         return !value.isEmpty() && value.charAt(0) == prefix;
@@ -273,10 +273,10 @@ public final class Utils {
      * http://pmd.sourceforge.net/pmd-5.3.1/pmd-java/rules/java/optimizations.html#SimplifyStartsWith
      * </p>
      *
-     * @param value the <code>String</code> to check
+     * @param value the {@code String} to check
      * @param suffix the suffix to find
-     * @return <code>true</code> if the <code>char</code> is a suffix of the given
-     * <code>String</code>; <code>false</code> otherwise.
+     * @return {@code true} if the {@code char} is a suffix of the given
+     * {@code String}; {@code false} otherwise.
      */
     public static boolean endsWithChar(String value, char suffix) {
         return !value.isEmpty() && value.charAt(value.length() - 1) == suffix;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -59,7 +59,7 @@ public class XMLLogger
     private PrintWriter writer;
 
     /**
-     * Creates a new <code>XMLLogger</code> instance.
+     * Creates a new {@code XMLLogger} instance.
      * Sets the output to a defined stream.
      * @param os the stream to write logs to.
      * @param closeStream close oS in auditFinished

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -333,8 +333,8 @@ public class CheckstyleAntTask extends Task {
     }
 
     /**
-     * Creates new instance of <code>Checker</code>.
-     * @return new instance of <code>Checker</code>
+     * Creates new instance of {@code Checker}.
+     * @return new instance of {@code Checker}
      */
     private Checker createChecker() {
         Checker checker;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -168,7 +168,7 @@ public abstract class AbstractFileSetCheck
 
     /**
      * Notify all listeners about the errors in a file.
-     * Calls <code>MessageDispatcher.fireErrors()</code> with
+     * Calls {@code MessageDispatcher.fireErrors()} with
      * all logged errors and than clears errors' list.
      * @param fileName the audited file
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
@@ -48,7 +48,7 @@ public abstract class AbstractViolationReporter
 
     /**
      * Sets the severity level.  The string should be one of the names
-     * defined in the <code>SeverityLevel</code> class.
+     * defined in the {@code SeverityLevel} class.
      *
      * @param severity  The new severity level
      * @see SeverityLevel

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AuditEvent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AuditEvent.java
@@ -56,7 +56,7 @@ public final class AuditEvent
     }
 
     /**
-     * Creates a new <code>AuditEvent</code> instance.
+     * Creates a new {@code AuditEvent} instance.
      * @param src source of the event
      * @param fileName file associated with the event
      */
@@ -65,7 +65,7 @@ public final class AuditEvent
     }
 
     /**
-     * Creates a new <code>AuditEvent</code> instance.
+     * Creates a new {@code AuditEvent} instance.
      *
      * @param src source of the event
      * @param fileName file associated with the event

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -113,7 +113,7 @@ public class AutomaticBean
      * is called to allow completion of the bean's local setup,
      * after that the method {@link #setupChild setupChild}
      * is called for each {@link Configuration#getChildren child Configuration}
-     * of <code>configuration</code>.
+     * of {@code configuration}.
      *
      * @param configuration {@inheritDoc}
      * @throws CheckstyleException {@inheritDoc}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
@@ -219,7 +219,7 @@ public abstract class Check extends AbstractViolationReporter {
 
     /**
      * Set the tab width to report errors with.
-     * @param tabWidth an <code>int</code> value
+     * @param tabWidth an {@code int} value
      */
     public final void setTabWidth(int tabWidth) {
         this.tabWidth = tabWidth;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/CheckstyleException.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/CheckstyleException.java
@@ -29,16 +29,16 @@ public class CheckstyleException extends Exception {
     private static final long serialVersionUID = -3517342299748221108L;
 
     /**
-     * Creates a new <code>CheckstyleException</code> instance.
+     * Creates a new {@code CheckstyleException} instance.
      *
-     * @param message a <code>String</code> value
+     * @param message a {@code String} value
      */
     public CheckstyleException(String message) {
         super(message);
     }
 
     /**
-     * Creates a new <code>CheckstyleException</code> instance
+     * Creates a new {@code CheckstyleException} instance
      * that was caused by another exception.
      *
      * @param message a message that explains this exception

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -314,7 +314,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
      * of the provided type.
      * @param type a TokenType
      * @return true if and only if this branch (including this node)
-     * contains a token of type <code>type</code>.
+     * contains a token of type {@code type}.
      */
     public boolean branchContains(int type) {
         return getBranchTokenTypes().get(type);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -67,7 +67,7 @@ public final class FileContents implements CommentListener {
     private final Map<Integer, List<TextBlock>> clangComments = Maps.newHashMap();
 
     /**
-     * Creates a new <code>FileContents</code> instance.
+     * Creates a new {@code FileContents} instance.
      *
      * @param filename name of the file
      * @param lines the contents of the file
@@ -81,7 +81,7 @@ public final class FileContents implements CommentListener {
     }
 
     /**
-     * Creates a new <code>FileContents</code> instance.
+     * Creates a new {@code FileContents} instance.
      *
      * @param text the contents of the file
      */
@@ -197,9 +197,9 @@ public final class FileContents implements CommentListener {
 
     /**
      * Returns the Javadoc comment before the specified line.
-     * A return value of <code>null</code> means there is no such comment.
+     * A return value of {@code null} means there is no such comment.
      * @param lineNoBefore the line number to check before
-     * @return the Javadoc comment, or <code>null</code> if none
+     * @return the Javadoc comment, or {@code null} if none
      **/
     public TextBlock getJavadocBefore(int lineNoBefore) {
         // Lines start at 1 to the callers perspective, so need to take off 2

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -73,13 +73,13 @@ public final class FileText extends AbstractList<String> {
 
     /**
      * The name of the file.
-     * <code>null</code> if no file name is available for whatever reason.
+     * {@code null} if no file name is available for whatever reason.
      */
     private final File file;
 
     /**
      * The charset used to read the file.
-     * <code>null</code> if the file was reconstructed from a list of lines.
+     * {@code null} if the file was reconstructed from a list of lines.
      */
     private final Charset charset;
 
@@ -229,7 +229,7 @@ public final class FileText extends AbstractList<String> {
 
     /**
      * Get the character set which was used to read the file.
-     * Will be <code>null</code> for a file reconstructed from its lines.
+     * Will be {@code null} for a file reconstructed from its lines.
      * @return the charset used when the file was read
      */
     public Charset getCharset() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
@@ -29,7 +29,7 @@ import org.apache.commons.lang3.StringUtils;
  * position information.
  *
  * <p>
- * Identifiers such as <code>java.util.HashMap</code> are spread across
+ * Identifiers such as {@code java.util.HashMap} are spread across
  * multiple AST nodes in the syntax tree (three IDENT nodes, two DOT nodes).
  * A FullIdent represents the whole String (excluding any intermediate
  * whitespace), which is often easier to work with in Checks.
@@ -98,7 +98,7 @@ public final class FullIdent {
     /**
      * Creates a new FullIdent starting from the specified node.
      * @param ast the node to start from
-     * @return a <code>FullIdent</code> value
+     * @return a {@code FullIdent} value
      */
     public static FullIdent createFullIdent(DetailAST ast) {
         final FullIdent fi = new FullIdent();
@@ -109,7 +109,7 @@ public final class FullIdent {
     /**
      * Creates a new FullIdent starting from the child of the specified node.
      * @param ast the parent node from where to start from
-     * @return a <code>FullIdent</code> value
+     * @return a {@code FullIdent} value
      */
     public static FullIdent createFullIdentBelow(DetailAST ast) {
         return createFullIdent(ast.getFirstChild());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
@@ -412,8 +412,8 @@ public enum JavadocTagInfo {
      *
      * <p>
      * If passing in a DetailAST representing a non-void METHOD_DEF
-     * <code> true </code> would be returned. If passing in a DetailAST
-     * representing a CLASS_DEF <code> false </code> would be returned because
+     * {@code true } would be returned. If passing in a DetailAST
+     * representing a CLASS_DEF {@code false } would be returned because
      * CLASS_DEF's cannot return a value.
      * </p>
      *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -82,7 +82,7 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example</b>
-     * <pre><code>&#64;param T The bar.</code></pre>
+     * <pre>{@code &#64;param T The bar.}</pre>
      * <b>Tree</b>
      * <pre>{@code
      *   |--JAVADOC_TAG[4x3] : [@param T The bar.]
@@ -117,17 +117,17 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>{&#64;link String}</code></pre>
+     * <pre>{@code {&#64;link String}}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_INLINE_TAG[4x3] : [{&#64;link String}]
+     * {@code |--JAVADOC_INLINE_TAG[4x3] : [{&#64;link String}]
      *        |--JAVADOC_INLINE_TAG_START[4x3] : [{]
      *        |--LINK_LITERAL[4x4] : [@link]
      *        |--WS[4x9] : [ ]
      *        |--REFERENCE[4x10] : [String]
      *            |--CLASS[4x10] : [String]
      *        |--JAVADOC_INLINE_TAG_END[4x16] : [}]
-     * </code>
+     * }
      * </pre>
      */
     public static final int JAVADOC_INLINE_TAG = JavadocParser.RULE_javadocInlineTag + RULE_TYPES_OFFSET;
@@ -139,7 +139,7 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@return true if file exists</code></pre>
+     * <pre>{@code @return true if file exists}</pre>
      * <b>Tree:</b>
      * <pre>{@code
      *   |--JAVADOC_TAG[4x3] : [@return true if file exists]
@@ -162,7 +162,7 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@deprecated it is deprecated method</code></pre>
+     * <pre>{@code @deprecated it is deprecated method}</pre>
      * <b>Tree:</b>
      * <pre>{@code
      *   |--JAVADOC_TAG[3x0] : [@deprecated it is deprecated method]
@@ -184,7 +184,7 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@since 3.4 RELEASE</code></pre>
+     * <pre>{@code @since 3.4 RELEASE}</pre>
      * <b>Tree:</b>
      * <pre>{@code
      *   |--JAVADOC_TAG[3x0] : [@since 3.4 RELEASE]
@@ -206,7 +206,7 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@serialData two values of Integer type</code></pre>
+     * <pre>{@code @serialData two values of Integer type}</pre>
      * <b>Tree:</b>
      * <pre>{@code
      *   |--JAVADOC_TAG[3x0] : [@serialData two values of Integer type ]
@@ -234,7 +234,7 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@serialField counter Integer objects counter</code></pre>
+     * <pre>{@code @serialField counter Integer objects counter}</pre>
      * <b>Tree:</b>
      * <pre>{@code
      *   |--JAVADOC_TAG[3x0] : [@serialField counter Integer objects counter]
@@ -288,7 +288,7 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@see org.apache.utils.Lists.Comparator#compare(Object)</code></pre>
+     * <pre>{@code @see org.apache.utils.Lists.Comparator#compare(Object)}</pre>
      * <b>Tree:</b>
      * <pre>{@code
      *   |--JAVADOC_TAG[3x0] : [@see org.apache.utils.Lists.Comparator#compare(Object)]
@@ -321,7 +321,7 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@serial include</code></pre>
+     * <pre>{@code @serial include}</pre>
      * <b>Tree:</b>
      * <pre>{@code
      *   |--JAVADOC_TAG[3x0] : [@serial include]
@@ -332,7 +332,7 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@serial serialized company name</code></pre>
+     * <pre>{@code @serial serialized company name}</pre>
      * <b>Tree:</b>
      * <pre>{@code
      *   |--JAVADOC_TAG[3x0] : [@serial serialized company name]
@@ -354,7 +354,7 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@version 1.3</code></pre>
+     * <pre>{@code @version 1.3}</pre>
      * <b>Tree:</b>
      * <pre>{@code
      *   |--JAVADOC_TAG[3x0] : [@version 1.3]
@@ -376,7 +376,7 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@exception SQLException if query is not correct</code></pre>
+     * <pre>{@code @exception SQLException if query is not correct}</pre>
      * <b>Tree:</b>
      * <pre>{@code
      *   |--JAVADOC_TAG[3x0] : [@exception SQLException if query is not correct]
@@ -400,7 +400,7 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@throws SQLException if query is not correct</code></pre>
+     * <pre>{@code @throws SQLException if query is not correct}</pre>
      * <b>Tree:</b>
      * <pre>{@code
      *   |--JAVADOC_TAG[3x0] : [@throws SQLException if query is not correct]
@@ -424,7 +424,7 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@author Baratali Izmailov</code></pre>
+     * <pre>{@code @author Baratali Izmailov}</pre>
      * <b>Tree:</b>
      * <pre>{@code
      *   |--JAVADOC_TAG[3x0] : [@author Baratali Izmailov]
@@ -446,7 +446,7 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@myJavadocTag some magic</code></pre>
+     * <pre>{@code @myJavadocTag some magic}</pre>
      * <b>Tree:</b>
      * <pre>{@code
      *   |--JAVADOC_TAG[3x0] : [@myJavadocTag some magic]
@@ -463,16 +463,16 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>{&#64;code Comparable&lt;E&gt;}</code></pre>
+     * <pre>{@code {&#64;code Comparable&lt;E&gt;}}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
+     * {@code |--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
      *         |--JAVADOC_INLINE_TAG_START[3x0] : [{]
      *         |--CODE_LITERAL[3x1] : [@code]
      *         |--WS[3x6] : [ ]
      *         |--TEXT[3x7] : [Comparable&lt;E&gt;]
      *         |--JAVADOC_INLINE_TAG_END[3x21] : [}]
-     * </code></pre>
+     * }</pre>
      */
     public static final int JAVADOC_INLINE_TAG_START = JavadocParser.JAVADOC_INLINE_TAG_START;
 
@@ -481,16 +481,16 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>{&#64;code Comparable&lt;E&gt;}</code></pre>
+     * <pre>{@code {&#64;code Comparable&lt;E&gt;}}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
+     * {@code |--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
      *         |--JAVADOC_INLINE_TAG_START[3x0] : [{]
      *         |--CODE_LITERAL[3x1] : [@code]
      *         |--WS[3x6] : [ ]
      *         |--TEXT[3x7] : [Comparable&lt;E&gt;]
      *         |--JAVADOC_INLINE_TAG_END[3x21] : [}]
-     * </code>
+     * }
      * </pre>
      */
     public static final int JAVADOC_INLINE_TAG_END = JavadocParser.JAVADOC_INLINE_TAG_END; // '}'
@@ -507,16 +507,16 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>{&#64;code Comparable&lt;E&gt;}</code></pre>
+     * <pre>{@code {&#64;code Comparable&lt;E&gt;}}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
+     * {@code |--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
      *         |--JAVADOC_INLINE_TAG_START[3x0] : [{]
      *         |--CODE_LITERAL[3x1] : [@code]
      *         |--WS[3x6] : [ ]
      *         |--TEXT[3x7] : [Comparable&lt;E&gt;]
      *         |--JAVADOC_INLINE_TAG_END[3x21] : [}]
-     * </code>
+     * }
      * </pre>
      *
      * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDFHHBB">Oracle Docs</a>
@@ -535,29 +535,29 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>{&#64;docRoot}</code></pre>
+     * <pre>{@code {&#64;docRoot}}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>  |--JAVADOC_INLINE_TAG[1x0] : [{&#64;docRoot \n}]
+     * {@code  |--JAVADOC_INLINE_TAG[1x0] : [{&#64;docRoot \n}]
      *            |--JAVADOC_INLINE_TAG_START[1x0] : [{]
      *            |--DOC_ROOT_LITERAL[1x1] : [@docRoot]
      *            |--JAVADOC_INLINE_TAG_END[2x0] : [}]
-     * </code>
+     * }
      * </pre>
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>{&#64;docRoot
-     *}</code></pre>
+     * <pre>{@code {&#64;docRoot
+     *}}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>  |--JAVADOC_INLINE_TAG[1x0] : [{&#64;docRoot \n}]
+     * {@code  |--JAVADOC_INLINE_TAG[1x0] : [{&#64;docRoot \n}]
      *            |--JAVADOC_INLINE_TAG_START[1x0] : [{]
      *            |--DOC_ROOT_LITERAL[1x1] : [@docRoot]
      *            |--WS[1x9] : [ ]
      *            |--NEWLINE[1x10] : [\n]
      *            |--JAVADOC_INLINE_TAG_END[2x0] : [}]
-     * </code>
+     * }
      * </pre>
      *
      * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDBACBF">Oracle Docs</a>
@@ -571,10 +571,10 @@ public final class JavadocTokenTypes {
      * Such Javadoc inline tag can have one argument - {@link #REFERENCE}
      * </p>
      * <p><b>Example:</b></p>
-     * <pre><code>{&#64;link org.apache.utils.Lists.Comparator#compare(Object)}</code></pre>
+     * <pre>{@code {&#64;link org.apache.utils.Lists.Comparator#compare(Object)}}</pre>
      * <p><b>Tree:</b></p>
      * <pre>
-     * <code>|--JAVADOC_INLINE_TAG[1x0] : [{&#64;link org.apache.utils.Lists.Comparator#compare(Object)}]
+     * {@code |--JAVADOC_INLINE_TAG[1x0] : [{&#64;link org.apache.utils.Lists.Comparator#compare(Object)}]
      *        |--JAVADOC_INLINE_TAG_START[1x0] : [{]
      *        |--LINK_LITERAL[1x1] : [@link]
      *        |--WS[1x6] : [ ]
@@ -591,7 +591,7 @@ public final class JavadocTokenTypes {
      *                |--ARGUMENT[1x49] : [Object]
      *                |--RIGHT_BRACE[1x55] : [)]
      *        |--JAVADOC_INLINE_TAG_END[1x56] : [}]
-     * </code>
+     * }
      * </pre>
      *
      * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDDIECH">Oracle Docs</a>
@@ -610,14 +610,14 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>{&#64;inheritDoc}</code></pre>
+     * <pre>{@code {&#64;inheritDoc}}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>  |--JAVADOC_INLINE_TAG[1x0] : [{&#64;inheritDoc}]
+     * {@code  |--JAVADOC_INLINE_TAG[1x0] : [{&#64;inheritDoc}]
      *            |--JAVADOC_INLINE_TAG_START[1x0] : [{]
      *            |--INHERIT_DOC_LITERAL[1x1] : [@inheritDoc]
      *            |--JAVADOC_INLINE_TAG_END[1x12] : [}]
-     * </code>
+     * }
      * </pre>
      *
      * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDGJCHC">Oracle Docs</a>
@@ -632,10 +632,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>{&#64;linkplain org.apache.utils.Lists.Comparator#compare(Object) compare}</code></pre>
+     * <pre>{@code {&#64;linkplain org.apache.utils.Lists.Comparator#compare(Object) compare}}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_INLINE_TAG[1x0] : [{&#64;linkplain org.apache.utils.Lists.Comparator#compare(Object) compare}]
+     * {@code |--JAVADOC_INLINE_TAG[1x0] : [{&#64;linkplain org.apache.utils.Lists.Comparator#compare(Object) compare}]
      *        |--JAVADOC_INLINE_TAG_START[1x0] : [{]
      *        |--LINKPLAIN_LITERAL[1x1] : [@linkplain]
      *        |--WS[1x11] : [ ]
@@ -654,7 +654,7 @@ public final class JavadocTokenTypes {
      *        |--DESCRIPTION[1x61] : [ compare]
      *            |--TEXT[1x61] : [ compare]
      *        |--JAVADOC_INLINE_TAG_END[1x69] : [}]
-     * </code>
+     * }
      * </pre>
      *
      * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDGBICD">Oracle Docs</a>
@@ -674,16 +674,16 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>{&#64;literal #compare(Object)}</code></pre>
+     * <pre>{@code {&#64;literal #compare(Object)}}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_INLINE_TAG[1x0] : [{&#64;literal #compare(Object)}]
+     * {@code |--JAVADOC_INLINE_TAG[1x0] : [{&#64;literal #compare(Object)}]
      *        |--JAVADOC_INLINE_TAG_START[1x0] : [{]
      *        |--LITERAL_LITERAL[1x1] : [@literal]
      *        |--WS[1x9] : [ ]
      *        |--TEXT[1x10] : [#compare(Object)]
      *        |--JAVADOC_INLINE_TAG_END[1x27] : [}]
-     * </code>
+     * }
      * </pre>
      *
      * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDCFJDG">Oracle Docs</a>
@@ -703,10 +703,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>{&#64;value Integer#MAX_VALUE}</code></pre>
+     * <pre>{@code {&#64;value Integer#MAX_VALUE}}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_INLINE_TAG[1x0] : [{&#64;value Integer#MAX_VALUE}]
+     * {@code |--JAVADOC_INLINE_TAG[1x0] : [{&#64;value Integer#MAX_VALUE}]
      *        |--JAVADOC_INLINE_TAG_START[1x0] : [{]
      *        |--VALUE_LITERAL[1x1] : [@value]
      *        |--WS[1x7] : [ ]
@@ -715,7 +715,7 @@ public final class JavadocTokenTypes {
      *            |--HASH[1x15] : [#]
      *            |--MEMBER[1x16] : [MAX_VALUE]
      *        |--JAVADOC_INLINE_TAG_END[1x25] : [}]
-     * </code>
+     * }
      * </pre>
      *
      * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDDCDHH">Oracle Docs</a>
@@ -740,10 +740,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@see org.apache.utils.Lists.Comparator#compare(Object)</code></pre>
+     * <pre>{@code @see org.apache.utils.Lists.Comparator#compare(Object)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[3x0] : [@see org.apache.utils.Lists.Comparator#compare(Object)]
+     * {@code |--JAVADOC_TAG[3x0] : [@see org.apache.utils.Lists.Comparator#compare(Object)]
      *        |--SEE_LITERAL[3x0] : [@see]
      *        |--WS[3x4] : [ ]
      *        |--REFERENCE[3x5] : [org.apache.utils.Lists.Comparator#compare(Object)]
@@ -758,7 +758,7 @@ public final class JavadocTokenTypes {
      *                |--LEFT_BRACE[3x46] : [(]
      *                |--ARGUMENT[3x47] : [Object]
      *                |--RIGHT_BRACE[3x53] : [)]
-     * </code>
+     * }
      * </pre>
      */
     public static final int PACKAGE = JavadocParser.PACKAGE;
@@ -770,10 +770,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@see org.apache.utils.Lists.Comparator#compare(Object)</code></pre>
+     * <pre>{@code @see org.apache.utils.Lists.Comparator#compare(Object)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[3x0] : [@see org.apache.utils.Lists.Comparator#compare(Object)]
+     * {@code |--JAVADOC_TAG[3x0] : [@see org.apache.utils.Lists.Comparator#compare(Object)]
      *        |--SEE_LITERAL[3x0] : [@see]
      *        |--WS[3x4] : [ ]
      *        |--REFERENCE[3x5] : [org.apache.utils.Lists.Comparator#compare(Object)]
@@ -788,7 +788,7 @@ public final class JavadocTokenTypes {
      *                |--LEFT_BRACE[3x46] : [(]
      *                |--ARGUMENT[3x47] : [Object]
      *                |--RIGHT_BRACE[3x53] : [)]
-     * </code>
+     * }
      * </pre>
      */
     public static final int CLASS = JavadocParser.CLASS;
@@ -800,10 +800,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@see org.apache.utils.Lists.Comparator#compare(Object)</code></pre>
+     * <pre>{@code @see org.apache.utils.Lists.Comparator#compare(Object)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[3x0] : [@see org.apache.utils.Lists.Comparator#compare(Object)]
+     * {@code |--JAVADOC_TAG[3x0] : [@see org.apache.utils.Lists.Comparator#compare(Object)]
      *        |--SEE_LITERAL[3x0] : [@see]
      *        |--WS[3x4] : [ ]
      *        |--REFERENCE[3x5] : [org.apache.utils.Lists.Comparator#compare(Object)]
@@ -818,7 +818,7 @@ public final class JavadocTokenTypes {
      *                |--LEFT_BRACE[3x46] : [(]
      *                |--ARGUMENT[3x47] : [Object]
      *                |--RIGHT_BRACE[3x53] : [)]
-     * </code>
+     * }
      * </pre>
      */
     public static final int DOT = JavadocParser.DOT;
@@ -829,10 +829,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@see org.apache.utils.Lists.Comparator#compare(Object)</code></pre>
+     * <pre>{@code @see org.apache.utils.Lists.Comparator#compare(Object)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[3x0] : [@see org.apache.utils.Lists.Comparator#compare(Object)]
+     * {@code |--JAVADOC_TAG[3x0] : [@see org.apache.utils.Lists.Comparator#compare(Object)]
      *        |--SEE_LITERAL[3x0] : [@see]
      *        |--WS[3x4] : [ ]
      *        |--REFERENCE[3x5] : [org.apache.utils.Lists.Comparator#compare(Object)]
@@ -847,7 +847,7 @@ public final class JavadocTokenTypes {
      *                |--LEFT_BRACE[3x46] : [(]
      *                |--ARGUMENT[3x47] : [Object]
      *                |--RIGHT_BRACE[3x53] : [)]
-     * </code>
+     * }
      * </pre>
      */
     public static final int HASH = JavadocParser.HASH;
@@ -858,10 +858,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@see org.apache.utils.Lists.Comparator#compare(Object)</code></pre>
+     * <pre>{@code @see org.apache.utils.Lists.Comparator#compare(Object)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[3x0] : [@see org.apache.utils.Lists.Comparator#compare(Object)]
+     * {@code |--JAVADOC_TAG[3x0] : [@see org.apache.utils.Lists.Comparator#compare(Object)]
      *        |--SEE_LITERAL[3x0] : [@see]
      *        |--WS[3x4] : [ ]
      *        |--REFERENCE[3x5] : [org.apache.utils.Lists.Comparator#compare(Object)]
@@ -876,7 +876,7 @@ public final class JavadocTokenTypes {
      *                |--LEFT_BRACE[3x46] : [(]
      *                |--ARGUMENT[3x47] : [Object]
      *                |--RIGHT_BRACE[3x53] : [)]
-     * </code>
+     * }
      * </pre>
      */
     public static final int MEMBER = JavadocParser.MEMBER;
@@ -890,10 +890,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@see #method(Processor, String)</code></pre>
+     * <pre>{@code @see #method(Processor, String)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[1x0] : [@see #method(Processor, String)]
+     * {@code |--JAVADOC_TAG[1x0] : [@see #method(Processor, String)]
      *        |--SEE_LITERAL[1x0] : [@see]
      *        |--WS[1x4] : [ ]
      *        |--REFERENCE[1x5] : [#method(Processor, String)]
@@ -906,7 +906,7 @@ public final class JavadocTokenTypes {
      *                |--WS[1x23] : [ ]
      *                |--ARGUMENT[1x24] : [String]
      *                |--RIGHT_BRACE[1x30] : [)]
-     * </code>
+     * }
      * </pre>
      */
     public static final int PARAMETERS = JavadocParser.RULE_parameters + RULE_TYPES_OFFSET;
@@ -916,10 +916,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@see #method(Processor, String)</code></pre>
+     * <pre>{@code @see #method(Processor, String)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[1x0] : [@see #method(Processor, String)]
+     * {@code |--JAVADOC_TAG[1x0] : [@see #method(Processor, String)]
      *        |--SEE_LITERAL[1x0] : [@see]
      *        |--WS[1x4] : [ ]
      *        |--REFERENCE[1x5] : [#method(Processor, String)]
@@ -932,7 +932,7 @@ public final class JavadocTokenTypes {
      *                |--WS[1x23] : [ ]
      *                |--ARGUMENT[1x24] : [String]
      *                |--RIGHT_BRACE[1x30] : [)]
-     * </code>
+     * }
      * </pre>
      */
     public static final int LEFT_BRACE = JavadocParser.LEFT_BRACE;
@@ -942,10 +942,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@see #method(Processor, String)</code></pre>
+     * <pre>{@code @see #method(Processor, String)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[1x0] : [@see #method(Processor, String)]
+     * {@code |--JAVADOC_TAG[1x0] : [@see #method(Processor, String)]
      *        |--SEE_LITERAL[1x0] : [@see]
      *        |--WS[1x4] : [ ]
      *        |--REFERENCE[1x5] : [#method(Processor, String)]
@@ -958,7 +958,7 @@ public final class JavadocTokenTypes {
      *                |--WS[1x23] : [ ]
      *                |--ARGUMENT[1x24] : [String]
      *                |--RIGHT_BRACE[1x30] : [)]
-     * </code>
+     * }
      * </pre>
      */
     public static final int RIGHT_BRACE = JavadocParser.RIGHT_BRACE;
@@ -968,10 +968,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@see #method(Processor, String)</code></pre>
+     * <pre>{@code @see #method(Processor, String)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[1x0] : [@see #method(Processor, String)]
+     * {@code |--JAVADOC_TAG[1x0] : [@see #method(Processor, String)]
      *        |--SEE_LITERAL[1x0] : [@see]
      *        |--WS[1x4] : [ ]
      *        |--REFERENCE[1x5] : [#method(Processor, String)]
@@ -984,7 +984,7 @@ public final class JavadocTokenTypes {
      *                |--WS[1x23] : [ ]
      *                |--ARGUMENT[1x24] : [String]
      *                |--RIGHT_BRACE[1x30] : [)]
-     * </code>
+     * }
      * </pre>
      */
     public static final int ARGUMENT = JavadocParser.ARGUMENT;
@@ -994,10 +994,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@see #method(Processor, String)</code></pre>
+     * <pre>{@code @see #method(Processor, String)}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[1x0] : [@see #method(Processor, String)]
+     * {@code |--JAVADOC_TAG[1x0] : [@see #method(Processor, String)]
      *        |--SEE_LITERAL[1x0] : [@see]
      *        |--WS[1x4] : [ ]
      *        |--REFERENCE[1x5] : [#method(Processor, String)]
@@ -1010,7 +1010,7 @@ public final class JavadocTokenTypes {
      *                |--WS[1x23] : [ ]
      *                |--ARGUMENT[1x24] : [String]
      *                |--RIGHT_BRACE[1x30] : [)]
-     * </code>
+     * }
      * </pre>
      *
      * @see #PARAMETERS
@@ -1025,14 +1025,14 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@see "Spring Framework"</code></pre>
+     * <pre>{@code @see "Spring Framework"}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[1x0] : [@see "Spring Framework"]
+     * {@code |--JAVADOC_TAG[1x0] : [@see "Spring Framework"]
      *        |--SEE_LITERAL[1x0] : [@see]
      *        |--WS[1x4] : [ ]
      *        |--STRING[1x5] : ["Spring Framework"]
-     * </code>
+     * }
      * </pre>
      *
      * @see #SEE_LITERAL
@@ -1052,10 +1052,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@throws IOException if &lt;b&gt;connection&lt;/b&gt; problems occur</code></pre>
+     * <pre>{@code @throws IOException if &lt;b&gt;connection&lt;/b&gt; problems occur}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[1x0] : [@throws IOException if &lt;b&gt;connection&lt;/b&gt; problems occur]
+     * {@code |--JAVADOC_TAG[1x0] : [@throws IOException if &lt;b&gt;connection&lt;/b&gt; problems occur]
      *        |--THROWS_LITERAL[1x0] : [@throws]
      *        |--WS[1x7] : [ ]
      *        |--CLASS_NAME[1x8] : [IOException]
@@ -1075,7 +1075,7 @@ public final class JavadocTokenTypes {
      *                        |--HTML_TAG_NAME[1x38] : [b]
      *                        |--CLOSE[1x39] : [&gt;]
      *            |--TEXT[1x40] : [ problems occur]
-     * </code>
+     * }
      * </pre>
      */
     public static final int DESCRIPTION = JavadocParser.RULE_description + RULE_TYPES_OFFSET;
@@ -1086,17 +1086,17 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@throws IOException connection problems</code></pre>
+     * <pre>{@code @throws IOException connection problems}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[1x0] : [@throws IOException connection problems]
+     * {@code |--JAVADOC_TAG[1x0] : [@throws IOException connection problems]
      *        |--THROWS_LITERAL[1x0] : [@throws]
      *        |--WS[1x7] : [ ]
      *        |--CLASS_NAME[1x8] : [IOException]
      *        |--WS[1x19] : [ ]
      *        |--DESCRIPTION[1x20] : [connection problems]
      *            |--TEXT[1x20] : [connection problems]
-     * </code>
+     * }
      * </pre>
      *
      * @see #EXCEPTION_LITERAL
@@ -1112,14 +1112,14 @@ public final class JavadocTokenTypes {
      * <pre>{@code @param T The bar.}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[4x3] : [@param T The bar.]
+     * {@code |--JAVADOC_TAG[4x3] : [@param T The bar.]
      *        |--PARAM_LITERAL[4x3] : [@param]
      *        |--WS[4x9] : [ ]
      *        |--PARAMETER_NAME[4x10] : [T]
      *        |--WS[4x11] : [ ]
      *        |--DESCRIPTION[4x12] : [The bar.]
      *            |--TEXT[4x12] : [The bar.]
-     * </code>
+     * }
      * </pre>
      *
      * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDHJECF">Oracle Docs</a>
@@ -1133,14 +1133,14 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@serial exclude</code></pre>
+     * <pre>{@code @serial exclude}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[1x0] : [@serial exclude]
+     * {@code |--JAVADOC_TAG[1x0] : [@serial exclude]
      *        |--SERIAL_LITERAL[1x0] : [@serial]
      *        |--WS[1x7] : [ ]
      *        |--LITERAL_EXCLUDE[1x8] : [exclude]
-     * </code>
+     * }
      * </pre>
      *
      * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDHDECF">Oracle Docs</a>
@@ -1154,14 +1154,14 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@serial include</code></pre>
+     * <pre>{@code @serial include}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[1x0] : [@serial include]
+     * {@code |--JAVADOC_TAG[1x0] : [@serial include]
      *        |--SERIAL_LITERAL[1x0] : [@serial]
      *        |--WS[1x7] : [ ]
      *        |--LITERAL_INCLUDE[1x8] : [include]
-     * </code>
+     * }
      * </pre>
      *
      * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDHDECF">Oracle Docs</a>
@@ -1174,10 +1174,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@serialField counter Integer objects counter</code></pre>
+     * <pre>{@code @serialField counter Integer objects counter}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[3x0] : [@serialField counter Integer objects counter]
+     * {@code |--JAVADOC_TAG[3x0] : [@serialField counter Integer objects counter]
      *        |--SERIAL_FIELD_LITERAL[3x0] : [@serialField]
      *        |--WS[3x12] : [ ]
      *        |--FIELD_NAME[3x13] : [counter]
@@ -1186,7 +1186,7 @@ public final class JavadocTokenTypes {
      *        |--WS[3x28] : [ ]
      *        |--DESCRIPTION[3x29] : [objects counter]
      *            |--TEXT[3x29] : [objects counter]
-     * </code>
+     * }
      * </pre>
      *
      * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDHDECF">Oracle Docs</a>
@@ -1199,10 +1199,10 @@ public final class JavadocTokenTypes {
      *
      * <p>
      * <b>Example:</b>
-     * <pre><code>@serialField counter Integer objects counter</code></pre>
+     * <pre>{@code @serialField counter Integer objects counter}</pre>
      * <b>Tree:</b>
      * <pre>
-     * <code>|--JAVADOC_TAG[3x0] : [@serialField counter Integer objects counter]
+     * {@code |--JAVADOC_TAG[3x0] : [@serialField counter Integer objects counter]
      *        |--SERIAL_FIELD_LITERAL[3x0] : [@serialField]
      *        |--WS[3x12] : [ ]
      *        |--FIELD_NAME[3x13] : [counter]
@@ -1211,7 +1211,7 @@ public final class JavadocTokenTypes {
      *        |--WS[3x28] : [ ]
      *        |--DESCRIPTION[3x29] : [objects counter]
      *            |--TEXT[3x29] : [objects counter]
-     * </code>
+     * }
      * </pre>
      *
      * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDHDECF">Oracle Docs</a>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -91,7 +91,7 @@ public final class LocalizedMessage
     private final String customMessage;
 
     /**
-     * Creates a new <code>LocalizedMessage</code> instance.
+     * Creates a new {@code LocalizedMessage} instance.
      *
      * @param lineNo line number associated with the message
      * @param colNo column number associated with the message
@@ -124,7 +124,7 @@ public final class LocalizedMessage
     }
 
     /**
-     * Creates a new <code>LocalizedMessage</code> instance.
+     * Creates a new {@code LocalizedMessage} instance.
      *
      * @param lineNo line number associated with the message
      * @param colNo column number associated with the message
@@ -155,7 +155,7 @@ public final class LocalizedMessage
     }
 
     /**
-     * Creates a new <code>LocalizedMessage</code> instance.
+     * Creates a new {@code LocalizedMessage} instance.
      *
      * @param lineNo line number associated with the message
      * @param bundle resource bundle name
@@ -179,7 +179,7 @@ public final class LocalizedMessage
     }
 
     /**
-     * Creates a new <code>LocalizedMessage</code> instance. The column number
+     * Creates a new {@code LocalizedMessage} instance. The column number
      * defaults to 0.
      *
      * @param lineNo line number associated with the message
@@ -262,7 +262,7 @@ public final class LocalizedMessage
 
     /**
      * Returns the formatted custom message if one is configured.
-     * @return the formatted custom message or <code>null</code>
+     * @return the formatted custom message or {@code null}
      *          if there is no custom message
      */
     private String getCustomMessage() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Scope.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Scope.java
@@ -58,8 +58,8 @@ public enum Scope {
      * Checks if this scope is a subscope of another scope.
      * Example: PUBLIC is a subscope of PRIVATE.
      *
-     * @param scope a <code>Scope</code> value
-     * @return if <code>this</code> is a subscope of <code>scope</code>.
+     * @param scope a {@code Scope} value
+     * @return if {@code this} is a subscope of {@code scope}.
      */
     public boolean isIn(Scope scope) {
         return compareTo(scope) <= 0;
@@ -69,7 +69,7 @@ public enum Scope {
      * Scope factory method.
      *
      * @param scopeName scope name, such as "nothing", "public", etc.
-     * @return the <code>Scope</code> associated with <code>scopeName</code>
+     * @return the {@code Scope} associated with {@code scopeName}
      */
     public static Scope getInstance(String scopeName) {
         return valueOf(Scope.class, scopeName.trim().toUpperCase(Locale.ENGLISH));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevel.java
@@ -60,8 +60,8 @@ public enum SeverityLevel {
      * SeverityLevel factory method.
      *
      * @param securityLevelName level name, such as "ignore", "info", etc.
-     * @return the <code>SeverityLevel</code>
-     * associated with <code>securityLevelName</code>
+     * @return the {@code SeverityLevel}
+     * associated with {@code securityLevelName}
      */
     public static SeverityLevel getInstance(String securityLevelName) {
         return valueOf(SeverityLevel.class, securityLevelName.trim()

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.api.Check;
  * <p> Abstract class for checks that verify strings using a
  * {@link Pattern regular expression}.  It
  * provides support for setting the regular
- * expression using the property name <code>format</code>.  </p>
+ * expression using the property name {@code format}.  </p>
  *
  * @author Oliver Burn
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractOptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractOptionCheck.java
@@ -43,7 +43,7 @@ public abstract class AbstractOptionCheck<T extends Enum<T>>
     private T option;
 
     /**
-     * Creates a new <code>AbstractOptionCheck</code> instance.
+     * Creates a new {@code AbstractOptionCheck} instance.
      * @param literalDefault the default option.
      * @param optionClass the class for the option. Required due to a quirk
      *        in the Java language.
@@ -68,7 +68,7 @@ public abstract class AbstractOptionCheck<T extends Enum<T>>
     }
 
     /**
-     * @return the <code>AbstractOption</code> set
+     * @return the {@code AbstractOption} set
      */
     public T getAbstractOption() {
         // WARNING!! Do not rename this method to getOption(). It breaks

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -53,7 +53,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
     /** Name of current class. */
     private String currentClass;
 
-    /** <code>ClassResolver</code> instance for current tree. */
+    /** {@code ClassResolver} instance for current tree. */
     private ClassResolver classResolver;
 
     /** Stack of maps for type params. */
@@ -173,10 +173,10 @@ public abstract class AbstractTypeAwareCheck extends Check {
     }
 
     /**
-     * Is exception is unchecked (subclass of <code>RuntimeException</code>
-     * or <code>Error</code>
+     * Is exception is unchecked (subclass of {@code RuntimeException}
+     * or {@code Error}
      *
-     * @param exception <code>Class</code> of exception to check
+     * @param exception {@code Class} of exception to check
      * @return true  if exception is unchecked
      *         false if exception is checked
      */
@@ -188,9 +188,9 @@ public abstract class AbstractTypeAwareCheck extends Check {
     /**
      * Checks if one class is subclass of another
      *
-     * @param child <code>Class</code> of class
+     * @param child {@code Class} of class
      *               which should be child
-     * @param parent <code>Class</code> of class
+     * @param parent {@code Class} of class
      *                which should be parent
      * @return true  if aChild is subclass of aParent
      *         false otherwise
@@ -200,7 +200,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
             &&  parent.isAssignableFrom(child);
     }
 
-    /** @return <code>ClassResolver</code> for current tree. */
+    /** @return {@code ClassResolver} for current tree. */
     private ClassResolver getClassResolver() {
         if (classResolver == null) {
             classResolver =
@@ -215,7 +215,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
      * Attempts to resolve the Class for a specified name.
      * @param className name of the class to resolve
      * @param currentClass name of surrounding class.
-     * @return the resolved class or <code>null</code>
+     * @return the resolved class or {@code null}
      *          if unable to resolve the class.
      */
     protected final Class<?> resolveClass(String className,
@@ -232,7 +232,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
      * Tries to load class. Logs error if unable.
      * @param ident name of class which we try to load.
      * @param currentClass name of surrounding class.
-     * @return <code>Class</code> for a ident.
+     * @return {@code Class} for a ident.
      */
     protected final Class<?> tryLoadClass(Token ident, String currentClass) {
         final Class<?> clazz = resolveClass(ident.getText(), currentClass);
@@ -383,10 +383,10 @@ public abstract class AbstractTypeAwareCheck extends Check {
     }
 
     /**
-     * Contains class's <code>Token</code>.
+     * Contains class's {@code Token}.
      */
     protected abstract static class AbstractClassInfo {
-        /** <code>FullIdent</code> associated with this class. */
+        /** {@code FullIdent} associated with this class. */
         private final Token name;
 
         /**
@@ -406,7 +406,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
             return name;
         }
 
-        /** @return <code>Class</code> associated with an object. */
+        /** @return {@code Class} associated with an object. */
         public abstract Class<?> getClazz();
     }
 
@@ -417,14 +417,14 @@ public abstract class AbstractTypeAwareCheck extends Check {
         private final String surroundingClass;
         /** is class loadable. */
         private boolean loadable = true;
-        /** <code>Class</code> object of this class if it's loadable. */
+        /** {@code Class} object of this class if it's loadable. */
         private Class<?> classObj;
         /** the check we use to resolve classes. */
         private final AbstractTypeAwareCheck check;
 
         /**
          * Creates new instance of of class information object.
-         * @param name <code>FullIdent</code> associated with new object.
+         * @param name {@code FullIdent} associated with new object.
          * @param surroundingClass name of current surrounding class.
          * @param check the check we use to load class.
          */
@@ -449,8 +449,8 @@ public abstract class AbstractTypeAwareCheck extends Check {
         }
 
         /**
-         * Associates <code> Class</code> with an object.
-         * @param classObj <code>Class</code> to associate with.
+         * Associates {@code Class} with an object.
+         * @param classObj {@code Class} to associate with.
          */
         private void setClazz(Class<?> classObj) {
             this.classObj = classObj;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheck.java
@@ -25,7 +25,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * Checks the style of array type definitions.
- * Some like Java-style: <code>public static void main(String[] args)</code>
+ * Some like Java-style: {@code public static void main(String[] args)}
  * and some like C-style: public static void main(String args[])
  *
  * By default the Check enforces Java style.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/CheckUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/CheckUtils.java
@@ -115,9 +115,9 @@ public final class CheckUtils {
     }
 
     /**
-     * Creates <code>FullIdent</code> for given type node.
+     * Creates {@code FullIdent} for given type node.
      * @param typeAST a type node.
-     * @return <code>FullIdent</code> for given type.
+     * @return {@code FullIdent} for given type.
      */
     public static FullIdent createFullType(DetailAST typeAST) {
         final DetailAST arrayDeclAST =
@@ -129,7 +129,7 @@ public final class CheckUtils {
 
     /**
      * @param typeAST a type node (no array)
-     * @return <code>FullIdent</code> for given type.
+     * @return {@code FullIdent} for given type.
      */
     private static FullIdent createFullTypeNoArrays(DetailAST typeAST) {
         return FullIdent.createFullIdent(typeAST.getFirstChild());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
@@ -38,7 +38,7 @@ public class ClassResolver {
     private final ClassLoader loader;
 
     /**
-     * Creates a new <code>ClassResolver</code> instance.
+     * Creates a new {@code ClassResolver} instance.
      *
      * @param loader the ClassLoader to load classes with.
      * @param pkg the name of the package the class may belong to
@@ -168,7 +168,7 @@ public class ClassResolver {
      * Will load a specified class is such a way that it will NOT be
      * initialised.
      * @param name name of the class to load
-     * @return the <code>Class</code> for the specified class
+     * @return the {@code Class} for the specified class
      * @throws ClassNotFoundException if an error occurs
      * @throws NoClassDefFoundError if an error occurs
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
@@ -385,7 +385,7 @@ public class DescendantTokenCheck extends Check {
     /**
      * Sets the error message for minimum count not reached.
      * @param message the error message for minimum count not reached.
-     * Used as a <code>MessageFormat</code> pattern with arguments
+     * Used as a {@code MessageFormat} pattern with arguments
      * <ul>
      * <li>{0} - token count</li>
      * <li>{1} - minimum number</li>
@@ -400,7 +400,7 @@ public class DescendantTokenCheck extends Check {
     /**
      * Sets the error message for maximum count exceeded.
      * @param message the error message for maximum count exceeded.
-     * Used as a <code>MessageFormat</code> pattern with arguments
+     * Used as a {@code MessageFormat} pattern with arguments
      * <ul>
      * <li>{0} - token count</li>
      * <li>{1} - maximum number</li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
@@ -40,9 +40,9 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  * E.g.:
  * <p>
- * <code>
+ * {@code
  * private void foo(int x) { ... } //parameter is of primitive type
- * </code>
+ * }
  * </p>
  *
  * @author lkuehne

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/LineSeparatorOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/LineSeparatorOption.java
@@ -48,7 +48,7 @@ public enum LineSeparatorOption {
     private final byte[] lineSeparator;
 
     /**
-     * Creates a new <code>LineSeparatorOption</code> instance.
+     * Creates a new {@code LineSeparatorOption} instance.
      * @param sep the line separator, e.g. "\r\n"
      */
     LineSeparatorOption(String sep) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheck.java
@@ -40,7 +40,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </pre>
  * <p>
  * An example of how to configure the check for comments that contain
- * <code>TODO</code> or <code>FIXME</code>is:
+ * {@code TODO} or {@code FIXME}is:
  * </p>
  *
  * <pre>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -36,7 +36,7 @@ import com.puppycrawl.tools.checkstyle.api.TextBlock;
  * precede it is whitespace.
  * It doesn't check comments if they do not end line, i.e. it accept
  * the following:
- * <code>Thread.sleep( 10 &lt;some comment here&gt; );</code>
+ * {@code Thread.sleep( 10 &lt;some comment here&gt; );}
  * Format property is intended to deal with the "} // while" example.
  * </p>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -91,7 +91,7 @@ public class TranslationCheck
     private String basenameSeparator;
 
     /**
-     * Creates a new <code>TranslationCheck</code> instance.
+     * Creates a new {@code TranslationCheck} instance.
      */
     public TranslationCheck() {
         setFileExtensions("properties");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -62,7 +62,7 @@ public class UncommentedMainCheck
 
     /**
      * Set the excluded classes pattern.
-     * @param excludedClasses a <code>String</code> value
+     * @param excludedClasses a {@code String} value
      */
     public void setExcludedClasses(String excludedClasses) {
         this.excludedClasses = excludedClasses;
@@ -152,7 +152,7 @@ public class UncommentedMainCheck
 
     /**
      * Checks method definition if this is
-     * <code>public static void main(String[])</code>.
+     * {@code public static void main(String[])}.
      * @param method method definition node
      */
     private void visitMethodDef(DetailAST method) {
@@ -202,7 +202,7 @@ public class UncommentedMainCheck
     }
 
     /**
-     * Checks that return type is <code>void</code>.
+     * Checks that return type is {@code void}.
      * @param method the METHOD_DEF node
      * @return true if check passed, false otherwise
      */
@@ -213,7 +213,7 @@ public class UncommentedMainCheck
     }
 
     /**
-     * Checks that method has only <code>String[]</code> param
+     * Checks that method has only {@code String[]} param
      * @param method the METHOD_DEF node
      * @return true if check passed, false otherwise
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -39,7 +39,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </ul>
  * To not enforce an element style
  * a {@link ElementStyle#IGNORE IGNORE} type is provided.  The desired style
- * can be set through the <code>elementStyle</code> property.
+ * can be set through the {@code elementStyle} property.
  *
  *
  * <p>
@@ -68,7 +68,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * {@link ClosingParens#ALWAYS ALWAYS} type.  To never have ending parenthesis
  * use the {@link ClosingParens#NEVER NEVER} type. To not enforce a
  * closing parenthesis preference a {@link ClosingParens#IGNORE IGNORE} type is
- * provided. Set this through the <code>closingParens</code> property.
+ * provided. Set this through the {@code closingParens} property.
  *
  *
  * <p>
@@ -78,7 +78,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * type. To never have a trailing comma use the
  * {@link TrailingArrayComma#NEVER NEVER} type. To not enforce a trailing
  * array comma preference a {@link TrailingArrayComma#IGNORE IGNORE} type
- * is provided.  Set this through the <code>trailingArrayComma</code> property.
+ * is provided.  Set this through the {@code trailingArrayComma} property.
  *
  *
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
@@ -57,10 +57,10 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * <p>
  * As a result of the aforementioned difference between Java 5 and Java 6, a
- * property called <code> javaFiveCompatibility </code> is available. This
+ * property called {@code javaFiveCompatibility } is available. This
  * property will only check classes, interfaces, etc. that do not contain the
  * extends or implements keyword or are not anonymous classes. This means it
- * only checks methods overridden from <code>java.lang.Object</code>
+ * only checks methods overridden from {@code java.lang.Object}
  *
  * <b>Java 5 Compatibility mode severely limits this check. It is recommended to
  * only use it on Java 5 source</b>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
@@ -76,7 +76,7 @@ public class EmptyBlockCheck
     public static final String MSG_KEY_BLOCK_EMPTY = "block.empty";
 
     /**
-     * Creates a new <code>EmptyBlockCheck</code> instance.
+     * Creates a new {@code EmptyBlockCheck} instance.
      */
     public EmptyBlockCheck() {
         super(BlockOption.STMT, BlockOption.class);
@@ -151,7 +151,7 @@ public class EmptyBlockCheck
     }
 
     /**
-     * @param slistAST a <code>DetailAST</code> value
+     * @param slistAST a {@code DetailAST} value
      * @return whether the SLIST token contains any text.
      */
     protected boolean hasText(final DetailAST slistAST) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheck.java
@@ -59,18 +59,18 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Such empty blocks would be both suppressed:<br>
  * </p>
  * <pre>
- * <code>
+ * {@code
  * try {
  *     throw new RuntimeException();
  * } catch (RuntimeException expected) {
  * }
- * </code>
- * <code>
+ * }
+ * {@code
  * try {
  *     throw new RuntimeException();
  * } catch (RuntimeException ignore) {
  * }
- * </code>
+ * }
  * </pre>
  * <p>
  * To configure the Check to suppress empty catch block if single-line comment inside
@@ -85,13 +85,13 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Such empty block would be suppressed:<br>
  * </p>
  * <pre>
- * <code>
+ * {@code
  * try {
  *     throw new RuntimeException();
  * } catch (RuntimeException e) {
  *     //This is expected
  * }
- * </code>
+ * }
  * </pre>
  * <p>
  * To configure the Check to suppress empty catch block if single-line comment inside
@@ -107,20 +107,20 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Such empty blocks would be both suppressed:<br>
  * </p>
  * <pre>
- * <code>
+ * {@code
  * try {
  *     throw new RuntimeException();
  * } catch (RuntimeException e) {
  *     //This is expected
  * }
- * </code>
- * <code>
+ * }
+ * {@code
  * try {
  *     throw new RuntimeException();
  * } catch (RuntimeException myException) {
  *
  * }
- * </code>
+ * }
  * </pre>
  * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -232,14 +232,14 @@ public class LeftCurlyCheck
     }
 
     /**
-     * Skip lines that only contain <code>TokenTypes.ANNOTATION</code>s.
-     * If the received <code>DetailAST</code>
+     * Skip lines that only contain {@code TokenTypes.ANNOTATION}s.
+     * If the received {@code DetailAST}
      * has annotations within its modifiers then first token on the line
      * of the first token afer all annotations is return. This might be
      * an annotation.
-     * Otherwise, the received <code>DetailAST</code> is returned.
-     * @param ast <code>DetailAST</code>.
-     * @return <code>DetailAST</code>.
+     * Otherwise, the received {@code DetailAST} is returned.
+     * @param ast {@code DetailAST}.
+     * @return {@code DetailAST}.
      */
     private static DetailAST skipAnnotationOnlyLines(DetailAST ast) {
         final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
@@ -266,10 +266,10 @@ public class LeftCurlyCheck
     }
 
     /**
-     * Find the last token of type <code>TokenTypes.ANNOTATION</code>
+     * Find the last token of type {@code TokenTypes.ANNOTATION}
      * under the given set of modifiers.
-     * @param modifiers <code>DetailAST</code>.
-     * @return <code>DetailAST</code> or null if there are no annotations.
+     * @param modifiers {@code DetailAST}.
+     * @return {@code DetailAST} or null if there are no annotations.
      */
     private static DetailAST findLastAnnotation(DetailAST modifiers) {
         DetailAST annot = modifiers.findFirstToken(TokenTypes.ANNOTATION);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyOption.java
@@ -20,7 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.blocks;
 
 /**
- * Represents the options for placing the left curly brace <code>'{'</code>.
+ * Represents the options for placing the left curly brace {@code '&#123;'}.
  *
  * @author Oliver Burn
  */
@@ -38,8 +38,8 @@ public enum LeftCurlyOption {
     /**
      * Represents the policy that if the brace will fit on the first line of
      * the statement, taking into account maximum line length, then apply
-     * <code>EOL</code> rule. Otherwise apply the <code>NL</code>
-     * rule. <code>NLOW</code> is a mnemonic for "new line on wrap".
+     * {@code EOL} rule. Otherwise apply the {@code NL}
+     * rule. {@code NLOW} is a mnemonic for "new line on wrap".
      *
      * <p> For the example above Checkstyle will enforce:
      *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -40,8 +40,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  * &lt;module name="NeedBraces"/&gt;
  * </pre>
- * <p> An example of how to configure the check for <code>if</code> and
- * <code>else</code> blocks is:
+ * <p> An example of how to configure the check for {@code if} and
+ * {@code else} blocks is:
  * </p>
  * <pre>
  * &lt;module name="NeedBraces"&gt;
@@ -51,27 +51,27 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Check has an option <b>allowSingleLineStatement</b> which allows single-line
  * statements without braces, e.g.:
  * <p>
- * <code>
+ * {@code
  * if (obj.isValid()) return true;
- * </code>
+ * }
  * </p>
  * <p>
- * <code>
+ * {@code
  * while (obj.isValid()) return true;
- * </code>
+ * }
  * </p>
  * <p>
- * <code>
+ * {@code
  * do this.notify(); while (o != null);
- * </code>
+ * }
  * </p>
  * <p>
- * <code>
+ * {@code
  * for (int i = 0; ; ) this.notify();
- * </code>
+ * }
  * </p>
  * <p>
- * To configure the Check to allow <code>case, default</code> single-line statements
+ * To configure the Check to allow {@code case, default} single-line statements
  * without braces:
  * </p>
  *
@@ -87,13 +87,13 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  *
  * <pre>
- * <code>
+ * {@code
  * switch (num) {
  *     case 1: counter++; break; // OK
  *     case 6: counter += 10; break; // OK
  *     default: counter = 100; break; // OK
  * }
- * </code>
+ * }
  * </pre>
  *
  *
@@ -220,9 +220,9 @@ public class NeedBracesCheck extends Check {
     /**
      * Checks if current while statement is single-line statement, e.g.:
      * <p>
-     * <code>
+     * {@code
      * while (obj.isValid()) return true;
-     * </code>
+     * }
      * </p>
      * @param literalWhile {@link TokenTypes#LITERAL_WHILE while statement}.
      * @return true if current while statement is single-line statement.
@@ -329,10 +329,10 @@ public class NeedBracesCheck extends Check {
     /**
      * Checks if current case statement is single-line statement, e.g.:
      * <p>
-     * <code>
+     * {@code
      * case 1: dosomeStuff(); break;
      * case 2: dosomeStuff(); break;
-     * </code>
+     * }
      * </p>
      * @param literalCase {@link TokenTypes#LITERAL_CASE case statement}.
      * @return true if current case statement is single-line statement.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -61,8 +61,8 @@ import com.puppycrawl.tools.checkstyle.checks.CheckUtils;
  * </pre>
  * <p>
  * An example of how to configure the check with policy
- * {@link RightCurlyOption#ALONE} for <code>else</code> and
- * <code>{@link TokenTypes#METHOD_DEF METHOD_DEF}</code>tokens is:
+ * {@link RightCurlyOption#ALONE} for {@code else} and
+ * {@code {@link TokenTypes#METHOD_DEF METHOD_DEF}}tokens is:
  * </p>
  * <pre>
  * &lt;module name="RightCurly"&gt;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java
@@ -20,7 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.blocks;
 
 /**
- * Represents the options for placing the right curly brace <code>'}'</code>.
+ * Represents the options for placing the right curly brace {@code '}'}.
  *
  * @author Oliver Burn
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java
@@ -25,13 +25,13 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * <p>
- * Check that the <code>default</code> is after all the <code>case</code>s
- * in a <code>switch</code> statement.
+ * Check that the {@code default} is after all the {@code case}s
+ * in a {@code switch} statement.
  * </p>
  * <p>
- * Rationale: Java allows <code>default</code> anywhere within the
- * <code>switch</code> statement. But if it comes after the last
- * <code>case</code> then it is more readable.
+ * Rationale: Java allows {@code default} anywhere within the
+ * {@code switch} statement. But if it comes after the last
+ * {@code case} then it is more readable.
  * </p>
  * <p>
  * An example of how to configure the check is:

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -38,18 +38,18 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * For example:
  *
  * <pre>
- *  <code>
+ *  {@code
  *    String nullString = null;
  *    nullString.equals(&quot;My_Sweet_String&quot;);
- *  </code>
+ *  }
  * </pre>
  * should be refactored to
  *
  * <pre>
- *  <code>
+ *  {@code
  *    String nullString = null;
  *    &quot;My_Sweet_String&quot;.equals(nullString);
- *  </code>
+ *  }
  * </pre>
  *
  *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -28,9 +28,9 @@ import com.puppycrawl.tools.checkstyle.checks.CheckUtils;
 /**
  * <p>
  * Checks if any class or object member explicitly initialized
- * to default for its type value (<code>null</code> for object
- * references, zero for numeric types and <code>char</code>
- * and <code>false</code> for <code>boolean</code>.
+ * to default for its type value ({@code null} for object
+ * references, zero for numeric types and {@code char}
+ * and {@code false} for {@code boolean}.
  * </p>
  * <p>
  * Rationale: each instance variable gets

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -52,7 +52,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </pre>
  * <p>
  * The recognized relief comment can be configured with the property
- * <code>reliefPattern</code>. Default value of this regular expression
+ * {@code reliefPattern}. Default value of this regular expression
  * is "fallthru|fall through|fallthrough|falls through".
  * </p>
  * <p>
@@ -299,8 +299,8 @@ public class FallThroughCheck extends Check {
     }
 
     /**
-     * Determines if the fall through case between <code>currentCase</code> and
-     * <code>nextCase</code> is reliefed by a appropriate comment.
+     * Determines if the fall through case between {@code currentCase} and
+     * {@code nextCase} is reliefed by a appropriate comment.
      *
      * @param currentCase AST of the case that falls through to the next case.
      * @param nextCase AST of the next case.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -64,11 +64,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </pre>
  * <p>Example:</p>
  * <p>
- * <code>
+ * {@code
  * for (int number : myNumbers) { // violation
  *    System.out.println(number);
  * }
- * </code>
+ * }
  * </p>
  * @author k_gibbs, r_auckenthaler
  */
@@ -232,11 +232,11 @@ public class FinalLocalVariableCheck extends Check {
      * Checks if current variable is defined in
      *  {@link TokenTypes#FOR_INIT for-loop init}, e.g.:
      * <p>
-     * <code>
+     * {@code
      * for (int i = 0, j = 0; i < j; i++) { . . . }
-     * </code>
+     * }
      * </p>
-     * <code>i, j</code> are defined in {@link TokenTypes#FOR_INIT for-loop init}
+     * {@code i, j} are defined in {@link TokenTypes#FOR_INIT for-loop init}
      * @param variableDef variable definition node.
      * @return true if variable is defined in {@link TokenTypes#FOR_INIT for-loop init}
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -106,7 +106,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </pre>
  *
  * <pre>
- * <code>
+ * {@code
  * class SomeClass
  * {
  *     private List&lt;String&gt; test;
@@ -122,7 +122,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *         ...
  *     }
  * }
- * </code>
+ * }
  * </pre>
  *
  * @author Dmitri Priimak

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractFormatCheck;
  * Checks for illegal token text.
  * </p>
  * <p> An example of how to configure the check to forbid String literals
- * containing <code>"a href"</code> is:
+ * containing {@code "a href"} is:
  * </p>
  * <pre>
  * &lt;module name="IllegalTokenText"&gt;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -61,13 +61,13 @@ import com.puppycrawl.tools.checkstyle.checks.CheckUtils;
  *   corresponding declarations
  *  (of variables, methods or parameters). This helps to avoid ambiguous cases, e.g.:
  * <p>
- * <code>java.awt.List</code> was set as illegal class name, then, code like:
+ * {@code java.awt.List} was set as illegal class name, then, code like:
  * <p>
- * <code>
+ * {@code
  * import java.util.List;<br>
  * ...<br>
  * List list; //No violation here
- * </code>
+ * }
  * </p>
  * <p>
  * will be ok.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
@@ -30,10 +30,10 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 /**
  * <p>
  * Checks for assignments in subexpressions, such as in
- * <code>String s = Integer.toString(i = 2);</code>.
+ * {@code String s = Integer.toString(i = 2);}.
  * </p>
  * <p>
- * Rationale: With the exception of <code>for</code> iterators, all assignments
+ * Rationale: With the exception of {@code for} iterators, all assignments
  * should occur in their own toplevel statement to increase readability.
  * With inner assignments like the above it is difficult to see all places
  * where a variable is set.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -39,12 +39,12 @@ import com.puppycrawl.tools.checkstyle.checks.CheckUtils;
  * Constant definition is any variable/field that has 'final' modifier.
  * It is fine to have one constant defining multiple numeric literals within one expression:
  * <pre>
- * <code>static final int SECONDS_PER_DAY = 24 * 60 * 60;
+ * {@code static final int SECONDS_PER_DAY = 24 * 60 * 60;
  * static final double SPECIAL_RATIO = 4.0 / 3.0;
  * static final double SPECIAL_SUM = 1 + Math.E;
  * static final double SPECIAL_DIFFERENCE = 4 - Math.PI;
  * static final Border STANDARD_BORDER = BorderFactory.createEmptyBorder(3, 3, 3, 3);
- * static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);</code>
+ * static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);}
  * </pre>
  *
  * <p>
@@ -62,7 +62,7 @@ import com.puppycrawl.tools.checkstyle.checks.CheckUtils;
  * results is following violations:
  * </p>
  * <pre>
- * <code>
+ * {@code
  *   {@literal @}MyAnnotation(6) // violation
  *   class MyClass {
  *       private field = 7; // violation
@@ -72,7 +72,7 @@ import com.puppycrawl.tools.checkstyle.checks.CheckUtils;
  *          int j = j + 8; // violation
  *       }
  *   }
- * </code>
+ * }
  * </pre>
  * <p>
  * To configure the check so that it checks floating-point numbers
@@ -90,7 +90,7 @@ import com.puppycrawl.tools.checkstyle.checks.CheckUtils;
  * results is following violations:
  * </p>
  * <pre>
- * <code>
+ * {@code
  *   {@literal @}MyAnnotation(6) // no violation
  *   class MyClass {
  *       private field = 7; // no violation
@@ -100,7 +100,7 @@ import com.puppycrawl.tools.checkstyle.checks.CheckUtils;
  *          int j = j + (int)0.5; // no violation
  *       }
  *   }
- * </code>
+ * }
  * </pre>
  * <p>
  * Config example of constantWaiverParentToken option:
@@ -115,7 +115,7 @@ import com.puppycrawl.tools.checkstyle.checks.CheckUtils;
  * result is following violation:
  * </p>
  * <pre>
- * <code>
+ * {@code
  * class TestMethodCall {
  *     public void method2() {
  *         final TestMethodCall dummyObject = new TestMethodCall(62);    //violation
@@ -131,7 +131,7 @@ import com.puppycrawl.tools.checkstyle.checks.CheckUtils;
  *         final int x = (int)(3.4);    //ok as waiver is TYPECAST
  *     }
  * }
- * </code>
+ * }
  * </pre>
  * @author Rick Giles
  * @author Lars Kühne

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -37,11 +37,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * inside the for block. An example is:
  *
  * <pre>
- * <code>
+ * {@code
  * for (int i = 0; i &lt; 1; i++) {
  *     i++;//violation
  * }
- * </code>
+ * }
  * </pre>
  * <p>
  * Rationale: If the control variable is modified inside the loop
@@ -58,11 +58,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Such loop would be supressed:
  *
  * <pre>
- * <code>
+ * {@code
  * for(int i=0; i &lt; 10;) {
  *     i++;
  * }
- * </code>
+ * }
  * </pre>
  *
  * <p>
@@ -85,11 +85,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <p>Example:</p>
  *
  * <pre>
- * <code>
+ * {@code
  * for (String line: lines) {
  *     line = line.trim();   // it will skip this violation
  * }
- * </code>
+ * }
  * </pre>
  *
  *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheck.java
@@ -23,7 +23,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
- * Check the number of nested <code>for</code> -statements. The maximum
+ * Check the number of nested {@code for} -statements. The maximum
  * number of nested layers can be configured. The default value is 1. Most of
  * the logic is implemented in the parent class. The code for the class is
  * copied from the NestedIfDepthCheck-class. The only difference is the

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
@@ -31,12 +31,12 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Checks that overload methods are grouped together. Example:
  * </p>
  * <pre>
- * <code>
+ * {@code
  * public void foo(int i) {}
  * public void foo(String s) {}
  * public void notFoo() {} // Have to be after foo(int i, String s)
  * public void foo(int i, String s) {}
- * </code>
+ * }
  * </pre>
  * <p>
  * An example of how to configure the check is:

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -34,7 +34,7 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractDeclarationCollector;
  * <pre>
  * &lt;module name=&quot;RequireThis&quot;/&gt;
  * </pre>
- * An example of how to configure to check <code>this</code> qualifier for
+ * An example of how to configure to check {@code this} qualifier for
  * methods only:
  * <pre>
  * &lt;module name=&quot;RequireThis&quot;&gt;
@@ -49,7 +49,7 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractDeclarationCollector;
  * Non-static methods invoked on either this or a variable name seem to be
  * OK, likewise.</p>
  * <p>Much of the code for this check was cribbed from Rick Giles's
- * <code>HiddenFieldCheck</code>.</p>
+ * {@code HiddenFieldCheck}.</p>
  *
  * @author Stephen Bloch
  * @author o_sukhodolsky
@@ -126,7 +126,7 @@ public class RequireThisCheck extends AbstractDeclarationCollector {
 
     /**
      * Checks if a given IDENT is method call or field name which
-     * require explicit <code>this</code> qualifier.
+     * require explicit {@code this} qualifier.
      *
      * @param ast IDENT to check.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
@@ -29,7 +29,7 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractFormatCheck;
 /**
  * <p>
  * Restricts the number of return statements in methods, constructors and lambda expressions
- * (2 by default). Ignores specified methods (<code>equals()</code> by default).
+ * (2 by default). Ignores specified methods ({@code equals()} by default).
  * </p>
  * <p>
  * Rationale: Too many return points can be indication that code is

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.java
@@ -26,7 +26,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 /**
  * <p>
  * Checks for overly complicated boolean expressions. Currently finds code like
- * <code>if (b == true)</code>, <code>b || true</code>, <code>!false</code>,
+ * {@code if (b == true)}, {@code b || true}, {@code !false},
  * etc.
  * </p>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
@@ -93,7 +93,7 @@ public class SimplifyBooleanReturnCheck
      * Returns if an AST is a return statment with a boolean literal
      * or a compound statement that contains only such a return statement.
      *
-     * Returns <code>true</code> iff ast represents
+     * Returns {@code true} iff ast represents
      * <br/>
      * <pre>
      * return true/false;
@@ -121,7 +121,7 @@ public class SimplifyBooleanReturnCheck
     /**
      * Returns if an AST is a return statment with a boolean literal.
      *
-     * Returns <code>true</code> iff ast represents
+     * Returns {@code true} iff ast represents
      * <br/>
      * <pre>
      * return true/false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -27,12 +27,12 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * <p>Checks that string literals are not used with
- * <code>==</code> or <code>&#33;=</code>.
+ * {@code ==} or {@code &#33;=}.
  * </p>
  * <p>
  * Rationale: Novice Java programmers often use code like
- * <code>if (x == &quot;something&quot;)</code> when they mean
- * <code>if (&quot;something&quot;.equals(x))</code>.
+ * {@code if (x == &quot;something&quot;)} when they mean
+ * {@code if (&quot;something&quot;.equals(x))}.
  * </p>
  *
  * @author Lars K&uuml;hne

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -44,7 +44,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *     int x = (a + b) + c;</pre>
  * <p>
  * In the above case, given that <em>a</em>, <em>b</em>, and <em>c</em> are
- * all <code>int</code> variables, the parentheses around <code>a + b</code>
+ * all {@code int} variables, the parentheses around {@code a + b}
  * are not needed.
  * </p>
  *
@@ -271,13 +271,13 @@ public class UnnecessaryParenthesesCheck extends Check {
     }
 
     /**
-     * Tests if the given <code>DetailAST</code> is surrounded by parentheses.
-     * In short, does <code>ast</code> have a previous sibling whose type is
-     * <code>TokenTypes.LPAREN</code> and a next sibling whose type is <code>
-     * TokenTypes.RPAREN</code>.
-     * @param ast the <code>DetailAST</code> to check if it is surrounded by
+     * Tests if the given {@code DetailAST} is surrounded by parentheses.
+     * In short, does {@code ast} have a previous sibling whose type is
+     * {@code TokenTypes.LPAREN} and a next sibling whose type is {@code
+     * TokenTypes.RPAREN}.
+     * @param ast the {@code DetailAST} to check if it is surrounded by
      *        parentheses.
-     * @return <code>true</code> if <code>ast</code> is surrounded by
+     * @return {@code true} if {@code ast} is surrounded by
      *         parentheses.
      */
     private static boolean isSurrounded(DetailAST ast) {
@@ -289,9 +289,9 @@ public class UnnecessaryParenthesesCheck extends Check {
 
     /**
      * Tests if the given expression node is surrounded by parentheses.
-     * @param ast a <code>DetailAST</code> whose type is
-     *        <code>TokenTypes.EXPR</code>.
-     * @return <code>true</code> if the expression is surrounded by
+     * @param ast a {@code DetailAST} whose type is
+     *        {@code TokenTypes.EXPR}.
+     * @return {@code true} if the expression is surrounded by
      *         parentheses.
      */
     private static boolean isExprSurrounded(DetailAST ast) {
@@ -302,8 +302,8 @@ public class UnnecessaryParenthesesCheck extends Check {
      * Check if the given token type can be found in an array of token types.
      * @param type the token type.
      * @param tokens an array of token types to search.
-     * @return <code>true</code> if <code>type</code> was found in <code>
-     *         tokens</code>.
+     * @return {@code true} if {@code type} was found in {@code
+     *         tokens}.
      */
     private static boolean inTokenList(int type, int... tokens) {
         // NOTE: Given the small size of the two arrays searched, I'm not sure
@@ -318,12 +318,12 @@ public class UnnecessaryParenthesesCheck extends Check {
     }
 
     /**
-     * Returns the specified string chopped to <code>MAX_QUOTED_LENGTH</code>
-     * plus an ellipsis (...) if the length of the string exceeds <code>
-     * MAX_QUOTED_LENGTH</code>.
+     * Returns the specified string chopped to {@code MAX_QUOTED_LENGTH}
+     * plus an ellipsis (...) if the length of the string exceeds {@code
+     * MAX_QUOTED_LENGTH}.
      * @param value the string to potentially chop.
-     * @return the chopped string if <code>string</code> is longer than
-     *         <code>MAX_QUOTED_LENGTH</code>; otherwise <code>string</code>.
+     * @return the chopped string if {@code string} is longer than
+     *         {@code MAX_QUOTED_LENGTH}; otherwise {@code string}.
      */
     private static String chopString(String value) {
         if (value.length() > MAX_QUOTED_LENGTH) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -40,20 +40,20 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  * Example #1:
  * <pre>
- *      <code>int count;
+ *      {@code int count;
  *      a = a + b;
  *      b = a + a;
  *      count = b; // DECLARATION OF VARIABLE 'count'
- *                 // SHOULD BE HERE (distance = 3)</code>
+ *                 // SHOULD BE HERE (distance = 3)}
  * </pre>
  * Example #2:
  * <pre>
- *     <code>int count;
+ *     {@code int count;
  *     {
  *         a = a + b;
  *         count = b; // DECLARATION OF VARIABLE 'count'
  *                    // SHOULD BE HERE (distance = 2)
- *     }</code>
+ *     }}
  * </pre>
  *
  * <p>
@@ -105,7 +105,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * ATTENTION!! (Not supported cases)
  * <pre>
  * Case #1:
- * <code>{
+ * {@code {
  * int c;
  * int a = 3;
  * int b = 2;
@@ -113,7 +113,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *     a = a + b;
  *     c = b;
  *     }
- * }</code>
+ * }}
  *
  * Distance for variable 'a' = 1;
  * Distance for variable 'b' = 1;
@@ -123,7 +123,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * and 'b' to move them into the block.
  * <pre>
  * Case #2:
- * <code>int sum = 0;
+ * {@code int sum = 0;
  * for (int i = 0; i &lt; 20; i++) {
  *     a++;
  *     b--;
@@ -131,7 +131,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *     if (sum &gt; 10) {
  *         res = true;
  *     }
- * }</code>
+ * }}
  * Distance for variable 'sum' = 3.
  * </pre>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheck.java
@@ -35,7 +35,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * <p>
  * The check can be configured to also disallow marker interfaces like
- * <code>java.io.Serializable</code>, that do not contain methods or
+ * {@code java.io.Serializable}, that do not contain methods or
  * constants at all.
  * </p>
  *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
@@ -64,7 +64,7 @@ public final class MutableExceptionCheck extends AbstractFormatCheck {
 
     /**
      * Sets the format of extended class name to the specified regular expression.
-     * @param extendedClassNameFormat a <code>String</code> value
+     * @param extendedClassNameFormat a {@code String} value
      */
     public void setExtendedClassNameFormat(String extendedClassNameFormat) {
         this.extendedClassNameFormat = extendedClassNameFormat;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheck.java
@@ -40,7 +40,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <p>
  * An example of code with violations:
  * </p>
- * <pre><code>
+ * <pre>{@code
  * public class Foo{
  *     //methods
  * }
@@ -48,11 +48,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * class Foo2{
  *     //methods
  * }
- * </code></pre>
+ * }</pre>
  * <p>
  * An example of code without top-level public type:
  * </p>
- * <pre><code>
+ * <pre>{@code
  * class Foo{ //top-level class
  *     //methods
  * }
@@ -60,7 +60,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * class Foo2{
  *     //methods
  * }
- * </code></pre>
+ * }</pre>
  * <p>
  * An example of check's configuration:
  * </p>
@@ -71,11 +71,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <p>
  * An example of code without violations:
  * </p>
- * <pre><code>
+ * <pre>{@code
  * public class Foo{
  *     //methods
  * }
- * </code></pre>
+ * }</pre>
  *
  * <p> ATTENTION: This Check does not support customization of validated tokens,
  *  so do not use the "tokens" property.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -64,9 +64,9 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  *
  * <pre>
- * <code> @org.junit.Rule
+ * {@code @org.junit.Rule
  * public TemporaryFolder publicJUnitRule = new TemporaryFolder();
- * </code>
+ * }
  * </pre>
  *
  * <p>
@@ -133,7 +133,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  *
  * <pre>
- * <code>
+ * {@code
  * public final class ImmutableClass
  * {
  *     public final int intValue; // No warning
@@ -148,7 +148,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *         this.notes = notes;
  *     }
  * }
- * </code>
+ * }
  * </pre>
  *
  * <p>
@@ -163,7 +163,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  *
  * <pre>
- * <code>
+ * {@code
  * public final class ImmutableClass
  * {
  *     public final ImmutableSet&lt;String&gt; includes; // No warning
@@ -179,7 +179,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *         this.notes = notes;
  *     }
  * }
- * </code>
+ * }
  * </pre>
  *
  * <p>
@@ -195,12 +195,12 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  *
  * <pre>
- * <code> @com.annotation.CustomAnnotation
+ * {@code @com.annotation.CustomAnnotation
  * String customAnnotated; // No warning
- * </code>
- * <code> @CustomAnnotation
+ * }
+ * {@code @CustomAnnotation
  * String shortCustomAnnotated; // No warning
- * </code>
+ * }
  * </pre>
  *
  * <p>
@@ -216,16 +216,16 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  *
  * <pre>
- * <code> @CustomAnnotation
+ * {@code @CustomAnnotation
  * String customAnnotated; // No warning
- * </code>
- * <code> @com.annotation.CustomAnnotation
+ * }
+ * {@code @com.annotation.CustomAnnotation
  * String customAnnotated1; // No warning
- * </code>
- * <code> @mypackage.annotation.CustomAnnotation
+ * }
+ * {@code @mypackage.annotation.CustomAnnotation
  * String customAnnotatedAnotherPackage; // another package but short name matches
  *                                       // so no violation
- * </code>
+ * }
  * </pre>
  *
  *
@@ -494,9 +494,9 @@ public class VisibilityModifierCheck
     /**
      * Checks if current import is star import. E.g.:
      * <p>
-     * <code>
+     * {@code
      * import java.util.*;
-     * </code>
+     * }
      * </p>
      * @param importAst {@link TokenTypes#IMPORT Import}
      * @return true if it is star import

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
@@ -53,7 +53,7 @@ public class HeaderCheck extends AbstractHeaderCheck {
 
     /**
      * @param lineNo a line number
-     * @return if <code>lineNo</code> is one of the ignored header lines.
+     * @return if {@code lineNo} is one of the ignored header lines.
      */
     private boolean isIgnoreLine(int lineNo) {
         return Arrays.binarySearch(ignoreLines, lineNo) >= 0;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -119,7 +119,7 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck {
 
     /**
      * @param lineNo a line number
-     * @return if <code>lineNo</code> is one of the repeat header lines.
+     * @return if {@code lineNo} is one of the repeat header lines.
      */
     private boolean isMultiLine(int lineNo) {
         return Arrays.binarySearch(multiLines, lineNo + 1) >= 0;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -49,7 +49,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  *
  * <pre>
- * <code>
+ * {@code
  * package java.util.concurrent.locks;
  *
  * import java.io.File;
@@ -61,7 +61,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * import java.util.concurrent.locks.LockSupport; //#6
  * import java.util.regex.Pattern; //#7
  * import java.util.regex.Matcher; //#8
- * </code>
+ * }
  * </pre>
  *
  * <p>
@@ -133,7 +133,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *          <li>groups are separated by, at least, one blank line</li>
  *        </ul>
  * <pre>
- *        <code>
+ *        {@code
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
  *    &lt;property name=&quot;customImportOrderRules&quot;
  *        value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS&quot;/&gt;
@@ -141,7 +141,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *    &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
  *    &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
- *        </code>
+ *        }
  * </pre>
  *
  *        <p>To configure the check so that it matches default IntelliJ IDEA formatter
@@ -161,7 +161,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *        </p>
  *
  * <pre>
- *        <code>
+ *        {@code
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
  *    &lt;property name=&quot;customImportOrderRules&quot;
  *        value=&quot;THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE
@@ -171,7 +171,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *    &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
  *    &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;false&quot;/&gt;
  *&lt;/module&gt;
- *        </code>
+ *        }
  * </pre>
  *
  * <p>To configure the check so that it matches default NetBeans formatter
@@ -182,20 +182,20 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *     <li>static imports are not separated, they will be sorted along with other imports</li>
  * </ul>
  *
- *        <code>
+ *        {@code
  *&lt;module name=&quot;CustomImportOrder&quot;/&gt;
- *        </code>
+ *        }
  * <p>To set RegExps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
  *         thirdPartyPackageRegExp and standardPackageRegExp options.</p>
  * <pre>
- * <code>
+ * {@code
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
  *    &lt;property name=&quot;customImportOrderRules&quot;
  *    value=&quot;STATIC###SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE&quot;/&gt;
  *    &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;com|org&quot;/&gt;
  *    &lt;property name=&quot;standardPackageRegExp&quot; value=&quot;^(java|javax)\.&quot;/&gt;
  * &lt;/module&gt;
- * </code>
+ * }
  * </pre>
  * <p>
  * Also, this check can be configured to force empty line separator between
@@ -203,11 +203,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  *
  * <pre>
- * <code>
+ * {@code
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
  *    &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
- * </code>
+ * }
  * </pre>
  * <p>
  * It is possible to enforce
@@ -215,27 +215,27 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * of imports in groups using the following configuration:
  * </p>
  * <pre>
- * <code>&lt;module name=&quot;CustomImportOrder&quot;&gt;
+ * {@code &lt;module name=&quot;CustomImportOrder&quot;&gt;
  *    &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
- * </code>
+ * }
  * </pre>
  * <p>
  * Example of ASCII order:
  * </p>
  * <pre>
- * <code>import java.awt.Dialog;
+ * {@code import java.awt.Dialog;
  * import java.awt.Window;
  * import java.awt.color.ColorSpace;
  * import java.awt.Frame; // violation here - in ASCII order 'F' should go before 'c',
- *                        // as all uppercase come before lowercase letters</code>
+ *                        // as all uppercase come before lowercase letters}
  * </pre>
  * <p>
  * To force checking imports sequence such as:
  * </p>
  *
  * <pre>
- * <code>
+ * {@code
  * package com.puppycrawl.tools.checkstyle.imports;
  *
  * import com.google.common.annotations.GwtCompatible;
@@ -248,16 +248,16 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * import com.google.common.annotations.GwtCompatible; // violation here - should be in the
  *                                                     // THIRD_PARTY_PACKAGE group
- * import android.*;</code>
+ * import android.*;}
  * </pre>
  * configure as follows:
  * <pre>
- * <code>
+ * {@code
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
  *    &lt;property name=&quot;customImportOrderRules&quot;
  *    value=&quot;SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STATIC###SPECIAL_IMPORTS&quot;/&gt;
  *    &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;android.*&quot;/&gt;
- * &lt;/module&gt;</code>
+ * &lt;/module&gt;}
  * </pre>
  *
  * @author maxvetrenko

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
@@ -27,8 +27,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 /**
  * <p>
  * Checks for imports from a set of illegal packages.
- * By default, the check rejects all <code>sun.*</code> packages
- * since programs that contain direct calls to the <code>sun.*</code> packages
+ * By default, the check rejects all {@code sun.*} packages
+ * since programs that contain direct calls to the {@code sun.*} packages
  * are <a href="http://www.oracle.com/technetwork/java/faq-sun-packages-142232.html">
  * not 100% Pure Java</a>.
  * </p>
@@ -44,7 +44,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </pre>
  * <p>
  * An example of how to configure the check so that it rejects packages
- * <code>java.io.*</code> and <code>java.sql.*</code> is
+ * {@code java.io.*} and {@code java.sql.*} is
  * </p>
  * <pre>
  * &lt;module name="IllegalImport"&gt;
@@ -115,7 +115,7 @@ public class IllegalImportCheck
     /**
      * Checks if an import is from a package that must not be used.
      * @param importText the argument of the import keyword
-     * @return if <code>importText</code> contains an illegal package prefix
+     * @return if {@code importText} contains an illegal package prefix
      */
     private boolean isIllegalImport(String importText) {
         for (String element : illegalPkgs) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -156,7 +156,7 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractOptionCheck;
  * </p>
  *
  * <pre>
- * <code>
+ * {@code
  * import static java.lang.Math.abs;
  * import static org.abego.treelayout.Configuration.AlignmentInLevel; // OK, alphabetical order
  *
@@ -165,7 +165,7 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractOptionCheck;
  * import java.util.Set;
  *
  * public class SomeClass { ... }
- * </code>
+ * }
  * </pre>
  *
  *
@@ -505,9 +505,9 @@ public class ImportOrderCheck
      *            the second string.
      * @param caseSensitive
      *            whether the comparison is case sensitive.
-     * @return the value <code>0</code> if string1 is equal to string2; a value
-     *         less than <code>0</code> if string1 is lexicographically less
-     *         than the string2; and a value greater than <code>0</code> if
+     * @return the value {@code 0} if string1 is equal to string2; a value
+     *         less than {@code 0} if string1 is lexicographically less
+     *         than the string2; and a value greater than {@code 0} if
      *         string1 is lexicographically greater than string2.
      */
     private static int compare(String string1, String string2,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
@@ -35,8 +35,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *<ul>
  *  <li>It is a duplicate of another import. This is, when a class is imported
  *  more than once.</li>
- *  <li>The class non-statically imported is from the <code>java.lang</code>
- *  package. For example importing <code>java.lang.String</code>.</li>
+ *  <li>The class non-statically imported is from the {@code java.lang}
+ *  package. For example importing {@code java.lang.String}.</li>
  *  <li>The class non-statically imported is from the same package as the
  *  current package.</li>
  *</ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -57,7 +57,7 @@ public abstract class AbstractExpressionHandler {
     public static final String MSG_CHILD_ERROR_MULTI = "indentation.child.error.multi";
 
     /**
-     * The instance of <code>IndentationCheck</code> using this handler.
+     * The instance of {@code IndentationCheck} using this handler.
      */
     private final IndentationCheck indentCheck;
 
@@ -541,17 +541,17 @@ public abstract class AbstractExpressionHandler {
     }
 
     /**
-     * A shortcut for <code>IndentationCheck</code> property.
-     * @return value of basicOffset property of <code>IndentationCheck</code>
+     * A shortcut for {@code IndentationCheck} property.
+     * @return value of basicOffset property of {@code IndentationCheck}
      */
     protected final int getBasicOffset() {
         return getIndentCheck().getBasicOffset();
     }
 
     /**
-     * A shortcut for <code>IndentationCheck</code> property.
+     * A shortcut for {@code IndentationCheck} property.
      * @return value of braceAdjustment property
-     *         of <code>IndentationCheck</code>
+     *         of {@code IndentationCheck}
      */
     protected final int getBraceAdjustment() {
         return getIndentCheck().getBraceAdjustment();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
@@ -130,9 +130,9 @@ public class ArrayInitHandler extends BlockParentHandler {
     }
 
     /**
-     * A shortcut for <code>IndentationCheck</code> property.
+     * A shortcut for {@code IndentationCheck} property.
      * @return value of lineWrappingIndentation property
-     *         of <code>IndentationCheck</code>
+     *         of {@code IndentationCheck}
      */
     private int getLineWrappingIndent() {
         return getIndentCheck().getLineWrappingIndentation();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -311,9 +311,9 @@ public class BlockParentHandler extends AbstractExpressionHandler {
     }
 
     /**
-     * A shortcut for <code>IndentationCheck</code> property.
+     * A shortcut for {@code IndentationCheck} property.
      * @return value of lineWrappingIndentation property
-     *         of <code>IndentationCheck</code>
+     *         of {@code IndentationCheck}
      */
     private int getLineWrappingIndent() {
         return getIndentCheck().getLineWrappingIndentation();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -39,10 +39,10 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  *
  * <pre>
- * <code>
+ * {@code
  * &lt;module name=&quot;CommentsIndentation&quot;/module&gt;
- * </code>
- * <code>
+ * }
+ * {@code
  * /*
  *  * comment
  *  * some comment
@@ -57,7 +57,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * String str = "";
  *     // some comment Comment has incorrect indentation level 8, expected 4.
  * String str1 = "";
- * </code>
+ * }
  * </pre>
  *
  *
@@ -123,12 +123,12 @@ public class CommentsIndentationCheck extends Check {
     /**
      * Checks single line comment indentations over surrounding code, e.g.:
      * <p>
-     * <code>
+     * {@code
      * // some comment - this is ok
      * double d = 3.14;
      *     // some comment - this is <b>not</b> ok.
      * double d1 = 5.0;
-     * </code>
+     * }
      * </p>
      * @param singleLineComment {@link TokenTypes#SINGLE_LINE_COMMENT single line comment}.
      */
@@ -194,7 +194,7 @@ public class CommentsIndentationCheck extends Check {
      * e.g.:
      * <p>
      * <pre>
-     * <code>
+     * {@code
      * // some comment - same indentation level
      * int x = 10;
      *     // some comment - different indentation level
@@ -203,7 +203,7 @@ public class CommentsIndentationCheck extends Check {
      *  *
      *  *&#47;
      *  boolean bool = true; - same indentation level
-     * </code>
+     * }
      * </pre>
      * </p>
      * @param singleLineComment {@link TokenTypes#SINGLE_LINE_COMMENT single line comment}.
@@ -243,12 +243,12 @@ public class CommentsIndentationCheck extends Check {
     /**
      * Checks comment block indentations over surrounding code, e.g.:
      * <p>
-     * <code>
+     * {@code
      * /* some comment *&#47; - this is ok
      * double d = 3.14;
      *     /* some comment *&#47; - this is <b>not</b> ok.
      * double d1 = 5.0;
-     * </code>
+     * }
      * </p>
      * @param blockComment {@link TokenTypes#BLOCK_COMMENT_BEGIN block comment begin}.
      */
@@ -269,10 +269,10 @@ public class CommentsIndentationCheck extends Check {
     /**
      * Checks if current comment block is trailing comment, e.g.:
      * <p>
-     * <code>
+     * {@code
      * double d = 3.14; /* some comment *&#47;
      * /* some comment *&#47; double d = 18.5;
-     * </code>
+     * }
      * </p>
      * @param blockComment {@link TokenTypes#BLOCK_COMMENT_BEGIN block comment begin}.
      * @return true if current comment block is trailing comment.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentLevel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentLevel.java
@@ -73,7 +73,7 @@ public class IndentLevel {
 
     /**
      * @param indent indentation to check.
-     * @return true if <code>indent</code> less then minimal of
+     * @return true if {@code indent} less then minimal of
      *         acceptable indentation levels, false otherwise.
      */
     public boolean greaterThan(int indent) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -38,7 +38,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 public class LineWrappingHandler {
 
     /**
-     * The current instance of <code>IndentationCheck</code> class using this
+     * The current instance of {@code IndentationCheck} class using this
      * handler. This field used to get access to private fields of
      * IndentationCheck instance.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
@@ -101,9 +101,9 @@ public class ObjectBlockHandler extends BlockParentHandler {
     }
 
     /**
-     * A shortcut for <code>IndentationCheck</code> property.
+     * A shortcut for {@code IndentationCheck} property.
      * @return value of lineWrappingIndentation property
-     *         of <code>IndentationCheck</code>
+     *         of {@code IndentationCheck}
      */
     private int getLineWrappingIndent() {
         return getIndentCheck().getLineWrappingIndentation();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java
@@ -75,7 +75,7 @@ class HtmlTag {
 
     /**
      * Indicates if this tag is a close (end) tag.
-     * @return <code>true</code> is this is a close tag.
+     * @return {@code true} is this is a close tag.
      */
     public boolean isCloseTag() {
         return position != text.length() - 1 && text.charAt(position + 1) == '/';
@@ -83,7 +83,7 @@ class HtmlTag {
 
     /**
      * Indicates if this tag is a self-closed XHTML style.
-     * @return <code>true</code> is this is a self-closed tag.
+     * @return {@code true} is this is a self-closed tag.
      */
     public boolean isClosedTag() {
         return closedTag;
@@ -91,7 +91,7 @@ class HtmlTag {
 
     /**
      * Indicates if this tag is incomplete (has no close &gt;).
-     * @return <code>true</code> if the tag is incomplete.
+     * @return {@code true} if the tag is incomplete.
      */
     public boolean isIncompleteTag() {
         return incomplete;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -243,7 +243,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     /**
      * Set the scope.
      *
-     * @param from a <code>String</code> value
+     * @param from a {@code String} value
      */
     public void setScope(String from) {
         scope = Scope.getInstance(from);
@@ -252,7 +252,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     /**
      * Set the excludeScope.
      *
-     * @param scope a <code>String</code> value
+     * @param scope a {@code String} value
      */
     public void setExcludeScope(String scope) {
         excludeScope = Scope.getInstance(scope);
@@ -262,7 +262,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * controls whether to allow documented exceptions that are not declared if
      * they are a subclass of java.lang.RuntimeException.
      *
-     * @param flag a <code>Boolean</code> value
+     * @param flag a {@code Boolean} value
      */
     public void setAllowUndeclaredRTE(boolean flag) {
         allowUndeclaredRTE = flag;
@@ -272,7 +272,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * controls whether to allow documented exception that are subclass of one
      * of declared exceptions.
      *
-     * @param flag a <code>Boolean</code> value
+     * @param flag a {@code Boolean} value
      */
     public void setAllowThrowsTagsForSubclasses(boolean flag) {
         allowThrowsTagsForSubclasses = flag;
@@ -282,7 +282,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * controls whether to allow a method which has parameters to omit matching
      * param tags in the javadoc. Defaults to false.
      *
-     * @param flag a <code>Boolean</code> value
+     * @param flag a {@code Boolean} value
      */
     public void setAllowMissingParamTags(boolean flag) {
         allowMissingParamTags = flag;
@@ -293,7 +293,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * exceptions to omit matching throws tags in the javadoc. Defaults to
      * false.
      *
-     * @param flag a <code>Boolean</code> value
+     * @param flag a {@code Boolean} value
      */
     public void setAllowMissingThrowsTags(boolean flag) {
         allowMissingThrowsTags = flag;
@@ -303,7 +303,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * controls whether to allow a method which returns non-void type to omit
      * the return tag in the javadoc. Defaults to false.
      *
-     * @param flag a <code>Boolean</code> value
+     * @param flag a {@code Boolean} value
      */
     public void setAllowMissingReturnTag(boolean flag) {
         allowMissingReturnTag = flag;
@@ -313,7 +313,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * Controls whether to ignore errors when there is no javadoc. Defaults to
      * false.
      *
-     * @param flag a <code>Boolean</code> value
+     * @param flag a {@code Boolean} value
      */
     public void setAllowMissingJavadoc(boolean flag) {
         allowMissingJavadoc = flag;
@@ -323,7 +323,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * Controls whether to ignore errors when there is no javadoc for a
      * property accessor (setter/getter methods). Defaults to false.
      *
-     * @param flag a <code>Boolean</code> value
+     * @param flag a {@code Boolean} value
      */
     public void setAllowMissingPropertyJavadoc(final boolean flag) {
         allowMissingPropertyJavadoc = flag;
@@ -426,9 +426,9 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * The JavadocMethodCheck is about to report a missing Javadoc.
      * This hook can be used by derived classes to allow a missing javadoc
      * in some situations.  The default implementation checks
-     * <code>allowMissingJavadoc</code> and
-     * <code>allowMissingPropertyJavadoc</code> properties, do not forget
-     * to call <code>super.isMissingJavadocAllowed(ast)</code> in case
+     * {@code allowMissingJavadoc} and
+     * {@code allowMissingPropertyJavadoc} properties, do not forget
+     * to call {@code super.isMissingJavadocAllowed(ast)} in case
      * you want to keep this logic.
      * @param ast the tree node for the method or constructor.
      * @return True if this method or constructor doesn't need Javadoc.
@@ -1023,7 +1023,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
         private final AbstractClassInfo classInfo;
 
         /**
-         * Creates new instance for <code>FullIdent</code>.
+         * Creates new instance for {@code FullIdent}.
          *
          * @param classInfo clas info
          */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -343,7 +343,7 @@ public class JavadocStyleCheck
      * primarily copied from the DocCheck checkHtml method.
      *
      * @param ast the node with the Javadoc
-     * @param comment the <code>TextBlock</code> which represents
+     * @param comment the {@code TextBlock} which represents
      *                 the Javadoc comment.
      */
     private void checkHtml(final DetailAST ast, final TextBlock comment) {
@@ -444,7 +444,7 @@ public class JavadocStyleCheck
      * Determines if the HtmlTag is one which does not require a close tag.
      *
      * @param tag the HtmlTag to check.
-     * @return <code>true</code> if the HtmlTag is a single tag.
+     * @return {@code true} if the HtmlTag is a single tag.
      */
     private static boolean isSingleTag(HtmlTag tag) {
         // If its a singleton tag (<p>, <br>, etc.), ignore it
@@ -458,7 +458,7 @@ public class JavadocStyleCheck
      * Determines if the HtmlTag is one which is allowed in a javadoc.
      *
      * @param tag the HtmlTag to check.
-     * @return <code>true</code> if the HtmlTag is an allowed html tag.
+     * @return {@code true} if the HtmlTag is an allowed html tag.
      */
     private static boolean isAllowedTag(HtmlTag tag) {
         return ALLOWED_TAGS.contains(tag.getId().toLowerCase(Locale.ENGLISH));
@@ -470,7 +470,7 @@ public class JavadocStyleCheck
      *
      * @param token an HTML tag id for which a close was found.
      * @param htmlStack a Stack of previous open HTML tags.
-     * @return <code>false</code> if a previous open tag was found
+     * @return {@code false} if a previous open tag was found
      *         for the token.
      */
     private static boolean isExtraHtml(String token, Deque<HtmlTag> htmlStack) {
@@ -499,7 +499,7 @@ public class JavadocStyleCheck
 
     /**
      * Set the excludeScope.
-     * @param scope a <code>String</code> value
+     * @param scope a {@code String} value
      */
     public void setExcludeScope(String scope) {
         excludeScope = Scope.getInstance(scope);
@@ -528,7 +528,7 @@ public class JavadocStyleCheck
     /**
      * Sets the flag that determines if the first sentence is checked for
      * proper end of sentence punctuation.
-     * @param flag <code>true</code> if the first sentence is to be checked
+     * @param flag {@code true} if the first sentence is to be checked
      */
     public void setCheckFirstSentence(boolean flag) {
         checkingFirstSentence = flag;
@@ -536,7 +536,7 @@ public class JavadocStyleCheck
 
     /**
      * Sets the flag that determines if HTML checking is to be performed.
-     * @param flag <code>true</code> if HTML checking is to be performed.
+     * @param flag {@code true} if HTML checking is to be performed.
      */
     public void setCheckHtml(boolean flag) {
         checkingHtml = flag;
@@ -544,7 +544,7 @@ public class JavadocStyleCheck
 
     /**
      * Sets the flag that determines if empty Javadoc checking should be done.
-     * @param flag <code>true</code> if empty Javadoc checking should be done.
+     * @param flag {@code true} if empty Javadoc checking should be done.
      */
     public void setCheckEmptyJavadoc(boolean flag) {
         checkingEmptyJavadoc = flag;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -112,7 +112,7 @@ public class JavadocTypeCheck
 
     /**
      * Set the excludeScope.
-     * @param scope a <code>String</code> value
+     * @param scope a {@code String} value
      */
     public void setExcludeScope(String scope) {
         excludeScope = Scope.getInstance(scope);
@@ -120,7 +120,7 @@ public class JavadocTypeCheck
 
     /**
      * Set the author tag pattern.
-     * @param format a <code>String</code> value
+     * @param format a {@code String} value
      */
     public void setAuthorFormat(String format) {
         authorFormat = format;
@@ -129,7 +129,7 @@ public class JavadocTypeCheck
 
     /**
      * Set the version format pattern.
-     * @param format a <code>String</code> value
+     * @param format a {@code String} value
      */
     public void setVersionFormat(String format) {
         versionFormat = format;
@@ -140,7 +140,7 @@ public class JavadocTypeCheck
      * Controls whether to allow a type which has type parameters to
      * omit matching param tags in the javadoc. Defaults to false.
      *
-     * @param flag a <code>Boolean</code> value
+     * @param flag a {@code Boolean} value
      */
     public void setAllowMissingParamTags(boolean flag) {
         allowMissingParamTags = flag;
@@ -148,7 +148,7 @@ public class JavadocTypeCheck
 
     /**
      * Controls whether to flag errors for unknown tags. Defaults to false.
-     * @param flag a <code>Boolean</code> value
+     * @param flag a {@code Boolean} value
      */
     public void setAllowUnknownTags(boolean flag) {
         allowUnknownTags = flag;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -63,7 +63,7 @@ public class JavadocVariableCheck
 
     /**
      * Set the excludeScope.
-     * @param scope a <code>String</code> value
+     * @param scope a {@code String} value
      */
     public void setExcludeScope(String scope) {
         excludeScope = Scope.getInstance(scope);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
@@ -24,14 +24,14 @@ import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 
 /**
  * Checks that the at-clause tag is followed by description .
- * Default configuration that will check <code>@param</code>, <code>@return</code>,
- * <code>@throws</code>, <code>@deprecated</code> to:
+ * Default configuration that will check {@code @param}, {@code @return},
+ * {@code @throws}, {@code @deprecated} to:
  * <pre>
  * &lt;module name=&quot;NonEmptyAtclauseDescription&quot;/&gt;
  * </pre>
  * <p>
- * To check non-empty at-clause description for tags <code>@throws</code>,
- * <code>@deprecated</code>, use following configuration:
+ * To check non-empty at-clause description for tags {@code @throws},
+ * {@code @deprecated}, use following configuration:
  * </p>
  * <pre>
  * &lt;module name=&quot;NonEmptyAtclauseDescription&quot;&gt;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
@@ -29,8 +29,8 @@ import com.google.common.collect.Lists;
  * from a single line of text. Just the beginning of the HTML tag
  * is located.  No attempt is made to parse out the complete tag,
  * particularly since some of the tag parameters could be located
- * on the following line of text.  The <code>hasNextTag</code> and
- * <code>nextTag</code> methods are used to iterate through the HTML
+ * on the following line of text.  The {@code hasNextTag} and
+ * {@code nextTag} methods are used to iterate through the HTML
  * tags or generic type identifiers that were found on the line of text.
  * </p>
  *
@@ -60,7 +60,7 @@ class TagParser {
 
     /**
      * Returns the next available HtmlTag.
-     * @return a HtmlTag or <code>null</code> if none available.
+     * @return a HtmlTag or {@code null} if none available.
      * @throws IndexOutOfBoundsException if there are no HtmlTags
      *         left to return.
      */
@@ -70,7 +70,7 @@ class TagParser {
 
     /**
      * Indicates if there are any more HtmlTag to retrieve.
-     * @return <code>true</code> if there are more tags.
+     * @return {@code true} if there are more tags.
      */
     public boolean hasNextTag() {
         return !tags.isEmpty();
@@ -133,7 +133,7 @@ class TagParser {
      * Checks if the given position is start one for HTML tag.
      * @param javadocText text of javadoc comments.
      * @param pos position to check.
-     * @return <code>true</code> some HTML tag starts from given position.
+     * @return {@code true} some HTML tag starts from given position.
      */
     private static boolean isTag(String[] javadocText, Point pos) {
         final int column = pos.getColumnNo() + 1;
@@ -182,7 +182,7 @@ class TagParser {
      * If this is a HTML-comments.
      * @param text text of javadoc comments
      * @param pos position to check
-     * @return <code>true</code> if HTML-comments
+     * @return {@code true} if HTML-comments
      *         starts form given position.
      */
     private static boolean isCommentTag(String[] text, Point pos) {
@@ -267,7 +267,7 @@ class TagParser {
         private final int column;
 
         /**
-         * Creates new <code>Point</code> instance.
+         * Creates new {@code Point} instance.
          * @param lineNo line number
          * @param columnNo column number
          */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
@@ -107,7 +107,7 @@ public class WriteTagCheck
 
     /**
      * Set the tag format.
-     * @param format a <code>String</code> value
+     * @param format a {@code String} value
      */
     public void setTagFormat(String format) {
         tagFormat = format;
@@ -116,7 +116,7 @@ public class WriteTagCheck
 
     /**
      * Sets the tag severity level.  The string should be one of the names
-     * defined in the <code>SeverityLevel</code> class.
+     * defined in the {@code SeverityLevel} class.
      *
      * @param severity  The new severity level
      * @see SeverityLevel

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -37,27 +37,27 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Google Style Guide</a> to get to know how to avoid long abbreviations in names.
  * </p>
  * <p>
- * Option <code>allowedAbbreviationLength</code> indicates on the allowed amount of capital
+ * Option {@code allowedAbbreviationLength} indicates on the allowed amount of capital
  * letters in abbreviations in the classes, interfaces,
  * variables and methods names. Default value is '3'.
  * </p>
  * <p>
- * Option <code>allowedAbbreviations</code> - list of abbreviations that
+ * Option {@code allowedAbbreviations} - list of abbreviations that
  * must be skipped for checking. Abbreviations should be separated by comma,
  * no spaces are allowed.
  * </p>
  * <p>
- * Option <code>ignoreFinal</code> allow to skip variables with <code>final</code> modifier.
- * Default value is <code>true</code>.
+ * Option {@code ignoreFinal} allow to skip variables with {@code final} modifier.
+ * Default value is {@code true}.
  * </p>
  * <p>
- * Option <code>ignoreStatic</code> allow to skip variables with <code>static</code> modifier.
- * Default value is <code>true</code>.
+ * Option {@code ignoreStatic} allow to skip variables with {@code static} modifier.
+ * Default value is {@code true}.
  * </p>
  * <p>
- * Option <code>ignoreOverriddenMethod</code> - Allows to
- * ignore methods tagged with <code>@Override</code> annotation
- * (that usually mean inherited name). Default value is <code>true</code>.
+ * Option {@code ignoreOverriddenMethod} - Allows to
+ * ignore methods tagged with {@code @Override} annotation
+ * (that usually mean inherited name). Default value is {@code true}.
  * </p>
  * Default configuration
  * <pre>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
@@ -26,7 +26,7 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractFormatCheck;
 /**
  * <p>
  * Ensures that the names of abstract classes conforming to some
- * regular expression and check that <code>abstract</code> modifier exists.
+ * regular expression and check that {@code abstract} modifier exists.
  * </p>
  * <p>
  * Rationale: Abstract classes are convenience base class

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractNameCheck.java
@@ -36,7 +36,7 @@ public abstract class AbstractNameCheck
     public static final String MSG_INVALID_PATTERN = "name.invalidPattern";
 
     /**
-     * Creates a new <code>AbstractNameCheck</code> instance.
+     * Creates a new {@code AbstractNameCheck} instance.
      * @param format format to check with
      */
     protected AbstractNameCheck(String format) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.java
@@ -36,7 +36,7 @@ public abstract class AbstractTypeParameterNameCheck
     extends AbstractNameCheck {
 
     /**
-     * Creates a new <code>AbstractTypeParameterNameCheck</code> instance.
+     * Creates a new {@code AbstractTypeParameterNameCheck} instance.
      * @param format format to check with
      */
     protected AbstractTypeParameterNameCheck(String format) {
@@ -68,8 +68,8 @@ public abstract class AbstractTypeParameterNameCheck
      * This method must be overriden to specify the
      * location of the type parameter to check.
      *
-     * @return <code> TokenTypes.CLASS_DEF </code>
-     * or <code> TokenTypes.METHOD_DEF </code>
+     * @return {@code TokenTypes.CLASS_DEF }
+     * or {@code TokenTypes.METHOD_DEF }
      */
     protected abstract int getLocation();
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ClassTypeParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ClassTypeParameterNameCheck.java
@@ -48,7 +48,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  */
 public class ClassTypeParameterNameCheck
     extends AbstractTypeParameterNameCheck {
-    /** Creates a new <code>ClassTypeParameterNameCheck</code> instance. */
+    /** Creates a new {@code ClassTypeParameterNameCheck} instance. */
     public ClassTypeParameterNameCheck() {
         super("^[A-Z]$");
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
@@ -55,7 +55,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  */
 public class ConstantNameCheck
     extends AbstractAccessControlNameCheck {
-    /** Creates a new <code>ConstantNameCheck</code> instance. */
+    /** Creates a new {@code ConstantNameCheck} instance. */
     public ConstantNameCheck() {
         super("^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$");
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/InterfaceTypeParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/InterfaceTypeParameterNameCheck.java
@@ -48,7 +48,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  */
 public class InterfaceTypeParameterNameCheck
     extends AbstractTypeParameterNameCheck {
-    /** Creates a new <code>InterfaceTypeParameterNameCheck</code> instance. */
+    /** Creates a new {@code InterfaceTypeParameterNameCheck} instance. */
     public InterfaceTypeParameterNameCheck() {
         super("^[A-Z]$");
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheck.java
@@ -51,7 +51,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  */
 public class LocalFinalVariableNameCheck
     extends AbstractNameCheck {
-    /** Creates a new <code>LocalFinalVariableNameCheck</code> instance. */
+    /** Creates a new {@code LocalFinalVariableNameCheck} instance. */
     public LocalFinalVariableNameCheck() {
         super("^[a-z][a-zA-Z0-9]*$");
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheck.java
@@ -81,7 +81,7 @@ public class LocalVariableNameCheck
      */
     private boolean allowOneCharVarInForLoop;
 
-    /** Creates a new <code>LocalVariableNameCheck</code> instance. */
+    /** Creates a new {@code LocalVariableNameCheck} instance. */
     public LocalVariableNameCheck() {
         super("^[a-z][a-zA-Z0-9]*$");
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheck.java
@@ -51,7 +51,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  */
 public class MemberNameCheck
     extends AbstractAccessControlNameCheck {
-    /** Creates a new <code>MemberNameCheck</code> instance. */
+    /** Creates a new {@code MemberNameCheck} instance. */
     public MemberNameCheck() {
         super("^[a-z][a-zA-Z0-9]*$");
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
@@ -93,7 +93,7 @@ public class MethodNameCheck
      */
     private boolean allowClassName;
 
-    /** Creates a new <code>MethodNameCheck</code> instance. */
+    /** Creates a new {@code MethodNameCheck} instance. */
     public MethodNameCheck() {
         super("^[a-z][a-zA-Z0-9]*$");
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodTypeParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodTypeParameterNameCheck.java
@@ -48,7 +48,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  */
 public class MethodTypeParameterNameCheck
     extends AbstractTypeParameterNameCheck {
-    /** Creates a new <code>MethodTypeParameterNameCheck</code> instance. */
+    /** Creates a new {@code MethodTypeParameterNameCheck} instance. */
     public MethodTypeParameterNameCheck() {
         super("^[A-Z]$");
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
@@ -49,7 +49,7 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractFormatCheck;
  * </pre>
  * <p>
  * An example of how to configure the check for package names that begin with
- * <code>com.puppycrawl.tools.checkstyle</code> is:
+ * {@code com.puppycrawl.tools.checkstyle} is:
  * </p>
  * <pre>
  * &lt;module name="PackageName"&gt;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -51,7 +51,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 public class ParameterNameCheck
     extends AbstractNameCheck {
     /**
-     * Creates a new <code>ParameterNameCheck</code> instance.
+     * Creates a new {@code ParameterNameCheck} instance.
      */
     public ParameterNameCheck() {
         super("^[a-z][a-zA-Z0-9]*$");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheck.java
@@ -49,7 +49,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  */
 public class StaticVariableNameCheck
     extends AbstractAccessControlNameCheck {
-    /** Creates a new <code>StaticVariableNameCheck</code> instance. */
+    /** Creates a new {@code StaticVariableNameCheck} instance. */
     public StaticVariableNameCheck() {
         super("^[a-z][a-zA-Z0-9]*$");
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java
@@ -54,7 +54,7 @@ public class TypeNameCheck
     public static final String DEFAULT_PATTERN = "^[A-Z][a-zA-Z0-9]*$";
 
     /**
-     * Creates a new <code>TypeNameCheck</code> instance.
+     * Creates a new {@code TypeNameCheck} instance.
      */
     public TypeNameCheck() {
         super(DEFAULT_PATTERN);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
@@ -52,7 +52,7 @@ public final class ExecutableStatementCountCheck
     /** Current method context. */
     private Context context;
 
-    /** Constructs a <code>ExecutableStatementCountCheck</code>. */
+    /** Constructs a {@code ExecutableStatementCountCheck}. */
     public ExecutableStatementCountCheck() {
         setMax(DEFAULT_MAX);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
@@ -91,7 +91,7 @@ public class LineLengthCheck extends Check {
     private Pattern ignorePattern;
 
     /**
-     * Creates a new <code>LineLengthCheck</code> instance.
+     * Creates a new {@code LineLengthCheck} instance.
      */
     public LineLengthCheck() {
         setIgnorePattern("^$");
@@ -127,7 +127,7 @@ public class LineLengthCheck extends Check {
 
     /**
      * Set the ignore pattern.
-     * @param format a <code>String</code> value
+     * @param format a {@code String} value
      */
     public final void setIgnorePattern(String format) {
         ignorePattern = Utils.createPattern(format);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
@@ -170,7 +170,7 @@ public final class MethodCountCheck extends Check {
     }
 
     /**
-     * Sets the maximum allowed <code>private</code> methods per type.
+     * Sets the maximum allowed {@code private} methods per type.
      * @param value the maximum allowed.
      */
     public void setMaxPrivate(int value) {
@@ -178,7 +178,7 @@ public final class MethodCountCheck extends Check {
     }
 
     /**
-     * Sets the maximum allowed <code>package</code> methods per type.
+     * Sets the maximum allowed {@code package} methods per type.
      * @param value the maximum allowed.
      */
     public void setMaxPackage(int value) {
@@ -186,7 +186,7 @@ public final class MethodCountCheck extends Check {
     }
 
     /**
-     * Sets the maximum allowed <code>protected</code> methods per type.
+     * Sets the maximum allowed {@code protected} methods per type.
      * @param value the maximum allowed.
      */
     public void setMaxProtected(int value) {
@@ -194,7 +194,7 @@ public final class MethodCountCheck extends Check {
     }
 
     /**
-     * Sets the maximum allowed <code>public</code> methods per type.
+     * Sets the maximum allowed {@code public} methods per type.
      * @param value the maximum allowed.
      */
     public void setMaxPublic(int value) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
@@ -51,14 +51,14 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </pre>
  * Java code that will be ignored:
  * <pre>
- * <code>
+ * {@code
  *
  *  &#064;Override
  *  public void needsLotsOfParameters(int a,
  *      int b, int c, int d, int e, int f, int g, int h) {
  *      ...
  *  }
- * </code>
+ * }
  * </pre>
  * @author Oliver Burn
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheck.java
@@ -33,12 +33,12 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <p class="body">
  *
  * Examples of line-wrapped statements (bad case):
- * <pre><code> package com.puppycrawl.
+ * <pre>{@code package com.puppycrawl.
  *    tools.checkstyle.checks;
  *
  * import com.puppycrawl.tools.
  *    checkstyle.api.Check;
- * </code></pre>
+ * }</pre>
  *
  * <p>
  * To configure the check to force no line-wrapping
@@ -59,8 +59,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </pre>
  *
  * Examples of not line-wrapped statements (good case):
- * <pre><code> import com.puppycrawl.tools.checkstyle.api.Check;
- * </code></pre>
+ * <pre>{@code import com.puppycrawl.tools.checkstyle.api.Check;
+ * }</pre>
  *
  * @author maxvetrenko
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -203,9 +203,9 @@ public class NoWhitespaceAfterCheck extends Check {
     /**
      * Gets array identifier, e.g.:
      * <p>
-     * <code>
+     * {@code
      * int[] someArray;
-     * </code>
+     * }
      * </p>
      * <p>
      * someArray is identifier.
@@ -262,14 +262,14 @@ public class NoWhitespaceAfterCheck extends Check {
     /**
      * Checks if current array is declared in C style, e.g.:
      * <p>
-     * <code>
+     * {@code
      * int array[] = { ... }; //C style
-     * </code>
+     * }
      * </p>
      * <p>
-     * <code>
+     * {@code
      * int[] array = { ... }; //Java style
-     * </code>
+     * }
      * </p>
      * @param arrayDeclaration {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR}
      * @return true if array is declared in C style

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -103,7 +103,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * For example:
  *
  *
- * <pre><code>
+ * <pre>{@code
  * public MyClass() {}      // empty constructor
  * public void func() {}    // empty method
  * public interface Foo {} // empty interface
@@ -114,7 +114,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * for (int i = 1; i &gt; 1; i++) {} // empty for loop
  * do {} while (i = 1); // empty do-while loop
  * public @interface Beta {} // empty annotation type
- * </code></pre>
+ * }</pre>
  *
  * <p>
  * To configure the check to allow empty method blocks use
@@ -479,11 +479,11 @@ public class WhitespaceAroundCheck extends Check {
     }
 
     /**
-     * Test if the given <code>DetailAST</code> is part of an allowed empty
+     * Test if the given {@code DetailAST} is part of an allowed empty
      * constructor (ctor) block.
-     * @param ast the <code>DetailAST</code> to test.
-     * @param parentType the token type of <code>ast</code>'s parent.
-     * @return <code>true</code> if <code>ast</code> makes up part of an
+     * @param ast the {@code DetailAST} to test.
+     * @param parentType the token type of {@code ast}'s parent.
+     * @return {@code true} if {@code ast} makes up part of an
      *         allowed empty constructor block.
      */
     private boolean isEmptyCtorBlock(DetailAST ast, int parentType) {
@@ -508,16 +508,16 @@ public class WhitespaceAroundCheck extends Check {
     }
 
     /**
-     * Test if the given <code>DetailAST</code> is part of an empty block.
+     * Test if the given {@code DetailAST} is part of an empty block.
      * An example empty block might look like the following
      * <p>
      * <pre>   class Foo {}</pre>
      * </p>
      *
-     * @param ast ast the <code>DetailAST</code> to test.
-     * @param parentType the token type of <code>ast</code>'s parent.
-     * @return <code>true</code> if <code>ast</code> makes up part of an
-     *         empty block contained under a <code>match</code> token type
+     * @param ast ast the {@code DetailAST} to test.
+     * @param parentType the token type of {@code ast}'s parent.
+     * @return {@code true} if {@code ast} makes up part of an
+     *         empty block contained under a {@code match} token type
      *         node.
      */
     private static boolean isEmptyType(DetailAST ast, int parentType) {
@@ -527,18 +527,18 @@ public class WhitespaceAroundCheck extends Check {
     }
 
     /**
-     * Tests if a given <code>DetailAST</code> is part of an empty block.
+     * Tests if a given {@code DetailAST} is part of an empty block.
      * An example empty block might look like the following
      * <p>
      * <pre>   public void myMethod(int val) {}</pre>
      * </p>
      * In the above, the method body is an empty block ("{}").
      *
-     * @param ast the <code>DetailAST</code> to test.
-     * @param parentType the token type of <code>ast</code>'s parent.
+     * @param ast the {@code DetailAST} to test.
+     * @param parentType the token type of {@code ast}'s parent.
      * @param match the parent token type we're looking to match.
-     * @return <code>true</code> if <code>ast</code> makes up part of an
-     *         empty block contained under a <code>match</code> token type
+     * @return {@code true} if {@code ast} makes up part of an
+     *         empty block contained under a {@code match} token type
      *         node.
      */
     private static boolean isEmptyBlock(DetailAST ast, int parentType, int match) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
@@ -48,8 +48,8 @@ public final class TokenTypesDoclet {
 
     /**
      * The doclet's starter method.
-     * @param root <code>RootDoc</code> given to the doclet
-     * @return true if the given <code>RootDoc</code> is processed.
+     * @param root {@code RootDoc} given to the doclet
+     * @return true if the given {@code RootDoc} is processed.
      * @exception FileNotFoundException will be thrown if the doclet
      *            will be unable to write to the specified file.
      * @exception UnsupportedEncodingException will be thrown if the doclet

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/CSVFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/CSVFilter.java
@@ -39,7 +39,7 @@ class CSVFilter implements IntFilter {
     private final Set<IntFilter> filters = Sets.newHashSet();
 
     /**
-     * Constructs a <code>CSVFilter</code> from a CSV, Comma-Separated Values,
+     * Constructs a {@code CSVFilter} from a CSV, Comma-Separated Values,
      * string. Each value is an integer, or a range of integers. A range of
      * integers is of the form integer-integer, such as 1-10.
      * Note: integers must be non-negative.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilter.java
@@ -33,7 +33,7 @@ class IntRangeFilter implements IntFilter {
     private final Integer upperBound;
 
     /**
-     * Constructs a <code>IntRangeFilter</code> with a
+     * Constructs a {@code IntRangeFilter} with a
      * lower bound and an upper bound for the range.
      * @param lowerBound the lower bound of the range.
      * @param upperBound the upper bound of the range.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
@@ -41,7 +41,7 @@ public class SeverityMatchFilter
 
     /**
      * Sets the severity level.  The string should be one of the names
-     * defined in the <code>SeverityLevel</code> class.
+     * defined in the {@code SeverityLevel} class.
      *
      * @param severity  The new severity level
      * @see SeverityLevel

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressElement.java
@@ -69,7 +69,7 @@ public class SuppressElement
     private String columnsCSV;
 
     /**
-     * Constructs a <code>SuppressElement</code> for a
+     * Constructs a {@code SuppressElement} for a
      * file name pattern. Must either call {@link #setColumns(String)} or
      * {@link #setModuleId(String)} before using this object.
      * @param files regular expression for names of filtered files.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -132,7 +132,7 @@ public class SuppressWithNearbyCommentFilter
 
     /**
      * Set the format for a comment that turns off reporting.
-     * @param format a <code>String</code> value.
+     * @param format a {@code String} value.
      * @throws ConversionException if unable to create Pattern object.
      */
     public final void setCommentFormat(String format) {
@@ -154,7 +154,7 @@ public class SuppressWithNearbyCommentFilter
 
     /**
      * Set the format for a check.
-     * @param format a <code>String</code> value
+     * @param format a {@code String} value
      */
     public final void setCheckFormat(String format) {
         checkFormat = format;
@@ -162,7 +162,7 @@ public class SuppressWithNearbyCommentFilter
 
     /**
      * Set the format for a message.
-     * @param format a <code>String</code> value
+     * @param format a {@code String} value
      */
     public void setMessageFormat(String format) {
         messageFormat = format;
@@ -170,7 +170,7 @@ public class SuppressWithNearbyCommentFilter
 
     /**
      * Set the format for the influence of this check.
-     * @param format a <code>String</code> value
+     * @param format a {@code String} value
      */
     public final void setInfluenceFormat(String format) {
         influenceFormat = format;
@@ -178,7 +178,7 @@ public class SuppressWithNearbyCommentFilter
 
     /**
      * Set whether to look in C++ comments.
-     * @param checkCPP <code>true</code> if C++ comments are checked.
+     * @param checkCPP {@code true} if C++ comments are checked.
      */
     public void setCheckCPP(boolean checkCPP) {
         this.checkCPP = checkCPP;
@@ -186,7 +186,7 @@ public class SuppressWithNearbyCommentFilter
 
     /**
      * Set whether to look in C comments.
-     * @param checkC <code>true</code> if C comments are checked.
+     * @param checkC {@code true} if C comments are checked.
      */
     public void setCheckC(boolean checkC) {
         this.checkC = checkC;
@@ -268,7 +268,7 @@ public class SuppressWithNearbyCommentFilter
     }
 
     /**
-     * Adds a comment suppression <code>Tag</code> to the list of all tags.
+     * Adds a comment suppression {@code Tag} to the list of all tags.
      * @param text the text of the tag.
      * @param line the line number of the tag.
      */
@@ -409,7 +409,7 @@ public class SuppressWithNearbyCommentFilter
         /**
          * Determines whether the source of an audit event
          * matches the text of this tag.
-         * @param event the <code>AuditEvent</code> to check.
+         * @param event the {@code AuditEvent} to check.
          * @return true if the source of event matches the text of this tag.
          */
         public boolean isMatch(AuditEvent event) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -118,7 +118,7 @@ public class SuppressionCommentFilter
 
     /**
      * Set the format for a comment that turns off reporting.
-     * @param format a <code>String</code> value.
+     * @param format a {@code String} value.
      * @throws ConversionException if unable to create Pattern object.
      */
     public final void setOffCommentFormat(String format) {
@@ -127,7 +127,7 @@ public class SuppressionCommentFilter
 
     /**
      * Set the format for a comment that turns on reporting.
-     * @param format a <code>String</code> value
+     * @param format a {@code String} value
      * @throws ConversionException if unable to create Pattern object.
      */
     public final void setOnCommentFormat(String format) {
@@ -149,7 +149,7 @@ public class SuppressionCommentFilter
 
     /**
      * Set the format for a check.
-     * @param format a <code>String</code> value
+     * @param format a {@code String} value
      */
     public final void setCheckFormat(String format) {
         checkFormat = format;
@@ -157,7 +157,7 @@ public class SuppressionCommentFilter
 
     /**
      * Set the format for a message.
-     * @param format a <code>String</code> value
+     * @param format a {@code String} value
      */
     public void setMessageFormat(String format) {
         messageFormat = format;
@@ -165,7 +165,7 @@ public class SuppressionCommentFilter
 
     /**
      * Set whether to look in C++ comments.
-     * @param checkCPP <code>true</code> if C++ comments are checked.
+     * @param checkCPP {@code true} if C++ comments are checked.
      */
     public void setCheckCPP(boolean checkCPP) {
         this.checkCPP = checkCPP;
@@ -173,7 +173,7 @@ public class SuppressionCommentFilter
 
     /**
      * Set whether to look in C comments.
-     * @param checkC <code>true</code> if C comments are checked.
+     * @param checkC {@code true} if C comments are checked.
      */
     public void setCheckC(boolean checkC) {
         this.checkC = checkC;
@@ -204,8 +204,8 @@ public class SuppressionCommentFilter
     /**
      * Finds the nearest comment text tag that matches an audit event.
      * The nearest tag is before the line and column of the event.
-     * @param event the <code>AuditEvent</code> to match.
-     * @return The <code>Tag</code> nearest event.
+     * @param event the {@code AuditEvent} to match.
+     * @return The {@code Tag} nearest event.
      */
     private Tag findNearestMatch(AuditEvent event) {
         Tag result = null;
@@ -279,11 +279,11 @@ public class SuppressionCommentFilter
     }
 
     /**
-     * Adds a <code>Tag</code> to the list of all tags.
+     * Adds a {@code Tag} to the list of all tags.
      * @param text the text of the tag.
      * @param line the line number of the tag.
      * @param column the column number of the tag.
-     * @param on <code>true</code> if the tag turns checkstyle reporting on.
+     * @param on {@code true} if the tag turns checkstyle reporting on.
      */
     private void addTag(String text, int line, int column, boolean on) {
         final Tag tag = new Tag(line, column, text, on, this);
@@ -320,7 +320,7 @@ public class SuppressionCommentFilter
          * @param line the line number.
          * @param column the column number.
          * @param text the text of the suppression.
-         * @param on <code>true</code> if the tag turns checkstyle reporting.
+         * @param on {@code true} if the tag turns checkstyle reporting.
          * @param filter the {@code SuppressionCommentFilter} with the context
          * @throws ConversionException if unable to parse expanded text.
          * on.
@@ -389,7 +389,7 @@ public class SuppressionCommentFilter
         /**
          * Determines whether the suppression turns checkstyle reporting on or
          * off.
-         * @return <code>true</code>if the suppression turns reporting on.
+         * @return {@code true}if the suppression turns reporting on.
          */
         public boolean isOn() {
             return on;
@@ -437,7 +437,7 @@ public class SuppressionCommentFilter
         /**
          * Determines whether the source of an audit event
          * matches the text of this tag.
-         * @param event the <code>AuditEvent</code> to check.
+         * @param event the {@code AuditEvent} to check.
          * @return true if the source of event matches the text of this tag.
          */
         public boolean isMatch(AuditEvent event) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -66,7 +66,7 @@ public final class SuppressionsLoader
     private final FilterSet filterChain = new FilterSet();
 
     /**
-     * Creates a new <code>SuppressionsLoader</code> instance.
+     * Creates a new {@code SuppressionsLoader} instance.
      * @throws ParserConfigurationException if an error occurs
      * @throws SAXException if an error occurs
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
@@ -53,7 +53,7 @@ import javax.swing.border.Border;
  * it the target component and a <tt>Listener</tt> to receive notification
  * when file(s) have been dropped. Here is an example:
  * <p/>
- * <code><pre>
+ * {@code <pre>
  *      JPanel myPanel = new JPanel();
  *      new FileDrop( myPanel, new FileDrop.Listener()
  *      {   public void filesDropped( java.io.File[] files )
@@ -62,7 +62,7 @@ import javax.swing.border.Border;
  *              ...
  *          }   // end filesDropped
  *      }); // end FileDrop.Listener
- * </pre></code>
+ * </pre>}
  * <p/>
  * You can specify the border that will appear when files are being dragged by
  * calling the constructor with a <tt>javax.swing.border.Border</tt>. Only

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
@@ -399,7 +399,7 @@ public class JTreeTable extends JTable {
         }
 
         /**
-         * This is overridden to set <code>updatingListSelectionModel</code>
+         * This is overridden to set {@code updatingListSelectionModel}
          * and message super. This is the only place DefaultTreeSelectionModel
          * alters the ListSelectionModel.
          */
@@ -431,7 +431,7 @@ public class JTreeTable extends JTable {
         }
 
         /**
-         * If <code>updatingListSelectionModel</code> is false, this will
+         * If {@code updatingListSelectionModel} is false, this will
          * reset the selected paths from the selected rows in the list
          * selection model.
          */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModel.java
@@ -63,27 +63,27 @@ public interface TreeTableModel extends TreeModel {
 
     /**
      * @param column the column number
-     * @return the name for column number <code>column</code>.
+     * @return the name for column number {@code column}.
      */
     String getColumnName(int column);
 
     /**
      * @param column the column number
-     * @return the type for column number <code>column</code>.
+     * @return the type for column number {@code column}.
      */
     Class<?> getColumnClass(int column);
 
     /**
      * @param node the node
      * @param column the column number
-     * @return the value to be displayed for node <code>node</code>,
-     * at column number <code>column</code>.
+     * @return the value to be displayed for node {@code node},
+     * at column number {@code column}.
      */
     Object getValueAt(Object node, int column);
 
     /**
-     * Indicates whether the the value for node <code>node</code>,
-     * at column number <code>column</code> is editable.
+     * Indicates whether the the value for node {@code node},
+     * at column number {@code column} is editable.
      *
      * @param node the node.
      * @param column the column number
@@ -92,8 +92,8 @@ public interface TreeTableModel extends TreeModel {
     boolean isCellEditable(Object node, int column);
 
     /**
-     * Sets the value for node <code>node</code>,
-     * at column number <code>column</code>.
+     * Sets the value for node {@code node},
+     * at column number {@code column}.
      *
      * @param aValue the value to set
      * @param node the node to set the value on


### PR DESCRIPTION
Fixes `HtmlTagCanBeJavadocTag` inspection violations.

Description:
>Reports use of `<code>` tags in Javadoc comments. Since JDK1.5 these constructs may be replaced with `{@code ...}` constructs. This allows the use of angle brackets (`<`, `>`) inside the comment, instead of HTML character entities.