### PR TITLE
Corrected acceptable, required and default token sets , issue #655

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -162,13 +162,7 @@ public class HiddenFieldCheck
 
     @Override
     public int[] getDefaultTokens() {
-        return new int[] {
-            TokenTypes.VARIABLE_DEF,
-            TokenTypes.PARAMETER_DEF,
-            TokenTypes.CLASS_DEF,
-            TokenTypes.ENUM_DEF,
-            TokenTypes.ENUM_CONSTANT_DEF,
-        };
+        return getAcceptableTokens();
     }
 
     @Override
@@ -176,6 +170,9 @@ public class HiddenFieldCheck
         return new int[] {
             TokenTypes.VARIABLE_DEF,
             TokenTypes.PARAMETER_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
         };
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -22,10 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import java.util.Set;
 import java.util.StringTokenizer;
 
-import org.apache.commons.lang3.ArrayUtils;
-
 import antlr.collections.AST;
-
 import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -92,18 +89,17 @@ public class IllegalInstantiationCheck
 
     @Override
     public int[] getDefaultTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
         return new int[] {
             TokenTypes.IMPORT,
             TokenTypes.LITERAL_NEW,
             TokenTypes.PACKAGE_DEF,
             TokenTypes.CLASS_DEF,
         };
-    }
-
-    @Override
-    public int[] getAcceptableTokens() {
-        // Return an empty array to not allow user to change configuration.
-        return ArrayUtils.EMPTY_INT_ARRAY;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -91,27 +91,23 @@ public class RequireThisCheck extends AbstractDeclarationCollector {
 
     @Override
     public int[] getDefaultTokens() {
-        return new int[] {
-            TokenTypes.CLASS_DEF,
-            TokenTypes.CTOR_DEF,
-            TokenTypes.ENUM_DEF,
-            TokenTypes.IDENT,
-            TokenTypes.INTERFACE_DEF,
-            TokenTypes.METHOD_DEF,
-            TokenTypes.PARAMETER_DEF,
-            TokenTypes.SLIST,
-            TokenTypes.VARIABLE_DEF,
-        };
+        return getAcceptableTokens();
     }
 
     @Override
     public int[] getRequiredTokens() {
-        return getDefaultTokens();
+        return getAcceptableTokens();
     }
 
     @Override
     public int[] getAcceptableTokens() {
         return new int[] {
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.SLIST,
             TokenTypes.IDENT,
         };
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.java
@@ -19,8 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import org.apache.commons.lang3.ArrayUtils;
-
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -53,19 +51,17 @@ public class SimplifyBooleanExpressionCheck
 
     @Override
     public int[] getDefaultTokens() {
-        return new int[] {TokenTypes.LITERAL_TRUE, TokenTypes.LITERAL_FALSE};
+        return getAcceptableTokens();
     }
 
     @Override
     public int[] getAcceptableTokens() {
-        // Return empty list to prevent user changing tokens in the
-        // configuration.
-        return ArrayUtils.EMPTY_INT_ARRAY;
+        return new int[] {TokenTypes.LITERAL_TRUE, TokenTypes.LITERAL_FALSE};
     }
 
     @Override
     public int[] getRequiredTokens() {
-        return new int[] {TokenTypes.LITERAL_TRUE, TokenTypes.LITERAL_FALSE};
+        return getAcceptableTokens();
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -322,18 +322,20 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
 
     @Override
     public int[] getDefaultTokens() {
-        return new int[] {TokenTypes.PACKAGE_DEF, TokenTypes.IMPORT,
-                          TokenTypes.CLASS_DEF, TokenTypes.ENUM_DEF,
-                          TokenTypes.INTERFACE_DEF,
-                          TokenTypes.METHOD_DEF, TokenTypes.CTOR_DEF,
-                          TokenTypes.ANNOTATION_FIELD_DEF,
-        };
+        return getAcceptableTokens();
     }
 
     @Override
     public int[] getAcceptableTokens() {
-        return new int[] {TokenTypes.METHOD_DEF, TokenTypes.CTOR_DEF,
-                          TokenTypes.ANNOTATION_FIELD_DEF,
+        return new int[] {
+            TokenTypes.PACKAGE_DEF,
+            TokenTypes.IMPORT,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.ANNOTATION_FIELD_DEF,
         };
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -54,6 +54,11 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
 
         int[] actual = javadocMethodCheck.getAcceptableTokens();
         int[] expected = {
+            TokenTypes.PACKAGE_DEF,
+            TokenTypes.IMPORT,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.INTERFACE_DEF,
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,


### PR DESCRIPTION
@romani

According to [documentation](http://checkstyle.sourceforge.net/config_sizes.html#MethodCount), MethodCountCheck checks the number of **methods** declared in each type. That means that user should specify only one toke from configuration - METHOD_DEF. But currect set of acceptable tokens for the check is:
```java
TokenTypes.CLASS_DEF,
TokenTypes.ENUM_CONSTANT_DEF,
TokenTypes.ENUM_DEF,
TokenTypes.INTERFACE_DEF,
TokenTypes.METHOD_DEF
```

That means that user can use the following configuration for the check:
```xml
<module name="MethodCount">
  <property name="tokens" value="ENUM_CONSTANT_DEF"/>
</module>    
```

With the configuration the check will throw NPE on file ```checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/sizes/MethodCountCheckInput.java``` :

```
SEVERE: NullPointerException occurred during the analysis of file /media/andreiselkin/TOURO/IDEA_Projects/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/sizes/MethodCountCheckInput.java.
java.lang.NullPointerException
	at com.puppycrawl.tools.checkstyle.checks.sizes.MethodCountCheck.raiseCounter(MethodCountCheck.java:138)
	at com.puppycrawl.tools.checkstyle.checks.sizes.MethodCountCheck.visitToken(MethodCountCheck.java:110)
	at com.puppycrawl.tools.checkstyle.TreeWalker.notifyVisit(TreeWalker.java:396)
	at com.puppycrawl.tools.checkstyle.TreeWalker.processIter(TreeWalker.java:492)
	at com.puppycrawl.tools.checkstyle.TreeWalker.walk(TreeWalker.java:325)
	at com.puppycrawl.tools.checkstyle.TreeWalker.processFiltered(TreeWalker.java:201)
	at com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.process(AbstractFileSetCheck.java:75)
	at com.puppycrawl.tools.checkstyle.Checker.process(Checker.java:260)
	at com.puppycrawl.tools.checkstyle.BaseCheckTestSupport.verify(BaseCheckTestSupport.java:121)
	at com.puppycrawl.tools.checkstyle.BaseCheckTestSupport.verify(BaseCheckTestSupport.java:108)
	at com.puppycrawl.tools.checkstyle.BaseCheckTestSupport.verify(BaseCheckTestSupport.java:95)
	at com.puppycrawl.tools.checkstyle.checks.sizes.MethodCountCheckTest.testDefaults(MethodCountCheckTest.java:71)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:78)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:212)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:68)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:140)
```

So, to fix the problem I've changed acceptable tokens set to the following:

```java
TokenTypes.METHOD_DEF
```
as a result, the check will become protected from malicious users who specify an unacceptable token set in the configuration file.

