### PR TITLE
Decrease visibility of inner classes. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -395,7 +395,7 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
     /**
      * Structure that contains all details for validation.
      */
-    static class Details {
+    private static class Details {
         /** Right curly. */
         private DetailAST rcurly;
         /** Left curly. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -780,7 +780,7 @@ public class CustomImportOrderCheck extends Check {
      * group.
      * @author max
      */
-    static class ImportDetails {
+    private static class ImportDetails {
         /** Import full path */
         private String importFullPath;
 


### PR DESCRIPTION
Fixes `PackageVisibleInnerClass` inspection violations.

Description:
>Reports package-local inner classes.