### PR TITLE
Replace for with foreach in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -225,11 +225,11 @@ public class ConfigurationLoaderTest {
         final String[] attNames = config.getAttributeNames();
         assertEquals("attributes.length", atts.size(), attNames.length);
 
-        for (int i = 0; i < attNames.length; i++) {
+        for (String attName : attNames) {
             assertEquals(
-                "attribute[" + attNames[i] + "]",
-                atts.get(attNames[i]),
-                config.getAttribute(attNames[i]));
+                "attribute[" + attName + "]",
+                atts.get(attName),
+                config.getAttribute(attName));
         }
     }
 
@@ -239,10 +239,10 @@ public class ConfigurationLoaderTest {
         final String[] testValues = {null, "", "a", "$a", "{a",
                                      "{a}", "a}", "$a}", "$", "a$b", };
         final Properties props = initProperties();
-        for (int i = 0; i < testValues.length; i++) {
+        for (String testValue : testValues) {
             final String value = ConfigurationLoader.replaceProperties(
-                testValues[i], new PropertiesExpander(props), null);
-            assertEquals("\"" + testValues[i] + "\"", value, testValues[i]);
+                testValue, new PropertiesExpander(props), null);
+            assertEquals("\"" + testValue + "\"", value, testValue);
         }
     }
 
@@ -290,11 +290,11 @@ public class ConfigurationLoaderTest {
             {"$$", "$"},
         };
         final Properties props = initProperties();
-        for (int i = 0; i < testValues.length; i++) {
+        for (String[] testValue : testValues) {
             final String value = ConfigurationLoader.replaceProperties(
-                testValues[i][0], new PropertiesExpander(props), null);
-            assertEquals("\"" + testValues[i][0] + "\"",
-                testValues[i][1], value);
+                testValue[0], new PropertiesExpander(props), null);
+            assertEquals("\"" + testValue[0] + "\"",
+                testValue[1], value);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -472,10 +472,10 @@ public class MainTest {
                 String format = "%s.java:%s: warning: File length is %s lines (max allowed is 80).";
                 StringBuilder sb = new StringBuilder();
                 sb.append("Starting audit..." + System.getProperty("line.separator"));
-                for (int i = 0; i < outputValues.length; i++) {
+                for (String[] outputValue : outputValues) {
                     String line = String.format(format,
-                            expectedPath + outputValues[i][0], outputValues[i][1],
-                            outputValues[i][2]);
+                            expectedPath + outputValue[0], outputValue[1],
+                            outputValue[2]);
                     sb.append(line + System.getProperty("line.separator"));
                 }
                 sb.append("Audit done." + System.getProperty("line.separator"));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -62,9 +62,9 @@ public class XMLLoggerTest {
             {"&#0", "&amp;#0"}, //not reference
             {"&#X0;", "&amp;#X0;"}, //not reference
         };
-        for (int i = 0; i < encodings.length; i++) {
-            final String encoded = XMLLogger.encode(encodings[i][0]);
-            assertEquals("\"" + encodings[i][0] + "\"", encodings[i][1], encoded);
+        for (String[] encoding : encodings) {
+            final String encoded = XMLLogger.encode(encoding[0]);
+            assertEquals("\"" + encoding[0] + "\"", encoding[1], encoded);
         }
         outStream.close();
     }
@@ -73,15 +73,15 @@ public class XMLLoggerTest {
     public void testIsReference()
         throws IOException {
         new XMLLogger(outStream, false);
-        final String[] reference = {
+        final String[] references = {
             "&#0;",
             "&#x0;",
         };
-        for (int i = 0; i < reference.length; i++) {
-            assertTrue("reference: " + reference[i],
-                       XMLLogger.isReference(reference[i]));
+        for (String reference : references) {
+            assertTrue("reference: " + reference,
+                    XMLLogger.isReference(reference));
         }
-        final String[] noReference = {
+        final String[] noReferences = {
             "&",
             "&;",
             "&#;",
@@ -91,9 +91,9 @@ public class XMLLoggerTest {
             "&#xg;",
             "ref",
         };
-        for (int i = 0; i < noReference.length; i++) {
-            assertFalse("no reference: " + noReference[i],
-                       XMLLogger.isReference(noReference[i]));
+        for (String noReference : noReferences) {
+            assertFalse("no reference: " + noReference,
+                    XMLLogger.isReference(noReference));
         }
 
         outStream.close();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
@@ -119,12 +119,12 @@ public class DetailASTTest {
                         && !file.getName().endsWith("InputGrammar.java");
                 }
             });
-        for (int i = 0; i < files.length; i++) {
-            if (files[i].isFile()) {
-                checkFile(files[i].getCanonicalPath());
+        for (File file : files) {
+            if (file.isFile()) {
+                checkFile(file.getCanonicalPath());
             }
-            else if (files[i].isDirectory()) {
-                checkDir(files[i]);
+            else if (file.isDirectory()) {
+                checkDir(file);
             }
         }
     }


### PR DESCRIPTION
Fixes `ForCanBeForeach` inspection violations in test code.

Description:
>Reports for loops which iterate over collections or arrays, and can be replaced with the foreach iteration syntax, available in Java 5 and newer.