### PR TITLE
Use diamond operator in test code. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -20,7 +20,7 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 
 	private File ROOT;
 
-	private List<File> files = new ArrayList<File>();
+	private List<File> files = new ArrayList<>();
 
 	Configuration config;
 	
@@ -100,7 +100,7 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 
 	public Integer[] getLinesWithWarn(String aFileName) throws IOException {
 		int lineNumber = 1;
-	    List<Integer> result = new ArrayList<Integer>();
+	    List<Integer> result = new ArrayList<>();
 	    try(BufferedReader br = new BufferedReader(new FileReader(aFileName))) {
 	        for(String line; (line = br.readLine()) != null; ) {
 	            if (warnPattern.matcher(line).find()) {


### PR DESCRIPTION
Fixes `Convert2Diamond` inspection violations.

Description:
>This inspection reports all new expressions with type arguments which can be replaced with diamond type <>
Such <> syntax is not supported under Java 1.6 or earlier JVMs.