### PR TITLE
Decrease scope of variables. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -209,8 +209,7 @@ public final class TreeWalker
                      fileName);
             LOG.error(exceptionMsg);
             final RecognitionException re = tre.recog;
-            String message;
-            message = re.getMessage();
+            final String message = re.getMessage();
             getMessageCollector().add(createLocalizedMessage(message));
         }
         // RecognitionException and any other (need to check if needed)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
@@ -159,8 +159,8 @@ public final class OneStatementPerLineCheck extends Check {
      */
     private static boolean isOnTheSameLine(DetailAST ast, int lastStatementEnd,
                                            int forStatementEnd) {
-        final boolean onTheSameLine;
-        onTheSameLine = lastStatementEnd == ast.getLineNo() && forStatementEnd != ast.getLineNo();
+        final boolean onTheSameLine =
+            lastStatementEnd == ast.getLineNo() && forStatementEnd != ast.getLineNo();
         return onTheSameLine;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -647,7 +647,6 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
      */
     private static DetailAST getFirstNodeInsideSwitchBlock(
             DetailAST block, DetailAST variable) {
-        DetailAST firstNodeInsideBlock = null;
 
         DetailAST currentNode = block
                 .findFirstToken(TokenTypes.CASE_GROUP);
@@ -669,6 +668,7 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
         // firstNodeInsideBlock = null, otherwise if variable usage exists
         // only inside one block, then get node from
         // variableUsageExpressions.
+        DetailAST firstNodeInsideBlock = null;
         if (variableUsageExpressions.size() == 1) {
             firstNodeInsideBlock = variableUsageExpressions.get(0);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -146,12 +146,11 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
      */
     private void checkOrderInTagSection(DetailNode javadoc) {
         int indexOrderOfPreviousTag = 0;
-        int indexOrderOfCurrentTag;
 
         for (DetailNode node : javadoc.getChildren()) {
             if (node.getType() == JavadocTokenTypes.JAVADOC_TAG) {
                 final String tagText = JavadocUtils.getFirstChild(node).getText();
-                indexOrderOfCurrentTag = tagOrder.indexOf(tagText);
+                final int indexOrderOfCurrentTag = tagOrder.indexOf(tagText);
 
                 if (tagOrder.contains(tagText)
                         && indexOrderOfCurrentTag < indexOrderOfPreviousTag) {


### PR DESCRIPTION
Fixes `TooBroadScope` inspection violations.

Description:
>Reports any variable declarations of which the scope can be narrowed. Especially useful for "Pascal style" declarations at the start of a method, but variables with too broad a scope are also often left over after refactorings.