### PR TITLE
Promote anonymous class to nested class. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
@@ -36,22 +36,7 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
  * @author lkuehne
  */
 public class AbstractViolationReporterTest extends BaseCheckTestSupport {
-    private final Check emptyCheck = new Check() {
-        @Override
-        public int[] getDefaultTokens() {
-            return ArrayUtils.EMPTY_INT_ARRAY;
-        }
-
-        @Override
-        public int[] getAcceptableTokens() {
-            return ArrayUtils.EMPTY_INT_ARRAY;
-        }
-
-        @Override
-        public int[] getRequiredTokens() {
-            return ArrayUtils.EMPTY_INT_ARRAY;
-        }
-    };
+    private final Check emptyCheck = new EmptyCheck();
 
     @Test
     public void testGetMessageBundleWithPackage() {
@@ -123,5 +108,22 @@ public class AbstractViolationReporterTest extends BaseCheckTestSupport {
         //we expect an exception here because of the bogus custom message
         //format
         messages.first().getMessage();
+    }
+
+    private static class EmptyCheck extends Check {
+        @Override
+        public int[] getDefaultTokens() {
+            return ArrayUtils.EMPTY_INT_ARRAY;
+        }
+
+        @Override
+        public int[] getAcceptableTokens() {
+            return ArrayUtils.EMPTY_INT_ARRAY;
+        }
+
+        @Override
+        public int[] getRequiredTokens() {
+            return ArrayUtils.EMPTY_INT_ARRAY;
+        }
     }
 }


### PR DESCRIPTION
Fixes `AnonymousClassMethodCount` inspection violation in test code.

Description:
>Reports anonymous inner class with too many methods. Anonymous classes with more than a very low number of methods may be difficult to understand, and should probably be promoted to become named inner classes.