### PR TITLE
Add missing toString() methods. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -266,7 +266,7 @@ public final class TreeWalker
                 else {
                     throw new CheckstyleException("Token \""
                         + token + "\" was not found in Acceptable tokens list"
-                                + " in check " + check);
+                                + " in check " + check.getClass().getName());
                 }
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -488,8 +488,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
 
         @Override
         public String toString() {
-            return "ClassAlias[alias " + getName()
-                + " for " + classInfo + "]";
+            return "ClassAlias[alias " + getName() + " for " + classInfo.getName() + "]";
         }
     }
 


### PR DESCRIPTION
Fixes `ObjectToString` inspection violations.

Description:
>Reports any calls to .toString() which use the default implementation from java.lang.Object. The default implementation is rarely desired, but easy to use by accident. Calls to .toString() on objects of type java.lang.Object are ignored by this inspection.