### PR TITLE
Issue #1566: MemberName and MethodName violations fixed

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -242,7 +242,7 @@ public class UnusedImportsCheck extends Check {
                 : getValidTags(cmt, JavadocUtils.JavadocTagType.BLOCK)) {
             if (tag.canReferenceImports()) {
                 references.addAll(
-                        matchPattern(tag.getArg1(), FIRST_CLASS_NAME));
+                        matchPattern(tag.getFirstArg(), FIRST_CLASS_NAME));
             }
         }
         return references;
@@ -266,7 +266,7 @@ public class UnusedImportsCheck extends Check {
      */
     private static Set<String> processJavadocTag(JavadocTag tag) {
         final Set<String> references = new HashSet<>();
-        final String identifier = tag.getArg1().trim();
+        final String identifier = tag.getFirstArg().trim();
         for (Pattern pattern : new Pattern[]
         {FIRST_CLASS_NAME, ARGUMENT_NAME}) {
             references.addAll(matchPattern(identifier, pattern));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -218,7 +218,7 @@ public abstract class AbstractJavadocCheck extends Check {
         }
 
         if (parseErrorMessage == null) {
-            final DetailNode tree = convertParseTree2DetailNode(parseTree);
+            final DetailNode tree = convertParseTreeToDetailNode(parseTree);
             result.setTree(tree);
         }
         else {
@@ -234,7 +234,7 @@ public abstract class AbstractJavadocCheck extends Check {
      * @param parseTreeNode root node of ParseTree
      * @return root of DetailNode tree
      */
-    private DetailNode convertParseTree2DetailNode(ParseTree parseTreeNode) {
+    private DetailNode convertParseTreeToDetailNode(ParseTree parseTreeNode) {
         final JavadocNodeImpl rootJavadocNode = createJavadocNode(parseTreeNode, null, -1);
 
         int childCount = parseTreeNode.getChildCount();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -730,7 +730,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
 
             // Loop looking for matching param
             final Iterator<DetailAST> paramIt = params.iterator();
-            final String arg1 = tag.getArg1();
+            final String arg1 = tag.getFirstArg();
             while (paramIt.hasNext()) {
                 final DetailAST param = paramIt.next();
                 if (param.getText().equals(arg1)) {
@@ -857,8 +857,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
             tagIt.remove();
 
             // Loop looking for matching throw
-            final String documentedEx = tag.getArg1();
-            final Token token = new Token(tag.getArg1(), tag.getLineNo(), tag
+            final String documentedEx = tag.getFirstArg();
+            final Token token = new Token(tag.getFirstArg(), tag.getLineNo(), tag
                     .getColumnNo());
             final AbstractClassInfo documentedCI = createClassInfo(token,
                     getCurrentClassName());
@@ -902,7 +902,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
                 if (reqd && validateThrows) {
                     log(tag.getLineNo(), tag.getColumnNo(),
                         MSG_UNUSED_TAG,
-                        JavadocTagInfo.THROWS.getText(), tag.getArg1());
+                        JavadocTagInfo.THROWS.getText(), tag.getFirstArg());
 
                 }
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java
@@ -31,7 +31,7 @@ public class JavadocTag {
     /** the column number of the tag **/
     private final int columnNo;
     /** an optional first argument. For example the parameter name. **/
-    private final String arg1;
+    private final String firstArg;
     /** the JavadocTagInfo representing this tag **/
     private final JavadocTagInfo tagInfo;
 
@@ -40,12 +40,12 @@ public class JavadocTag {
      * @param line the line number of the tag
      * @param column the column number of the tag
      * @param tag the tag string
-     * @param arg1 the tag argument
+     * @param firstArg the tag argument
      **/
-    public JavadocTag(int line, int column, String tag, String arg1) {
+    public JavadocTag(int line, int column, String tag, String firstArg) {
         lineNo = line;
         columnNo = column;
-        this.arg1 = arg1;
+        this.firstArg = firstArg;
         tagInfo = JavadocTagInfo.fromName(tag);
     }
 
@@ -65,8 +65,8 @@ public class JavadocTag {
     }
 
     /** @return the first argument. null if not set. **/
-    public String getArg1() {
-        return arg1;
+    public String getFirstArg() {
+        return firstArg;
     }
 
     /** @return the line number **/
@@ -82,7 +82,7 @@ public class JavadocTag {
     @Override
     public String toString() {
         return "JavadocTag{tag='" + getTagName() + "' lineNo=" + lineNo + ", columnNo=" + columnNo
-                + ", arg1='" + arg1 + "'}";
+                + ", firstArg='" + firstArg + "'}";
     }
 
     /** @return whether the tag is an 'return' tag **/

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -266,7 +266,7 @@ public class JavadocTypeCheck
             final JavadocTag tag = tags.get(i);
             if (tag.getTagName().equals(tagName)) {
                 tagCount++;
-                if (!formatPattern.matcher(tag.getArg1()).find()) {
+                if (!formatPattern.matcher(tag.getFirstArg()).find()) {
                     log(lineNo, TAG_FORMAT, "@" + tagName, format);
                 }
             }
@@ -289,7 +289,7 @@ public class JavadocTypeCheck
         for (int i = tags.size() - 1; i >= 0; i--) {
             final JavadocTag tag = tags.get(i);
             if (tag.isParamTag()
-                && tag.getArg1().indexOf("<" + typeParamName + ">") == 0) {
+                && tag.getFirstArg().indexOf("<" + typeParamName + ">") == 0) {
                 found = true;
             }
         }
@@ -312,7 +312,7 @@ public class JavadocTypeCheck
             final JavadocTag tag = tags.get(i);
             if (tag.isParamTag()) {
 
-                final Matcher matcher = pattern.matcher(tag.getArg1());
+                final Matcher matcher = pattern.matcher(tag.getFirstArg());
                 matcher.find();
                 final String typeParamName = matcher.group(1).trim();
                 if (!typeParamNames.contains(typeParamName)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java
@@ -39,10 +39,10 @@ class ListToTreeSelectionModelWrapper extends DefaultTreeSelectionModel {
     /** Set to true when we are updating the ListSelectionModel. */
     protected boolean updatingListSelectionModel;
     /** JTreeTable to perform updates on */
-    private final JTreeTable jTreeTable;
+    private final JTreeTable treeTable;
 
     public ListToTreeSelectionModelWrapper(JTreeTable jTreeTable) {
-        this.jTreeTable = jTreeTable;
+        this.treeTable = jTreeTable;
         getListSelectionModel().addListSelectionListener(createListSelectionListener());
     }
 
@@ -122,7 +122,7 @@ class ListToTreeSelectionModelWrapper extends DefaultTreeSelectionModel {
      */
     private void updateSelectedPathIfRowIsSelected(int counter) {
         if (listSelectionModel.isSelectedIndex(counter)) {
-            final TreePath selPath = jTreeTable.tree.getPathForRow(counter);
+            final TreePath selPath = treeTable.tree.getPathForRow(counter);
 
             if (selPath != null) {
                 addSelectionPath(selPath);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -61,11 +61,11 @@ public class ParseTreeInfoPanel extends JPanel {
     private static final long serialVersionUID = -4243405131202059043L;
 
     private final transient ParseTreeModel parseTreeModel;
-    private final JTextArea jTextArea;
+    private final JTextArea textArea;
     private File lastDirectory;
     private File currentFile;
     private final Action reloadAction;
-    private final List<Integer>   lines2position  = new ArrayList<>();
+    private final List<Integer>   linesToPosition  = new ArrayList<>();
 
     /**
      * Create a new ParseTreeInfoPanel instance.
@@ -85,12 +85,12 @@ public class ParseTreeInfoPanel extends JPanel {
         reloadAction.setEnabled(false);
         final JButton reloadButton = new JButton(reloadAction);
 
-        jTextArea = new JTextArea(20, 15);
-        jTextArea.setEditable(false);
-        treeTable.setEditor(jTextArea);
-        treeTable.setLinePositionMap(lines2position);
+        textArea = new JTextArea(20, 15);
+        textArea.setEditable(false);
+        treeTable.setEditor(textArea);
+        treeTable.setLinePositionMap(linesToPosition);
 
-        final JScrollPane sp2 = new JScrollPane(jTextArea);
+        final JScrollPane sp2 = new JScrollPane(textArea);
         add(sp2, BorderLayout.CENTER);
 
         final JPanel p = new JPanel(new GridLayout(1, 2));
@@ -112,18 +112,18 @@ public class ParseTreeInfoPanel extends JPanel {
         reloadAction.setEnabled(true);
 
         // clear for each new file
-        getLines2position().clear();
+        getLinesToPosition().clear();
         // starts line counting at 1
-        getLines2position().add(0);
+        getLinesToPosition().add(0);
         // insert the contents of the file to the text area
 
         // clean the text area before inserting the lines of the new file
-        if (!jTextArea.getText().isEmpty()) {
-            jTextArea.replaceRange("", 0, jTextArea.getText().length());
+        if (!textArea.getText().isEmpty()) {
+            textArea.replaceRange("", 0, textArea.getText().length());
         }
 
         // move back to the top of the file
-        jTextArea.moveCaretPosition(0);
+        textArea.moveCaretPosition(0);
     }
 
     public void openFile(File file, final Component parent) {
@@ -141,28 +141,28 @@ public class ParseTreeInfoPanel extends JPanel {
                 final String[] sourceLines = text.toLinesArray();
 
                 // clear for each new file
-                getLines2position().clear();
+                getLinesToPosition().clear();
                 // starts line counting at 1
-                getLines2position().add(0);
+                getLinesToPosition().add(0);
                 // insert the contents of the file to the text area
                 for (String element : sourceLines) {
-                    getLines2position().add(jTextArea.getText().length());
-                    jTextArea.append(element + "\n");
+                    getLinesToPosition().add(textArea.getText().length());
+                    textArea.append(element + "\n");
                 }
 
                 //clean the text area before inserting the lines of the new file
-                if (!jTextArea.getText().isEmpty()) {
-                    jTextArea.replaceRange("", 0, jTextArea.getText()
+                if (!textArea.getText().isEmpty()) {
+                    textArea.replaceRange("", 0, textArea.getText()
                             .length());
                 }
 
                 // insert the contents of the file to the text area
                 for (final String element : sourceLines) {
-                    jTextArea.append(element + "\n");
+                    textArea.append(element + "\n");
                 }
 
                 // move back to the top of the file
-                jTextArea.moveCaretPosition(0);
+                textArea.moveCaretPosition(0);
             }
             catch (final IOException | ANTLRException ex) {
                 showErrorDialog(
@@ -199,8 +199,8 @@ public class ParseTreeInfoPanel extends JPanel {
         SwingUtilities.invokeLater(showError);
     }
 
-    public List<Integer> getLines2position() {
-        return Collections.unmodifiableList(lines2position);
+    public List<Integer> getLinesToPosition() {
+        return Collections.unmodifiableList(linesToPosition);
     }
 
     /**
@@ -294,17 +294,17 @@ public class ParseTreeInfoPanel extends JPanel {
     }
 
     private class FileDropListener implements FileDrop.Listener {
-        private final JScrollPane mSp;
+        private final JScrollPane scrollPane;
 
-        public FileDropListener(JScrollPane aSp) {
-            mSp = aSp;
+        public FileDropListener(JScrollPane scrollPane) {
+            this.scrollPane = scrollPane;
         }
 
         @Override
         public void filesDropped(File... files) {
             if (files != null && files.length > 0) {
                 final File file = files[0];
-                openFile(file, mSp);
+                openFile(file, scrollPane);
             }
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagTest.java
@@ -26,10 +26,10 @@ import org.junit.Test;
 public class JavadocTagTest {
     @Test
     public void testToString() {
-        JavadocTag javadocTag = new JavadocTag(0, 1, "author", "arg1");
+        JavadocTag javadocTag = new JavadocTag(0, 1, "author", "firstArg");
 
         String result = javadocTag.toString();
 
-        assertEquals("JavadocTag{tag='author' lineNo=0, columnNo=1, arg1='arg1'}", result);
+        assertEquals("JavadocTag{tag='author' lineNo=0, columnNo=1, firstArg='firstArg'}", result);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtilsTest.java
@@ -74,7 +74,7 @@ public class JavadocUtilsTest {
         final Comment comment = new Comment(text, 1, 1, text[0].length());
         final List<JavadocTag> tags = JavadocUtils.getJavadocTags(
             comment, JavadocUtils.JavadocTagType.ALL).getValidTags();
-        assertEquals("List link text", tags.get(0).getArg1());
+        assertEquals("List link text", tags.get(0).getFirstArg());
     }
 
     @Test
@@ -85,7 +85,7 @@ public class JavadocUtilsTest {
         final Comment comment = new Comment(text, 1, 1, text[0].length());
         final List<JavadocTag> tags = JavadocUtils.getJavadocTags(
             comment, JavadocUtils.JavadocTagType.ALL).getValidTags();
-        assertEquals("List#add(Object)", tags.get(0).getArg1());
+        assertEquals("List#add(Object)", tags.get(0).getFirstArg());
     }
 
     @Test


### PR DESCRIPTION
Violations fixed:
- MemberName Name 'x' must match pattern '^[a-z][a-z0-9][a-zA-Z0-9]*$'.
- MethodName Name 'x' must match pattern '^[a-z]{2,}[a-zA-Z]+$'.