### PR TITLE
Remove unnecessarily fully qualified names in test code. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
@@ -22,8 +22,8 @@ public class CustomImportOrderTest extends BaseCheckTestSupport{
     String msgNongroup = "custom.import.order.nongroup.import";
 
     /** Shortcuts to make code more compact */
-    private static final String STD = com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.STANDARD_JAVA_PACKAGE_RULE_GROUP;
-    private static final String SPECIAL = com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.SPECIAL_IMPORTS_RULE_GROUP;
+    private static final String STD = CustomImportOrderCheck.STANDARD_JAVA_PACKAGE_RULE_GROUP;
+    private static final String SPECIAL = CustomImportOrderCheck.SPECIAL_IMPORTS_RULE_GROUP;
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException, IOException {

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3sourcefile/EmptyLineSeparatorTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3sourcefile/EmptyLineSeparatorTest.java
@@ -24,7 +24,7 @@ public class EmptyLineSeparatorTest extends BaseCheckTestSupport{
     @Test
     public void emptyLineSeparatorTest() throws IOException, Exception {
         
-        java.lang.Class<EmptyLineSeparatorCheck> clazz = EmptyLineSeparatorCheck.class;
+        Class<EmptyLineSeparatorCheck> clazz = EmptyLineSeparatorCheck.class;
         String messageKey = "empty.line.separator";
 
         final String[] expected = {

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java
@@ -24,7 +24,7 @@ public class EmptyLineSeparatorTest extends BaseCheckTestSupport{
     @Test
     public void emptyLineSeparatorTest() throws IOException, Exception {
         
-        java.lang.Class<EmptyLineSeparatorCheck> clazz = EmptyLineSeparatorCheck.class;
+        Class<EmptyLineSeparatorCheck> clazz = EmptyLineSeparatorCheck.class;
         String messageKey = "empty.line.separator";
 
         final String[] expected = {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorInput.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorInput.java
@@ -107,8 +107,8 @@ class InputEmptyLineSeparatorCheck //warn
     }
 }
 
-class Class { //ok
-    private Class() {} //ok
+class Clazz { //ok
+    private Clazz() {} //ok
 } 
 class Class2{ //warn
     public int compareTo(InputEmptyLineSeparatorCheck aObject) //ok

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheckTest.java
@@ -29,7 +29,7 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
 /**
  * The unit-test for the {@code NestedForDepthCheck}-checkstyle enhancement.
- * @see com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck
+ * @see NestedForDepthCheck
  */
 public class NestedForDepthCheckTest extends BaseCheckTestSupport {
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -41,11 +41,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
     /** Shortcuts to make code more compact */
-    private static final String STATIC = com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.STATIC_RULE_GROUP;
-    private static final String SAME = com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.SAME_PACKAGE_RULE_GROUP;
-    private static final String THIRD = com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.THIRD_PARTY_PACKAGE_RULE_GROUP;
-    private static final String STD = com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.STANDARD_JAVA_PACKAGE_RULE_GROUP;
-    private static final String SPECIAL = com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.SPECIAL_IMPORTS_RULE_GROUP;
+    private static final String STATIC = CustomImportOrderCheck.STATIC_RULE_GROUP;
+    private static final String SAME = CustomImportOrderCheck.SAME_PACKAGE_RULE_GROUP;
+    private static final String THIRD = CustomImportOrderCheck.THIRD_PARTY_PACKAGE_RULE_GROUP;
+    private static final String STD = CustomImportOrderCheck.STANDARD_JAVA_PACKAGE_RULE_GROUP;
+    private static final String SPECIAL = CustomImportOrderCheck.SPECIAL_IMPORTS_RULE_GROUP;
 
     @Test
     public void testGetRequiredTokens() {


### PR DESCRIPTION
Fixes `UnnecessaryFullyQualifiedName` inspection violations in test code.

Description:
>Reports on fully qualified class names which can be shortened. The quick fix for this inspection will shorten the fully qualified names, adding import statements as necessary.