### PR TITLE
Issue #1566: ImportOrder violations fixed

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -42,12 +42,12 @@ import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 import javax.swing.filechooser.FileFilter;
 
+import antlr.ANTLRException;
+
 import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FileText;
-
-import antlr.ANTLRException;
 
 /**
  * Displays information about a parse tree.


### PR DESCRIPTION
Fixed violations:
- ImportOrder	Wrong order for 'antlr.ANTLRException' import.

We already have configuration for this check in our checkstyle_checks.xml:
```
<module name="ImportOrder">
      <property name="groups" value="/^javax?\./,org"/>
      <property name="ordered" value="true"/>
      <property name="separated" value="true"/>
      <property name="option" value="top"/>
      <property name="sortStaticImportsAlphabetically" value="true"/>
    </module>
```

But I have no idea why the build was passing. Looked at suppressions.xml, there is nothing related there. Any thoughts?