### PR TITLE
Remove unnecessary this in test code. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -32,7 +32,7 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 
 	public ConfigurationBuilder(File aROOT)
 			throws CheckstyleException, IOException {
-		this.ROOT = aROOT;
+		ROOT = aROOT;
 		config = getConfigurationFromXML(xmlName, System.getProperties());
 		listFiles(files, ROOT, "java");
 	}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -122,7 +122,7 @@ public class AutomaticBean
     @Override
     public final void configure(Configuration config)
         throws CheckstyleException {
-        this.configuration = config;
+        configuration = config;
 
         final String[] attributes = config.getAttributeNames();
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -161,7 +161,7 @@ public final class FileText extends AbstractList<String> {
             }
             textLines.add(line);
         }
-        this.lines = textLines.toArray(new String[textLines.size()]);
+        lines = textLines.toArray(new String[textLines.size()]);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
@@ -213,7 +213,7 @@ public final class ExecutableStatementCountCheck
          * @param addition the count increment.
          */
         public void addCount(int addition) {
-            this.count += addition;
+            count += addition;
         }
 
         /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java
@@ -42,7 +42,7 @@ class ListToTreeSelectionModelWrapper extends DefaultTreeSelectionModel {
     private final JTreeTable treeTable;
 
     public ListToTreeSelectionModelWrapper(JTreeTable jTreeTable) {
-        this.treeTable = jTreeTable;
+        treeTable = jTreeTable;
         getListSelectionModel().addListSelectionListener(createListSelectionListener());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -186,8 +186,8 @@ public class CheckerTest {
     public void testSetters() throws Exception {
         // all  that is set by reflection, so just make code coverage be happy
         final Checker c = new Checker();
-        c.setClassLoader(this.getClass().getClassLoader());
-        c.setClassloader(this.getClass().getClassLoader());
+        c.setClassLoader(getClass().getClassLoader());
+        c.setClassloader(getClass().getClassLoader());
         c.setBasedir("some");
         c.setSeverity("ignore");
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -151,7 +151,7 @@ public class XMLLoggerTest {
         final LocalizedMessage message =
             new LocalizedMessage(1, 1,
                 "messages.properties", "key", null, SeverityLevel.ERROR, null,
-                this.getClass(), null);
+                    getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "Test.java", message);
         logger.addError(ev);
         logger.auditFinished(null);
@@ -168,7 +168,7 @@ public class XMLLoggerTest {
         final LocalizedMessage message =
                 new LocalizedMessage(1, 0,
                         "messages.properties", "key", null, SeverityLevel.ERROR, null,
-                        this.getClass(), null);
+                        getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "Test.java", message);
         logger.addError(ev);
         logger.auditFinished(null);
@@ -185,7 +185,7 @@ public class XMLLoggerTest {
         final LocalizedMessage message =
                 new LocalizedMessage(1, 1,
                         "messages.properties", "key", null, SeverityLevel.IGNORE, null,
-                        this.getClass(), null);
+                        getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "Test.java", message);
         logger.addError(ev);
         logger.auditFinished(null);
@@ -200,7 +200,7 @@ public class XMLLoggerTest {
         logger.auditStarted(null);
         final LocalizedMessage message =
             new LocalizedMessage(1, 1,
-                "messages.properties", null, null, null, this.getClass(), null);
+                "messages.properties", null, null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "Test.java", message);
         logger.addException(ev, new TestException());
         logger.auditFinished(null);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterTest.java
@@ -39,12 +39,11 @@ public class SeverityMatchFilterTest {
         SeverityLevel level = SeverityLevel.ERROR;
         LocalizedMessage message =
             new LocalizedMessage(0, 0, "", "", null,
-                level, null, this.getClass(), null);
+                level, null, getClass(), null);
         final AuditEvent ev2 = new AuditEvent(this, "ATest.java", message);
         assertTrue("level:" + level, filter.accept(ev2));
         level = SeverityLevel.INFO;
-        message = new LocalizedMessage(0, 0, "", "", null, level, null, this
-                .getClass(), null);
+        message = new LocalizedMessage(0, 0, "", "", null, level, null, getClass(), null);
         final AuditEvent ev3 = new AuditEvent(this, "ATest.java", message);
         assertFalse("level:" + level, filter.accept(ev3));
     }
@@ -58,12 +57,11 @@ public class SeverityMatchFilterTest {
         SeverityLevel level = SeverityLevel.ERROR;
         LocalizedMessage message =
             new LocalizedMessage(0, 0, "", "", null,
-                level, null, this.getClass(), null);
+                level, null, getClass(), null);
         final AuditEvent ev2 = new AuditEvent(this, "ATest.java", message);
         assertFalse("level:" + level, filter.accept(ev2));
         level = SeverityLevel.INFO;
-        message = new LocalizedMessage(0, 0, "", "", null, level, null, this
-                .getClass(), null);
+        message = new LocalizedMessage(0, 0, "", "", null, level, null, getClass(), null);
         final AuditEvent ev3 = new AuditEvent(this, "ATest.java", message);
         assertTrue("level:" + level, filter.accept(ev3));
     }
@@ -78,12 +76,11 @@ public class SeverityMatchFilterTest {
         SeverityLevel level = SeverityLevel.ERROR;
         LocalizedMessage message =
             new LocalizedMessage(0, 0, "", "", null,
-                level, null, this.getClass(), null);
+                level, null, getClass(), null);
         final AuditEvent ev2 = new AuditEvent(this, "ATest.java", message);
         assertTrue("level:" + level, filter.accept(ev2));
         level = SeverityLevel.INFO;
-        message = new LocalizedMessage(0, 0, "", "", null, level, null, this
-                .getClass(), null);
+        message = new LocalizedMessage(0, 0, "", "", null, level, null, getClass(), null);
         final AuditEvent ev3 = new AuditEvent(this, "ATest.java", message);
         assertFalse("level:" + level, filter.accept(ev3));
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressElementTest.java
@@ -53,7 +53,7 @@ public class SuppressElementTest {
     @Test
     public void testDecideLocalizedMessage() {
         LocalizedMessage message =
-            new LocalizedMessage(0, 0, "", "", null, null, this.getClass(), null);
+            new LocalizedMessage(0, 0, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         //deny because there are matches on file and check names
         assertFalse("Names match", filter.accept(ev));
@@ -62,7 +62,7 @@ public class SuppressElementTest {
     @Test
     public void testDecideByLine() {
         LocalizedMessage message =
-            new LocalizedMessage(10, 10, "", "", null, null, this.getClass(), null);
+            new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         //deny because there are matches on file name, check name, and line
         filter.setLines("1-10");
@@ -76,7 +76,7 @@ public class SuppressElementTest {
     @Test
     public void testDecideByColumn() {
         LocalizedMessage message =
-            new LocalizedMessage(10, 10, "", "", null, null, this.getClass(), null);
+            new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         //deny because there are matches on file name, check name, and column
         filter.setColumns("1-10");
@@ -88,7 +88,7 @@ public class SuppressElementTest {
     @Test
     public void testDecideByFileNameAndModuleMatching_FileNameNull() {
         LocalizedMessage message =
-                new LocalizedMessage(10, 10, "", "", null, null, this.getClass(), null);
+                new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, null, message);
         assertTrue(filter.accept(ev));
     }
@@ -102,7 +102,7 @@ public class SuppressElementTest {
     @Test
     public void testDecideByFileNameAndModuleMatching_ModuleNull() {
         LocalizedMessage message =
-                new LocalizedMessage(10, 10, "", "", null, "MyModule", this.getClass(), null);
+                new LocalizedMessage(10, 10, "", "", null, "MyModule", getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         filter.setModuleId(null);
         assertFalse(filter.accept(ev));
@@ -111,7 +111,7 @@ public class SuppressElementTest {
     @Test
     public void testDecideByFileNameAndModuleMatching_ModuleEqual() {
         LocalizedMessage message =
-                new LocalizedMessage(10, 10, "", "", null, "MyModule", this.getClass(), null);
+                new LocalizedMessage(10, 10, "", "", null, "MyModule", getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         filter.setModuleId("MyModule");
         assertFalse(filter.accept(ev));
@@ -120,7 +120,7 @@ public class SuppressElementTest {
     @Test
     public void testDecideByFileNameAndModuleMatching_ModuleNotEqual() {
         LocalizedMessage message =
-                new LocalizedMessage(10, 10, "", "", null, "TheirModule", this.getClass(), null);
+                new LocalizedMessage(10, 10, "", "", null, "TheirModule", getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         filter.setModuleId("MyModule");
         assertTrue(filter.accept(ev));
@@ -129,7 +129,7 @@ public class SuppressElementTest {
     @Test
     public void testDecideByFileNameAndModuleMatching_RegExpNotMatch() {
         LocalizedMessage message =
-                new LocalizedMessage(10, 10, "", "", null, null, this.getClass(), null);
+                new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "T1est", message);
         assertTrue(filter.accept(ev));
     }
@@ -137,7 +137,7 @@ public class SuppressElementTest {
     @Test
     public void testDecideByFileNameAndModuleMatching_RegExpMatch() {
         LocalizedMessage message =
-                new LocalizedMessage(10, 10, "", "", null, null, this.getClass(), null);
+                new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "TestSUFFIX", message);
         SuppressElement filterWithoutChecks = new SuppressElement("Test");
         assertFalse(filterWithoutChecks.accept(ev));
@@ -146,7 +146,7 @@ public class SuppressElementTest {
     @Test
     public void testDecideByFileNameAndModuleMatching_CheckRegExpNotMatch() {
         LocalizedMessage message =
-                new LocalizedMessage(10, 10, "", "", null, null, this.getClass(), null);
+                new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         filter.setChecks("NON_EXISTING_CHECK");
         assertTrue(filter.accept(ev));
@@ -155,9 +155,9 @@ public class SuppressElementTest {
     @Test
     public void testDecideByFileNameAndModuleMatching_CheckRegExpMatch() {
         LocalizedMessage message =
-                new LocalizedMessage(10, 10, "", "", null, null, this.getClass(), null);
+                new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
-        filter.setChecks(this.getClass().getCanonicalName());
+        filter.setChecks(getClass().getCanonicalName());
         assertFalse(filter.accept(ev));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -280,7 +280,7 @@ public class SuppressionCommentFilterTest
         final LocalizedMessage message =
             new LocalizedMessage(1, 1,
                 "messages.properties", "key", null, SeverityLevel.ERROR, null,
-                this.getClass(), null);
+                    getClass(), null);
         final AuditEvent auditEvent = new AuditEvent(this, "Test.java", message);
         SuppressionCommentFilter filter = new SuppressionCommentFilter();
         Assert.assertTrue(filter.accept(auditEvent));


### PR DESCRIPTION
Fixes `UnnecessaryThis` inspection violations in test code.

Description:
>Reports on any unnecessary uses of this in the code. Using this to disambiguate a code reference may easily become unnecessary via automatic refactorings, and is discouraged by many coding styles.