### PR TITLE
Fix non-static non-final all upper-case names in test code. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -46,8 +46,8 @@ public abstract class BaseCheckTestSupport
         public void fileStarted(AuditEvent evt) {}
     }
 
-    protected final ByteArrayOutputStream BAOS = new ByteArrayOutputStream();
-    protected final PrintStream stream = new PrintStream(BAOS);
+    protected final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    protected final PrintStream stream = new PrintStream(baos);
     protected final Properties props = new Properties();
 
     public static DefaultConfiguration createCheckConfig(Class<?> aClazz)
@@ -134,7 +134,7 @@ public abstract class BaseCheckTestSupport
 
         // process each of the lines
         final ByteArrayInputStream bais =
-            new ByteArrayInputStream(BAOS.toByteArray());
+            new ByteArrayInputStream(baos.toByteArray());
         final LineNumberReader lnr =
             new LineNumberReader(new InputStreamReader(bais));
 

--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -18,7 +18,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class ConfigurationBuilder extends BaseCheckTestSupport {
 
-	private File ROOT;
+	private File root;
 
 	private List<File> files = new ArrayList<>();
 
@@ -32,9 +32,9 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 
 	public ConfigurationBuilder(File aROOT)
 			throws CheckstyleException, IOException {
-		ROOT = aROOT;
+		root = aROOT;
 		config = getConfigurationFromXML(xmlName, System.getProperties());
-		listFiles(files, ROOT, "java");
+		listFiles(files, root, "java");
 	}
 
 	private static Configuration getConfigurationFromXML(String aConfigName,
@@ -66,7 +66,7 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 	}
 
 	public String getFilePath(String aFileName) {
-		String absoluteRootPath = ROOT.getAbsolutePath();
+		String absoluteRootPath = root.getAbsolutePath();
 		String rootPath = absoluteRootPath.substring(0,
 				absoluteRootPath.lastIndexOf("src"));
 		for (File file : files) {
@@ -90,8 +90,8 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 		}
 	}
 
-	public File getROOT() {
-		return ROOT;
+	public File getRoot() {
+		return root;
 	}
 
 	public List<File> getFiles() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -44,8 +44,8 @@ public abstract class BaseCheckTestSupport {
         }
     }
 
-    protected final ByteArrayOutputStream BAOS = new ByteArrayOutputStream();
-    protected final PrintStream stream = new PrintStream(BAOS);
+    protected final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    protected final PrintStream stream = new PrintStream(baos);
     protected final Properties props = new Properties();
 
     public static DefaultConfiguration createCheckConfig(Class<?> clazz) {
@@ -122,7 +122,7 @@ public abstract class BaseCheckTestSupport {
 
         // process each of the lines
         final ByteArrayInputStream bais =
-                new ByteArrayInputStream(BAOS.toByteArray());
+                new ByteArrayInputStream(baos.toByteArray());
         final LineNumberReader lnr =
                 new LineNumberReader(new InputStreamReader(bais));
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport {
 
-    private final String MSG = getCheckMessage("forbid.escaped.unicode.char");
+    private final String msg = getCheckMessage("forbid.escaped.unicode.char");
 
     @Test
     public void testGetRequiredTokens() {
@@ -48,32 +48,32 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
         DefaultConfiguration checkConfig =
                 createCheckConfig(AvoidEscapedUnicodeCharactersCheck.class);
         final String[] expected = {
-            "7: " + MSG,
-            "9: " + MSG,
-            "11: " + MSG,
-            "15: " + MSG,
-            "16: " + MSG,
-            "20: " + MSG,
-            "24: " + MSG,
-            "25: " + MSG,
-            "27: " + MSG,
-            "31: " + MSG,
-            "32: " + MSG,
-            "33: " + MSG,
-            "34: " + MSG,
-            "42: " + MSG,
-            "59: " + MSG,
-            "60: " + MSG,
-            "61: " + MSG,
-            "62: " + MSG,
-            "72: " + MSG,
-            "73: " + MSG,
-            "74: " + MSG,
-            "75: " + MSG,
-            "76: " + MSG,
-            "77: " + MSG,
-            "79: " + MSG,
-            "82: " + MSG,
+            "7: " + msg,
+            "9: " + msg,
+            "11: " + msg,
+            "15: " + msg,
+            "16: " + msg,
+            "20: " + msg,
+            "24: " + msg,
+            "25: " + msg,
+            "27: " + msg,
+            "31: " + msg,
+            "32: " + msg,
+            "33: " + msg,
+            "34: " + msg,
+            "42: " + msg,
+            "59: " + msg,
+            "60: " + msg,
+            "61: " + msg,
+            "62: " + msg,
+            "72: " + msg,
+            "73: " + msg,
+            "74: " + msg,
+            "75: " + msg,
+            "76: " + msg,
+            "77: " + msg,
+            "79: " + msg,
+            "82: " + msg,
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharactersCheck.java"), expected);
     }
@@ -84,29 +84,29 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
                 createCheckConfig(AvoidEscapedUnicodeCharactersCheck.class);
         checkConfig.addAttribute("allowEscapesForControlCharacters", "true");
         final String[] expected = {
-            "7: " + MSG,
-            "9: " + MSG,
-            "11: " + MSG,
-            "15: " + MSG,
-            "16: " + MSG,
-            "24: " + MSG,
-            "25: " + MSG,
-            "31: " + MSG,
-            "32: " + MSG,
-            "33: " + MSG,
-            "34: " + MSG,
-            "42: " + MSG,
-            "59: " + MSG,
-            "60: " + MSG,
-            "61: " + MSG,
-            "62: " + MSG,
-            "73: " + MSG,
-            "74: " + MSG,
-            "75: " + MSG,
-            "76: " + MSG,
-            "77: " + MSG,
-            "79: " + MSG,
-            "82: " + MSG,
+            "7: " + msg,
+            "9: " + msg,
+            "11: " + msg,
+            "15: " + msg,
+            "16: " + msg,
+            "24: " + msg,
+            "25: " + msg,
+            "31: " + msg,
+            "32: " + msg,
+            "33: " + msg,
+            "34: " + msg,
+            "42: " + msg,
+            "59: " + msg,
+            "60: " + msg,
+            "61: " + msg,
+            "62: " + msg,
+            "73: " + msg,
+            "74: " + msg,
+            "75: " + msg,
+            "76: " + msg,
+            "77: " + msg,
+            "79: " + msg,
+            "82: " + msg,
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharactersCheck.java"), expected);
     }
@@ -117,24 +117,24 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
                 createCheckConfig(AvoidEscapedUnicodeCharactersCheck.class);
         checkConfig.addAttribute("allowByTailComment", "true");
         final String[] expected = {
-            "7: " + MSG,
-            "15: " + MSG,
-            "24: " + MSG,
-            "31: " + MSG,
-            "33: " + MSG,
-            "34: " + MSG,
-            "59: " + MSG,
-            "60: " + MSG,
-            "61: " + MSG,
-            "62: " + MSG,
-            "72: " + MSG,
-            "73: " + MSG,
-            "74: " + MSG,
-            "75: " + MSG,
-            "76: " + MSG,
-            "77: " + MSG,
-            "79: " + MSG,
-            "82: " + MSG,
+            "7: " + msg,
+            "15: " + msg,
+            "24: " + msg,
+            "31: " + msg,
+            "33: " + msg,
+            "34: " + msg,
+            "59: " + msg,
+            "60: " + msg,
+            "61: " + msg,
+            "62: " + msg,
+            "72: " + msg,
+            "73: " + msg,
+            "74: " + msg,
+            "75: " + msg,
+            "76: " + msg,
+            "77: " + msg,
+            "79: " + msg,
+            "82: " + msg,
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharactersCheck.java"), expected);
     }
@@ -145,15 +145,15 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
                 createCheckConfig(AvoidEscapedUnicodeCharactersCheck.class);
         checkConfig.addAttribute("allowIfAllCharactersEscaped", "true");
         final String[] expected = {
-            "7: " + MSG,
-            "9: " + MSG,
-            "11: " + MSG,
-            "15: " + MSG,
-            "16: " + MSG,
-            "31: " + MSG,
-            "32: " + MSG,
-            "33: " + MSG,
-            "42: " + MSG,
+            "7: " + msg,
+            "9: " + msg,
+            "11: " + msg,
+            "15: " + msg,
+            "16: " + msg,
+            "31: " + msg,
+            "32: " + msg,
+            "33: " + msg,
+            "42: " + msg,
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharactersCheck.java"), expected);
     }
@@ -164,18 +164,18 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
                 createCheckConfig(AvoidEscapedUnicodeCharactersCheck.class);
         checkConfig.addAttribute("allowNonPrintableEscapes", "true");
         final String[] expected = {
-            "7: " + MSG,
-            "9: " + MSG,
-            "11: " + MSG,
-            "15: " + MSG,
-            "16: " + MSG,
-            "24: " + MSG,
-            "25: " + MSG,
-            "31: " + MSG,
-            "32: " + MSG,
-            "33: " + MSG,
-            "34: " + MSG,
-            "42: " + MSG,
+            "7: " + msg,
+            "9: " + msg,
+            "11: " + msg,
+            "15: " + msg,
+            "16: " + msg,
+            "24: " + msg,
+            "25: " + msg,
+            "31: " + msg,
+            "32: " + msg,
+            "33: " + msg,
+            "34: " + msg,
+            "42: " + msg,
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharactersCheck.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -204,7 +204,7 @@ public class WriteTagCheckTest extends BaseCheckTestSupport {
 
         // process each of the lines
         final ByteArrayInputStream bais =
-            new ByteArrayInputStream(BAOS.toByteArray());
+            new ByteArrayInputStream(baos.toByteArray());
         final LineNumberReader lnr =
             new LineNumberReader(new InputStreamReader(bais));
 


### PR DESCRIPTION
Fixes `UpperCaseFieldNameNotConstant` inspection violations in test code.

Description:
>Reports non-static non-final fields whose names are all upper-case. Such fields may cause confusion by breaking a common naming convention, and are often the result of developer error.