### PR TITLE
Use assertSame instead of assertEquals where possible. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle;
 import static com.puppycrawl.tools.checkstyle.TestUtils.assertUtilsClassHasPrivateConstructor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -144,7 +145,7 @@ public class UtilsTest {
             fail();
         }
         catch (IllegalStateException expected) {
-            assertEquals(NoSuchMethodException.class, expected.getCause().getClass());
+            assertSame(NoSuchMethodException.class, expected.getCause().getClass());
         }
     }
 
@@ -167,7 +168,7 @@ public class UtilsTest {
             fail();
         }
         catch (IllegalStateException expected) {
-            assertEquals(InstantiationException.class, expected.getCause().getClass());
+            assertSame(InstantiationException.class, expected.getCause().getClass());
         }
     }
 


### PR DESCRIPTION
Fixes `AssertEqualsMayBeAssertSame` inspection violation in test code.

Description:
>Reports any calls to org.junit.Assert.assertEquals() or junit.framework.Assert.assertEquals() which can be replaced with an equivalent call to assertSame(). This is possible when the arguments are instances of a final class which does not override the equals() method.