### PR TITLE
Fix exception creation without any arguments specified. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/CheckUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/CheckUtils.java
@@ -47,7 +47,6 @@ public final class CheckUtils {
 
     /** prevent instances */
     private CheckUtils() {
-        throw new UnsupportedOperationException();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -568,13 +568,13 @@ public abstract class AbstractJavadocCheck extends Check {
                 errorMessage = new ParseErrorMessage(lineNumber,
                         JAVADOC_MISSED_HTML_CLOSE, charPositionInLine, token.getText());
 
-                throw new ParseCancellationException();
+                throw new ParseCancellationException(msg);
             }
             else if (JAVADOC_WRONG_SINGLETON_TAG.equals(msg)) {
                 errorMessage = new ParseErrorMessage(lineNumber,
                         JAVADOC_WRONG_SINGLETON_TAG, charPositionInLine, token.getText());
 
-                throw new ParseCancellationException();
+                throw new ParseCancellationException(msg);
             }
             else {
                 final int ruleIndex = ex.getCtx().getRuleIndex();


### PR DESCRIPTION
Fixes `NewExceptionWithoutArguments` inspection violation.

Description:
>Reports exception instance creation without any arguments specified. When an exception is constructed without arguments it contains no information about the fault that happened, which makes debugging needlessly hard.