### PR TITLE
Mark fields as final. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/CommentSuppressor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/CommentSuppressor.java
@@ -28,7 +28,7 @@ import com.puppycrawl.tools.checkstyle.api.FileContents;
  */
 class CommentSuppressor implements MatchSuppressor {
     /** File contents to check for comments. */
-    private FileContents currentContents;
+    private final FileContents currentContents;
 
     /**
      * Constructor for this suppressor.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -312,7 +312,7 @@ public class SuppressionCommentFilter
         private final Pattern tagCheckRegexp;
 
         /** The parsed message regexp, expanded for the text of this tag. */
-        private Pattern tagMessageRegexp;
+        private final Pattern tagMessageRegexp;
 
         /**
          * Constructs a tag.
@@ -343,6 +343,9 @@ public class SuppressionCommentFilter
                             expandFromCoont(text, filter.messageFormat, filter.onRegexp);
                         tagMessageRegexp = Pattern.compile(format);
                     }
+                    else {
+                        tagMessageRegexp = null;
+                    }
                 }
                 else {
                     format =
@@ -355,6 +358,9 @@ public class SuppressionCommentFilter
                                 filter.messageFormat,
                                 filter.offRegexp);
                         tagMessageRegexp = Pattern.compile(format);
+                    }
+                    else {
+                        tagMessageRegexp = null;
                     }
                 }
             }


### PR DESCRIPTION
Fixes `FieldMayBeFinal` inspection violations.

Description:
>Reports any fields which may safely be made final. A static field may be final if it is initialized in its declaration or in one static class initializer, but not both. A non-static field may be final if it is initialized in its declaration or in one non-static class initializer or in all constructors.