### PR TITLE
Remove unnecessary explicit numeric cast. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -147,7 +147,7 @@ public abstract class BaseCheckTestSupport
             parseInt = parseInt.substring(0, parseInt.indexOf(":"));
             int lineNumber = Integer.parseInt(parseInt);
 			Integer integer = Arrays.asList(aWarnsExpected).contains(lineNumber) ? lineNumber : 0;
-            assertEquals("error message " + i, (long) integer, (long) lineNumber);
+            assertEquals("error message " + i, (long) integer, lineNumber);
         }
 
         assertEquals("unexpected output: " + lnr.readLine(),


### PR DESCRIPTION
Fixes `UnnecessaryExplicitNumericCast` inspection violations in test code.

Description:
>Reports any primitive numeric casts which would otherwise be inserted implicitly by the compiler.