### PR TITLE
Add private constructor to test utility class. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/ParseTreeBuilder.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/ParseTreeBuilder.java
@@ -49,8 +49,11 @@ import com.puppycrawl.tools.checkstyle.grammars.javadoc.JavadocParser.TrTagClose
 import com.puppycrawl.tools.checkstyle.grammars.javadoc.JavadocParser.TrTagOpenContext;
 
 //@formatter:off
-public class ParseTreeBuilder {
+public final class ParseTreeBuilder {
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
+    private ParseTreeBuilder() {
+    }
 
     public static ParseTree treeOneSimpleHtmlTag() {
         JavadocContext Rohae = new JavadocContext(null, 0);


### PR DESCRIPTION
Fixes `UtilityClassWithoutPrivateConstructor` inspection violation.

Description:
>Reports utility classes which do not have private constructors. Utility classes have all fields and methods declared static. Giving such classes a private constructor prevents them from being inadvertently instantiated.