### PR TITLE
Simplify JUnit assertions. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AnnotationUtilityTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AnnotationUtilityTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.puppycrawl.tools.checkstyle.TestUtils.assertUtilsClassHasPrivateConstructor;
+import static org.junit.Assert.assertEquals;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -37,7 +38,7 @@ public class AnnotationUtilityTest {
             assertUtilsClassHasPrivateConstructor(AnnotationUtility.class);
         }
         catch (InvocationTargetException ex) {
-            Assert.assertTrue("do not instantiate.".equals(ex.getCause().getMessage()));
+            assertEquals("do not instantiate.", ex.getCause().getMessage());
         }
     }
 
@@ -48,7 +49,7 @@ public class AnnotationUtilityTest {
             Assert.fail();
         }
         catch (IllegalArgumentException ex) {
-            Assert.assertTrue("the ast is null".equals(ex.getMessage()));
+            assertEquals("the ast is null", ex.getMessage());
         }
     }
 
@@ -59,7 +60,7 @@ public class AnnotationUtilityTest {
             Assert.fail();
         }
         catch (IllegalArgumentException ex) {
-            Assert.assertTrue("the ast is null".equals(ex.getMessage()));
+            assertEquals("the ast is null", ex.getMessage());
         }
     }
 
@@ -100,7 +101,7 @@ public class AnnotationUtilityTest {
             Assert.fail();
         }
         catch (IllegalArgumentException ex) {
-            Assert.assertTrue("the ast is null".equals(ex.getMessage()));
+            assertEquals("the ast is null", ex.getMessage());
         }
     }
 
@@ -111,7 +112,7 @@ public class AnnotationUtilityTest {
             Assert.fail();
         }
         catch (IllegalArgumentException ex) {
-            Assert.assertTrue("the ast is null".equals(ex.getMessage()));
+            assertEquals("the ast is null", ex.getMessage());
         }
     }
 
@@ -122,7 +123,7 @@ public class AnnotationUtilityTest {
             Assert.fail();
         }
         catch (IllegalArgumentException ex) {
-            Assert.assertTrue("the annotation is null".equals(ex.getMessage()));
+            assertEquals("the annotation is null", ex.getMessage());
         }
     }
 
@@ -133,8 +134,7 @@ public class AnnotationUtilityTest {
             Assert.fail();
         }
         catch (IllegalArgumentException ex) {
-            Assert.assertTrue("the annotation is empty or spaces"
-                    .equals(ex.getMessage()));
+            assertEquals("the annotation is empty or spaces", ex.getMessage());
         }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -416,7 +416,7 @@ public class ConfigurationLoaderTest {
                         new PropertiesExpander(new Properties()), true);
 
         final Configuration[] children = config.getChildren();
-        assertTrue(children[0].getChildren().length == 0);
+        assertEquals(0, children[0].getChildren().length);
     }
 
     @Test
@@ -429,7 +429,7 @@ public class ConfigurationLoaderTest {
                         new PropertiesExpander(new Properties()), true);
 
         final Configuration[] children = config.getChildren();
-        assertTrue(children.length == 0);
+        assertEquals(0, children.length);
     }
 
     @Test
@@ -441,7 +441,7 @@ public class ConfigurationLoaderTest {
                             new PropertiesExpander(new Properties()), true);
 
             final Configuration[] children = config.getChildren();
-            assertTrue(children[0].getChildren().length == 0);
+            assertEquals(0, children[0].getChildren().length);
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
@@ -487,7 +487,7 @@ public class ConfigurationLoaderTest {
                             new PropertiesExpander(new Properties()), true);
 
             final Configuration[] children = config.getChildren();
-            assertTrue(children[0].getChildren().length == 0);
+            assertEquals(0, children[0].getChildren().length);
         }
         catch (CheckstyleException ex) {
             fail("unexpected exception");
@@ -518,7 +518,7 @@ public class ConfigurationLoaderTest {
                             new PropertiesExpander(new Properties()), true);
 
             final Configuration[] children = config.getChildren();
-            assertTrue(children[0].getChildren().length == 0);
+            assertEquals(0, children[0].getChildren().length);
         }
         catch (CheckstyleException ex) {
             fail("unexpected exception");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultConfigurationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultConfigurationTest.java
@@ -19,7 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 public class DefaultConfigurationTest {
@@ -28,10 +29,10 @@ public class DefaultConfigurationTest {
     public void testRemoveChild() {
         DefaultConfiguration config = new DefaultConfiguration("Myconfig");
         DefaultConfiguration configChild = new DefaultConfiguration("childConfig");
-        Assert.assertTrue(config.getChildren().length == 0);
+        assertEquals(0, config.getChildren().length);
         config.addChild(configChild);
-        Assert.assertTrue(config.getChildren().length == 1);
+        assertEquals(1, config.getChildren().length);
         config.removeChild(configChild);
-        Assert.assertTrue(config.getChildren().length == 0);
+        assertEquals(0, config.getChildren().length);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -502,7 +502,7 @@ public class MainTest {
         when(fileMock.isFile()).thenReturn(false);
 
         List<File> result = (List<File>) method.invoke(null, fileMock);
-        assertTrue(result.size() == 0);
+        assertEquals(0, result.size());
     }
 
     @Test
@@ -519,6 +519,6 @@ public class MainTest {
         when(fileMock.listFiles()).thenReturn(null);
 
         List<File> result = (List<File>) method.invoke(null, fileMock);
-        assertTrue(result.size() == 0);
+        assertEquals(0, result.size());
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.SortedSet;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -83,7 +82,7 @@ public class AbstractViolationReporterTest extends BaseCheckTestSupport {
         emptyCheck.log(0, "msgKey");
 
         SortedSet<LocalizedMessage> messages = collector.getMessages();
-        Assert.assertTrue(messages.size() == 1);
+        assertEquals(1, messages.size());
         assertEquals("This is a custom message.", messages.first()
                 .getMessage());
     }
@@ -100,7 +99,7 @@ public class AbstractViolationReporterTest extends BaseCheckTestSupport {
         emptyCheck.log(0, "msgKey", "TestParam");
 
         SortedSet<LocalizedMessage> messages = collector.getMessages();
-        Assert.assertTrue(messages.size() == 1);
+        assertEquals(1, messages.size());
 
         assertEquals("This is a custom message with TestParam.",
                 messages.first().getMessage());
@@ -118,7 +117,7 @@ public class AbstractViolationReporterTest extends BaseCheckTestSupport {
         emptyCheck.log(0, "msgKey", "TestParam");
 
         SortedSet<LocalizedMessage> messages = collector.getMessages();
-        Assert.assertTrue(messages.size() == 1);
+        assertEquals(1, messages.size());
 
         //we expect an exception here because of the bogus custom message
         //format

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounterTest.java
@@ -19,7 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 public class SeverityLevelCounterTest {
@@ -33,17 +34,17 @@ public class SeverityLevelCounterTest {
     public void testAddException() {
         final SeverityLevelCounter counter = new SeverityLevelCounter(SeverityLevel.ERROR);
         final AuditEvent event = new AuditEvent(this, "ATest.java", null);
-        Assert.assertTrue(counter.getCount() == 0);
+        assertEquals(0, counter.getCount());
         counter.addException(event, new IllegalStateException());
-        Assert.assertTrue(counter.getCount() == 1);
+        assertEquals(1, counter.getCount());
     }
 
     @Test
     public void testAddExceptionWarning() {
         final SeverityLevelCounter counter = new SeverityLevelCounter(SeverityLevel.WARNING);
         final AuditEvent event = new AuditEvent(this, "ATest.java", null);
-        Assert.assertTrue(counter.getCount() == 0);
+        assertEquals(0, counter.getCount());
         counter.addException(event, new IllegalStateException());
-        Assert.assertTrue(counter.getCount() == 0);
+        assertEquals(0, counter.getCount());
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheckTest.java
@@ -20,7 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
@@ -70,7 +70,7 @@ public class ArrayTypeStyleCheckTest
         int[] expected = {TokenTypes.ARRAY_DECLARATOR };
         ArrayTypeStyleCheck check = new ArrayTypeStyleCheck();
         int[] actual = check.getAcceptableTokens();
-        assertTrue(actual.length == 1);
+        assertEquals(1, actual.length);
         assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckTest.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck.MSG_KEY;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
@@ -58,7 +58,7 @@ public class TodoCommentCheckTest
         int[] expected = {TokenTypes.COMMENT_CONTENT };
         TodoCommentCheck check = new TodoCommentCheck();
         int[] actual = check.getAcceptableTokens();
-        assertTrue(actual.length == 1);
+        assertEquals(1, actual.length);
         assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UpperEllCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UpperEllCheckTest.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.UpperEllCheck.MSG_KEY;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
@@ -55,7 +55,7 @@ public class UpperEllCheckTest
         int[] expected = {TokenTypes.NUM_LONG };
         UpperEllCheck check = new UpperEllCheck();
         int[] actual = check.getAcceptableTokens();
-        assertTrue(actual.length == 1);
+        assertEquals(1, actual.length);
         assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.annotation;
 
 import static com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideCheck.MSG_KEY_ANNOTATION_MISSING_OVERRIDE;
 import static com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideCheck.MSG_KEY_TAG_NOT_VALID_ON;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 
@@ -240,7 +241,7 @@ public class MissingOverrideCheckTest extends BaseCheckTestSupport {
         int[] expectedTokens = {TokenTypes.METHOD_DEF };
         MissingOverrideCheck check = new MissingOverrideCheck();
         int[] actual = check.getAcceptableTokens();
-        Assert.assertTrue(actual.length == 1);
+        assertEquals(1, actual.length);
         Assert.assertArrayEquals(expectedTokens, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/FilterSetTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/FilterSetTest.java
@@ -19,7 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
@@ -67,26 +69,26 @@ public class FilterSetTest {
     @Test
     public void testGetFilters() {
         filter.addFilter(new IntMatchFilter(0));
-        assertTrue("size is the same", filter.getFilters().size() == 1);
+        assertEquals("size is the same", 1, filter.getFilters().size());
     }
 
     @Test
     public void testToString() {
         filter.addFilter(new IntMatchFilter(0));
-        assertTrue("toString works", filter.toString() != null);
+        assertNotNull("toString works", filter.toString());
     }
 
     @Test
     public void testGetFilters2() {
         FilterSet filterSet = new FilterSet();
         filterSet.addFilter(new SeverityMatchFilter());
-        assertTrue("size is the same", filterSet.getFilters().size() == 1);
+        assertEquals("size is the same", 1, filterSet.getFilters().size());
     }
 
     @Test
     public void testToString2() {
         FilterSet filterSet = new FilterSet();
         filterSet.addFilter(new SeverityMatchFilter());
-        assertTrue("size is the same", filterSet.toString() != null);
+        assertNotNull("size is the same", filterSet.toString());
     }
 }


### PR DESCRIPTION
Fixes `SimplifiableJUnitAssertion` inspection violation in test code.

Description:
>Reports any JUnit assertTrue calls which can be replaced by equivalent assertEquals calls. assertEquals calls will normally give better error messages in case of test failure than assertTrue can.