### PR TITLE
Do not allocate arrays of zero length. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.SortedSet;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -93,7 +94,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
     private final FilterSet filters = new FilterSet();
 
     /** the file extensions that are accepted */
-    private String[] fileExtensions = {};
+    private String[] fileExtensions = ArrayUtils.EMPTY_STRING_ARRAY;
 
     /**
      * The severity level of any violations found by submodules.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Utils.java
@@ -56,7 +56,7 @@ public final class Utils {
         final ImmutableMap.Builder<String, Integer> builder =
                 ImmutableMap.builder();
         final Field[] fields = TokenTypes.class.getDeclaredFields();
-        String[] tempTokenValueToName = new String[0];
+        String[] tempTokenValueToName = ArrayUtils.EMPTY_STRING_ARRAY;
         for (final Field field : fields) {
             // Only process the int declarations.
             if (field.getType() != Integer.TYPE) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
@@ -22,6 +22,8 @@ package com.puppycrawl.tools.checkstyle.api;
 import java.util.Collections;
 import java.util.Set;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.Utils;
 
@@ -87,7 +89,7 @@ public abstract class Check extends AbstractViolationReporter {
      * @see TokenTypes
      */
     public int[] getRequiredTokens() {
-        return new int[] {};
+        return ArrayUtils.EMPTY_INT_ARRAY;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
@@ -22,8 +22,9 @@ package com.puppycrawl.tools.checkstyle.checks;
 import java.util.Arrays;
 import java.util.Set;
 
-import antlr.collections.AST;
+import org.apache.commons.lang3.ArrayUtils;
 
+import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.Utils;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -202,7 +203,7 @@ public class DescendantTokenCheck extends Check {
     /** Whether to sum the number of tokens found. */
     private boolean sumTokenCounts;
     /** limited tokens */
-    private int[] limitedTokens = new int[0];
+    private int[] limitedTokens = ArrayUtils.EMPTY_INT_ARRAY;
     /** error message when minimum count not reached */
     private String minimumMessage;
     /** error message when maximum count exceeded */
@@ -212,11 +213,11 @@ public class DescendantTokenCheck extends Check {
      * Counts of descendant tokens.
      * Indexed by (token ID - 1) for performance.
      */
-    private int[] counts = new int[0];
+    private int[] counts = ArrayUtils.EMPTY_INT_ARRAY;
 
     @Override
     public int[] getDefaultTokens() {
-        return new int[0];
+        return ArrayUtils.EMPTY_INT_ARRAY;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/FileContentsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/FileContentsHolder.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
@@ -42,7 +44,7 @@ public class FileContentsHolder
 
     @Override
     public int[] getDefaultTokens() {
-        return new int[0];
+        return ArrayUtils.EMPTY_INT_ARRAY;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.Utils;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -128,7 +130,7 @@ public class TrailingCommentCheck extends AbstractFormatCheck {
 
     @Override
     public int[] getDefaultTokens() {
-        return new int[0];
+        return ArrayUtils.EMPTY_INT_ARRAY;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.indentation;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import com.puppycrawl.tools.checkstyle.Utils;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -97,7 +99,7 @@ public class CommentsIndentationCheck extends Check {
 
     @Override
     public int[] getRequiredTokens() {
-        return new int[] {};
+        return ArrayUtils.EMPTY_INT_ARRAY;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
@@ -22,6 +22,8 @@ package com.puppycrawl.tools.checkstyle.checks.modifier;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -58,7 +60,7 @@ public class RedundantModifierCheck
 
     @Override
     public int[] getRequiredTokens() {
-        return new int[] {};
+        return ArrayUtils.EMPTY_INT_ARRAY;
     }
 
     @Override


### PR DESCRIPTION
Fixes `ZeroLengthArrayInitialization` inspection violations.

Description:
>Reports on allocations of arrays with known lengths of zero. Since array lengths in Java are non-modifiable, it is almost always possible to share zero-length arrays, rather than repeatedly allocating new zero-length arrays. Such sharing may provide useful optimizations in program runtime or footprint. Note that this inspection does not report zero-length arrays allocated as static final fields, as it is assumed that those arrays are being used to implement array sharing.