### PR TITLE
Remove redundant overriding methods. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -40,10 +40,6 @@ public abstract class BaseCheckTestSupport
         }
         @Override
         public void auditStarted(AuditEvent evt) {}
-        @Override
-        public void fileFinished(AuditEvent evt) {}
-        @Override
-        public void fileStarted(AuditEvent evt) {}
     }
 
     protected final ByteArrayOutputStream BAOS = new ByteArrayOutputStream();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -35,13 +35,6 @@ public abstract class BaseCheckTestSupport {
         public void auditStarted(AuditEvent evt) {
         }
 
-        @Override
-        public void fileFinished(AuditEvent evt) {
-        }
-
-        @Override
-        public void fileStarted(AuditEvent evt) {
-        }
     }
 
     protected final ByteArrayOutputStream BAOS = new ByteArrayOutputStream();


### PR DESCRIPTION
Fixes `RedundantMethodOverride` inspection violations in test code.

Description:
>Reports any method that has a body and signature that are identical to its super method. Such a method is redundant and probably a coding error.