### PR TITLE
Remove calls to simple setters from within classes. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -432,7 +432,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
      */
     @Deprecated
     public final void setClassloader(ClassLoader loader) {
-        setClassLoader(loader);
+        classLoader = loader;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -95,7 +95,7 @@ public class TranslationCheck
      */
     public TranslationCheck() {
         setFileExtensions("properties");
-        setBasenameSeparator("_");
+        basenameSeparator = "_";
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -802,10 +802,10 @@ public class CustomImportOrderCheck extends Check {
          */
         public ImportDetails(String importFullPath,
                 int lineNumber, String importGroup, boolean staticImport) {
-            setImportFullPath(importFullPath);
-            setLineNumber(lineNumber);
-            setImportGroup(importGroup);
-            setStaticImport(staticImport);
+            this.importFullPath = importFullPath;
+            this.lineNumber = lineNumber;
+            this.importGroup = importGroup;
+            this.staticImport = staticImport;
         }
 
         /**
@@ -817,29 +817,11 @@ public class CustomImportOrderCheck extends Check {
         }
 
         /**
-         * Set import full path variable.
-         * @param importFullPath
-         *        import full path variable.
-         */
-        public final void setImportFullPath(String importFullPath) {
-            this.importFullPath = importFullPath;
-        }
-
-        /**
          * Get import line number.
          * @return import line.
          */
         public int getLineNumber() {
             return lineNumber;
-        }
-
-        /**
-         * Set import line number.
-         * @param lineNumber
-         *        import line number.
-         */
-        public final void setLineNumber(int lineNumber) {
-            this.lineNumber = lineNumber;
         }
 
         /**
@@ -851,29 +833,11 @@ public class CustomImportOrderCheck extends Check {
         }
 
         /**
-         * Set import group.
-         * @param importGroup
-         *        import group.
-         */
-        public final void setImportGroup(String importGroup) {
-            this.importGroup = importGroup;
-        }
-
-        /**
          * Checks if import is static.
          * @return true, if import is static.
          */
         public boolean isStaticImport() {
             return staticImport;
-        }
-
-        /**
-         * Set true, if import is static
-         * @param isStatic
-         *        if import is static.
-         */
-        public final void setStaticImport(boolean isStatic) {
-            staticImport = isStatic;
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -78,7 +78,7 @@ public abstract class AbstractClassCouplingCheck extends Check {
      * @param defaultMax default value for allowed complexity.
      */
     protected AbstractClassCouplingCheck(int defaultMax) {
-        setMax(defaultMax);
+        max = defaultMax;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.java
@@ -153,7 +153,7 @@ public abstract class AbstractComplexityCheck
      * @param by the amount to increment by
      */
     protected final void incrementCurrentValue(BigInteger by) {
-        setCurrentValue(getCurrentValue().add(by));
+        currentValue = getCurrentValue().add(by);
     }
 
     /** Push the current value on the stack */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
@@ -57,7 +57,7 @@ public final class BooleanExpressionComplexityCheck extends Check {
 
     /** Creates new instance of the check. */
     public BooleanExpressionComplexityCheck() {
-        setMax(DEFAULT_MAX);
+        max = DEFAULT_MAX;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -126,8 +126,8 @@ public class SuppressWithNearbyCommentFilter
      */
     public SuppressWithNearbyCommentFilter() {
         setCommentFormat(DEFAULT_COMMENT_FORMAT);
-        setCheckFormat(DEFAULT_CHECK_FORMAT);
-        setInfluenceFormat(DEFAULT_INFLUENCE_FORMAT);
+        checkFormat = DEFAULT_CHECK_FORMAT;
+        influenceFormat = DEFAULT_INFLUENCE_FORMAT;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -113,7 +113,7 @@ public class SuppressionCommentFilter
     public SuppressionCommentFilter() {
         setOnCommentFormat(DEFAULT_ON_FORMAT);
         setOffCommentFormat(DEFAULT_OFF_FORMAT);
-        setCheckFormat(DEFAULT_CHECK_FORMAT);
+        checkFormat = DEFAULT_CHECK_FORMAT;
     }
 
     /**


### PR DESCRIPTION
Fixes `CallToSimpleSetterInClass` inspection violations.

Description:
>Reports any calls to a simple property setter from within the property's class. A simple property setter is defined as one which simply assigns the value of its parameter to a field, and does no other calculation. Such simple setter calls may be safely inlined, at a small performance improvement. Some coding standards also suggest against the use of simple setters for code clarity reasons.