### PR TITLE
Replace <code> tags with {@code ...} constructs. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.java
@@ -44,7 +44,7 @@ public abstract class AbstractFormatCheck
     private String format;
 
     /**
-     * Creates a new <code>AbstractFormatCheck</code> instance. Defaults the
+     * Creates a new {@code AbstractFormatCheck} instance. Defaults the
      * compile flag to 0 (the default).
      * @param defaultFormat default format
      * @throws ConversionException unable to parse defaultFormat
@@ -54,7 +54,7 @@ public abstract class AbstractFormatCheck
     }
 
     /**
-     * Creates a new <code>AbstractFormatCheck</code> instance.
+     * Creates a new {@code AbstractFormatCheck} instance.
      * @param defaultFormat default format
      * @param compileFlags the Pattern flags to compile the regexp with.
      * See {@link Pattern#compile(String, int)}
@@ -66,7 +66,7 @@ public abstract class AbstractFormatCheck
 
     /**
      * Set the format to the specified regular expression.
-     * @param format a <code>String</code> value
+     * @param format a {@code String} value
      * @throws ConversionException unable to parse format
      */
     public final void setFormat(String format) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
@@ -70,7 +70,7 @@ public class IllegalImportCheck
     private String[] illegalPkgs;
 
     /**
-     * Creates a new <code>IllegalImportCheck</code> instance.
+     * Creates a new {@code IllegalImportCheck} instance.
      */
     public IllegalImportCheck() {
         setIllegalPkgs("sun");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -229,9 +229,9 @@ public class CommentsIndentationCheck extends Check {
     /**
      * Checks if current single line comment is trailing comment, e.g.:
      * <p>
-     * <code>
+     * {@code
      * double d = 3.14; // some comment
-     * </code>
+     * }
      * </p>
      * @param singleLineComment {@link TokenTypes#SINGLE_LINE_COMMENT single line comment}.
      * @return true if current single line comment is trailing comment.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
@@ -68,7 +68,7 @@ public final class AbstractClassNameCheck extends AbstractFormatCheck {
     }
 
     /**
-     * Whether to ignore checking for the <code>abstract</code> modifier.
+     * Whether to ignore checking for the {@code abstract} modifier.
      * @param value new value
      */
     public void setIgnoreModifier(boolean value) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
@@ -63,7 +63,7 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractFormatCheck;
 public class PackageNameCheck
     extends AbstractFormatCheck {
     /**
-     * Creates a new <code>PackageNameCheck</code> instance.
+     * Creates a new {@code PackageNameCheck} instance.
      */
     public PackageNameCheck() {
         // Uppercase letters seem rather uncommon, but they're allowed in

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -295,7 +295,7 @@ public class WhitespaceAroundCheck extends Check {
 
     /**
      * Sets whether or not empty method bodies are allowed.
-     * @param allow <code>true</code> to allow empty method bodies.
+     * @param allow {@code true} to allow empty method bodies.
      */
     public void setAllowEmptyMethods(boolean allow) {
         allowEmptyMethods = allow;
@@ -303,7 +303,7 @@ public class WhitespaceAroundCheck extends Check {
 
     /**
      * Sets whether or not empty constructor bodies are allowed.
-     * @param allow <code>true</code> to allow empty constructor bodies.
+     * @param allow {@code true} to allow empty constructor bodies.
      */
     public void setAllowEmptyConstructors(boolean allow) {
         allowEmptyCtors = allow;
@@ -312,7 +312,7 @@ public class WhitespaceAroundCheck extends Check {
     /**
      * Sets whether or not to ignore the whitespace around the
      * colon in an enhanced for loop.
-     * @param ignore <code>true</code> to ignore enhanced for colon.
+     * @param ignore {@code true} to ignore enhanced for colon.
      */
     public void setIgnoreEnhancedForColon(boolean ignore) {
         ignoreEnhancedForColon = ignore;
@@ -320,7 +320,7 @@ public class WhitespaceAroundCheck extends Check {
 
     /**
      * Sets whether or not empty type bodies are allowed.
-     * @param allow <code>true</code> to allow empty type bodies.
+     * @param allow {@code true} to allow empty type bodies.
      */
     public void setAllowEmptyTypes(boolean allow) {
         allowEmptyTypes = allow;
@@ -328,7 +328,7 @@ public class WhitespaceAroundCheck extends Check {
 
     /**
      * Sets whether or not empty loop bodies are allowed.
-     * @param allow <code>true</code> to allow empty loops bodies.
+     * @param allow {@code true} to allow empty loops bodies.
      */
     public void setAllowEmptyLoops(boolean allow) {
         allowEmptyLoops = allow;
@@ -466,11 +466,11 @@ public class WhitespaceAroundCheck extends Check {
     }
 
     /**
-     * Test if the given <code>DetailAST</code> is part of an allowed empty
+     * Test if the given {@code DetailAST} is part of an allowed empty
      * method block.
-     * @param ast the <code>DetailAST</code> to test.
-     * @param parentType the token type of <code>ast</code>'s parent.
-     * @return <code>true</code> if <code>ast</code> makes up part of an
+     * @param ast the {@code DetailAST} to test.
+     * @param parentType the token type of {@code ast}'s parent.
+     * @return {@code true} if {@code ast} makes up part of an
      *         allowed empty method block.
      */
     private boolean isEmptyMethodBlock(DetailAST ast, int parentType) {
@@ -493,9 +493,9 @@ public class WhitespaceAroundCheck extends Check {
 
     /**
      *
-     * @param ast ast the <code>DetailAST</code> to test.
-     * @param parentType the token type of <code>ast</code>'s parent.
-     * @return <code>true</code> if <code>ast</code> makes up part of an
+     * @param ast ast the {@code DetailAST} to test.
+     * @param parentType the token type of {@code ast}'s parent.
+     * @return {@code true} if {@code ast} makes up part of an
      *         allowed empty loop block.
      */
     private boolean isEmptyLoop(DetailAST ast, int parentType) {


### PR DESCRIPTION
Fixes `HtmlTagCanBeJavadocTag` inspection violations.

Description:
>Reports use of <code> tags in Javadoc comments. Since JDK1.5 these constructs may be replaced with {@code ...} constructs. This allows the use of angle brackets (<, >) inside the comment, instead of HTML character entities.