### PR TITLE
Mark methods as static. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule231filetab/FileTabCharacterTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule231filetab/FileTabCharacterTest.java
@@ -56,7 +56,7 @@ public class FileTabCharacterTest extends BaseCheckTestSupport{
     /**
      * Creates a configuration that is functionally close to that in the docs.
      */
-    private DefaultConfiguration createConfig(boolean verbose)
+    private static DefaultConfiguration createConfig(boolean verbose)
     {
         final DefaultConfiguration checkConfig =
             createCheckConfig(FileTabCharacterCheck.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -115,7 +115,7 @@ public class AutomaticBeanTest {
         }
 
         public void setExceptionalMethod(String value) {
-            throw new IllegalStateException("for UT");
+            throw new IllegalStateException(wrong);
         }
 
         public void setName(String name) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
@@ -110,7 +110,7 @@ public class DetailASTTest {
         checkDir(new File("src/test/resources/com/puppycrawl/tools/checkstyle"));
     }
 
-    private void checkDir(File dir) throws Exception {
+    private static void checkDir(File dir) throws Exception {
         File[] files = dir.listFiles(new FileFilter() {
                 @Override
                 public boolean accept(File file) {


### PR DESCRIPTION
Fixes `MethodMayBeStatic` inspection violations in test code introduced after recent commits.

Description:
>Reports any methods which may safely be made static. A method may be static if it is not synchronized, it does not reference any of its class' non static methods and non static fields and is not overridden in a sub class.