### PR TITLE
Remove unnecessary @inheritDoc tags. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -57,14 +57,12 @@ public final class DefaultConfiguration implements Configuration {
         this.name = name;
     }
 
-    /** {@inheritDoc} */
     @Override
     public String[] getAttributeNames() {
         final Set<String> keySet = attributeMap.keySet();
         return keySet.toArray(new String[keySet.size()]);
     }
 
-    /** {@inheritDoc} */
     @Override
     public String getAttribute(String name) throws CheckstyleException {
         if (!attributeMap.containsKey(name)) {
@@ -74,14 +72,12 @@ public final class DefaultConfiguration implements Configuration {
         return attributeMap.get(name);
     }
 
-    /** {@inheritDoc} */
     @Override
     public Configuration[] getChildren() {
         return children.toArray(
             new Configuration[children.size()]);
     }
 
-    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultContext.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultContext.java
@@ -34,13 +34,11 @@ public final class DefaultContext implements Context {
     /** stores the context entries */
     private final Map<String, Object> entries = Maps.newHashMap();
 
-    /** {@inheritDoc} */
     @Override
     public Object get(String key) {
         return entries.get(key);
     }
 
-    /** {@inheritDoc} */
     @Override
     public ImmutableCollection<String> getAttributeNames() {
         return ImmutableList.copyOf(entries.keySet());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
@@ -94,7 +94,6 @@ public class DefaultLogger
     /**
      * Print an Emacs compliant line on the error stream.
      * If the column number is non zero, then also display it.
-     * @param evt {@inheritDoc}
      * @see AuditListener
      **/
     @Override
@@ -122,7 +121,6 @@ public class DefaultLogger
         }
     }
 
-    /** {@inheritDoc} */
     @Override
     public void addException(AuditEvent evt, Throwable throwable) {
         synchronized (errorWriter) {
@@ -131,25 +129,21 @@ public class DefaultLogger
         }
     }
 
-    /** {@inheritDoc} */
     @Override
     public void auditStarted(AuditEvent evt) {
         infoWriter.println("Starting audit...");
     }
 
-    /** {@inheritDoc} */
     @Override
     public void fileFinished(AuditEvent evt) {
         // No need to implement this method in this class
     }
 
-    /** {@inheritDoc} */
     @Override
     public void fileStarted(AuditEvent evt) {
         // No need to implement this method in this class
     }
 
-    /** {@inheritDoc} */
     @Override
     public void auditFinished(AuditEvent evt) {
         infoWriter.println("Audit done.");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
@@ -45,7 +45,6 @@ public final class PropertiesExpander
         this.properties.putAll(properties);
     }
 
-    /** {@inheritDoc} */
     @Override
     public String resolve(String propertyName) {
         return properties.getProperty(propertyName);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -80,7 +80,6 @@ public class XMLLogger
         writer = new PrintWriter(osw);
     }
 
-    /** {@inheritDoc} */
     @Override
     public void auditStarted(AuditEvent evt) {
         writer.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
@@ -93,7 +92,6 @@ public class XMLLogger
         writer.println("<checkstyle version=\"" + version + "\">");
     }
 
-    /** {@inheritDoc} */
     @Override
     public void auditFinished(AuditEvent evt) {
         writer.println("</checkstyle>");
@@ -105,19 +103,16 @@ public class XMLLogger
         }
     }
 
-    /** {@inheritDoc} */
     @Override
     public void fileStarted(AuditEvent evt) {
         writer.println("<file name=\"" + encode(evt.getFileName()) + "\">");
     }
 
-    /** {@inheritDoc} */
     @Override
     public void fileFinished(AuditEvent evt) {
         writer.println("</file>");
     }
 
-    /** {@inheritDoc} */
     @Override
     public void addError(AuditEvent evt) {
         if (evt.getSeverityLevel() != SeverityLevel.IGNORE) {
@@ -137,7 +132,6 @@ public class XMLLogger
         }
     }
 
-    /** {@inheritDoc} */
     @Override
     public void addException(AuditEvent evt, Throwable throwable) {
         final StringWriter sw = new StringWriter();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -51,25 +51,21 @@ public abstract class AbstractFileSetCheck
      */
     protected abstract void processFiltered(File file, List<String> lines);
 
-    /** {@inheritDoc} */
     @Override
     public void init() {
         // No code by default, should be overridden only by demand at subclasses
     }
 
-    /** {@inheritDoc} */
     @Override
     public void destroy() {
         // No code by default, should be overridden only by demand at subclasses
     }
 
-    /** {@inheritDoc} */
     @Override
     public void beginProcessing(String charset) {
         // No code by default, should be overridden only by demand at subclasses
     }
 
-    /** {@inheritDoc} */
     @Override
     public final SortedSet<LocalizedMessage> process(File file,
                                                    List<String> lines) {
@@ -81,13 +77,11 @@ public abstract class AbstractFileSetCheck
         return getMessageCollector().getMessages();
     }
 
-    /** {@inheritDoc} */
     @Override
     public void finishProcessing() {
         // No code by default, should be overridden only by demand at subclasses
     }
 
-    /** {@inheritDoc} */
     @Override
     public final void setMessageDispatcher(MessageDispatcher dispatcher) {
         this.dispatcher = dispatcher;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -115,8 +115,6 @@ public class AutomaticBean
      * is called for each {@link Configuration#getChildren child Configuration}
      * of <code>configuration</code>.
      *
-     * @param configuration {@inheritDoc}
-     * @throws CheckstyleException {@inheritDoc}
      * @see Configurable
      */
     @Override
@@ -189,8 +187,6 @@ public class AutomaticBean
 
     /**
      * Implements the Contextualizable interface using bean introspection.
-     * @param context {@inheritDoc}
-     * @throws CheckstyleException {@inheritDoc}
      * @see Contextualizable
      */
     @Override
@@ -246,7 +242,6 @@ public class AutomaticBean
      * with this characters.
      */
     private static class RelaxedStringArrayConverter implements Converter {
-        /** {@inheritDoc} */
         @SuppressWarnings({"unchecked", "rawtypes"})
         @Override
         public Object convert(Class type, Object value) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Comment.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Comment.java
@@ -57,37 +57,31 @@ public class Comment implements TextBlock {
         this.lastCol = lastCol;
     }
 
-    /** {@inheritDoc} */
     @Override
     public final String[] getText() {
         return text.clone();
     }
 
-    /** {@inheritDoc} */
     @Override
     public final int getStartLineNo() {
         return firstLine;
     }
 
-    /** {@inheritDoc} */
     @Override
     public final int getEndLineNo() {
         return lastLine;
     }
 
-    /** {@inheritDoc} */
     @Override
     public int getStartColNo() {
         return firstCol;
     }
 
-    /** {@inheritDoc} */
     @Override
     public int getEndColNo() {
         return lastCol;
     }
 
-    /** {@inheritDoc} */
     @Override
     public boolean intersects(int startLineNo, int startColNo,
                               int endLineNo, int endColNo) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -90,14 +90,12 @@ public final class FileContents implements CommentListener {
         this.text = new FileText(text);
     }
 
-    /** {@inheritDoc} */
     @Override
     public void reportSingleLineComment(String type, int startLineNo,
             int startColNo) {
         reportCppComment(startLineNo, startColNo);
     }
 
-    /** {@inheritDoc} */
     @Override
     public void reportBlockComment(String type, int startLineNo,
             int startColNo, int endLineNo, int endColNo) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FilterSet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FilterSet.java
@@ -82,7 +82,6 @@ public class FilterSet
         return Objects.hash(filters);
     }
 
-    /** {@inheritDoc} */
     @Override
     public boolean accept(AuditEvent event) {
         for (Filter filter : filters) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
@@ -67,7 +67,6 @@ public enum JavadocTagInfo {
      * {@code @author}.
      */
     AUTHOR("@author", "author", Type.BLOCK) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -83,7 +82,6 @@ public enum JavadocTagInfo {
      * {@code {@code}}.
      */
     CODE("{@code}", "code", Type.INLINE) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -96,7 +94,6 @@ public enum JavadocTagInfo {
      * {@code {@docRoot}}.
      */
     DOC_ROOT("{@docRoot}", "docRoot", Type.INLINE) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -109,7 +106,6 @@ public enum JavadocTagInfo {
      * {@code @deprecated}.
      */
     DEPRECATED("@deprecated", "deprecated", Type.BLOCK) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -122,7 +118,6 @@ public enum JavadocTagInfo {
      * {@code @exception}.
      */
     EXCEPTION("@exception", "exception", Type.BLOCK) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -134,7 +129,6 @@ public enum JavadocTagInfo {
      * {@code {@inheritDoc}}.
      */
     INHERIT_DOC("{@inheritDoc}", "inheritDoc", Type.INLINE) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -150,7 +144,6 @@ public enum JavadocTagInfo {
      * {@code {@link}}.
      */
     LINK("{@link}", "link", Type.INLINE) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -163,7 +156,6 @@ public enum JavadocTagInfo {
      * {@code {@linkplain}}.
      */
     LINKPLAIN("{@linkplain}", "linkplain", Type.INLINE) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -176,7 +168,6 @@ public enum JavadocTagInfo {
      * {@code {@literal}}.
      */
     LITERAL("{@literal}", "literal", Type.INLINE) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -189,7 +180,6 @@ public enum JavadocTagInfo {
      * {@code @param}.
      */
     PARAM("@param", "param", Type.BLOCK) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -204,7 +194,6 @@ public enum JavadocTagInfo {
      * {@code @return}.
      */
     RETURN("@return", "return", Type.BLOCK) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -220,7 +209,6 @@ public enum JavadocTagInfo {
      * {@code @see}.
      */
     SEE("@see", "see", Type.BLOCK) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -233,7 +221,6 @@ public enum JavadocTagInfo {
      * {@code @serial}.
      */
     SERIAL("@serial", "serial", Type.BLOCK) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -247,7 +234,6 @@ public enum JavadocTagInfo {
      * {@code @serialData}.
      */
     SERIAL_DATA("@serialData", "serialData", Type.BLOCK) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -268,7 +254,6 @@ public enum JavadocTagInfo {
      * {@code @serialField}.
      */
     SERIAL_FIELD("@serialField", "serialField", Type.BLOCK) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -284,7 +269,6 @@ public enum JavadocTagInfo {
      * {@code @since}.
      */
     SINCE("@since", "since", Type.BLOCK) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -297,7 +281,6 @@ public enum JavadocTagInfo {
      * {@code @throws}.
      */
     THROWS("@throws", "throws", Type.BLOCK) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -310,7 +293,6 @@ public enum JavadocTagInfo {
      * {@code {@value}}.
      */
     VALUE("{@value}", "value", Type.INLINE) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -323,7 +305,6 @@ public enum JavadocTagInfo {
      * {@code @version}.
      */
     VERSION("@version", "version", Type.BLOCK) {
-        /** {@inheritDoc} */
         @Override
         public boolean isValidOn(final DetailAST ast) {
             final int type = ast.getType();
@@ -500,9 +481,6 @@ public enum JavadocTagInfo {
         return NAME_TO_TAG.containsKey(name);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return "text [" + text + "] name [" + name

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
@@ -54,7 +54,6 @@ public class LineColumn implements Comparable<LineColumn> {
         return col;
     }
 
-    /** {@inheritDoc} */
     @Override
     public int compareTo(LineColumn lineColumn) {
         return getLine() != lineColumn.getLine()
@@ -62,7 +61,6 @@ public class LineColumn implements Comparable<LineColumn> {
             : Integer.compare(getColumn(), lineColumn.getColumn());
     }
 
-    /** {@inheritDoc} */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -76,7 +74,6 @@ public class LineColumn implements Comparable<LineColumn> {
                 && Objects.equals(col, lineColumn.col);
     }
 
-    /** {@inheritDoc} */
     @Override
     public int hashCode() {
         return Objects.hash(line, col);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -343,7 +343,6 @@ public final class LocalizedMessage
     // Interface Comparable methods
     ////////////////////////////////////////////////////////////////////////////
 
-    /** {@inheritDoc} */
     @Override
     public int compareTo(LocalizedMessage other) {
         if (getLineNo() == other.getLineNo()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounter.java
@@ -43,7 +43,6 @@ public final class SeverityLevelCounter implements AuditListener {
         this.level = level;
     }
 
-    /** {@inheritDoc} */
     @Override
     public void addError(AuditEvent evt) {
         if (level == evt.getSeverityLevel()) {
@@ -51,7 +50,6 @@ public final class SeverityLevelCounter implements AuditListener {
         }
     }
 
-    /** {@inheritDoc} */
     @Override
     public void addException(AuditEvent evt, Throwable throwable) {
         if (level == SeverityLevel.ERROR) {
@@ -59,25 +57,21 @@ public final class SeverityLevelCounter implements AuditListener {
         }
     }
 
-    /** {@inheritDoc} */
     @Override
     public void auditStarted(AuditEvent evt) {
         count = 0;
     }
 
-    /** {@inheritDoc} */
     @Override
     public void fileStarted(AuditEvent evt) {
         // No code by default, should be overridden only by demand at subclasses
     }
 
-    /** {@inheritDoc} */
     @Override
     public void auditFinished(AuditEvent evt) {
         // No code by default, should be overridden only by demand at subclasses
     }
 
-    /** {@inheritDoc} */
     @Override
     public void fileFinished(AuditEvent evt) {
         // No code by default, should be overridden only by demand at subclasses

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -222,13 +222,11 @@ public final class AnnotationUseStyleCheck extends Check {
         }
     }
 
-    /** {@inheritDoc} */
     @Override
     public int[] getDefaultTokens() {
         return getRequiredTokens();
     }
 
-    /** {@inheritDoc} */
     @Override
     public int[] getRequiredTokens() {
         return new int[] {
@@ -236,13 +234,11 @@ public final class AnnotationUseStyleCheck extends Check {
         };
     }
 
-    /** {@inheritDoc} */
     @Override
     public int[] getAcceptableTokens() {
         return getRequiredTokens();
     }
 
-    /** {@inheritDoc} */
     @Override
     public void visitToken(final DetailAST ast) {
         checkStyleType(ast);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
@@ -116,13 +116,11 @@ public final class MissingDeprecatedCheck extends Check {
     /** Multiline finished at next Javadoc * */
     private static final String NEXT_TAG = "@";
 
-    /** {@inheritDoc} */
     @Override
     public int[] getDefaultTokens() {
         return getAcceptableTokens();
     }
 
-    /** {@inheritDoc} */
     @Override
     public int[] getAcceptableTokens() {
         return new int[] {
@@ -138,7 +136,6 @@ public final class MissingDeprecatedCheck extends Check {
         };
     }
 
-    /** {@inheritDoc} */
     @Override
     public void visitToken(final DetailAST ast) {
         final TextBlock javadoc =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
@@ -122,26 +122,22 @@ public final class MissingOverrideCheck extends Check {
         javaFiveCompatibility = compatibility;
     }
 
-    /** {@inheritDoc} */
     @Override
     public int[] getDefaultTokens() {
         return getRequiredTokens();
     }
 
-    /** {@inheritDoc} */
     @Override
     public int[] getAcceptableTokens() {
         return getRequiredTokens();
     }
 
-    /** {@inheritDoc} */
     @Override
     public int[] getRequiredTokens() {
         return new int[]
         {TokenTypes.METHOD_DEF, };
     }
 
-    /** {@inheritDoc} */
     @Override
     public void visitToken(final DetailAST ast) {
         final TextBlock javadoc =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheck.java
@@ -46,13 +46,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  */
 public class PackageAnnotationCheck extends Check {
 
-    /** {@inheritDoc} */
     @Override
     public int[] getDefaultTokens() {
         return getRequiredTokens();
     }
 
-    /** {@inheritDoc} */
     @Override
     public int[] getRequiredTokens() {
         return new int[] {
@@ -60,13 +58,11 @@ public class PackageAnnotationCheck extends Check {
         };
     }
 
-    /** {@inheritDoc} */
     @Override
     public int[] getAcceptableTokens() {
         return getRequiredTokens();
     }
 
-    /** {@inheritDoc} */
     @Override
     public void visitToken(final DetailAST ast) {
         final boolean containsAnnotation =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -115,13 +115,11 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
         super("^$|^\\s+$");
     }
 
-    /** {@inheritDoc} */
     @Override
     public final int[] getDefaultTokens() {
         return getAcceptableTokens();
     }
 
-    /** {@inheritDoc} */
     @Override
     public final int[] getAcceptableTokens() {
         return new int[] {
@@ -138,7 +136,6 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
         };
     }
 
-    /** {@inheritDoc} */
     @Override
     public void visitToken(final DetailAST ast) {
         final DetailAST annotation = getSuppressWarnings(ast);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java
@@ -60,7 +60,6 @@ public class TypeNameCheck
         super(DEFAULT_PATTERN);
     }
 
-    /** {@inheritDoc} */
     @Override
     public int[] getDefaultTokens() {
         return new int[] {TokenTypes.CLASS_DEF,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/CommentSuppressor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/CommentSuppressor.java
@@ -30,7 +30,6 @@ class CommentSuppressor implements MatchSuppressor {
     /** File contents to check for comments. */
     private FileContents currentContents;
 
-    /** {@inheritDoc} */
     @Override
     public boolean shouldSuppress(int startLineNo, int startColNo,
             int endLineNo, int endColNo) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/NeverSuppress.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/NeverSuppress.java
@@ -32,7 +32,6 @@ public final class NeverSuppress implements MatchSuppressor {
     private NeverSuppress() {
     }
 
-    /** {@inheritDoc} */
     @Override
     public boolean shouldSuppress(int startLineNo, int startColNo,
             int endLineNo, int endColNo) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilter.java
@@ -35,7 +35,6 @@ class IntMatchFilter implements IntFilter {
         this.matchValue = matchValue;
     }
 
-    /** {@inheritDoc} */
     @Override
     public boolean accept(int intValue) {
         return matchValue == intValue;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilter.java
@@ -43,7 +43,6 @@ class IntRangeFilter implements IntFilter {
         this.upperBound = upperBound;
     }
 
-    /** {@inheritDoc} */
     @Override
     public boolean accept(int intValue) {
         return lowerBound.compareTo(intValue) <= 0

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
@@ -59,7 +59,6 @@ public class SeverityMatchFilter
         this.acceptOnMatch = acceptOnMatch;
     }
 
-    /** {@inheritDoc} */
     @Override
     public boolean accept(AuditEvent event) {
         final boolean result = severityLevel == event.getSeverityLevel();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressElement.java
@@ -125,7 +125,6 @@ public class SuppressElement
         }
     }
 
-    /** {@inheritDoc} */
     @Override
     public boolean accept(AuditEvent event) {
         // reject if file or check module mismatch?

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilter.java
@@ -32,7 +32,6 @@ import com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder;
 public class SuppressWarningsFilter
     extends AutomaticBean
     implements Filter {
-    /** {@inheritDoc} */
     @Override
     public boolean accept(AuditEvent event) {
         return !SuppressWarningsHolder.isSuppressed(event.getSourceName(),

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -192,7 +192,6 @@ public class SuppressWithNearbyCommentFilter
         this.checkC = checkC;
     }
 
-    /** {@inheritDoc} */
     @Override
     public boolean accept(AuditEvent event) {
         if (event.getLocalizedMessage() == null) {
@@ -383,7 +382,6 @@ public class SuppressWithNearbyCommentFilter
             return Integer.compare(firstLine, other.firstLine);
         }
 
-        /** {@inheritDoc} */
         @Override
         public boolean equals(Object o) {
             if (this == o) {
@@ -400,7 +398,6 @@ public class SuppressWithNearbyCommentFilter
                     && Objects.equals(tagMessageRegexp, tag.tagMessageRegexp);
         }
 
-        /** {@inheritDoc} */
         @Override
         public int hashCode() {
             return Objects.hash(text, firstLine, lastLine, tagCheckRegexp, tagMessageRegexp);
@@ -457,7 +454,6 @@ public class SuppressWithNearbyCommentFilter
             return result;
         }
 
-        /** {@inheritDoc} */
         @Override
         public final String toString() {
             return "Tag[lines=[" + getFirstLine() + " to " + getLastLine()

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -179,7 +179,6 @@ public class SuppressionCommentFilter
         this.checkC = checkC;
     }
 
-    /** {@inheritDoc} */
     @Override
     public boolean accept(AuditEvent event) {
         if (event.getLocalizedMessage() == null) {
@@ -412,7 +411,6 @@ public class SuppressionCommentFilter
             return Integer.compare(line, object.line);
         }
 
-        /** {@inheritDoc} */
         @Override
         public boolean equals(Object o) {
             if (this == o) {
@@ -428,7 +426,6 @@ public class SuppressionCommentFilter
                     && Objects.equals(text, tag.text);
         }
 
-        /** {@inheritDoc} */
         @Override
         public int hashCode() {
             return Objects.hash(text, line, column, on);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
@@ -50,7 +50,6 @@ public class SuppressionFilter
         filters = SuppressionsLoader.loadSuppressions(fileName);
     }
 
-    /** {@inheritDoc} */
     @Override
     public boolean accept(AuditEvent event) {
         return filters.accept(event);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModelAdapter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModelAdapter.java
@@ -107,17 +107,11 @@ public class TreeTableModelAdapter extends AbstractTableModel {
         return treeTableModel.getColumnCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getColumnName(int column) {
         return treeTableModel.getColumnName(column);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Class<?> getColumnClass(int column) {
         return treeTableModel.getColumnClass(column);
@@ -138,17 +132,11 @@ public class TreeTableModelAdapter extends AbstractTableModel {
         return treeTableModel.getValueAt(nodeForRow(row), column);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean isCellEditable(int row, int column) {
         return treeTableModel.isCellEditable(nodeForRow(row), column);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setValueAt(Object value, int row, int column) {
         treeTableModel.setValueAt(value, nodeForRow(row), column);


### PR DESCRIPTION
Fixes `UnnecessaryInheritDoc` inspection violations.

Description:
>Reports any Javadoc comments which contain only the {@inheritDoc} tag. Since Javadoc copies the super class' comment if no comment is present, a comment containing only an {@inheritDoc} adds nothing.