### PR TITLE
Issue #1243: Useless Class variables

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java
@@ -10,17 +10,15 @@ import com.google.checkstyle.test.base.BaseCheckTestSupport;
 import com.google.checkstyle.test.base.ConfigurationBuilder;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
-import com.puppycrawl.tools.checkstyle.checks.naming.PackageNameCheck;
 
 public class PackageNameTest extends BaseCheckTestSupport{
-    
-	private Class<PackageNameCheck> clazz = PackageNameCheck.class;
+
 	private static ConfigurationBuilder builder;
 	private static Configuration checkConfig;
 	private String msgKey = "name.invalidPattern";
 	private static String format;
-    
-    
+
+
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
         builder = new ConfigurationBuilder(new File("src/it/"));
@@ -30,19 +28,19 @@ public class PackageNameTest extends BaseCheckTestSupport{
 
     @Test
     public void goodPackageNameTest() throws IOException, Exception {
-        
-        
+
+
         final String[] expected = {};
-        
+
         String filePath = builder.getFilePath("PackageNameInputGood");
-        
+
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }
-    
+
     @Test
     public void badPackageNameTest() throws IOException, Exception {
-        
+
         String packagePath =
                 "com.google.checkstyle.test.chapter5naming.rule521packageNamesCamelCase";
         String msg = getCheckMessage(checkConfig.getMessages(), msgKey, packagePath, format);
@@ -50,43 +48,43 @@ public class PackageNameTest extends BaseCheckTestSupport{
         final String[] expected = {
             "1:9: " + msg,
         };
-        
+
         String filePath = builder.getFilePath("PackageNameInputBad");
-        
+
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }
 
     @Test
     public void badPackageName2Test() throws IOException, Exception {
-        
-        
+
+
         String packagePath = "com.google.checkstyle.test.chapter5naming.rule521_packagenames";
         String msg = getCheckMessage(checkConfig.getMessages(), msgKey, packagePath, format);
 
         final String[] expected = {
             "1:9: " + msg,
         };
-        
+
         String filePath = builder.getFilePath("BadPackageNameInput2");
-        
+
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }
-    
+
     @Test
     public void badPackageName3Test() throws IOException, Exception {
-        
-        
+
+
         String packagePath = "com.google.checkstyle.test.chapter5naming.rule521$packagenames";
         String msg = getCheckMessage(checkConfig.getMessages(), msgKey, packagePath, format);
 
         final String[] expected = {
             "1:9: " + msg,
         };
-        
+
         String filePath = builder.getFilePath("PackageBadNameInput3");
-        
+
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule522typenames/TypeNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule522typenames/TypeNameTest.java
@@ -10,12 +10,11 @@ import com.google.checkstyle.test.base.BaseCheckTestSupport;
 import com.google.checkstyle.test.base.ConfigurationBuilder;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
-import com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck;
 
 public class TypeNameTest extends BaseCheckTestSupport{
-    
+
 	private static ConfigurationBuilder builder;
-    
+
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
         builder = new ConfigurationBuilder(new File("src/it/"));
@@ -23,9 +22,8 @@ public class TypeNameTest extends BaseCheckTestSupport{
 
     @Test
     public void typeNameTest() throws IOException, Exception {
-        
+
         Configuration checkConfig = builder.getCheckConfig("TypeName");
-        Class<TypeNameCheck> clazz = TypeNameCheck.class;
         String msgKey = "name.invalidPattern";
         String format = "^[A-Z][a-zA-Z0-9]*$";
 
@@ -61,9 +59,9 @@ public class TypeNameTest extends BaseCheckTestSupport{
             "69:12: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Annot$ation", format),
             "71:12: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Annotation$", format),
         };
-        
+
         String filePath = builder.getFilePath("TypeNameInput");
-        
+
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java
@@ -10,12 +10,10 @@ import com.google.checkstyle.test.base.BaseCheckTestSupport;
 import com.google.checkstyle.test.base.ConfigurationBuilder;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
-import com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck;
 
 public class MemberNameTest extends BaseCheckTestSupport{
-    
+
 	private static ConfigurationBuilder builder;
-	private Class<TypeNameCheck> clazz = TypeNameCheck.class;
 	private String msgKey = "name.invalidPattern";
 	private static Configuration checkConfig;
 	private static String format;
@@ -29,7 +27,7 @@ public class MemberNameTest extends BaseCheckTestSupport{
 
     @Test
     public void memberNameTest() throws IOException, Exception {
-        
+
         final String[] expected = {
             "5:16: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mPublic", format),
             "6:19: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mProtected", format),
@@ -47,14 +45,14 @@ public class MemberNameTest extends BaseCheckTestSupport{
         };
 
         String filePath = builder.getFilePath("MemberNameInput_Basic");
-        
+
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }
 
     @Test
     public void simpleTest() throws IOException, Exception {
-        
+
         final String[] expected = {
             "12:17: " + getCheckMessage(checkConfig.getMessages(), msgKey, "bad$Static", format),
             "17:17: " + getCheckMessage(checkConfig.getMessages(), msgKey, "bad_Member", format),
@@ -91,7 +89,7 @@ public class MemberNameTest extends BaseCheckTestSupport{
         };
 
         String filePath = builder.getFilePath("MemberNameInput_Simple");
-        
+
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java
@@ -10,11 +10,9 @@ import com.google.checkstyle.test.base.BaseCheckTestSupport;
 import com.google.checkstyle.test.base.ConfigurationBuilder;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
-import com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck;
 
 public class ParameterNameTest extends BaseCheckTestSupport{
 
-	private Class<ParameterNameCheck> clazz = ParameterNameCheck.class;
 	private String msgKey = "name.invalidPattern";
 	private static String format;
 	private static ConfigurationBuilder builder;
@@ -46,7 +44,7 @@ public class ParameterNameTest extends BaseCheckTestSupport{
         };
 
         String filePath = builder.getFilePath("ParameterNameInput_Simple");
-        
+
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
@@ -10,12 +10,10 @@ import com.google.checkstyle.test.base.BaseCheckTestSupport;
 import com.google.checkstyle.test.base.ConfigurationBuilder;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
-import com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck;
 
 public class LocalVariableNameTest extends BaseCheckTestSupport{
 
 	private static ConfigurationBuilder builder;
-	private Class<LocalVariableNameCheck> clazz = LocalVariableNameCheck.class;
 	private String msgKey = "name.invalidPattern";
 	private static Configuration checkConfig;
 	private static String format;
@@ -49,7 +47,7 @@ public class LocalVariableNameTest extends BaseCheckTestSupport{
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }
-    
+
     @Test
     public void oneCharTest() throws IOException, Exception {
 
@@ -64,7 +62,7 @@ public class LocalVariableNameTest extends BaseCheckTestSupport{
         };
 
         String filePath = builder.getFilePath("LocalVariableNameInput_OneCharVarName");
-        
+
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassMethodTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassMethodTypeParameterNameTest.java
@@ -10,17 +10,14 @@ import com.google.checkstyle.test.base.BaseCheckTestSupport;
 import com.google.checkstyle.test.base.ConfigurationBuilder;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
-import com.puppycrawl.tools.checkstyle.checks.naming.ClassTypeParameterNameCheck;
-import com.puppycrawl.tools.checkstyle.checks.naming.MethodTypeParameterNameCheck;
 
 public class ClassMethodTypeParameterNameTest extends BaseCheckTestSupport{
 
     private static ConfigurationBuilder builder;
-    private Class<ClassTypeParameterNameCheck> clazz = ClassTypeParameterNameCheck.class;
     private String msgKey = "name.invalidPattern";
     private static Configuration checkConfig;
     private static String format;
-    
+
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {
         builder = new ConfigurationBuilder(new File("src/it/"));
@@ -38,7 +35,7 @@ public class ClassMethodTypeParameterNameTest extends BaseCheckTestSupport{
         };
 
         String filePath = builder.getFilePath("ClassTypeParameterNameInput");
-        
+
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }
@@ -46,7 +43,6 @@ public class ClassMethodTypeParameterNameTest extends BaseCheckTestSupport{
     @Test
     public void testMethodDefault() throws IOException, Exception {
 
-        Class<MethodTypeParameterNameCheck> clazz = MethodTypeParameterNameCheck.class;
         Configuration checkConfig = builder.getCheckConfig("MethodTypeParameterName");
 
         final String[] expected = {
@@ -58,9 +54,9 @@ public class ClassMethodTypeParameterNameTest extends BaseCheckTestSupport{
             "42:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "EE", format),
         };
 
-        
+
         String filePath = builder.getFilePath("MethodTypeParameterNameInput");
-        
+
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }


### PR DESCRIPTION
I'm not sure why these variable are defined. Maybe for loading a class, however ConfigurationBuilder does it by itself, so unit tests don't fail.