### PR TITLE
Add missing case in switch. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -265,6 +265,7 @@ public final class AnnotationUseStyleCheck extends Check {
             case EXPANDED:
                 checkExpandedStyle(annotation);
                 break;
+            case IGNORE:
             default:
                 break;
         }


### PR DESCRIPTION
Fixes `EnumSwitchStatementWhichMissesCases` inspection violation.

Description:
>Reports switch statements over enumerated types which do not include all of the enumerated type's elements as cases.