### PR TITLE
Change name of private method conflicting with superclass method. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
@@ -68,7 +68,7 @@ public class ArrayInitHandler extends BlockParentHandler {
     @Override
     protected IndentLevel curlyLevel() {
         final IndentLevel level = new IndentLevel(getLevel(), getBraceAdjustment());
-        level.addAcceptedIndent(level.getLastIndentLevel() + getLineWrappingIndent());
+        level.addAcceptedIndent(level.getLastIndentLevel() + getLineWrappingIndentation());
         return level;
     }
 
@@ -104,7 +104,7 @@ public class ArrayInitHandler extends BlockParentHandler {
             getNextFirstNonblankOnLineAfter(firstLine, lcurlyPos);
         if (firstChildPos >= 0) {
             expectedIndent.addAcceptedIndent(firstChildPos);
-            expectedIndent.addAcceptedIndent(lcurlyPos + getLineWrappingIndent());
+            expectedIndent.addAcceptedIndent(lcurlyPos + getLineWrappingIndentation());
         }
         return expectedIndent;
     }
@@ -134,7 +134,7 @@ public class ArrayInitHandler extends BlockParentHandler {
      * @return value of lineWrappingIndentation property
      *         of {@code IndentationCheck}
      */
-    private int getLineWrappingIndent() {
+    private int getLineWrappingIndentation() {
         return getIndentCheck().getLineWrappingIndentation();
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
@@ -93,7 +93,7 @@ public class ObjectBlockHandler extends BlockParentHandler {
         final DetailAST rcurly = getRCurly();
         final int rcurlyPos = expandedTabsColumnNo(rcurly);
         final IndentLevel level = curlyLevel();
-        level.addAcceptedIndent(level.getFirstIndentLevel() + getLineWrappingIndent());
+        level.addAcceptedIndent(level.getFirstIndentLevel() + getLineWrappingIndentation());
 
         if (!level.accept(rcurlyPos) && startsLine(rcurly)) {
             logError(rcurly, "rcurly", rcurlyPos, curlyLevel());
@@ -105,7 +105,7 @@ public class ObjectBlockHandler extends BlockParentHandler {
      * @return value of lineWrappingIndentation property
      *         of {@code IndentationCheck}
      */
-    private int getLineWrappingIndent() {
+    private int getLineWrappingIndentation() {
         return getIndentCheck().getLineWrappingIndentation();
     }
 }


### PR DESCRIPTION
Fixes `MethodOverridesPrivateMethod` inspection violations.

Description:
>Reports instance methods having the same name as a private method of a superclass. Such methods may result in confusing semantics, particularly if the private method is ever made publicly visible.