### PR TITLE
Remove unused field. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -95,21 +95,6 @@ public class LeftCurlyCheck
      */
     public static final String MSG_KEY_LINE_BREAK_AFTER = "line.break.after";
 
-    /**
-     * Default maximum line length.
-     * @deprecated since 6.10 release, option maxLineLength is not required for the Check.
-     */
-    @Deprecated
-    private static final int DEFAULT_MAX_LINE_LENGTH = 80;
-
-    /**
-     * Maximum line length.
-     * @deprecated since 6.10 release, option is not required for the Check.
-     */
-    @Deprecated
-    @SuppressWarnings("unused")
-    private int maxLineLength = DEFAULT_MAX_LINE_LENGTH;
-
     /** If true, Check will ignore enums*/
     private boolean ignoreEnums = true;
 
@@ -128,7 +113,7 @@ public class LeftCurlyCheck
      */
     @Deprecated
     public void setMaxLineLength(int maxLineLength) {
-        this.maxLineLength = maxLineLength;
+        // do nothing, option is deprecated
     }
 
     /**


### PR DESCRIPTION
Fixes ` FieldCanBeLocal` inspection violation.

Description:
>This inspection searches for redundant class fields that can be replaced with local variables. If all local usages of a field are preceded by assignments to that field, the field can be removed and its usages replaced with local variables.