### PR TITLE
Replace <code> tags with {@code ...} constructs. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyOption.java
@@ -37,9 +37,9 @@ public enum LeftCurlyOption {
 
     /**
      * Represents the policy that if the brace will fit on the first line of
-     * the statement, then apply <code>EOL</code> rule.
-     * Otherwise apply the <code>NL</code> rule.
-     * <code>NLOW</code> is a mnemonic for "new line on wrap".
+     * the statement, then apply {@code EOL} rule.
+     * Otherwise apply the {@code NL} rule.
+     * {@code NLOW} is a mnemonic for "new line on wrap".
      *
      * <p> For the example above Checkstyle will enforce:
      *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -180,14 +180,14 @@ public class NeedBracesCheck extends Check {
     /**
      * Checks if current statement is single-line statement, e.g.:
      * <p>
-     * <code>
+     * {@code
      * if (obj.isValid()) return true;
-     * </code>
+     * }
      * </p>
      * <p>
-     * <code>
+     * {@code
      * while (obj.isValid()) return true;
-     * </code>
+     * }
      * </p>
      * @param statement if, for, while, do-while, lambda, else, case, default statements.
      * @return true if current statement is single-line statement.
@@ -247,9 +247,9 @@ public class NeedBracesCheck extends Check {
     /**
      * Checks if current do-while statement is single-line statement, e.g.:
      * <p>
-     * <code>
+     * {@code
      * do this.notify(); while (o != null);
-     * </code>
+     * }
      * </p>
      * @param literalDo {@link TokenTypes#LITERAL_DO do-while statement}.
      * @return true if current do-while statement is single-line statement.
@@ -267,9 +267,9 @@ public class NeedBracesCheck extends Check {
     /**
      * Checks if current for statement is single-line statement, e.g.:
      * <p>
-     * <code>
+     * {@code
      * for (int i = 0; ; ) this.notify();
-     * </code>
+     * }
      * </p>
      * @param literalFor {@link TokenTypes#LITERAL_FOR for statement}.
      * @return true if current for statement is single-line statement.
@@ -290,9 +290,9 @@ public class NeedBracesCheck extends Check {
     /**
      * Checks if current if statement is single-line statement, e.g.:
      * <p>
-     * <code>
+     * {@code
      * if (obj.isValid()) return true;
-     * </code>
+     * }
      * </p>
      * @param literalIf {@link TokenTypes#LITERAL_IF if statement}.
      * @return true if current if statement is single-line statement.
@@ -317,9 +317,9 @@ public class NeedBracesCheck extends Check {
     /**
      * Checks if current lambda statement is single-line statement, e.g.:
      * <p>
-     * <code>
+     * {@code
      * Runnable r = () -> System.out.println("Hello, world!");
-     * </code>
+     * }
      * </p>
      * @param lambda {@link TokenTypes#LAMBDA lambda statement}.
      * @return true if current lambda statement is single-line statement.
@@ -361,9 +361,9 @@ public class NeedBracesCheck extends Check {
     /**
      * Checks if current default statement is single-line statement, e.g.:
      * <p>
-     * <code>
+     * {@code
      * default: doSomeStuff();
-     * </code>
+     * }
      * </p>
      * @param literalDefault {@link TokenTypes#LITERAL_DEFAULT default statement}.
      * @return true if current default statement is single-line statement.
@@ -381,9 +381,9 @@ public class NeedBracesCheck extends Check {
     /**
      * Checks if current else statement is single-line statement, e.g.:
      * <p>
-     * <code>
+     * {@code
      * else doSomeStuff();
-     * </code>
+     * }
      * </p>
      * @param literalElse {@link TokenTypes#LITERAL_ELSE else statement}.
      * @return true if current else statement is single-line statement.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -62,35 +62,35 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * <p>
  * For example:
- * <pre><code>
+ * <pre>{@code
  *     class K {
  *         int a;
  *         void m(){}
  *         K(){}  &lt;-- "Constructor definition in wrong order"
  *         int b; &lt;-- "Instance variable definition in wrong order"
  *     }
- * </code></pre>
+ * }</pre>
  *
  * <p>
  * With <b>ignoreConstructors</b> option:
- * <pre><code>
+ * <pre>{@code
  *     class K {
  *         int a;
  *         void m(){}
  *         K(){}
  *         int b; &lt;-- "Instance variable definition in wrong order"
  *     }
- * </code></pre>
+ * }</pre>
  *
  * <p>
  * With <b>ignoreConstructors</b> option and without a method definition in a source class:
- * <pre><code>
+ * <pre>{@code
  *     class K {
  *         int a;
  *         K(){}
  *         int b; &lt;-- "Instance variable definition in wrong order"
  *     }
- * </code></pre>
+ * }</pre>
  *
  * <p>
  * An example of how to configure the check is:

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -461,7 +461,7 @@ public class HiddenFieldCheck
 
     /**
      * Set the ignore format to the specified regular expression.
-     * @param format a <code>String</code> value
+     * @param format a {@code String} value
      */
     public void setIgnoreFormat(String format) {
         regexp = Utils.createPattern(format);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -262,9 +262,9 @@ public final class IllegalTypeCheck extends AbstractFormatCheck {
     /**
      * Checks if current import is star import. E.g.:
      * <p>
-     * <code>
+     * {@code
      * import java.util.*;
-     * </code>
+     * }
      * </p>
      * @param importAst {@link TokenTypes#IMPORT Import}
      * @return true if it is star import

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
@@ -216,7 +216,7 @@ class FileDrop {
     /**
      * Implement this inner interface to listen for when files are dropped. For example
      * your class declaration may begin like this:
-     * <code><pre>
+     * {@code <pre>
      *      public class MyClass implements FileDrop.Listener
      *      ...
      *      public void filesDropped( File[] files )
@@ -224,7 +224,7 @@ class FileDrop {
      *          ...
      *      }   // end filesDropped
      *      ...
-     * </pre></code>
+     * </pre>}
      *
      * @since 1.0
      */


### PR DESCRIPTION
Fixes `HtmlTagCanBeJavadocTag` inspection violations in test code.

Description:
>Reports use of <code> tags in Javadoc comments. Since JDK1.5 these constructs may be replaced with {@code ...} constructs. This allows the use of angle brackets (<, >) inside the comment, instead of HTML character entities.