### PR TITLE
Create constants out of fields in test code. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java
@@ -13,7 +13,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class ParameterNameTest extends BaseCheckTestSupport{
 
-	private String msgKey = "name.invalidPattern";
+	private static final String MSG_KEY = "name.invalidPattern";
 	private static String format;
 	private static ConfigurationBuilder builder;
 	private static Configuration checkConfig;
@@ -29,18 +29,18 @@ public class ParameterNameTest extends BaseCheckTestSupport{
     public void parameterNameTest() throws IOException, Exception {
 
         final String[] expected = {
-            "8:21: " + getCheckMessage(checkConfig.getMessages(), msgKey, "$arg1", format),
-            "9:21: " + getCheckMessage(checkConfig.getMessages(), msgKey, "ar$g2", format),
-            "10:21: " + getCheckMessage(checkConfig.getMessages(), msgKey, "arg3$", format),
-            "11:21: " + getCheckMessage(checkConfig.getMessages(), msgKey, "a_rg4", format),
-            "12:21: " + getCheckMessage(checkConfig.getMessages(), msgKey, "_arg5", format),
-            "13:21: " + getCheckMessage(checkConfig.getMessages(), msgKey, "arg6_", format),
-            "14:21: " + getCheckMessage(checkConfig.getMessages(), msgKey, "aArg7", format),
-            "15:21: " + getCheckMessage(checkConfig.getMessages(), msgKey, "aArg8", format),
-            "16:21: " + getCheckMessage(checkConfig.getMessages(), msgKey, "aar_g", format),
-            "26:21: " + getCheckMessage(checkConfig.getMessages(), msgKey, "bB", format),
-            "49:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "llll_llll", format),
-            "50:21: " + getCheckMessage(checkConfig.getMessages(), msgKey, "bB", format),
+            "8:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$arg1", format),
+            "9:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "ar$g2", format),
+            "10:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "arg3$", format),
+            "11:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "a_rg4", format),
+            "12:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_arg5", format),
+            "13:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "arg6_", format),
+            "14:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aArg7", format),
+            "15:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aArg8", format),
+            "16:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aar_g", format),
+            "26:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bB", format),
+            "49:22: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "llll_llll", format),
+            "50:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bB", format),
         };
 
         String filePath = builder.getFilePath("ParameterNameInput_Simple");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
@@ -14,9 +14,9 @@ import com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameChe
 
 public class AbbreviationAsWordInNameTest extends BaseCheckTestSupport{
 
+    private static final String MSG_KEY = "abbreviation.as.word";
     private static ConfigurationBuilder builder;
     private Class<AbbreviationAsWordInNameCheck> clazz = AbbreviationAsWordInNameCheck.class;
-    private String msgKey = "abbreviation.as.word";
     private static Configuration checkConfig;
     
     @BeforeClass
@@ -29,7 +29,7 @@ public class AbbreviationAsWordInNameTest extends BaseCheckTestSupport{
     public void abbreviationAsWordInNameTest() throws IOException, Exception {
 
         int maxCapitalCount = 1;
-        String msg = getCheckMessage(clazz, msgKey, maxCapitalCount);
+        String msg = getCheckMessage(clazz, MSG_KEY, maxCapitalCount);
 
         final String[] expected = {
             "50: " + msg,


### PR DESCRIPTION
Fixes `FieldCanBeLocal` inspection violation in test code.

Description:
>This inspection searches for redundant class fields that can be replaced with local variables. If all local usages of a field are preceded by assignments to that field, the field can be removed and its usages replaced with local variables.