### PR TITLE
Issue #1566: First sentence in a comment should start with a capital letter (Multiline comments)

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/AnnotationUtility.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AnnotationUtility.java
@@ -38,7 +38,7 @@ public final class AnnotationUtility {
     private static final String THE_AST_IS_NULL = "the ast is null";
 
     /**
-     * private utility constructor.
+     * Private utility constructor.
      * @throws UnsupportedOperationException if called
      */
     private AnnotationUtility() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -339,7 +339,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
     }
 
     /**
-     * notify all listeners about the errors in a file.
+     * Notify all listeners about the errors in a file.
      *
      * @param fileName the audited file
      * @param errors the audit errors from the file

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -96,7 +96,7 @@ final class PropertyCacheFile {
     }
 
     /**
-     * load cached values from file
+     * Load cached values from file
      * @throws IOException when there is a problems with file read
      */
     void load() throws IOException {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -71,7 +71,7 @@ public class XMLLogger
     }
 
     /**
-     * sets the OutputStream
+     * Sets the OutputStream
      * @param oS the OutputStream to use
      * @throws UnsupportedEncodingException is UTF-8 is not supported
      **/

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -99,7 +99,7 @@ public class CheckstyleAntTask extends Task {
     private int maxWarnings = Integer.MAX_VALUE;
 
     /**
-     * whether to omit ignored modules - some modules may log tove
+     * Whether to omit ignored modules - some modules may log tove
      * their severity depending on their configuration (e.g. WriteTag) so
      * need to be included
      */
@@ -441,7 +441,7 @@ public class CheckstyleAntTask extends Task {
     }
 
     /**
-     * returns the list of files (full path name) to process.
+     * Returns the list of files (full path name) to process.
      * @return the list of files included via the filesets.
      */
     protected List<File> scanFileSets() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
@@ -125,7 +125,7 @@ public abstract class AbstractViolationReporter
     }
 
     /**
-     * for unit tests, especially with a class with no package name.
+     * For unit tests, especially with a class with no package name.
      * @param className class name of the module.
      * @return name of a resource bundle that contains the messages
      * used by the module.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AuditEvent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AuditEvent.java
@@ -86,7 +86,7 @@ public final class AuditEvent
     }
 
     /**
-     * return the line number on the source file where the event occurred.
+     * Return the line number on the source file where the event occurred.
      * This may be 0 if there is no relation to a file content.
      * @return an integer representing the line number in the file source code.
      */
@@ -95,7 +95,7 @@ public final class AuditEvent
     }
 
     /**
-     * return the message associated to the event.
+     * Return the message associated to the event.
      * @return the event message
      */
     public String getMessage() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -139,7 +139,7 @@ public class AutomaticBean
     }
 
     /**
-     * recheck property and try to copy it
+     * Recheck property and try to copy it
      * @param moduleName name of the module/class
      * @param key key of value
      * @param value value

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -38,7 +38,7 @@ import com.puppycrawl.tools.checkstyle.grammars.CommentListener;
  */
 public final class FileContents implements CommentListener {
     /**
-     * the pattern to match a single line comment containing only the comment
+     * The pattern to match a single line comment containing only the comment
      * itself -- no code.
      */
     private static final String MATCH_SINGLELINE_COMMENT_PAT = "^\\s*//.*$";
@@ -61,7 +61,7 @@ public final class FileContents implements CommentListener {
         Maps.newHashMap();
 
     /**
-     * map of the C comments indexed on the first line of the comment to a list
+     * Map of the C comments indexed on the first line of the comment to a list
      * of comments on that line
      */
     private final Map<Integer, List<TextBlock>> clangComments = Maps.newHashMap();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
@@ -428,7 +428,7 @@ public enum JavadocTagInfo {
     }
 
     /**
-     * returns a JavadocTag from the tag text.
+     * Returns a JavadocTag from the tag text.
      * @param text String representing the tag text
      * @return Returns a JavadocTag type from a String representing the tag
      * @throws NullPointerException if the text is null
@@ -450,7 +450,7 @@ public enum JavadocTagInfo {
     }
 
     /**
-     * returns a JavadocTag from the tag name.
+     * Returns a JavadocTag from the tag name.
      * @param name String name of the tag
      * @return Returns a JavadocTag type from a String representing the tag
      * @throws NullPointerException if the text is null

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
@@ -139,7 +139,7 @@ public abstract class AbstractDeclarationCollector extends Check {
     }
 
     /**
-     * collect Variable Declarations
+     * Collect Variable Declarations
      * @param ast variable token
      * @param frame current frame
      */
@@ -235,7 +235,7 @@ public abstract class AbstractDeclarationCollector extends Check {
         private final LexicalFrame parent;
 
         /**
-         * constructor -- invokable only via super() from subclasses
+         * Constructor -- invokable only via super() from subclasses
          *
          * @param parent parent frame
          */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
@@ -111,7 +111,7 @@ public class ClassResolver {
     }
 
     /**
-     * see if inner class of this class
+     * See if inner class of this class
      * @param name name of the search Class to search
      * @param currentClass class where search in
      * @return class if found , or null if not resolved
@@ -135,7 +135,7 @@ public class ClassResolver {
     }
 
     /**
-     * try star imports
+     * Try star imports
      * @param name name of the Class to search
      * @return  class if found , or null if not resolved
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
@@ -240,7 +240,7 @@ public class DescendantTokenCheck extends Check {
     }
 
     /**
-     * log violations for each Token
+     * Log violations for each Token
      * @param ast token
      */
     private void logAsSeparated(DetailAST ast) {
@@ -279,7 +279,7 @@ public class DescendantTokenCheck extends Check {
     }
 
     /**
-     * log validation as one violation
+     * Log validation as one violation
      * @param ast curent token
      */
     private void logAsTotal(DetailAST ast) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -66,7 +66,7 @@ public class SuppressWarningsHolder
     private static final Map<String, String> CHECK_ALIAS_MAP = new HashMap<>();
 
     /**
-     * a thread-local holder for the list of suppression entries for the last
+     * A thread-local holder for the list of suppression entries for the last
      * file parsed
      */
     private static final ThreadLocal<List<Entry>> ENTRIES = new ThreadLocal<>();
@@ -240,7 +240,7 @@ public class SuppressWarningsHolder
     }
 
     /**
-     * get all annotation values
+     * Get all annotation values
      * @param ast annotation token
      * @return list values
      */
@@ -285,7 +285,7 @@ public class SuppressWarningsHolder
     }
 
     /**
-     * get target of annotation
+     * Get target of annotation
      * @param ast the AST node to get the child of
      * @return get target of annotation
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -212,7 +212,7 @@ public class TranslationCheck
     }
 
     /**
-     * helper method to log an io exception.
+     * Helper method to log an io exception.
      * @param ex the exception that occured
      * @param file the file that could not be processed
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -156,7 +156,7 @@ public final class AnnotationUseStyleCheck extends Check {
         "annotation.trailing.comma.present";
 
     /**
-     * the element name used to receive special linguistic support
+     * The element name used to receive special linguistic support
      * for annotation use.
      */
     private static final String ANNOTATION_ELEMENT_SINGLE_NAME =
@@ -376,7 +376,7 @@ public final class AnnotationUseStyleCheck extends Check {
     }
 
     /**
-     * logs a trailing array comma violation if one exists.
+     * Logs a trailing array comma violation if one exists.
      *
      * @param ast the array init
      * {@link TokenTypes#ANNOTATION_ARRAY_INIT ANNOTATION_ARRAY_INIT}.
@@ -433,14 +433,14 @@ public final class AnnotationUseStyleCheck extends Check {
     public enum ElementStyle {
 
         /**
-         * expanded example
+         * Expanded example
          *
          * <pre>@SuppressWarnings(value={"unchecked","unused",})</pre>.
          */
         EXPANDED,
 
         /**
-         * compact example
+         * Compact example
          *
          * <pre>@SuppressWarnings({"unchecked","unused",})</pre>
          * <br>or<br>
@@ -449,14 +449,14 @@ public final class AnnotationUseStyleCheck extends Check {
         COMPACT,
 
         /**
-         * compact example.]
+         * Compact example.]
          *
          * <pre>@SuppressWarnings("unchecked")</pre>.
          */
         COMPACT_NO_ARRAY,
 
         /**
-         * mixed styles.
+         * Mixed styles.
          */
         IGNORE,
     }
@@ -470,21 +470,21 @@ public final class AnnotationUseStyleCheck extends Check {
     public enum TrailingArrayComma {
 
         /**
-         * with comma example
+         * With comma example
          *
          * <pre>@SuppressWarnings(value={"unchecked","unused",})</pre>.
          */
         ALWAYS,
 
         /**
-         * without comma example
+         * Without comma example
          *
          * <pre>@SuppressWarnings(value={"unchecked","unused"})</pre>.
          */
         NEVER,
 
         /**
-         * mixed styles.
+         * Mixed styles.
          */
         IGNORE,
     }
@@ -498,21 +498,21 @@ public final class AnnotationUseStyleCheck extends Check {
     public enum ClosingParens {
 
         /**
-         * with parens example
+         * With parens example
          *
          * <pre>@Deprecated()</pre>.
          */
         ALWAYS,
 
         /**
-         * without parens example
+         * Without parens example
          *
          * <pre>@Deprecated</pre>.
          */
         NEVER,
 
         /**
-         * mixed styles.
+         * Mixed styles.
          */
         IGNORE,
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -103,7 +103,7 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
     private static final String SUPPRESS_WARNINGS = "SuppressWarnings";
 
     /**
-     * fully-qualified {@link SuppressWarnings SuppressWarnings}
+     * Fully-qualified {@link SuppressWarnings SuppressWarnings}
      * annotation name
      */
     private static final String FQ_SUPPRESS_WARNINGS =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -305,7 +305,7 @@ public class LeftCurlyCheck
     }
 
     /**
-     * validate EOL case
+     * Validate EOL case
      * @param brace brase AST
      * @param braceLine line content
      */
@@ -319,7 +319,7 @@ public class LeftCurlyCheck
     }
 
     /**
-     * validate token on new Line position
+     * Validate token on new Line position
      * @param brace brace AST
      * @param startToken start Token
      * @param braceLine content of line with Brace

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -132,7 +132,7 @@ public abstract class AbstractSuperCheck
     }
 
     /**
-     * is same name of method
+     * Is same name of method
      * @param ast method AST
      * @return true if method name is the same
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -220,7 +220,7 @@ public class DeclarationOrderCheck extends Check {
     }
 
     /**
-     * process constructor
+     * Process constructor
      * @param ast constructor AST
      */
     private void processConstructor(DetailAST ast) {
@@ -237,7 +237,7 @@ public class DeclarationOrderCheck extends Check {
     }
 
     /**
-     * process Method Token
+     * Process Method Token
      * @param ast ,ethod token AST
      */
     private void processMethod(DetailAST ast) {
@@ -254,7 +254,7 @@ public class DeclarationOrderCheck extends Check {
     }
 
     /**
-     * process modifiers
+     * Process modifiers
      * @param ast ast of Modifiers
      */
     private void processModifiers(DetailAST ast) {
@@ -324,7 +324,7 @@ public class DeclarationOrderCheck extends Check {
     }
 
     /**
-     * private class to encapsulate the state
+     * Private class to encapsulate the state
      */
     private static class ScopeState {
         /** The state the check is in */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -158,7 +158,7 @@ public class EqualsAvoidNullCheck extends Check {
     }
 
     /**
-     * checks for calling equals on String literal and
+     * Checks for calling equals on String literal and
      * anon object which cannot be null
      * Also, checks if calling using strange inner class
      * syntax outter.inner.equals(otherObj) by looking

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -102,7 +102,7 @@ public class ExplicitInitializationCheck extends Check {
     }
 
     /**
-     * examin Char literal for initializing to default value
+     * Examin Char literal for initializing to default value
      * @param exprStart exprssion
      * @return true is literal is initialized by zero symbol
      */
@@ -113,7 +113,7 @@ public class ExplicitInitializationCheck extends Check {
     }
 
     /**
-     * chekc for cases that should be skipped: no assignment, local variable, final variables
+     * Chekc for cases that should be skipped: no assignment, local variable, final variables
      * @param ast Variable def AST
      * @return true is that is a case that need to be skipped.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -210,7 +210,7 @@ public class FinalLocalVariableCheck extends Check {
     }
 
     /**
-     * is Arithmetic operator
+     * Is Arithmetic operator
      * @param parentType token AST
      * @return true is token type is in arithmetic operator
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -147,7 +147,7 @@ public class HiddenFieldCheck
     private boolean ignoreSetter;
 
     /**
-     * if ignoreSetter is set to true then this variable controls what
+     * If ignoreSetter is set to true then this variable controls what
      * the setter method can return By default setter must return void.
      * However, is this variable is set to true then setter can also
      * return class in which is declared.
@@ -294,7 +294,7 @@ public class HiddenFieldCheck
     }
 
     /**
-     * check for static or instance field.
+     * Check for static or instance field.
      * @param ast token
      * @param name identifier of token
      * @return true if static or instance field
@@ -305,7 +305,7 @@ public class HiddenFieldCheck
     }
 
     /**
-     * check name by regExp
+     * Check name by regExp
      * @param name string value to check
      * @return true is regexp is matching
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -253,7 +253,7 @@ public class IllegalInstantiationCheck
     }
 
     /**
-     * check import statements
+     * Check import statements
      * @param className name of the class
      * @return value of illegal instatiated type
      */
@@ -282,7 +282,7 @@ public class IllegalInstantiationCheck
     }
 
     /**
-     * check that type is of the same package
+     * Check that type is of the same package
      * @param className class name
      * @param pkgNameLen package name
      * @param illegal illegal value
@@ -304,7 +304,7 @@ public class IllegalInstantiationCheck
     }
 
     /**
-     * is Standard Class
+     * Is Standard Class
      * @param className class name
      * @param illegal illegal value
      * @return true if type is standard
@@ -331,7 +331,7 @@ public class IllegalInstantiationCheck
     }
 
     /**
-     * is class of the same package
+     * Is class of the same package
      * @param className class name
      * @return true if same package class
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
@@ -51,7 +51,7 @@ public class InnerAssignmentCheck
     public static final String MSG_KEY = "assignment.inner.avoid";
 
     /**
-     * list of allowed AST types from an assignement AST node
+     * List of allowed AST types from an assignement AST node
      * towards the root.
      */
     private static final int[][] ALLOWED_ASSIGMENT_CONTEXT = {
@@ -68,7 +68,7 @@ public class InnerAssignmentCheck
     };
 
     /**
-     * list of allowed AST types from an assignement AST node
+     * List of allowed AST types from an assignement AST node
      * towards the root.
      */
     private static final int[][] CONTROL_CONTEXT = {
@@ -80,7 +80,7 @@ public class InnerAssignmentCheck
     };
 
     /**
-     * list of allowed AST types from a comparison node (above an assignement)
+     * List of allowed AST types from a comparison node (above an assignement)
      * towards the root.
      */
     private static final int[][] ALLOWED_ASSIGMENT_IN_COMPARISON_CONTEXT = {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -234,7 +234,7 @@ public class MagicNumberCheck extends Check {
     }
 
     /**
-     * is magic number some where at ast tree
+     * Is magic number some where at ast tree
      * @param ast ast token
      * @param constantDefAST constant ast
      * @return true if magic number is present
@@ -390,7 +390,7 @@ public class MagicNumberCheck extends Check {
     }
 
     /**
-     * sets the tokens which are allowed between Magic Number and defined Object.
+     * Sets the tokens which are allowed between Magic Number and defined Object.
      * @param tokens The string representation of the tokens interested in
      */
     public void setConstantWaiverParentToken(String... tokens) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -153,7 +153,7 @@ public class RequireThisCheck extends AbstractDeclarationCollector {
     }
 
     /**
-     * process validation of Field
+     * Process validation of Field
      * @param ast field definition ast token
      * @param parentType type of the parrent
      */
@@ -187,7 +187,7 @@ public class RequireThisCheck extends AbstractDeclarationCollector {
     }
 
     /**
-     * check that token is related to Definition tokens
+     * Check that token is related to Definition tokens
      * @param parentType token Type
      * @return true if token is related to Definition Tokens
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -121,7 +121,7 @@ public class DesignForExtensionCheck extends Check {
     }
 
     /**
-     * check for modifiers
+     * Check for modifiers
      * @param ast modifier ast
      * @return tru in modifier is in checked ones
      */
@@ -135,7 +135,7 @@ public class DesignForExtensionCheck extends Check {
     }
 
     /**
-     * has Default Or Expl Non Private Ctor
+     * Has Default Or Expl Non Private Ctor
      * @param classDef class ast
      * @return true if Check should make a violation
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -119,7 +119,7 @@ public class FinalClassCheck
         private boolean withPrivateCtor;
 
         /**
-         *  create a new ClassDesc instance.
+         *  Create a new ClassDesc instance.
          *  @param declaredAsFinal indicates if the
          *         class declared as final
          *  @param declaredAsAbstract indicates if the
@@ -141,7 +141,7 @@ public class FinalClassCheck
         }
 
         /**
-         *  does class have private ctors.
+         *  Does class have private ctors.
          *  @return true if class has private ctors
          */
         boolean isWithPrivateCtor() {
@@ -149,7 +149,7 @@ public class FinalClassCheck
         }
 
         /**
-         *  does class have non-private ctors.
+         *  Does class have non-private ctors.
          *  @return true if class has non-private ctors
          */
         boolean isWithNonPrivateCtor() {
@@ -157,7 +157,7 @@ public class FinalClassCheck
         }
 
         /**
-         *  is class declared as final.
+         *  Is class declared as final.
          *  @return true if class is declared as final
          */
         boolean isDeclaredAsFinal() {
@@ -165,7 +165,7 @@ public class FinalClassCheck
         }
 
         /**
-         *  is class declared as abstract.
+         *  Is class declared as abstract.
          *  @return true if class is declared as final
          */
         boolean isDeclaredAsAbstract() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -132,7 +132,7 @@ public class HideUtilityClassConstructorCheck extends Check {
         }
 
         /**
-         * getter
+         * Getter
          * @return boolean
          */
         public boolean isHasMethodOrField() {
@@ -140,7 +140,7 @@ public class HideUtilityClassConstructorCheck extends Check {
         }
 
         /**
-         * getter
+         * Getter
          * @return boolean
          */
         public boolean isHasNonStaticMethodOrField() {
@@ -148,7 +148,7 @@ public class HideUtilityClassConstructorCheck extends Check {
         }
 
         /**
-         * getter
+         * Getter
          * @return boolean
          */
         public boolean isHasNonPrivateStaticMethodOrField() {
@@ -156,7 +156,7 @@ public class HideUtilityClassConstructorCheck extends Check {
         }
 
         /**
-         * getter
+         * Getter
          * @return boolean
          */
         public boolean isHasDefaultCtor() {
@@ -164,7 +164,7 @@ public class HideUtilityClassConstructorCheck extends Check {
         }
 
         /**
-         * getter
+         * Getter
          * @return boolean
          */
         public boolean isHasPublicCtor() {
@@ -172,7 +172,7 @@ public class HideUtilityClassConstructorCheck extends Check {
         }
 
         /**
-         *  main method to gather statistics
+         *  Main method to gather statistics
          */
         public void invoke() {
             final DetailAST objBlock = ast.findFirstToken(TokenTypes.OBJBLOCK);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -280,7 +280,7 @@ public class VisibilityModifierCheck
     private boolean packageAllowed;
 
     /**
-     * pattern for public members that should be ignored.  Note:
+     * Pattern for public members that should be ignored.  Note:
      * Earlier versions of checkstyle used ^f[A-Z][a-zA-Z0-9]*$ as the
      * default to allow CMP for EJB 1.1 with the default settings.
      * With EJB 2.0 it is not longer necessary to have public access

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
@@ -78,7 +78,7 @@ public class HandlerFactory {
     }
 
     /**
-     * registers a handler
+     * Registers a handler
      *
      * @param type
      *                type from TokenTypes

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -74,7 +74,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
     }
 
     /**
-     * if this is the first chained method call which was moved to the next line
+     * If this is the first chained method call which was moved to the next line
      * @return true if chained class are wrapped
      */
     private boolean isChainedMethodCallWrapped() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -74,7 +74,7 @@ public abstract class AbstractJavadocCheck extends Check {
         "javadoc.wrong.singleton.html.tag";
 
     /**
-     * key is "line:column"
+     * Key is "line:column"
      * value is DetailNode tree
      */
     private static final Map<String, ParseStatus> TREE_CACHE = new HashMap<>();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -140,7 +140,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     private int minLineCount = DEFAULT_MIN_LINE_COUNT;
 
     /**
-     * controls whether to allow documented exceptions that are not declared if
+     * Controls whether to allow documented exceptions that are not declared if
      * they are a subclass of java.lang.RuntimeException.
      */
     private boolean allowUndeclaredRTE;
@@ -151,26 +151,26 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     private boolean validateThrows;
 
     /**
-     * controls whether to allow documented exceptions that are subclass of one
+     * Controls whether to allow documented exceptions that are subclass of one
      * of declared exception. Defaults to false (backward compatibility).
      */
     private boolean allowThrowsTagsForSubclasses;
 
     /**
-     * controls whether to ignore errors when a method has parameters but does
+     * Controls whether to ignore errors when a method has parameters but does
      * not have matching param tags in the javadoc. Defaults to false.
      */
     private boolean allowMissingParamTags;
 
     /**
-     * controls whether to ignore errors when a method declares that it throws
+     * Controls whether to ignore errors when a method declares that it throws
      * exceptions but does not have matching throws tags in the javadoc.
      * Defaults to false.
      */
     private boolean allowMissingThrowsTags;
 
     /**
-     * controls whether to ignore errors when a method returns non-void type
+     * Controls whether to ignore errors when a method returns non-void type
      * but does not have a return tag in the javadoc. Defaults to false.
      */
     private boolean allowMissingReturnTag;
@@ -251,7 +251,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     }
 
     /**
-     * controls whether to allow documented exceptions that are not declared if
+     * Controls whether to allow documented exceptions that are not declared if
      * they are a subclass of java.lang.RuntimeException.
      *
      * @param flag a {@code Boolean} value
@@ -261,7 +261,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     }
 
     /**
-     * controls whether to allow documented exception that are subclass of one
+     * Controls whether to allow documented exception that are subclass of one
      * of declared exceptions.
      *
      * @param flag a {@code Boolean} value
@@ -271,7 +271,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     }
 
     /**
-     * controls whether to allow a method which has parameters to omit matching
+     * Controls whether to allow a method which has parameters to omit matching
      * param tags in the javadoc. Defaults to false.
      *
      * @param flag a {@code Boolean} value
@@ -281,7 +281,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     }
 
     /**
-     * controls whether to allow a method which declares that it throws
+     * Controls whether to allow a method which declares that it throws
      * exceptions to omit matching throws tags in the javadoc. Defaults to
      * false.
      *
@@ -292,7 +292,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     }
 
     /**
-     * controls whether to allow a method which returns non-void type to omit
+     * Controls whether to allow a method which returns non-void type to omit
      * the return tag in the javadoc. Defaults to false.
      *
      * @param flag a {@code Boolean} value

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -95,7 +95,7 @@ public class JavadocTypeCheck
     /** Regexp to match version tag content */
     private String versionFormat;
     /**
-     * controls whether to ignore errors when a method has type parameters but
+     * Controls whether to ignore errors when a method has type parameters but
      * does not have matching param tags in the javadoc. Defaults to false.
      */
     private boolean allowMissingParamTags;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -66,7 +66,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
     public static final String MSG_KEY = "singleline.javadoc";
 
     /**
-     * allows to specify a list of tags to be ignored by check.
+     * Allows to specify a list of tags to be ignored by check.
      */
     private List<String> ignoredTags = new ArrayList<>();
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
@@ -125,7 +125,7 @@ public class RedundantModifierCheck
     }
 
     /**
-     * do validation of interface of annotation
+     * Do validation of interface of annotation
      * @param ast token AST
      */
     private void processInterfaceOrAnnotation(DetailAST ast) {
@@ -153,7 +153,7 @@ public class RedundantModifierCheck
     }
 
     /**
-     * process validation ofMethods
+     * Process validation ofMethods
      * @param ast method AST
      */
     private void processMethods(DetailAST ast) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -326,7 +326,7 @@ public class AbbreviationAsWordInNameCheck extends Check {
     }
 
     /**
-     * get Abbreviation if it is illegal
+     * Get Abbreviation if it is illegal
      * @param str name
      * @param beginIndex begin index
      * @param endIndex end index

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
@@ -89,7 +89,7 @@ public class MethodNameCheck
     private static final String CANONICAL_OVERRIDE = "java.lang." + OVERRIDE;
 
     /**
-     * for allowing method name to be the same as the class name.
+     * For allowing method name to be the same as the class name.
      */
     private boolean allowClassName;
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java
@@ -51,7 +51,7 @@ public class TypeNameCheck
     extends AbstractAccessControlNameCheck {
 
     /**
-     * default pattern for type name.
+     * Default pattern for type name.
      */
     public static final String DEFAULT_PATTERN = "^[A-Z][a-zA-Z0-9]*$";
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
@@ -231,7 +231,7 @@ public class RegexpCheck extends AbstractFormatCheck {
     }
 
     /**
-     * check if we can stop valiation
+     * Check if we can stop valiation
      * @param ignore flag
      * @return true is we can continue
      */
@@ -241,7 +241,7 @@ public class RegexpCheck extends AbstractFormatCheck {
     }
 
     /**
-     * detect ignore situation
+     * Detect ignore situation
      * @param startLine position of line
      * @param text file text
      * @param start line colun

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -238,7 +238,7 @@ public class EmptyLineSeparatorCheck extends Check {
     }
 
     /**
-     * process Package
+     * Process Package
      * @param ast token
      * @param nextToken next token
      */
@@ -255,7 +255,7 @@ public class EmptyLineSeparatorCheck extends Check {
     }
 
     /**
-     * process Import
+     * Process Import
      * @param ast token
      * @param nextToken next token
      * @param astType token Type
@@ -270,7 +270,7 @@ public class EmptyLineSeparatorCheck extends Check {
     }
 
     /**
-     * process Variable
+     * Process Variable
      * @param ast token
      * @param nextToken next Token
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -162,7 +162,7 @@ public class GenericWhitespaceCheck extends Check {
     }
 
     /**
-     * process Nested generics
+     * Process Nested generics
      * @param ast token
      * @param line line content
      * @param after position after
@@ -192,7 +192,7 @@ public class GenericWhitespaceCheck extends Check {
     }
 
     /**
-     * process Single-generic
+     * Process Single-generic
      * @param ast token
      * @param line line content
      * @param after position after
@@ -218,7 +218,7 @@ public class GenericWhitespaceCheck extends Check {
     }
 
     /**
-     * is generic before method reference
+     * Is generic before method reference
      * @param ast ast
      * @return true if generic before a method ref
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java
@@ -111,7 +111,7 @@ public class WhitespaceAfterCheck
     }
 
     /**
-     * checks whether token is followed by a whitespace.
+     * Checks whether token is followed by a whitespace.
      * @param targetAST Ast token.
      * @param line The line associated with the ast token.
      * @return true if ast token is followed by a whitespace.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -388,7 +388,7 @@ public class WhitespaceAroundCheck extends Check {
     }
 
     /**
-     * is ast is not a target of Check
+     * Is ast is not a target of Check
      * @param ast ast
      * @param currentType type of ast
      * @return true is ok to skip validation
@@ -427,7 +427,7 @@ public class WhitespaceAroundCheck extends Check {
     }
 
     /**
-     * is empty block
+     * Is empty block
      * @param ast ast
      * @param parentType parent
      * @return true is block is empty
@@ -439,7 +439,7 @@ public class WhitespaceAroundCheck extends Check {
     }
 
     /**
-     * we do not want to check colon for cases and defaults
+     * We do not want to check colon for cases and defaults
      * @param currentType current
      * @param parentType parent
      * @return true is cur token in colon of case or default tokens
@@ -460,7 +460,7 @@ public class WhitespaceAroundCheck extends Check {
     }
 
     /**
-     * is array initialization
+     * Is array initialization
      * @param currentType curret token
      * @param parentType parent token
      * @return true is current token inside array initialization

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressElement.java
@@ -139,7 +139,7 @@ public class SuppressElement
     }
 
     /**
-     * is matching by file name and Check name
+     * Is matching by file name and Check name
      * @param event event
      * @return true is matching
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -60,7 +60,7 @@ public final class SuppressionsLoader
         "com/puppycrawl/tools/checkstyle/suppressions_1_1.dtd";
 
     /**
-     * the filter chain to return in getAFilterChain(),
+     * The filter chain to return in getAFilterChain(),
      * configured during parsing
      */
     private final FilterSet filterChain = new FilterSet();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
@@ -200,7 +200,7 @@ public class JTreeTable extends JTable {
         }
 
         /**
-         * updateUI is overridden to set the colors of the Tree's renderer
+         * UpdateUI is overridden to set the colors of the Tree's renderer
          * to match that of the table.
          */
         @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
@@ -80,23 +80,23 @@ public final class Main {
     }
 
     /**
-     * http://findbugs.sourceforge.net/bugDescriptions.html#SW_SWING_METHODS_INVOKED_IN_SWING_THREAD
+     * Http://findbugs.sourceforge.net/bugDescriptions.html#SW_SWING_METHODS_INVOKED_IN_SWING_THREAD
      */
     private static class FrameShower implements Runnable {
         /**
-         * frame
+         * Frame
          */
         private final JFrame frame;
 
         /**
-         * contstructor
+         * Contstructor
          */
         public FrameShower(JFrame frame) {
             this.frame = frame;
         }
 
         /**
-         * display a frame
+         * Display a frame
          */
         @Override
         public void run() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -207,21 +207,21 @@ public class ParseTreeInfoPanel extends JPanel {
     }
 
     /**
-     * http://findbugs.sourceforge.net/bugDescriptions.html#SW_SWING_METHODS_INVOKED_IN_SWING_THREAD
+     * Http://findbugs.sourceforge.net/bugDescriptions.html#SW_SWING_METHODS_INVOKED_IN_SWING_THREAD
      */
     private static class FrameShower implements Runnable {
         /**
-         * frame
+         * Frame
          */
         private final Component parent;
 
         /**
-         * frame
+         * Frame
          */
         private final String msg;
 
         /**
-         * contstructor
+         * Contstructor
          */
         public FrameShower(Component parent, final String msg) {
             this.parent = parent;
@@ -229,7 +229,7 @@ public class ParseTreeInfoPanel extends JPanel {
         }
 
         /**
-         * display a frame
+         * Display a frame
          */
         @Override
         public void run() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -23,7 +23,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public abstract class BaseCheckTestSupport {
     /**
-     * a brief logger that only display info about errors
+     * A brief logger that only display info about errors
      */
     protected static class BriefLogger
             extends DefaultLogger {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -122,7 +122,7 @@ public class AutomaticBeanTest {
         }
 
         /**
-         * just for code coverage
+         * Just for code coverage
          * @param childConf a child of this component's Configuration
          */
         @Override


### PR DESCRIPTION
There are many false-positives. For example:
 ```
checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
Warning 	regexp 	RegexpMultiline 	First sentence in a comment should start with a capital letter 	558
```
http://rdiachenko.github.io/site-src/xref/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.html#L558