### PR TITLE
Use float in canonical form in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -71,7 +71,7 @@ public class AutomaticBeanTest {
     public void testContextualize_InvocationTargetException() {
         final TestBean testBean = new TestBean();
         DefaultContext context = new DefaultContext();
-        context.add("exceptionalMethod", 123f);
+        context.add("exceptionalMethod", 123.0f);
         try {
             testBean.contextualize(context);
             fail();


### PR DESCRIPTION
Fixes `ConfusingFloatingPointLiteral` inspection violation in test code.

Description:
>Reports any floating point numbers which do not have a decimal point, numbers before the decimal point, and numbers after the decimal point. Such literals may be confusing, and violate several coding standards.