### PR TITLE
Remove string concatenation done inside string builders. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -471,14 +471,14 @@ public class MainTest {
                         .replace("/", File.separator);
                 String format = "%s.java:%s: warning: File length is %s lines (max allowed is 80).";
                 StringBuilder sb = new StringBuilder();
-                sb.append("Starting audit..." + System.getProperty("line.separator"));
+                sb.append("Starting audit...").append(System.getProperty("line.separator"));
                 for (String[] outputValue : outputValues) {
                     String line = String.format(format,
                             expectedPath + outputValue[0], outputValue[1],
                             outputValue[2]);
-                    sb.append(line + System.getProperty("line.separator"));
+                    sb.append(line).append(System.getProperty("line.separator"));
                 }
-                sb.append("Audit done." + System.getProperty("line.separator"));
+                sb.append("Audit done.").append(System.getProperty("line.separator"));
                 assertEquals(sb.toString(), systemOut.getLog());
                 assertEquals("", systemErr.getLog());
             }


### PR DESCRIPTION
Fixes `StringConcatenationInsideStringBufferAppend` inspection violations in test code.

Description:
>Reports String concatenation used as the argument to StringBuffer.append(), StringBuilder.append() or Appendable.append(). Such calls may profitably be turned into chained append calls on the existing StringBuffer/Builder/Appendable, saving the cost of an extra StringBuffer/Builder allocation.
This inspection ignores compile time evaluated String concatenations, which when converted to chained append calls would only worsen performance.