### PR TITLE
Issue #1566: Constructor definition in wrong order violations fixed

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -296,16 +296,16 @@ public class ParseTreeInfoPanel extends JPanel {
     private class FileDropListener implements FileDrop.Listener {
         private final JScrollPane mSp;
 
+        public FileDropListener(JScrollPane aSp) {
+            mSp = aSp;
+        }
+
         @Override
         public void filesDropped(File... files) {
             if (files != null && files.length > 0) {
                 final File file = files[0];
                 openFile(file, mSp);
             }
-        }
-
-        public FileDropListener(JScrollPane aSp) {
-            mSp = aSp;
         }
     }
 }


### PR DESCRIPTION
Fixed violations:
- DeclarationOrder Constructor definition in wrong order.

Another strange behavior. We already have ```<module name="DeclarationOrder"/>``` which is turned on in our checkstyle_checks.xml but the "verify" phase continue passing all the checks even though the violation is present.

If you know some secret knowledge about that please share.