### PR TITLE
Mark method as synchronized if it override synchronized method. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -137,7 +137,7 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
         private final Object lock = new Object();
 
         @Override
-        public Object put(Object key, Object value) {
+        public synchronized Object put(Object key, Object value) {
             synchronized (lock) {
                 final Object oldValue = super.put(key, value);
                 if (oldValue != null && key instanceof String) {


### PR DESCRIPTION
Fixes `NonSynchronizedMethodOverridesSynchronizedMethod` inspection violations.

Description:
>Reports non-synchronized methods overriding synchronized methods.