### PR TITLE
Mark util class as final in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/TestUtils.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TestUtils.java
@@ -24,7 +24,7 @@ import java.lang.reflect.Modifier;
 
 import org.junit.Assert;
 
-public class TestUtils {
+public final class TestUtils {
 
     private TestUtils() {
     }


### PR DESCRIPTION
Fixes `ClassWithOnlyPrivateConstructors` inspection violation in test code.

Description:
>Reports classes with only private constructors that are not extended by any nested class. Such classes can not be extended and should be declared final.