### PR TITLE
Decrease visibility of public constructor in non-public classes. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -197,7 +197,7 @@ public class MultipleStringLiteralsCheck extends Check {
          * @param line int
          * @param col int
          */
-        public StringInfo(int line, int col) {
+        StringInfo(int line, int col) {
             this.line = line;
             this.col = col;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -122,7 +122,7 @@ public class HideUtilityClassConstructorCheck extends Check {
         /** c-tor
          * @param ast class ast
          * */
-        public Details(DetailAST ast) {
+        Details(DetailAST ast) {
             this.ast = ast;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -814,7 +814,7 @@ public class CustomImportOrderCheck extends Check {
          * @param staticImport
          *        if import is static.
          */
-        public ImportDetails(String importFullPath,
+        ImportDetails(String importFullPath,
                 int lineNumber, String importGroup, boolean staticImport) {
             this.importFullPath = importFullPath;
             this.lineNumber = lineNumber;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
@@ -54,7 +54,7 @@ class TagParser {
      * @param text the line of text to parse.
      * @param lineNo the source line number.
      */
-    public TagParser(String[] text, int lineNo) {
+    TagParser(String[] text, int lineNo) {
         parseTags(text, lineNo);
     }
 
@@ -271,7 +271,7 @@ class TagParser {
          * @param lineNo line number
          * @param columnNo column number
          */
-        public Point(int lineNo, int columnNo) {
+        Point(int lineNo, int columnNo) {
             line = lineNo;
             column = columnNo;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/CommentSuppressor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/CommentSuppressor.java
@@ -36,7 +36,7 @@ class CommentSuppressor implements MatchSuppressor {
      * @param currentContents
      *            content of checked file.
      **/
-    public CommentSuppressor(FileContents currentContents) {
+    CommentSuppressor(FileContents currentContents) {
         this.currentContents = currentContents;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
@@ -56,7 +56,7 @@ class DetectorOptions {
      * @param compileFlags the flags to create the regular expression with.
      * @param reporter used to report violations.
      */
-    public DetectorOptions(int compileFlags,
+    DetectorOptions(int compileFlags,
             AbstractViolationReporter reporter) {
         this.compileFlags = compileFlags;
         this.reporter = reporter;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
@@ -67,7 +67,7 @@ class MultilineDetector {
      * Creates an instance.
      * @param options the options to use.
      */
-    public MultilineDetector(DetectorOptions options) {
+    MultilineDetector(DetectorOptions options) {
         this.options = options;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java
@@ -36,7 +36,7 @@ class SinglelineDetector {
      * Creates an instance.
      * @param options the options to use.
      */
-    public SinglelineDetector(DetectorOptions options) {
+    SinglelineDetector(DetectorOptions options) {
         this.options = options;
     }
 


### PR DESCRIPTION
Fixes `PublicConstructorInNonPublicClass` inspection violations.

Description:
>Reports all constructors in non-public classes that are declared public.