### PR TITLE
Short-circuit logic should be used in boolean contexts. Issue #46

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -221,7 +221,7 @@ public class CommentsIndentationCheck extends Check {
         }
         else {
             result = singleLineComment.getColumnNo() == nextStmt.getColumnNo()
-                | singleLineComment.getColumnNo() == prevStmt.getColumnNo();
+                || singleLineComment.getColumnNo() == prevStmt.getColumnNo();
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
@@ -50,6 +50,7 @@ public class CommentsIndentationCheckTest extends BaseCheckTestSupport {
             "28: " + getCheckMessage(MSG_KEY_BLOCK, 31, 16, 12),
             "50: " + getCheckMessage(MSG_KEY_SINGLE, 51, 27, 23),
             "51: " + getCheckMessage(MSG_KEY_BLOCK, 53, 23, 36),
+            "136: " + getCheckMessage(MSG_KEY_SINGLE, 137, 20, 16),
         };
         verify(checkConfig, getPath("comments" + File.separator
                  + "InputCommentsIndentationCheckSurroundingCode.java"), expected);
@@ -73,6 +74,7 @@ public class CommentsIndentationCheckTest extends BaseCheckTestSupport {
         final String[] expected = {
             "13: " + getCheckMessage(MSG_KEY_SINGLE, 14, 14, 12),
             "50: " + getCheckMessage(MSG_KEY_SINGLE, 51, 27, 23),
+            "136: " + getCheckMessage(MSG_KEY_SINGLE, 137, 20, 16),
         };
         verify(checkConfig, getPath("comments" + File.separator
                  + "InputCommentsIndentationCheckSurroundingCode.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/comments/InputCommentsIndentationCheckSurroundingCode.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/comments/InputCommentsIndentationCheckSurroundingCode.java
@@ -126,4 +126,17 @@ public class InputCommentsIndentationCheckSurroundingCode
      * some javadoc
      */
     private static void l() {}
+    
+    private void foo32() {
+        if (true) {
+            switch(1) {
+            case 0:
+                
+            case 1:
+                    // initialize b
+                int b = 10;
+            }
+            
+        }
+    }
 } // The Check should not throw NPE here!


### PR DESCRIPTION
PS: if you do review of this check you will not be happy. Ask author to recheck method names, what they do and javadoc. (Ex: line 156 getPreviousStmt look for cases only. I have no idea what should it do in fact and why it do it, but I'm sure when anyone see getPreviousStmt he think about statements, not only about cases.)