### PR TITLE
Decrease visibility of constructor in abstract class. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.java
@@ -51,7 +51,7 @@ public abstract class AbstractComplexityCheck
      * Creates an instance.
      * @param max the threshold of when to report an error
      */
-    public AbstractComplexityCheck(int max) {
+    protected AbstractComplexityCheck(int max) {
         this.max = max;
     }
 


### PR DESCRIPTION
Fixes `NonProtectedConstructorInAbstractClass` inspection violation.

Description:
>Reports constructors in abstract classes that are not declared protected, package-protected or private.