### PR TITLE
Do not allocate arrays of zero length. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -72,7 +74,7 @@ public class AvoidStaticImportCheck
     public static final String MSG_KEY = "import.avoidStatic";
 
     /** the classes/static members to exempt from this check. */
-    private String[] excludes = new String[0];
+    private String[] excludes = ArrayUtils.EMPTY_STRING_ARRAY;
 
     @Override
     public int[] getDefaultTokens() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.Utils;
@@ -51,7 +53,7 @@ public final class JavadocUtils {
 
         final Field[] fields = JavadocTokenTypes.class.getDeclaredFields();
 
-        String[] tempTokenValueToName = new String[0];
+        String[] tempTokenValueToName = ArrayUtils.EMPTY_STRING_ARRAY;
 
         for (final Field field : fields) {
 


### PR DESCRIPTION
Fixes `ZeroLengthArrayInitialization` inspection violations.

Description:
>Reports on allocations of arrays with known lengths of zero. Since array lengths in Java are non-modifiable, it is almost always possible to share zero-length arrays, rather than repeatedly allocating new zero-length arrays. Such sharing may provide useful optimizations in program runtime or footprint. Note that this inspection does not report zero-length arrays allocated as static final fields, as it is assumed that those arrays are being used to implement array sharing.