### PR TITLE
Prevent classes to escape their scope. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -531,7 +531,7 @@ public abstract class AbstractJavadocCheck extends Check {
          */
         private ParseErrorMessage errorMessage;
 
-        public ParseErrorMessage getErrorMessage() {
+        private ParseErrorMessage getErrorMessage() {
             return errorMessage;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/NeverSuppress.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/NeverSuppress.java
@@ -26,7 +26,7 @@ package com.puppycrawl.tools.checkstyle.checks.regexp;
  */
 public final class NeverSuppress implements MatchSuppressor {
     /** The shared instance. */
-    public static final MatchSuppressor INSTANCE = new NeverSuppress();
+    static final MatchSuppressor INSTANCE = new NeverSuppress();
 
     /** Stop creation of instances. */
     private NeverSuppress() {


### PR DESCRIPTION
Fixes `ClassEscapesItsScope` inspection violation.

Description:
>Reports any references to classes which allow the class name to be used outside the class's stated scope. For instance, this inspection would report a public method which returns a private inner class, or a protected field whose type is a package-visible class. While legal Java, such references can be very confusing, and make reuse difficult.