### PR TITLE
Remove redundant unit in zero value form CSS. #1555

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -27,7 +27,7 @@ h4 {
 #bannerLeft img {
   float:left;
   position: relative;
-  top: 0px;
+  top: 0;
   left: 40px;
 
 }


### PR DESCRIPTION
Fixes `CssRedundantUnit` inspection violations.

Description:
>This inspection highlights zero values with specified unit of measurement.