### PR TITLE
Issue #1243: Resolved varargs ambiguity

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -194,7 +194,7 @@ public class CheckerTest {
                 new HashSet<String>(), Thread.currentThread().getContextClassLoader());
         c.setModuleFactory(factory);
 
-        c.setFileExtensions(null);
+        c.setFileExtensions((String[]) null);
         c.setFileExtensions(new String[]{".java", "xml"});
 
         try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
@@ -76,7 +76,7 @@ public class UtilsTest {
         final String[] fileExtensions = {"java"};
         File file = new File("file.pdf");
         assertFalse(Utils.fileExtensionMatches(file, fileExtensions));
-        assertTrue(Utils.fileExtensionMatches(file, null));
+        assertTrue(Utils.fileExtensionMatches(file, (String[]) null));
         file = new File("file.java");
         assertTrue(Utils.fileExtensionMatches(file, fileExtensions));
         file = new File("file.");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
@@ -99,7 +99,7 @@ public class FileLengthCheckTest
         check.setFileExtensions(".java");
         assertEquals("extension should be the same", ".java", check.getFileExtensions()[0]);
         try {
-            check.setFileExtensions(null);
+            check.setFileExtensions((String[]) null);
             fail();
         }
         catch (IllegalArgumentException ex) {


### PR DESCRIPTION
Eclipse warning:
> Type null of the last argument to method fileExtensionMatches(File, String...) doesn't exactly match the vararg parameter type. Cast to String[] to confirm the non-varargs invocation, or pass individual arguments of type String for a varargs invocation.

Compiler doesn't know how to treat **null** argument: array or element of array