### PR TITLE
Correct names for constants. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/comments/AllBlockCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/comments/AllBlockCommentsTest.java
@@ -34,7 +34,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class AllBlockCommentsTest extends BaseCheckTestSupport {
-    protected static final Set<String> allComments = Sets.newLinkedHashSet();
+    protected static final Set<String> ALL_COMMENTS = Sets.newLinkedHashSet();
 
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
@@ -44,7 +44,7 @@ public class AllBlockCommentsTest extends BaseCheckTestSupport {
         final String[] expected = {};
         verify(checkConfig, getPath("comments" + File.separator
                 + "InputFullOfBlockComments.java"), expected);
-        Assert.assertTrue(allComments.isEmpty());
+        Assert.assertTrue(ALL_COMMENTS.isEmpty());
     }
 
     public static class BlockCommentListenerCheck extends Check {
@@ -65,7 +65,7 @@ public class AllBlockCommentsTest extends BaseCheckTestSupport {
 
         @Override
         public void init() {
-            allComments.addAll(Arrays.asList("0", "1", "2", "3", "4", "5",
+            ALL_COMMENTS.addAll(Arrays.asList("0", "1", "2", "3", "4", "5",
                     "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
                     "16", "17", "18", "19", "20",
                     LINE_SEPARATOR + "21" + LINE_SEPARATOR,
@@ -79,7 +79,7 @@ public class AllBlockCommentsTest extends BaseCheckTestSupport {
         @Override
         public void visitToken(DetailAST aAST) {
             String commentContent = aAST.getFirstChild().getText();
-            if (!allComments.remove(commentContent)) {
+            if (!ALL_COMMENTS.remove(commentContent)) {
                 Assert.fail("Unexpected comment: " + commentContent);
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/comments/AllSinglelineCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/comments/AllSinglelineCommentsTest.java
@@ -33,7 +33,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class AllSinglelineCommentsTest extends BaseCheckTestSupport {
-    protected static final Set<String> allComments = Sets.newLinkedHashSet();
+    protected static final Set<String> ALL_COMMENTS = Sets.newLinkedHashSet();
 
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
@@ -43,7 +43,7 @@ public class AllSinglelineCommentsTest extends BaseCheckTestSupport {
         final String[] expected = {};
         verify(checkConfig, getPath("comments" + File.separator
                 + "InputFullOfSinglelineComments.java"), expected);
-        Assert.assertTrue(allComments.isEmpty());
+        Assert.assertTrue(ALL_COMMENTS.isEmpty());
     }
 
     public static class SinglelineCommentListenerCheck extends Check {
@@ -66,15 +66,15 @@ public class AllSinglelineCommentsTest extends BaseCheckTestSupport {
         public void init() {
             int lines = 63;
             for (int i = 0; i < lines; i++) {
-                allComments.add(i + LINE_SEPARATOR);
+                ALL_COMMENTS.add(i + LINE_SEPARATOR);
             }
-            allComments.add(String.valueOf(lines));
+            ALL_COMMENTS.add(String.valueOf(lines));
         }
 
         @Override
         public void visitToken(DetailAST aAST) {
             String commentContent = aAST.getFirstChild().getText();
-            if (!allComments.remove(commentContent)) {
+            if (!ALL_COMMENTS.remove(commentContent)) {
                 Assert.fail("Unexpected comment: " + commentContent);
             }
         }


### PR DESCRIPTION
Fixes `ConstantNamingConvention` inspection violation in test code.

Description:
>Reports any constants whose names are either too short, too long, or do not follow the specified regular expression pattern. Constants are fields declared static final.