### PR TITLE
Remove nested assignment. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -102,7 +102,11 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 		int lineNumber = 1;
 	    List<Integer> result = new ArrayList<>();
 	    try(BufferedReader br = new BufferedReader(new FileReader(aFileName))) {
-	        for(String line; (line = br.readLine()) != null; ) {
+	        while (true) {
+	            String line = br.readLine();
+	            if (line == null) {
+	                break;
+	            }
 	            if (warnPattern.matcher(line).find()) {
 	            	result.add(lineNumber);
 	            }


### PR DESCRIPTION
Fixes `NestedAssignment` inspection violation in test code.

Description:
>Reports assignment expressions nested inside other expressions. While admirably terse, such expressions may be confusing, and violate the general design principle that a given construct should do precisely one thing.