### PR TITLE
Remove unnecessary this. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -150,7 +150,7 @@ public abstract class AbstractJavadocCheck extends Check {
     @Override
     public final void visitToken(DetailAST blockCommentNode) {
         if (JavadocUtils.isJavadocComment(blockCommentNode)) {
-            this.blockCommentAst = blockCommentNode;
+            blockCommentAst = blockCommentNode;
 
             final String treeCacheKey = blockCommentNode.getLineNo() + ":"
                     + blockCommentNode.getColumnNo();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -469,8 +469,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     private boolean shouldCheck(final DetailAST ast, final Scope nodeScope) {
         final Scope surroundingScope = ScopeUtils.getSurroundingScope(ast);
 
-        return nodeScope.isIn(this.scope)
-                && surroundingScope.isIn(this.scope)
+        return nodeScope.isIn(scope)
+                && surroundingScope.isIn(scope)
                 && (excludeScope == null || !nodeScope.isIn(excludeScope)
                     || !surroundingScope.isIn(excludeScope));
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -184,8 +184,8 @@ public class JavadocStyleCheck
             ? Scope.PUBLIC : declaredScope;
         final Scope surroundingScope = ScopeUtils.getSurroundingScope(ast);
 
-        return customScope.isIn(this.scope)
-            && (surroundingScope == null || surroundingScope.isIn(this.scope))
+        return customScope.isIn(scope)
+            && (surroundingScope == null || surroundingScope.isIn(scope))
             && (excludeScope == null
                 || !customScope.isIn(excludeScope)
                 || surroundingScope != null

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -222,8 +222,8 @@ public class JavadocTypeCheck
                 ? Scope.PUBLIC : declaredScope;
         final Scope surroundingScope = ScopeUtils.getSurroundingScope(ast);
 
-        return customScope.isIn(this.scope)
-            && (surroundingScope == null || surroundingScope.isIn(this.scope))
+        return customScope.isIn(scope)
+            && (surroundingScope == null || surroundingScope.isIn(scope))
             && (excludeScope == null
                 || !customScope.isIn(excludeScope)
                 || surroundingScope != null

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -142,7 +142,7 @@ public class JavadocVariableCheck
 
         final Scope surroundingScope = ScopeUtils.getSurroundingScope(ast);
 
-        return customScope.isIn(this.scope) && surroundingScope.isIn(this.scope)
+        return customScope.isIn(scope) && surroundingScope.isIn(scope)
             && (excludeScope == null
                 || !customScope.isIn(excludeScope)
                 || !surroundingScope.isIn(excludeScope));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -83,7 +83,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
         for (String sTag : sTags) {
             tagList.add(sTag.trim());
         }
-        this.ignoredTags = tagList;
+        ignoredTags = tagList;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
@@ -76,7 +76,7 @@ class MultilineDetector {
      * @param fileText the text to process
      */
     public void processLines(FileText fileText) {
-        this.text = new FileText(fileText);
+        text = new FileText(fileText);
         resetState();
 
         if (Strings.isNullOrEmpty(options.getFormat())) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java
@@ -106,6 +106,6 @@ public class RegexpSinglelineJavaCheck extends Check {
      * @param ignore whether to ignore comments when matching.
      */
     public void setIgnoreComments(boolean ignore) {
-        this.ignoreComments = ignore;
+        ignoreComments = ignore;
     }
 }


### PR DESCRIPTION
Fixes `UnnecessaryThis` inspection violations after recent commits.

Description:
>Reports on any unnecessary uses of this in the code. Using this to disambiguate a code reference may easily become unnecessary via automatic refactorings, and is discouraged by many coding styles.