### PR TITLE
Issue #1566: HiddenField violations fixed

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -297,6 +297,11 @@
     </module>
 
     <module name="CommentsIndentation"/>
+    <module name="HiddenField">
+        <property name="ignoreConstructorParameter" value="true"/>
+		<property name="ignoreSetter" value="true"/>
+        <property name="setterCanReturnItsClass" value="true"/>
+    </module>
 
 <!--
     <module name="AvoidInlineConditionals"/>
@@ -305,7 +310,6 @@
     <module name="DesignForExtension"/>
     <module name="ExecutableStatementCount"/>
     <module name="FinalParameters"/>
-    <module name="HiddenField"/>
     <module name="IllegalToken"/>
     <module name="IllegalType"/>
     <module name="InnerTypeLast"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -69,7 +69,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
     private final List<FileSetCheck> fileSetChecks = Lists.newArrayList();
 
     /** class loader to resolve classes with. **/
-    private ClassLoader loader = Thread.currentThread()
+    private ClassLoader classLoader = Thread.currentThread()
             .getContextClassLoader();
 
     /** the basedir to strip off in filenames */
@@ -139,7 +139,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
 
         final DefaultContext context = new DefaultContext();
         context.add("charset", charset);
-        context.add("classLoader", loader);
+        context.add("classLoader", classLoader);
         context.add("moduleFactory", moduleFactory);
         context.add("severity", severityLevel.getName());
         context.add("basedir", basedir);
@@ -415,10 +415,10 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
      * Some Check implementations will use that classloader to improve the
      * quality of their reports, e.g. to load a class and then analyze it via
      * reflection.
-     * @param loader the new classloader
+     * @param classLoader the new classloader
      */
-    public final void setClassLoader(ClassLoader loader) {
-        this.loader = loader;
+    public final void setClassLoader(ClassLoader classLoader) {
+        this.classLoader = classLoader;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -64,12 +64,12 @@ public final class DefaultConfiguration implements Configuration {
     }
 
     @Override
-    public String getAttribute(String name) throws CheckstyleException {
-        if (!attributeMap.containsKey(name)) {
+    public String getAttribute(String attributeName) throws CheckstyleException {
+        if (!attributeMap.containsKey(attributeName)) {
             throw new CheckstyleException(
-                    "missing key '" + name + "' in " + getName());
+                    "missing key '" + attributeName + "' in " + getName());
         }
-        return attributeMap.get(name);
+        return attributeMap.get(attributeName);
     }
 
     @Override
@@ -101,16 +101,16 @@ public final class DefaultConfiguration implements Configuration {
 
     /**
      * Adds an attribute to this configuration.
-     * @param name the name of the attribute.
+     * @param attributeName the name of the attribute.
      * @param value the value of the attribute.
      */
-    public void addAttribute(String name, String value) {
-        final String current = attributeMap.put(name, value);
+    public void addAttribute(String attributeName, String value) {
+        final String current = attributeMap.put(attributeName, value);
         if (current == null) {
-            attributeMap.put(name, value);
+            attributeMap.put(attributeName, value);
         }
         else {
-            attributeMap.put(name, current + "," + value);
+            attributeMap.put(attributeName, current + "," + value);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -153,23 +153,23 @@ final class PropertyCacheFile {
     }
 
     /**
-     * @param fileName the file to check
+     * @param uncheckedFileName the file to check
      * @param timestamp the timestamp of the file to check
      * @return whether the specified file has already been checked ok
      */
-    boolean inCache(String fileName, long timestamp) {
-        final String lastChecked = details.getProperty(fileName);
+    boolean inCache(String uncheckedFileName, long timestamp) {
+        final String lastChecked = details.getProperty(uncheckedFileName);
         return lastChecked != null
             && lastChecked.equals(Long.toString(timestamp));
     }
 
     /**
      * Records that a file checked ok.
-     * @param fileName name of the file that checked ok
+     * @param checkedFileName name of the file that checked ok
      * @param timestamp the timestamp of the file
      */
-    void put(String fileName, long timestamp) {
-        details.setProperty(fileName, Long.toString(timestamp));
+    void put(String checkedFileName, long timestamp) {
+        details.setProperty(checkedFileName, Long.toString(timestamp));
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -598,9 +598,9 @@ public class CheckstyleAntTask extends Task {
             this.value = value;
         }
 
-        /** @param value set the property value from a File */
-        public void setFile(File value) {
-            setValue(value.getAbsolutePath());
+        /** @param file set the property value from a File */
+        public void setFile(File file) {
+            setValue(file.getAbsolutePath());
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -36,7 +36,7 @@ public abstract class AbstractFileSetCheck
     extends AbstractViolationReporter
     implements FileSetCheck {
     /** The dispatcher errors are fired to. */
-    private MessageDispatcher dispatcher;
+    private MessageDispatcher messageDispatcher;
 
     /** the file extensions that are accepted by this filter */
     private String[] fileExtensions = {};
@@ -83,8 +83,8 @@ public abstract class AbstractFileSetCheck
     }
 
     @Override
-    public final void setMessageDispatcher(MessageDispatcher dispatcher) {
-        this.dispatcher = dispatcher;
+    public final void setMessageDispatcher(MessageDispatcher messageDispatcher) {
+        this.messageDispatcher = messageDispatcher;
     }
 
     /**
@@ -94,7 +94,7 @@ public abstract class AbstractFileSetCheck
      * @return the current MessageDispatcher.
      */
     protected final MessageDispatcher getMessageDispatcher() {
-        return dispatcher;
+        return messageDispatcher;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -115,24 +115,26 @@ public class AutomaticBean
      * is called for each {@link Configuration#getChildren child Configuration}
      * of {@code configuration}.
      *
+     * @param config {@inheritDoc}
+     * @throws CheckstyleException {@inheritDoc}
      * @see Configurable
      */
     @Override
-    public final void configure(Configuration configuration)
+    public final void configure(Configuration config)
         throws CheckstyleException {
-        this.configuration = configuration;
+        this.configuration = config;
 
-        final String[] attributes = configuration.getAttributeNames();
+        final String[] attributes = config.getAttributeNames();
 
         for (final String key : attributes) {
-            final String value = configuration.getAttribute(key);
+            final String value = config.getAttribute(key);
 
-            tryCopyProperty(configuration.getName(), key, value, true);
+            tryCopyProperty(config.getName(), key, value, true);
         }
 
         finishLocalSetup();
 
-        final Configuration[] childConfigs = configuration.getChildren();
+        final Configuration[] childConfigs = config.getChildren();
         for (final Configuration childConfig : childConfigs) {
             setupChild(childConfig);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
@@ -52,7 +52,7 @@ public abstract class Check extends AbstractViolationReporter {
      * The class loader to load external classes. Not initialised as this must
      * be set by my creator.
      */
-    private ClassLoader loader;
+    private ClassLoader classLoader;
 
     public boolean isCommentNodesRequired() {
         return false;
@@ -198,10 +198,10 @@ public abstract class Check extends AbstractViolationReporter {
 
     /**
      * Set the class loader associated with the tree.
-     * @param loader the class loader
+     * @param classLoader the class loader
      */
-    public final void setClassLoader(ClassLoader loader) {
-        this.loader = loader;
+    public final void setClassLoader(ClassLoader classLoader) {
+        this.classLoader = classLoader;
     }
 
     /**
@@ -209,7 +209,7 @@ public abstract class Check extends AbstractViolationReporter {
      * @return the class loader
      */
     public final ClassLoader getClassLoader() {
-        return loader;
+        return classLoader;
     }
 
     /** @return the tab width to report errors with */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -108,11 +108,11 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
     public void addPreviousSibling(DetailAST ast) {
         if (ast != null) {
             ast.setParent(parent);
-            final DetailAST previousSibling = getPreviousSibling();
+            final DetailAST previousSiblingNode = getPreviousSibling();
 
-            if (previousSibling != null) {
-                ast.setPreviousSibling(previousSibling);
-                previousSibling.setNextSibling(ast);
+            if (previousSiblingNode != null) {
+                ast.setPreviousSibling(previousSiblingNode);
+                previousSiblingNode.setNextSibling(ast);
             }
             else if (parent != null) {
                 parent.setFirstChild(ast);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -151,7 +151,7 @@ public final class FileText extends AbstractList<String> {
         // Use the BufferedReader to break down the lines as this
         // is about 30% faster than using the
         // LINE_TERMINATOR.split(fullText, -1) method
-        final ArrayList<String> lines = new ArrayList<>();
+        final ArrayList<String> textLines = new ArrayList<>();
         final BufferedReader br =
             new BufferedReader(new StringReader(fullText));
         while (true) {
@@ -159,9 +159,9 @@ public final class FileText extends AbstractList<String> {
             if (line == null) {
                 break;
             }
-            lines.add(line);
+            textLines.add(line);
         }
-        this.lines = lines.toArray(new String[lines.size()]);
+        this.lines = textLines.toArray(new String[textLines.size()]);
     }
 
     /**
@@ -260,18 +260,18 @@ public final class FileText extends AbstractList<String> {
      */
     private int[] findLineBreaks() {
         if (lineBreaks == null) {
-            final int[] lineBreaks = new int[size() + 1];
-            lineBreaks[0] = 0;
+            final int[] lineBreakPositions = new int[size() + 1];
+            lineBreakPositions[0] = 0;
             int lineNo = 1;
             final Matcher matcher = LINE_TERMINATOR.matcher(fullText);
             while (matcher.find()) {
-                lineBreaks[lineNo] = matcher.end();
+                lineBreakPositions[lineNo] = matcher.end();
                 lineNo++;
             }
-            if (lineNo < lineBreaks.length) {
-                lineBreaks[lineNo] = fullText.length();
+            if (lineNo < lineBreakPositions.length) {
+                lineBreakPositions[lineNo] = fullText.length();
             }
-            this.lineBreaks = lineBreaks;
+            this.lineBreaks = lineBreakPositions;
         }
         return lineBreaks;
     }
@@ -282,14 +282,14 @@ public final class FileText extends AbstractList<String> {
      * @return the line and column numbers of this character
      */
     public LineColumn lineColumn(int pos) {
-        final int[] lineBreaks = findLineBreaks();
-        int lineNo = Arrays.binarySearch(lineBreaks, pos);
+        final int[] lineBreakPositions = findLineBreaks();
+        int lineNo = Arrays.binarySearch(lineBreakPositions, pos);
         if (lineNo < 0) {
             // we have: lineNo = -(insertion point) - 1
             // we want: lineNo =  (insertion point) - 1
             lineNo = -lineNo - 2;
         }
-        final int startOfLine = lineBreaks[lineNo];
+        final int startOfLine = lineBreakPositions[lineNo];
         final int columnNo = pos - startOfLine;
         // now we have lineNo and columnNo, both starting at zero.
         return new LineColumn(lineNo + 1, columnNo);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
@@ -69,12 +69,12 @@ public enum JavadocTagInfo {
     AUTHOR("@author", "author", Type.BLOCK) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
-            return type == TokenTypes.PACKAGE_DEF
-                || type == TokenTypes.CLASS_DEF
-                || type == TokenTypes.INTERFACE_DEF
-                || type == TokenTypes.ENUM_DEF
-                || type == TokenTypes.ANNOTATION_DEF;
+            final int astType = ast.getType();
+            return astType == TokenTypes.PACKAGE_DEF
+                || astType == TokenTypes.CLASS_DEF
+                || astType == TokenTypes.INTERFACE_DEF
+                || astType == TokenTypes.ENUM_DEF
+                || astType == TokenTypes.ANNOTATION_DEF;
         }
     },
 
@@ -84,8 +84,8 @@ public enum JavadocTagInfo {
     CODE("{@code}", "code", Type.INLINE) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
-            return Arrays.binarySearch(DEF_TOKEN_TYPES, type) >= 0
+            final int astType = ast.getType();
+            return Arrays.binarySearch(DEF_TOKEN_TYPES, astType) >= 0
                 && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
@@ -96,8 +96,8 @@ public enum JavadocTagInfo {
     DOC_ROOT("{@docRoot}", "docRoot", Type.INLINE) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
-            return Arrays.binarySearch(DEF_TOKEN_TYPES, type) >= 0
+            final int astType = ast.getType();
+            return Arrays.binarySearch(DEF_TOKEN_TYPES, astType) >= 0
                 && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
@@ -108,8 +108,8 @@ public enum JavadocTagInfo {
     DEPRECATED("@deprecated", "deprecated", Type.BLOCK) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
-            return Arrays.binarySearch(DEF_TOKEN_TYPES_DEPRECATED, type) >= 0
+            final int astType = ast.getType();
+            return Arrays.binarySearch(DEF_TOKEN_TYPES_DEPRECATED, astType) >= 0
                 && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
@@ -120,8 +120,8 @@ public enum JavadocTagInfo {
     EXCEPTION("@exception", "exception", Type.BLOCK) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
-            return type == TokenTypes.METHOD_DEF || type == TokenTypes.CTOR_DEF;
+            final int astType = ast.getType();
+            return astType == TokenTypes.METHOD_DEF || astType == TokenTypes.CTOR_DEF;
         }
     },
 
@@ -131,9 +131,9 @@ public enum JavadocTagInfo {
     INHERIT_DOC("{@inheritDoc}", "inheritDoc", Type.INLINE) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
+            final int astType = ast.getType();
 
-            return type == TokenTypes.METHOD_DEF
+            return astType == TokenTypes.METHOD_DEF
                 && !ast.branchContains(TokenTypes.LITERAL_STATIC)
                 && ScopeUtils.getScopeFromMods(ast
                     .findFirstToken(TokenTypes.MODIFIERS)) != Scope.PRIVATE;
@@ -146,8 +146,8 @@ public enum JavadocTagInfo {
     LINK("{@link}", "link", Type.INLINE) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
-            return Arrays.binarySearch(DEF_TOKEN_TYPES, type) >= 0
+            final int astType = ast.getType();
+            return Arrays.binarySearch(DEF_TOKEN_TYPES, astType) >= 0
                 && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
@@ -158,8 +158,8 @@ public enum JavadocTagInfo {
     LINKPLAIN("{@linkplain}", "linkplain", Type.INLINE) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
-            return Arrays.binarySearch(DEF_TOKEN_TYPES, type) >= 0
+            final int astType = ast.getType();
+            return Arrays.binarySearch(DEF_TOKEN_TYPES, astType) >= 0
                 && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
@@ -170,8 +170,8 @@ public enum JavadocTagInfo {
     LITERAL("{@literal}", "literal", Type.INLINE) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
-            return Arrays.binarySearch(DEF_TOKEN_TYPES, type) >= 0
+            final int astType = ast.getType();
+            return Arrays.binarySearch(DEF_TOKEN_TYPES, astType) >= 0
                 && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
@@ -182,11 +182,11 @@ public enum JavadocTagInfo {
     PARAM("@param", "param", Type.BLOCK) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
-            return type == TokenTypes.CLASS_DEF
-                || type == TokenTypes.INTERFACE_DEF
-                || type == TokenTypes.METHOD_DEF
-                || type == TokenTypes.CTOR_DEF;
+            final int astType = ast.getType();
+            return astType == TokenTypes.CLASS_DEF
+                || astType == TokenTypes.INTERFACE_DEF
+                || astType == TokenTypes.METHOD_DEF
+                || astType == TokenTypes.CTOR_DEF;
         }
     },
 
@@ -196,10 +196,10 @@ public enum JavadocTagInfo {
     RETURN("@return", "return", Type.BLOCK) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
+            final int astType = ast.getType();
             final DetailAST returnType = ast.findFirstToken(TokenTypes.TYPE);
 
-            return type == TokenTypes.METHOD_DEF
+            return astType == TokenTypes.METHOD_DEF
                 && returnType.getFirstChild().getType() != TokenTypes.LITERAL_VOID;
 
         }
@@ -211,8 +211,8 @@ public enum JavadocTagInfo {
     SEE("@see", "see", Type.BLOCK) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
-            return Arrays.binarySearch(DEF_TOKEN_TYPES, type) >= 0
+            final int astType = ast.getType();
+            return Arrays.binarySearch(DEF_TOKEN_TYPES, astType) >= 0
                 && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
@@ -223,9 +223,9 @@ public enum JavadocTagInfo {
     SERIAL("@serial", "serial", Type.BLOCK) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
+            final int astType = ast.getType();
 
-            return type == TokenTypes.VARIABLE_DEF
+            return astType == TokenTypes.VARIABLE_DEF
                 && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
@@ -236,11 +236,11 @@ public enum JavadocTagInfo {
     SERIAL_DATA("@serialData", "serialData", Type.BLOCK) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
+            final int astType = ast.getType();
             final DetailAST methodNameAst = ast.findFirstToken(TokenTypes.IDENT);
             final String methodName = methodNameAst.getText();
 
-            return type == TokenTypes.METHOD_DEF
+            return astType == TokenTypes.METHOD_DEF
                 && ("writeObject".equals(methodName)
                     || "readObject".equals(methodName)
                     || "writeExternal".equals(methodName)
@@ -256,10 +256,10 @@ public enum JavadocTagInfo {
     SERIAL_FIELD("@serialField", "serialField", Type.BLOCK) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
+            final int astType = ast.getType();
             final DetailAST varType = ast.findFirstToken(TokenTypes.TYPE);
 
-            return type == TokenTypes.VARIABLE_DEF
+            return astType == TokenTypes.VARIABLE_DEF
                 && varType.getFirstChild().getType() == TokenTypes.ARRAY_DECLARATOR
                 && "ObjectStreafield".equals(varType.getFirstChild().getText());
         }
@@ -271,8 +271,8 @@ public enum JavadocTagInfo {
     SINCE("@since", "since", Type.BLOCK) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
-            return Arrays.binarySearch(DEF_TOKEN_TYPES, type) >= 0
+            final int astType = ast.getType();
+            return Arrays.binarySearch(DEF_TOKEN_TYPES, astType) >= 0
                 && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
@@ -283,9 +283,9 @@ public enum JavadocTagInfo {
     THROWS("@throws", "throws", Type.BLOCK) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
-            return type == TokenTypes.METHOD_DEF
-                || type == TokenTypes.CTOR_DEF;
+            final int astType = ast.getType();
+            return astType == TokenTypes.METHOD_DEF
+                || astType == TokenTypes.CTOR_DEF;
         }
     },
 
@@ -295,8 +295,8 @@ public enum JavadocTagInfo {
     VALUE("{@value}", "value", Type.INLINE) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
-            return Arrays.binarySearch(DEF_TOKEN_TYPES, type) >= 0
+            final int astType = ast.getType();
+            return Arrays.binarySearch(DEF_TOKEN_TYPES, astType) >= 0
                 && !ScopeUtils.isLocalVariableDef(ast);
         }
     },
@@ -307,12 +307,12 @@ public enum JavadocTagInfo {
     VERSION("@version", "version", Type.BLOCK) {
         @Override
         public boolean isValidOn(final DetailAST ast) {
-            final int type = ast.getType();
-            return type == TokenTypes.PACKAGE_DEF
-                || type == TokenTypes.CLASS_DEF
-                || type == TokenTypes.INTERFACE_DEF
-                || type == TokenTypes.ENUM_DEF
-                || type == TokenTypes.ANNOTATION_DEF;
+            final int astType = ast.getType();
+            return astType == TokenTypes.PACKAGE_DEF
+                || astType == TokenTypes.CLASS_DEF
+                || astType == TokenTypes.INTERFACE_DEF
+                || astType == TokenTypes.ENUM_DEF
+                || astType == TokenTypes.ANNOTATION_DEF;
         }
     };
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -238,9 +238,9 @@ public final class LocalizedMessage
     /** @return the translated message **/
     public String getMessage() {
 
-        final String customMessage = getCustomMessage();
-        if (customMessage != null) {
-            return customMessage;
+        final String message = getCustomMessage();
+        if (message != null) {
+            return message;
         }
 
         try {
@@ -248,8 +248,8 @@ public final class LocalizedMessage
             // the GlobalProperties object. This is because the class loader in
             // the GlobalProperties is specified by the user for resolving
             // custom classes.
-            final ResourceBundle bundle = getBundle(this.bundle);
-            final String pattern = bundle.getString(key);
+            final ResourceBundle resourceBundle = getBundle(this.bundle);
+            final String pattern = resourceBundle.getString(key);
             return MessageFormat.format(pattern, args);
         }
         catch (final MissingResourceException ignored) {
@@ -283,14 +283,14 @@ public final class LocalizedMessage
      */
     private ResourceBundle getBundle(String bundleName) {
         synchronized (BUNDLE_CACHE) {
-            ResourceBundle bundle = BUNDLE_CACHE
+            ResourceBundle resourceBundle = BUNDLE_CACHE
                     .get(bundleName);
-            if (bundle == null) {
-                bundle = ResourceBundle.getBundle(bundleName, sLocale,
+            if (resourceBundle == null) {
+                resourceBundle = ResourceBundle.getBundle(bundleName, sLocale,
                         sourceClass.getClassLoader(), new UTF8Control());
-                BUNDLE_CACHE.put(bundleName, bundle);
+                BUNDLE_CACHE.put(bundleName, resourceBundle);
             }
-            return bundle;
+            return resourceBundle;
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.java
@@ -94,17 +94,17 @@ public abstract class AbstractFormatCheck
     /**
      * Updates the regular expression using the supplied format and compiler
      * flags. Will also update the member variables.
-     * @param format the format of the regular expression.
+     * @param regexpFormat the format of the regular expression.
      * @param compileFlagsParam the compiler flags to use.
      */
-    private void updateRegexp(String format, int compileFlagsParam) {
+    private void updateRegexp(String regexpFormat, int compileFlagsParam) {
         try {
-            regexp = Pattern.compile(format, compileFlagsParam);
-            this.format = format;
+            regexp = Pattern.compile(regexpFormat, compileFlagsParam);
+            this.format = regexpFormat;
             compileFlags |= compileFlagsParam;
         }
         catch (final PatternSyntaxException e) {
-            throw new ConversionException("unable to parse " + format, e);
+            throw new ConversionException("unable to parse " + regexpFormat, e);
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -213,15 +213,15 @@ public abstract class AbstractTypeAwareCheck extends Check {
 
     /**
      * Attempts to resolve the Class for a specified name.
-     * @param className name of the class to resolve
-     * @param currentClass name of surrounding class.
+     * @param resolvableClassName name of the class to resolve
+     * @param currentClassName name of surrounding class.
      * @return the resolved class or {@code null}
      *          if unable to resolve the class.
      */
-    protected final Class<?> resolveClass(String className,
-            String currentClass) {
+    protected final Class<?> resolveClass(String resolvableClassName,
+            String currentClassName) {
         try {
-            return getClassResolver().resolve(className, currentClass);
+            return getClassResolver().resolve(resolvableClassName, currentClassName);
         }
         catch (final ClassNotFoundException ignored) {
             return null;
@@ -231,11 +231,11 @@ public abstract class AbstractTypeAwareCheck extends Check {
     /**
      * Tries to load class. Logs error if unable.
      * @param ident name of class which we try to load.
-     * @param currentClass name of surrounding class.
+     * @param currentClassName name of surrounding class.
      * @return {@code Class} for a ident.
      */
-    protected final Class<?> tryLoadClass(Token ident, String currentClass) {
-        final Class<?> clazz = resolveClass(ident.getText(), currentClass);
+    protected final Class<?> tryLoadClass(Token ident, String currentClassName) {
+        final Class<?> clazz = resolveClass(ident.getText(), currentClassName);
         if (clazz == null) {
             logLoadError(ident);
         }
@@ -450,11 +450,11 @@ public abstract class AbstractTypeAwareCheck extends Check {
 
         /**
          * Associates {@code Class} with an object.
-         * @param classObj {@code Class} to associate with.
+         * @param clazz {@code Class} to associate with.
          */
-        private void setClazz(Class<?> classObj) {
-            this.classObj = classObj;
-            loadable = classObj != null;
+        private void setClazz(Class<?> clazz) {
+            this.classObj = clazz;
+            loadable = clazz != null;
         }
 
         @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -166,14 +166,14 @@ public final class AnnotationUseStyleCheck extends Check {
     //has more than one option type.
 
     /** @see #setElementStyle(String) */
-    private ElementStyle style = ElementStyle.COMPACT_NO_ARRAY;
+    private ElementStyle elementStyle = ElementStyle.COMPACT_NO_ARRAY;
 
     //defaulting to NEVER because of the strange compiler behavior
     /** @see #setTrailingArrayComma(String) */
-    private TrailingArrayComma comma = TrailingArrayComma.NEVER;
+    private TrailingArrayComma trailingArrayComma = TrailingArrayComma.NEVER;
 
     /** @see #setClosingParens(String) */
-    private ClosingParens parens = ClosingParens.NEVER;
+    private ClosingParens closingParens = ClosingParens.NEVER;
 
     /**
      * Sets the ElementStyle from a string.
@@ -182,7 +182,7 @@ public final class AnnotationUseStyleCheck extends Check {
      * @throws ConversionException if cannot convert string.
      */
     public void setElementStyle(final String style) {
-        this.style = getOption(ElementStyle.class, style);
+        this.elementStyle = getOption(ElementStyle.class, style);
     }
 
     /**
@@ -192,7 +192,7 @@ public final class AnnotationUseStyleCheck extends Check {
      * @throws ConversionException if cannot convert string.
      */
     public void setTrailingArrayComma(final String comma) {
-        this.comma = getOption(TrailingArrayComma.class, comma);
+        this.trailingArrayComma = getOption(TrailingArrayComma.class, comma);
     }
 
     /**
@@ -202,7 +202,7 @@ public final class AnnotationUseStyleCheck extends Check {
      * @throws ConversionException if cannot convert string.
      */
     public void setClosingParens(final String parens) {
-        this.parens = getOption(ClosingParens.class, parens);
+        this.closingParens = getOption(ClosingParens.class, parens);
     }
 
     /**
@@ -255,7 +255,7 @@ public final class AnnotationUseStyleCheck extends Check {
      */
     private void checkStyleType(final DetailAST annotation) {
 
-        switch (style) {
+        switch (elementStyle) {
             case COMPACT_NO_ARRAY:
                 checkCompactNoArrayStyle(annotation);
                 break;
@@ -352,7 +352,7 @@ public final class AnnotationUseStyleCheck extends Check {
      * @param annotation the annotation token
      */
     private void checkTrailingComma(final DetailAST annotation) {
-        if (TrailingArrayComma.IGNORE == comma) {
+        if (TrailingArrayComma.IGNORE == trailingArrayComma) {
             return;
         }
 
@@ -387,12 +387,12 @@ public final class AnnotationUseStyleCheck extends Check {
         //comma can be null if array is empty
         final DetailAST comma = rCurly.getPreviousSibling();
 
-        if (this.comma == TrailingArrayComma.ALWAYS
+        if (this.trailingArrayComma == TrailingArrayComma.ALWAYS
             && (comma == null || comma.getType() != TokenTypes.COMMA)) {
             log(rCurly.getLineNo(),
                 rCurly.getColumnNo(), MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING);
         }
-        else if (this.comma == TrailingArrayComma.NEVER
+        else if (this.trailingArrayComma == TrailingArrayComma.NEVER
             && comma != null && comma.getType() == TokenTypes.COMMA) {
             log(comma.getLineNo(),
                 comma.getColumnNo(), MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT);
@@ -406,18 +406,18 @@ public final class AnnotationUseStyleCheck extends Check {
      * @param ast the annotation token
      */
     private void checkCheckClosingParens(final DetailAST ast) {
-        if (ClosingParens.IGNORE == parens) {
+        if (ClosingParens.IGNORE == closingParens) {
             return;
         }
 
         final DetailAST paren = ast.getLastChild();
         final boolean parenExists = paren.getType() == TokenTypes.RPAREN;
 
-        if (ClosingParens.ALWAYS == parens
+        if (ClosingParens.ALWAYS == closingParens
             && !parenExists) {
             log(ast.getLineNo(), MSG_KEY_ANNOTATION_PARENS_MISSING);
         }
-        else if (ClosingParens.NEVER == parens
+        else if (ClosingParens.NEVER == closingParens
             && !ast.branchContains(TokenTypes.EXPR)
             && !ast.branchContains(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR)
             && !ast.branchContains(TokenTypes.ANNOTATION_ARRAY_INIT)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheck.java
@@ -245,9 +245,9 @@ public class EmptyCatchBlockCheck extends Check {
      * @return true if empty catch block is verifiable by Check.
      */
     private boolean isVerifiable(DetailAST emptyCatchAst, String commentContent) {
-        final String exceptionVariableName = getExceptionVariableName(emptyCatchAst);
+        final String variableName = getExceptionVariableName(emptyCatchAst);
         final boolean isMatchingVariableName = variableNameRegexp
-                .matcher(exceptionVariableName).find();
+                .matcher(variableName).find();
         final boolean isMatchingCommentContent = !commentContent.isEmpty()
                  && commentRegexp.matcher(commentContent).find();
         return !isMatchingVariableName && !isMatchingCommentContent;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -349,11 +349,11 @@ public class IllegalInstantiationCheck
 
     /**
      * Sets the classes that are illegal to instantiate.
-     * @param classNames a comma seperate list of class names
+     * @param names a comma seperate list of class names
      */
-    public void setClasses(String classNames) {
+    public void setClasses(String names) {
         illegalClasses.clear();
-        final StringTokenizer tok = new StringTokenizer(classNames, ",");
+        final StringTokenizer tok = new StringTokenizer(names, ",");
         while (tok.hasMoreTokens()) {
             illegalClasses.add(tok.nextToken());
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -91,14 +91,14 @@ public class IllegalTokenTextCheck
     public void visitToken(DetailAST ast) {
         final String text = ast.getText();
         if (getRegexp().matcher(text).find()) {
-            String message = getMessage();
-            if (message.isEmpty()) {
-                message = MSG_KEY;
+            String customMessage = getMessage();
+            if (customMessage.isEmpty()) {
+                customMessage = MSG_KEY;
             }
             log(
                 ast.getLineNo(),
                 ast.getColumnNo(),
-                message,
+                customMessage,
                 getFormat());
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -374,19 +374,19 @@ public abstract class AbstractExpressionHandler {
      * Check the indent level of the children of the specified parent
      * expression.
      *
-     * @param parent             the parent whose children we are checking
+     * @param parentNode             the parent whose children we are checking
      * @param tokenTypes         the token types to check
      * @param startLevel         the starting indent level
      * @param firstLineMatches   whether or not the first line needs to match
      * @param allowNesting       whether or not nested children are allowed
      */
-    protected final void checkChildren(DetailAST parent,
+    protected final void checkChildren(DetailAST parentNode,
                                        int[] tokenTypes,
                                        IndentLevel startLevel,
                                        boolean firstLineMatches,
                                        boolean allowNesting) {
         Arrays.sort(tokenTypes);
-        for (DetailAST child = parent.getFirstChild();
+        for (DetailAST child = parentNode.getFirstChild();
                 child != null;
                 child = child.getNextSibling()) {
             if (Arrays.binarySearch(tokenTypes, child.getType()) >= 0) {
@@ -400,13 +400,13 @@ public abstract class AbstractExpressionHandler {
      * Check the indentation level for an expression subtree.
      *
      * @param tree               the expression subtree to check
-     * @param level              the indentation level
+     * @param indentLevel              the indentation level
      * @param firstLineMatches   whether or not the first line has to match
      * @param allowNesting       whether or not subtree nesting is allowed
      */
     protected final void checkExpressionSubtree(
         DetailAST tree,
-        IndentLevel level,
+        IndentLevel indentLevel,
         boolean firstLineMatches,
         boolean allowNesting
     ) {
@@ -418,7 +418,7 @@ public abstract class AbstractExpressionHandler {
         }
         findSubtreeLines(subtreeLines, tree, allowNesting);
 
-        checkLinesIndent(subtreeLines, level, firstLineMatches, firstLine);
+        checkLinesIndent(subtreeLines, indentLevel, firstLineMatches, firstLine);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -96,14 +96,14 @@ public class LineWrappingHandler {
     public void checkIndentation() {
         final NavigableMap<Integer, DetailAST> firstNodesOnLines = collectFirstNodes();
 
-        final DetailAST firstNode = firstNodesOnLines.get(firstNodesOnLines.firstKey());
-        if (firstNode.getType() == TokenTypes.AT) {
-            checkAnnotationIndentation(firstNode, firstNodesOnLines);
+        final DetailAST firstLineNode = firstNodesOnLines.get(firstNodesOnLines.firstKey());
+        if (firstLineNode.getType() == TokenTypes.AT) {
+            checkAnnotationIndentation(firstLineNode, firstNodesOnLines);
         }
 
         // First node should be removed because it was already checked before.
         firstNodesOnLines.remove(firstNodesOnLines.firstKey());
-        final int firstNodeIndent = getFirstNodeIndent(firstNode);
+        final int firstNodeIndent = getFirstNodeIndent(firstLineNode);
         final int currentIndent = firstNodeIndent + indentLevel;
 
         for (DetailAST node : firstNodesOnLines.values()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -148,12 +148,12 @@ public abstract class AbstractJavadocCheck extends Check {
     }
 
     @Override
-    public final void visitToken(DetailAST blockCommentAst) {
-        if (JavadocUtils.isJavadocComment(blockCommentAst)) {
-            this.blockCommentAst = blockCommentAst;
+    public final void visitToken(DetailAST blockCommentNode) {
+        if (JavadocUtils.isJavadocComment(blockCommentNode)) {
+            this.blockCommentAst = blockCommentNode;
 
-            final String treeCacheKey = blockCommentAst.getLineNo() + ":"
-                    + blockCommentAst.getColumnNo();
+            final String treeCacheKey = blockCommentNode.getLineNo() + ":"
+                    + blockCommentNode.getColumnNo();
 
             ParseStatus ps;
 
@@ -161,7 +161,7 @@ public abstract class AbstractJavadocCheck extends Check {
                 ps = TREE_CACHE.get(treeCacheKey);
             }
             else {
-                ps = parseJavadocAsDetailNode(blockCommentAst);
+                ps = parseJavadocAsDetailNode(blockCommentNode);
                 TREE_CACHE.put(treeCacheKey, ps);
             }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -252,10 +252,10 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     /**
      * Set the excludeScope.
      *
-     * @param scope a {@code String} value
+     * @param excludeScope a {@code String} value
      */
-    public void setExcludeScope(String scope) {
-        excludeScope = Scope.getInstance(scope);
+    public void setExcludeScope(String excludeScope) {
+        this.excludeScope = Scope.getInstance(excludeScope);
     }
 
     /**
@@ -463,15 +463,15 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * Whether we should check this node.
      *
      * @param ast a given node.
-     * @param scope the scope of the node.
+     * @param nodeScope the scope of the node.
      * @return whether we should check a given node.
      */
-    private boolean shouldCheck(final DetailAST ast, final Scope scope) {
+    private boolean shouldCheck(final DetailAST ast, final Scope nodeScope) {
         final Scope surroundingScope = ScopeUtils.getSurroundingScope(ast);
 
-        return scope.isIn(this.scope)
+        return nodeScope.isIn(this.scope)
                 && surroundingScope.isIn(this.scope)
-                && (excludeScope == null || !scope.isIn(excludeScope)
+                && (excludeScope == null || !nodeScope.isIn(excludeScope)
                     || !surroundingScope.isIn(excludeScope));
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -179,15 +179,15 @@ public class JavadocStyleCheck
                 ast.findFirstToken(TokenTypes.MODIFIERS));
         }
 
-        final Scope scope =
+        final Scope customScope =
             ScopeUtils.inInterfaceOrAnnotationBlock(ast)
             ? Scope.PUBLIC : declaredScope;
         final Scope surroundingScope = ScopeUtils.getSurroundingScope(ast);
 
-        return scope.isIn(this.scope)
+        return customScope.isIn(this.scope)
             && (surroundingScope == null || surroundingScope.isIn(this.scope))
             && (excludeScope == null
-                || !scope.isIn(excludeScope)
+                || !customScope.isIn(excludeScope)
                 || surroundingScope != null
                 && !surroundingScope.isIn(excludeScope));
     }
@@ -499,10 +499,10 @@ public class JavadocStyleCheck
 
     /**
      * Set the excludeScope.
-     * @param scope a {@code String} value
+     * @param excludeScope a {@code String} value
      */
-    public void setExcludeScope(String scope) {
-        excludeScope = Scope.getInstance(scope);
+    public void setExcludeScope(String excludeScope) {
+        this.excludeScope = Scope.getInstance(excludeScope);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -112,10 +112,10 @@ public class JavadocTypeCheck
 
     /**
      * Set the excludeScope.
-     * @param scope a {@code String} value
+     * @param excludeScope a {@code String} value
      */
-    public void setExcludeScope(String scope) {
-        excludeScope = Scope.getInstance(scope);
+    public void setExcludeScope(String excludeScope) {
+        this.excludeScope = Scope.getInstance(excludeScope);
     }
 
     /**
@@ -217,15 +217,15 @@ public class JavadocTypeCheck
     private boolean shouldCheck(final DetailAST ast) {
         final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
         final Scope declaredScope = ScopeUtils.getScopeFromMods(mods);
-        final Scope scope =
+        final Scope customScope =
             ScopeUtils.inInterfaceOrAnnotationBlock(ast)
                 ? Scope.PUBLIC : declaredScope;
         final Scope surroundingScope = ScopeUtils.getSurroundingScope(ast);
 
-        return scope.isIn(this.scope)
+        return customScope.isIn(this.scope)
             && (surroundingScope == null || surroundingScope.isIn(this.scope))
             && (excludeScope == null
-                || !scope.isIn(excludeScope)
+                || !customScope.isIn(excludeScope)
                 || surroundingScope != null
                 && !surroundingScope.isIn(excludeScope));
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -63,10 +63,10 @@ public class JavadocVariableCheck
 
     /**
      * Set the excludeScope.
-     * @param scope a {@code String} value
+     * @param excludeScope a {@code String} value
      */
-    public void setExcludeScope(String scope) {
-        excludeScope = Scope.getInstance(scope);
+    public void setExcludeScope(String excludeScope) {
+        this.excludeScope = Scope.getInstance(excludeScope);
     }
 
     /**
@@ -128,23 +128,23 @@ public class JavadocVariableCheck
             return false;
         }
 
-        final Scope scope;
+        final Scope customScope;
         if (ast.getType() == TokenTypes.ENUM_CONSTANT_DEF) {
-            scope = Scope.PUBLIC;
+            customScope = Scope.PUBLIC;
         }
         else {
             final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
             final Scope declaredScope = ScopeUtils.getScopeFromMods(mods);
-            scope =
+            customScope =
                 ScopeUtils.inInterfaceOrAnnotationBlock(ast)
                     ? Scope.PUBLIC : declaredScope;
         }
 
         final Scope surroundingScope = ScopeUtils.getSurroundingScope(ast);
 
-        return scope.isIn(this.scope) && surroundingScope.isIn(this.scope)
+        return customScope.isIn(this.scope) && surroundingScope.isIn(this.scope)
             && (excludeScope == null
-                || !scope.isIn(excludeScope)
+                || !customScope.isIn(excludeScope)
                 || !surroundingScope.isIn(excludeScope));
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -78,12 +78,12 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
      * @param tags to be ignored by check.
      */
     public void setIgnoredTags(String tags) {
-        final List<String> ignoredTags = new ArrayList<>();
+        final List<String> tagList = new ArrayList<>();
         final String[] sTags = tags.split(",");
         for (String sTag : sTags) {
-            ignoredTags.add(sTag.trim());
+            tagList.add(sTag.trim());
         }
-        this.ignoredTags = ignoredTags;
+        this.ignoredTags = tagList;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
@@ -166,42 +166,42 @@ public class WriteTagCheck
      * Verifies that a type definition has a required tag.
      * @param lineNo the line number for the type definition.
      * @param comment the Javadoc comment for the type definition.
-     * @param tag the required tag name.
-     * @param tagRE regexp for the full tag.
+     * @param tagName the required tag name.
+     * @param tagRegexp regexp for the full tag.
      * @param formatRE regexp for the tag value.
      * @param format pattern for the tag value.
      */
     private void checkTag(
             int lineNo,
             String[] comment,
-            String tag,
-            Pattern tagRE,
+            String tagName,
+            Pattern tagRegexp,
             Pattern formatRE,
             String format) {
-        if (tagRE == null) {
+        if (tagRegexp == null) {
             return;
         }
 
         int tagCount = 0;
         for (int i = 0; i < comment.length; i++) {
             final String s = comment[i];
-            final Matcher matcher = tagRE.matcher(s);
+            final Matcher matcher = tagRegexp.matcher(s);
             if (matcher.find()) {
                 tagCount += 1;
                 final int contentStart = matcher.start(1);
                 final String content = s.substring(contentStart);
                 if (formatRE != null && !formatRE.matcher(content).find()) {
-                    log(lineNo + i - comment.length, TAG_FORMAT, tag,
+                    log(lineNo + i - comment.length, TAG_FORMAT, tagName,
                         format);
                 }
                 else {
-                    logTag(lineNo + i - comment.length, tag, content);
+                    logTag(lineNo + i - comment.length, tagName, content);
                 }
 
             }
         }
         if (tagCount == 0) {
-            log(lineNo, MISSING_TAG, tag);
+            log(lineNo, MISSING_TAG, tagName);
         }
 
     }
@@ -210,16 +210,16 @@ public class WriteTagCheck
      * Log a message.
      *
      * @param line the line number where the error was found
-     * @param tag the javadoc tag to be logged
+     * @param tagName the javadoc tag to be logged
      * @param tagValue the contents of the tag
      *
      * @see java.text.MessageFormat
      */
-    protected final void logTag(int line, String tag, String tagValue) {
+    protected final void logTag(int line, String tagName, String tagValue) {
         final String originalSeverity = getSeverity();
         setSeverity(tagSeverityLevel.getName());
 
-        log(line, WRITE_TAG, tag, tagValue);
+        log(line, WRITE_TAG, tagName, tagValue);
 
         setSeverity(originalSeverity);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -235,8 +235,8 @@ public abstract class AbstractClassCouplingCheck extends Check {
          * @param ast type to process.
          */
         public void visitType(DetailAST ast) {
-            final String className = CheckUtils.createFullType(ast).getText();
-            context.addReferencedClassName(className);
+            final String fullTypeName = CheckUtils.createFullType(ast).getText();
+            context.addReferencedClassName(fullTypeName);
         }
 
         /**
@@ -252,17 +252,17 @@ public abstract class AbstractClassCouplingCheck extends Check {
          * @param ast a node which represents referenced class.
          */
         private void addReferencedClassName(DetailAST ast) {
-            final String className = FullIdent.createFullIdent(ast).getText();
-            addReferencedClassName(className);
+            final String fullIdentName = FullIdent.createFullIdent(ast).getText();
+            addReferencedClassName(fullIdentName);
         }
 
         /**
          * Adds new referenced class.
-         * @param className class name of the referenced class.
+         * @param referencedClassName class name of the referenced class.
          */
-        private void addReferencedClassName(String className) {
-            if (isSignificant(className)) {
-                referencedClassNames.add(className);
+        private void addReferencedClassName(String referencedClassName) {
+            if (isSignificant(referencedClassName)) {
+                referencedClassNames.add(referencedClassName);
             }
         }
 
@@ -280,12 +280,12 @@ public abstract class AbstractClassCouplingCheck extends Check {
 
         /**
          * Checks if given class shouldn't be ignored and not from java.lang.
-         * @param className class to check.
+         * @param candidateClassName class to check.
          * @return true if we should count this class.
          */
-        private boolean isSignificant(String className) {
-            return !excludedClasses.contains(className)
-                    && !className.startsWith("java.lang.");
+        private boolean isSignificant(String candidateClassName) {
+            return !excludedClasses.contains(candidateClassName)
+                    && !candidateClassName.startsWith("java.lang.");
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -68,13 +68,13 @@ public class JavaNCSSCheck extends Check {
     private static final int METHOD_MAX_NCSS = 50;
 
     /** maximum ncss for a complete source file */
-    private int fileMax = FILE_MAX_NCSS;
+    private int fileMaximum = FILE_MAX_NCSS;
 
     /** maximum ncss for a class */
-    private int classMax = CLASS_MAX_NCSS;
+    private int classMaximum = CLASS_MAX_NCSS;
 
     /** maximum ncss for a method */
-    private int methodMax = METHOD_MAX_NCSS;
+    private int methodMaximum = METHOD_MAX_NCSS;
 
     /** list containing the stacked counters */
     private Deque<Counter> counters;
@@ -222,9 +222,9 @@ public class JavaNCSSCheck extends Check {
             final Counter counter = counters.pop();
 
             final int count = counter.getCount();
-            if (count > methodMax) {
+            if (count > methodMaximum) {
                 log(ast.getLineNo(), ast.getColumnNo(), MSG_METHOD,
-                        count, methodMax);
+                        count, methodMaximum);
             }
         }
         else if (tokenType == TokenTypes.CLASS_DEF) {
@@ -232,9 +232,9 @@ public class JavaNCSSCheck extends Check {
             final Counter counter = counters.pop();
 
             final int count = counter.getCount();
-            if (count > classMax) {
+            if (count > classMaximum) {
                 log(ast.getLineNo(), ast.getColumnNo(), MSG_CLASS,
-                        count, classMax);
+                        count, classMaximum);
             }
         }
     }
@@ -245,40 +245,40 @@ public class JavaNCSSCheck extends Check {
         final Counter counter = counters.pop();
 
         final int count = counter.getCount();
-        if (count > fileMax) {
+        if (count > fileMaximum) {
             log(rootAST.getLineNo(), rootAST.getColumnNo(), MSG_FILE,
-                    count, fileMax);
+                    count, fileMaximum);
         }
     }
 
     /**
      * Sets the maximum ncss for a file.
      *
-     * @param fileMax
+     * @param fileMaximum
      *            the maximum ncss
      */
-    public void setFileMaximum(int fileMax) {
-        this.fileMax = fileMax;
+    public void setFileMaximum(int fileMaximum) {
+        this.fileMaximum = fileMaximum;
     }
 
     /**
      * Sets the maximum ncss for a class.
      *
-     * @param classMax
+     * @param classMaximum
      *            the maximum ncss
      */
-    public void setClassMaximum(int classMax) {
-        this.classMax = classMax;
+    public void setClassMaximum(int classMaximum) {
+        this.classMaximum = classMaximum;
     }
 
     /**
      * Sets the maximum ncss for a method.
      *
-     * @param methodMax
+     * @param methodMaximum
      *            the maximum ncss
      */
-    public void setMethodMaximum(int methodMax) {
-        this.methodMax = methodMax;
+    public void setMethodMaximum(int methodMaximum) {
+        this.methodMaximum = methodMaximum;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
@@ -73,17 +73,17 @@ class MultilineDetector {
 
     /**
      * Processes an entire text file looking for matches.
-     * @param text the text to process
+     * @param fileText the text to process
      */
-    public void processLines(FileText text) {
-        this.text = new FileText(text);
+    public void processLines(FileText fileText) {
+        this.text = new FileText(fileText);
         resetState();
 
         if (Strings.isNullOrEmpty(options.getFormat())) {
             options.getReporter().log(0, EMPTY);
         }
         else {
-            matcher = options.getPattern().matcher(text.getFullText());
+            matcher = options.getPattern().matcher(fileText.getFullText());
             findMatch();
             finish();
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
@@ -210,10 +210,10 @@ public final class ExecutableStatementCountCheck
 
         /**
          * Increase count.
-         * @param count the count increment.
+         * @param addition the count increment.
          */
-        public void addCount(int count) {
-            this.count += count;
+        public void addCount(int addition) {
+            this.count += addition;
         }
 
         /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java
@@ -65,13 +65,13 @@ public class CodeSelector {
         editor.transferFocusBackward();
     }
 
-    private int findLastPosition(final DetailAST ast) {
-        if (ast.getChildCount() == 0) {
-            return lines2position.get(ast.getLineNo()) + ast.getColumnNo()
-                + ast.getText().length();
+    private int findLastPosition(final DetailAST astNode) {
+        if (astNode.getChildCount() == 0) {
+            return lines2position.get(astNode.getLineNo()) + astNode.getColumnNo()
+                + astNode.getText().length();
         }
         else {
-            return findLastPosition(ast.getLastChild());
+            return findLastPosition(astNode.getLastChild());
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
@@ -107,7 +107,7 @@ public class JTreeTable extends JTable {
     /** A subclass of JTree. */
     protected final TreeTableCellRenderer tree;
     private JTextArea editor;
-    private List<Integer> lines2position;
+    private List<Integer> linePositionMap;
 
     public JTreeTable(TreeTableModel treeTableModel) {
 
@@ -147,7 +147,7 @@ public class JTreeTable extends JTable {
                 public void actionPerformed(ActionEvent e) {
                     final TreePath selected = tree.getSelectionPath();
                     final DetailAST ast = (DetailAST) selected.getLastPathComponent();
-                    new CodeSelector(ast, editor, lines2position).select();
+                    new CodeSelector(ast, editor, linePositionMap).select();
 
                     if (tree.isExpanded(selected)) {
                         tree.collapsePath(selected);
@@ -215,8 +215,8 @@ public class JTreeTable extends JTable {
         editor = mJTextArea;
     }
 
-    public void setLinePositionMap(List<Integer> lines2position) {
-        this.lines2position = ImmutableList.copyOf(lines2position);
+    public void setLinePositionMap(List<Integer> linePositionMap) {
+        this.linePositionMap = ImmutableList.copyOf(linePositionMap);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
@@ -59,13 +59,13 @@ public final class Main {
      * @param ast tree to display
      */
     public static void displayAst(DetailAST ast) {
-        final JFrame frame = new JFrame("CheckStyle");
+        final JFrame testFrame = new JFrame("CheckStyle");
         final ParseTreeInfoPanel panel = new ParseTreeInfoPanel();
-        frame.getContentPane().add(panel);
-        panel.openAst(ast, frame);
-        frame.setSize(1500, 800);
-        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-        frame.setVisible(true);
+        testFrame.getContentPane().add(panel);
+        panel.openAst(ast, testFrame);
+        testFrame.setSize(1500, 800);
+        testFrame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        testFrame.setVisible(true);
     }
 
     static JFrame getFrame() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -41,8 +41,7 @@ public class PackageObjectFactoryTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testCtorException()  throws CheckstyleException {
-        PackageObjectFactory factory = new PackageObjectFactory(
-                new HashSet<String>(), null);
+        new PackageObjectFactory(new HashSet<String>(), null);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -45,11 +45,11 @@ public class AutomaticBeanTest {
             this.wrong = wrong;
         }
 
-        public void setIntVal(int val) {
+        public void setVal(int val) {
             this.val = val;
         }
 
-        public void setExceptionalMethod(String val) {
+        public void setExceptionalMethod(String value) {
             throw new IllegalStateException("for UT");
         }
 
@@ -119,7 +119,7 @@ public class AutomaticBeanTest {
     public void testContextualize_ConversionException() {
         final TestBean testBean = new TestBean();
         DefaultContext context = new DefaultContext();
-        context.add("intVal", "some string");
+        context.add("val", "some string");
         try {
             testBean.contextualize(context);
             fail();


### PR DESCRIPTION
Violations fixed:
- HiddenField 'X' hides a field.

HiddenField gave us 350 violations. After configuring the check with the following options:
```
<property name="ignoreConstructorParameter" value="true"/>
<property name="ignoreSetter" value="true"/>
<property name="setterCanReturnItsClass" value="true"/>
```

the number of violations were reduced to 75 which were fixed manually.
