### PR TITLE
Remove redundant throws declarations. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -505,8 +505,7 @@ public final class ConfigurationLoader {
         @Override
         public void endElement(String namespaceURI,
                                String localName,
-                               String qName)
-            throws SAXException {
+                               String qName) {
             if (qName.equals(MODULE)) {
 
                 final Configuration recentModule =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -89,8 +89,7 @@ public final class PackageNamesLoader
     public void startElement(String namespaceURI,
                              String localName,
                              String qName,
-                             Attributes atts)
-        throws SAXException {
+                             Attributes atts) {
         if ("package".equals(qName)) {
             //push package name, name is mandatory attribute with not empty value by DTD
             final String name = atts.getValue("name");


### PR DESCRIPTION
Fixes `RedundantThrowsDeclaration` inspection violations.

Description:
>This inspection reports exceptions that are declared in a method's signature but never thrown by the method itself.