### PR TITLE
Remove obsolete method with casting that looses precision. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/CheckUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/CheckUtils.java
@@ -225,18 +225,6 @@ public final class CheckUtils {
     }
 
     /**
-     * Returns the value represented by the specified string of the specified
-     * type. Returns 0 for types other than float, double, int, and long.
-     * @param text the string to be parsed.
-     * @param type the token type of the text. Should be a constant of
-     * {@link TokenTypes}.
-     * @return the float value represented by the string argument.
-     */
-    public static double parseFloat(String text, int type) {
-        return (float) parseDouble(text, type);
-    }
-
-    /**
      * Finds sub-node for given node minimal (line, column) pair.
      * @param node the root of tree for search.
      * @return sub-node with minimal (line, column) pair.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -173,7 +173,7 @@ public class ExplicitInitializationCheck extends Check {
             case TokenTypes.NUM_INT:
             case TokenTypes.NUM_LONG:
                 final String text = expr.getText();
-                return CheckUtils.parseFloat(text, type) == 0.0;
+                return CheckUtils.parseDouble(text, type) == 0.0;
             default:
                 return false;
         }


### PR DESCRIPTION
Fixes `CastThatLosesPrecision` inspection violation.

Description:
>Reports any cast operations between built-in numeric types which may result in loss of precision. Such casts are not necessarily a problem, but may result in difficult to trace bugs if the loss of precision is unexpected.