### PR TITLE
Convert parameters to varargs in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -90,12 +90,12 @@ public abstract class BaseCheckTestSupport {
         return new File("src/test/java/com/puppycrawl/tools/checkstyle/" + filename).getCanonicalPath();
     }
 
-    protected void verify(Configuration aConfig, String fileName, String[] expected)
+    protected void verify(Configuration aConfig, String fileName, String... expected)
             throws Exception {
         verify(createChecker(aConfig), fileName, fileName, expected);
     }
 
-    protected void verify(Checker c, String fileName, String[] expected)
+    protected void verify(Checker c, String fileName, String... expected)
             throws Exception {
         verify(c, fileName, fileName, expected);
     }
@@ -103,7 +103,7 @@ public abstract class BaseCheckTestSupport {
     protected void verify(Checker c,
                           String processedFilename,
                           String messageFileName,
-                          String[] expected)
+                          String... expected)
             throws Exception {
         verify(c,
                 new File[]{new File(processedFilename)},
@@ -113,7 +113,7 @@ public abstract class BaseCheckTestSupport {
     protected void verify(Checker c,
                           File[] processedFiles,
                           String messageFileName,
-                          String[] expected)
+                          String... expected)
             throws Exception {
         stream.flush();
         final List<File> theFiles = Lists.newArrayList();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -238,7 +238,7 @@ public class XMLLoggerTest {
      * Take into consideration checkstyle element (first and last lines).
      * @param expectedLines expected error report lines
      */
-    private void verifyLines(String[] expectedLines)
+    private void verifyLines(String... expectedLines)
         throws IOException {
         final String[] lines = getOutStreamLines();
         assertEquals("length.", expectedLines.length + 3, lines.length);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -180,7 +180,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
     }
 
     private void verifyWarns(Configuration config, String filePath,
-                    String[] expected)
+                    String... expected)
                     throws Exception {
         verifyWarns(config, filePath, expected, 0);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -195,7 +195,7 @@ public class WriteTagCheckTest extends BaseCheckTestSupport {
     protected void verify(Checker c,
                           File[] processedFiles,
                           String messageFileName,
-                          String[] expected)
+                          String... expected)
         throws Exception {
         stream.flush();
         final List<File> theFiles = Lists.newArrayList();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -78,7 +78,7 @@ public class SuppressWarningsFilterTest
     }
 
     protected void verifySuppressed(Configuration aFilterConfig,
-        String[] aSuppressed) throws Exception {
+        String... aSuppressed) throws Exception {
         verify(createChecker(aFilterConfig),
             getPath("filters/InputSuppressWarningsFilter.java"),
             removeSuppressed(sAllMessages, aSuppressed));
@@ -116,7 +116,7 @@ public class SuppressWarningsFilterTest
         return checker;
     }
 
-    private static String[] removeSuppressed(String[] from, String[] remove) {
+    private static String[] removeSuppressed(String[] from, String... remove) {
         final Collection<String> coll =
             Lists.newArrayList(Arrays.asList(from));
         coll.removeAll(Arrays.asList(remove));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -196,7 +196,7 @@ public class SuppressWithNearbyCommentFilterTest
     }
 
     protected void verifySuppressed(Configuration filterConfig,
-                                    String[] suppressed)
+                                    String... suppressed)
         throws Exception {
         verify(createChecker(filterConfig),
                getPath("filters/InputSuppressWithNearbyCommentFilter.java"),
@@ -227,7 +227,7 @@ public class SuppressWithNearbyCommentFilterTest
         return checker;
     }
 
-    private static String[] removeSuppressed(String[] from, String[] remove) {
+    private static String[] removeSuppressed(String[] from, String... remove) {
         final Collection<String> coll =
             Lists.newArrayList(Arrays.asList(from));
         coll.removeAll(Arrays.asList(remove));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -196,7 +196,7 @@ public class SuppressionCommentFilterTest
     }
 
     protected void verifySuppressed(Configuration aFilterConfig,
-                                    String[] aSuppressed)
+                                    String... aSuppressed)
         throws Exception {
         verify(createChecker(aFilterConfig),
                getPath("filters/InputSuppressionCommentFilter.java"),
@@ -227,7 +227,7 @@ public class SuppressionCommentFilterTest
         return checker;
     }
 
-    private static String[] removeSuppressed(String[] from, String[] remove) {
+    private static String[] removeSuppressed(String[] from, String... remove) {
         final Collection<String> coll =
             Lists.newArrayList(Arrays.asList(from));
         coll.removeAll(Arrays.asList(remove));


### PR DESCRIPTION
Fixes `MethodCanBeVariableArityMethod` inspection violations in test code.

Description:
>Reports methods with which can be converted to be a variable arity/varargs method, available in Java 5 and newer.
This inspection only reports if the project or module is configured to use a language level of 5.0 or higher.