### PR TITLE
Replace <code> tags with {@code ...} constructs in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheckTest.java
@@ -28,7 +28,7 @@ import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
 /**
- * The unit-test for the <code>NestedForDepthCheck</code>-checkstyle enhancement.
+ * The unit-test for the {@code NestedForDepthCheck}-checkstyle enhancement.
  * @see com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck
  */
 public class NestedForDepthCheckTest extends BaseCheckTestSupport {


### PR DESCRIPTION
Fixes `HtmlTagCanBeJavadocTag` inspection violation in test code.

Description:
>Reports use of <code> tags in Javadoc comments. Since JDK1.5 these constructs may be replaced with {@code ...} constructs. This allows the use of angle brackets (<, >) inside the comment, instead of HTML character entities.