### PR TITLE
Remove unnecessary synchronization. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -131,21 +131,15 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
          */
         private final Multiset<String> duplicatedStrings = HashMultiset
                 .create();
-        /**
-         * Lock for this class to synchronize on
-         */
-        private final Object lock = new Object();
 
         @Override
         public Object put(Object key, Object value) {
-            synchronized (lock) {
-                final Object oldValue = super.put(key, value);
-                if (oldValue != null && key instanceof String) {
-                    final String keyString = (String) key;
-                    duplicatedStrings.add(keyString);
-                }
-                return oldValue;
+            final Object oldValue = super.put(key, value);
+            if (oldValue != null && key instanceof String) {
+                final String keyString = (String) key;
+                duplicatedStrings.add(keyString);
             }
+            return oldValue;
         }
 
         public Multiset<String> getDuplicatedStrings() {


### PR DESCRIPTION
Fixes `NonSerializableFieldInSerializableClass` inspection violation.

Description:
>Reports non-synchronized methods overriding synchronized methods.

Fixes `NonSynchronizedMethodOverridesSynchronizedMethod` inspection violation.

Description:
>Reports non-Serializable fields in Serializable classes. Such fields will result in runtime exceptions if the object is serialized. Fields declared transient or static are not reported, nor are fields of classes which have defined a writeObject method. For purposes of this inspection, fields with java.util.Collection or java.util.Map types are assumed to be Serializable, unless the types they are declared to contain are non-Serializable.