### PR TITLE
Make inner class static. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -98,7 +98,7 @@ public class AutomaticBeanTest {
     }
 
     @SuppressWarnings("unused")
-    public class TestBean extends AutomaticBean {
+    public static class TestBean extends AutomaticBean {
 
         private String privateField;
 


### PR DESCRIPTION
Fixes `InnerClassMayBeStatic` inspection violation in test code.

Description:
>Reports any inner classes which may safely be made static. An inner class may be static if it doesn't reference its enclosing instance.
 A static inner class does not keep an implicit reference to its enclosing instance. This prevents a common cause of memory leaks and uses less memory per instance of the class.