### PR TITLE
Remove unnecessary boxing in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/CSVFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/CSVFilterTest.java
@@ -31,49 +31,49 @@ public class CSVFilterTest {
     @Test
     public void testDecideSingle() {
         final IntFilter filter = new CSVFilter("0");
-        assertFalse("less than", filter.accept(Integer.valueOf(-1)));
-        assertTrue("equal", filter.accept(Integer.valueOf(0)));
-        assertFalse("greater than", filter.accept(Integer.valueOf(1)));
+        assertFalse("less than", filter.accept(-1));
+        assertTrue("equal", filter.accept(0));
+        assertFalse("greater than", filter.accept(1));
     }
 
     @Test
     public void testDecidePair() {
         final IntFilter filter = new CSVFilter("0, 2");
-        assertFalse("less than", filter.accept(Integer.valueOf(-1)));
-        assertTrue("equal 0", filter.accept(Integer.valueOf(0)));
-        assertFalse("greater than", filter.accept(Integer.valueOf(1)));
-        assertTrue("equal 2", filter.accept(Integer.valueOf(2)));
+        assertFalse("less than", filter.accept(-1));
+        assertTrue("equal 0", filter.accept(0));
+        assertFalse("greater than", filter.accept(1));
+        assertTrue("equal 2", filter.accept(2));
     }
 
     @Test
     public void testDecideRange() {
         final IntFilter filter = new CSVFilter("0-2");
-        assertFalse("less than", filter.accept(Integer.valueOf(-1)));
-        assertTrue("equal 0", filter.accept(Integer.valueOf(0)));
-        assertTrue("equal 1", filter.accept(Integer.valueOf(1)));
-        assertTrue("equal 2", filter.accept(Integer.valueOf(2)));
-        assertFalse("greater than", filter.accept(Integer.valueOf(3)));
+        assertFalse("less than", filter.accept(-1));
+        assertTrue("equal 0", filter.accept(0));
+        assertTrue("equal 1", filter.accept(1));
+        assertTrue("equal 2", filter.accept(2));
+        assertFalse("greater than", filter.accept(3));
     }
 
     @Test
     public void testDecideEmptyRange() {
         final IntFilter filter = new CSVFilter("2-0");
-        assertFalse("less than", filter.accept(Integer.valueOf(-1)));
-        assertFalse("equal 0", filter.accept(Integer.valueOf(0)));
-        assertFalse("equal 1", filter.accept(Integer.valueOf(1)));
-        assertFalse("equal 2", filter.accept(Integer.valueOf(2)));
-        assertFalse("greater than", filter.accept(Integer.valueOf(3)));
+        assertFalse("less than", filter.accept(-1));
+        assertFalse("equal 0", filter.accept(0));
+        assertFalse("equal 1", filter.accept(1));
+        assertFalse("equal 2", filter.accept(2));
+        assertFalse("greater than", filter.accept(3));
     }
 
     @Test
     public void testDecideRangePlusValue() {
         final IntFilter filter = new CSVFilter("0-2, 10");
-        assertFalse("less than", filter.accept(Integer.valueOf(-1)));
-        assertTrue("equal 0", filter.accept(Integer.valueOf(0)));
-        assertTrue("equal 1", filter.accept(Integer.valueOf(1)));
-        assertTrue("equal 2", filter.accept(Integer.valueOf(2)));
-        assertFalse("greater than", filter.accept(Integer.valueOf(3)));
-        assertTrue("equal 10", filter.accept(Integer.valueOf(10)));
+        assertFalse("less than", filter.accept(-1));
+        assertTrue("equal 0", filter.accept(0));
+        assertTrue("equal 1", filter.accept(1));
+        assertTrue("equal 2", filter.accept(2));
+        assertFalse("greater than", filter.accept(3));
+        assertTrue("equal 10", filter.accept(10));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterTest.java
@@ -30,9 +30,9 @@ public class IntMatchFilterTest {
     @Test
     public void testDecide() {
         final IntFilter filter = new IntMatchFilter(0);
-        assertFalse("less than", filter.accept(Integer.valueOf(-1)));
-        assertTrue("equal", filter.accept(Integer.valueOf(0)));
-        assertFalse("greater than", filter.accept(Integer.valueOf(1)));
+        assertFalse("less than", filter.accept(-1));
+        assertTrue("equal", filter.accept(0));
+        assertFalse("greater than", filter.accept(1));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterTest.java
@@ -32,29 +32,29 @@ public class IntRangeFilterTest {
     @Test
     public void testDecide() {
         final IntFilter filter = new IntRangeFilter(0, 10);
-        assertFalse("less than", filter.accept(Integer.valueOf(-1)));
-        assertTrue("in range", filter.accept(Integer.valueOf(0)));
-        assertTrue("in range", filter.accept(Integer.valueOf(5)));
-        assertTrue("in range", filter.accept(Integer.valueOf(10)));
-        assertFalse("greater than", filter.accept(Integer.valueOf(11)));
+        assertFalse("less than", filter.accept(-1));
+        assertTrue("in range", filter.accept(0));
+        assertTrue("in range", filter.accept(5));
+        assertTrue("in range", filter.accept(10));
+        assertFalse("greater than", filter.accept(11));
     }
 
     @Test
     public void testDecideSingle() {
         final IntFilter filter = new IntRangeFilter(0, 0);
-        assertFalse("less than", filter.accept(Integer.valueOf(-1)));
-        assertTrue("in range", filter.accept(Integer.valueOf(0)));
-        assertFalse("greater than", filter.accept(Integer.valueOf(1)));
+        assertFalse("less than", filter.accept(-1));
+        assertTrue("in range", filter.accept(0));
+        assertFalse("greater than", filter.accept(1));
     }
 
     @Test
     public void testDecideEmpty() {
         final IntFilter filter = new IntRangeFilter(10, 0);
-        assertFalse("out", filter.accept(Integer.valueOf(-1)));
-        assertFalse("out", filter.accept(Integer.valueOf(0)));
-        assertFalse("out", filter.accept(Integer.valueOf(5)));
-        assertFalse("out", filter.accept(Integer.valueOf(10)));
-        assertFalse("out", filter.accept(Integer.valueOf(11)));
+        assertFalse("out", filter.accept(-1));
+        assertFalse("out", filter.accept(0));
+        assertFalse("out", filter.accept(5));
+        assertFalse("out", filter.accept(10));
+        assertFalse("out", filter.accept(11));
     }
 
     @Test


### PR DESCRIPTION
Fixes `UnnecessaryBoxing` inspection violations in test code.

Description:
>Reports "boxing", e.g. wrapping of primitive values in objects. Boxing is unnecessary under Java 5 and newer, and can be safely removed.
This inspection only reports if the project or module is configured to use a language level of 5.0 or higher.