### PR TITLE
Issue #1243: SuppressWarnings(deprecated) has been removed

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -414,7 +414,6 @@ public abstract class AbstractTypeAwareCheck extends Check {
     }
 
     /** Represents regular classes/enumes. */
-    @SuppressWarnings("deprecation")
     private static final class RegularClass extends AbstractClassInfo {
         /** name of surrounding class. */
         private final String surroundingClass;


### PR DESCRIPTION
This Eclipse violation actually is not false-positive. JDK compiler doesn't warns inner class that uses outer deprecated class.
**Example:**
*File1:*
```java
@Deprecated
public class MyDeprecated{
	class AA {
		MyDeprecated a = new MyDeprecated();
	}
}
```
*File 2:*
```java
public class B {
	class BB {
		MyDeprecated a = new MyDeprecated();
	}
}
```
*Compiler output:*
```
bizmailov@bizmailov-VirtualBox:~/test$ javac MyDeprecated.java -Xlint:deprecation
bizmailov@bizmailov-VirtualBox:~/test$ javac B.java -Xlint:deprecation
B.java:3: warning: [deprecation] MyDeprecated in unnamed package has been deprecated
		MyDeprecated a = new MyDeprecated();
		^
B.java:3: warning: [deprecation] MyDeprecated in unnamed package has been deprecated
		MyDeprecated a = new MyDeprecated();
		                     ^
2 warnings
bizmailov@bizmailov-VirtualBox:~/test$ 
```

As we can see, there are warnings only in second file.

Reported bug about similar situation: https://bugs.eclipse.org/bugs/show_bug.cgi?id=376425
