### PR TITLE
Remove unnecessary @inheritDoc. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -115,8 +115,6 @@ public class AutomaticBean
      * is called for each {@link Configuration#getChildren child Configuration}
      * of {@code configuration}.
      *
-     * @param config {@inheritDoc}
-     * @throws CheckstyleException {@inheritDoc}
      * @see Configurable
      */
     @Override


### PR DESCRIPTION
Fixes `UnnecessaryInheritDoc` inspection violations.

Description:
>Reports any Javadoc comments which contain only the {@inheritDoc} tag. Since Javadoc copies the super class' comment if no comment is present, a comment containing only an {@inheritDoc} adds nothing.