### PR TITLE
Replace assertEquals() with arrayAssertEquals(). #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfoTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfoTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -59,7 +60,7 @@ public class JavadocTagInfoTest {
             JavadocTagInfo.Type.INLINE,
         };
         JavadocTagInfo.Type[] actual = JavadocTagInfo.Type.values();
-        assertEquals(expected, actual);
+        assertArrayEquals(expected, actual);
     }
 
     @Test


### PR DESCRIPTION
Fixes `AssertEqualsCalledOnArray` inspection violations in test code.

Description:
>Reports any calls to JUnit's assertEquals() method with arguments of type array. Arrays should be checked with one of the assertArrayEquals() methods.