### PR TITLE
Issue #1566: HideUtilityClassConstructor violations fixed

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
@@ -37,6 +37,13 @@ public final class Main {
     private static JFrame frame;
 
     /**
+     * Hidden constructor of the current utility class.
+     */
+    private Main() {
+        // no code
+    }
+
+    /**
      * Entry point.
      * @param args the command line arguments.
      */


### PR DESCRIPTION
Violations fixed:
- HideUtilityClassConstructor - Utility classes should not have a public or default constructor.