### PR TITLE
Remove redundant suppressions from test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -195,7 +195,6 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testUnableToFindSuppressions() throws Exception {
         Class<SuppressionsLoader> loaderClass = SuppressionsLoader.class;
         Method loadSuppressions =
@@ -212,7 +211,6 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testUnableToReadSuppressions() throws Exception {
         Class<SuppressionsLoader> loaderClass = SuppressionsLoader.class;
         Method loadSuppressions =


### PR DESCRIPTION
Fixes `RedundantSuppression` inspection violations in test code.

Description:
>This inspection reports usages of
@SuppressWarning annotation, or
// noinspection line comment, or
/** noinspection */ JavaDoc comment
which can be safely removed because inspection they affect is no longer applicable in this context.