### PR TITLE
Remove string concatenation in format string argument. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -179,12 +179,10 @@ public class MainTest {
                         ResourceBundle.getBundle("checkstylecompilation");
                 String version = compilationProperties.getString("checkstyle.compile.version");
                 assertEquals(String.format("<?xml version=\"1.0\" encoding=\"UTF-8\"?>%n"
-                        + "<checkstyle version=\"" + version + "\">%n"
-                        + "<file name=\""
-                        + expectedPath
-                        + "\">%n"
+                        + "<checkstyle version=\"%s\">%n"
+                        + "<file name=\"%s\">%n"
                         + "</file>%n"
-                        + "</checkstyle>%n"), systemOut.getLog());
+                        + "</checkstyle>%n", version, expectedPath), systemOut.getLog());
                 assertEquals("", systemErr.getLog());
             }
         });
@@ -218,11 +216,11 @@ public class MainTest {
                     + "/src/test/resources/com/puppycrawl/tools/checkstyle/InputMain.java"
                     .replace("/", File.separator);
                 assertEquals(String.format("Starting audit...%n"
-                                + expectedPath + ":3:14: "
+                                + "%1$s:3:14: "
                                 + "warning: Name 'InputMain' must match pattern '^[a-z0-9]*$'.%n"
-                                + expectedPath + ":5:7: "
+                                + "%1$s:5:7: "
                                 + "warning: Name 'InputMainInner' must match pattern '^[a-z0-9]*$'.%n"
-                                + "Audit done.%n"),
+                                + "Audit done.%n", expectedPath),
                         systemOut.getLog());
                 assertEquals("", systemErr.getLog());
             }
@@ -242,12 +240,12 @@ public class MainTest {
                     + "/src/test/resources/com/puppycrawl/tools/checkstyle/InputMain.java"
                     .replace("/", File.separator);
                 assertEquals(String.format("Starting audit...%n"
-                        + expectedPath + ":3:14: "
+                        + "%1$s:3:14: "
                         + "Name 'InputMain' must match pattern '^[a-z0-9]*$'.%n"
-                        + expectedPath + ":5:7: "
+                        + "%1$s:5:7: "
                         + "Name 'InputMainInner' must match pattern '^[a-z0-9]*$'.%n"
                         + "Audit done.%n"
-                        + "Checkstyle ends with 2 errors.%n"), systemOut.getLog());
+                        + "Checkstyle ends with 2 errors.%n", expectedPath), systemOut.getLog());
                 assertEquals("", systemErr.getLog());
             }
         });


### PR DESCRIPTION
Fixes `StringConcatenationInFormatCall` inspection violations.

Description:
>Reports non-constant string concatenations used as a format string argument. Often this is the result of mistakenly concatenating a string format argument by typing a '+' when a ',' was meant. This inspection checks calls to appropriate methods on java.util.Formatter, java.lang.String, java.io.PrintWriter, or java.io.PrintStream.