### PR TITLE
Fixes logic bug in gui ParseTreeInfoPanel making linesToPositions assign

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -143,11 +143,6 @@ public class ParseTreeInfoPanel extends JPanel {
                 clearLinesToPosition();
                 // starts line counting at 1
                 addLineToPosition(0);
-                // insert the contents of the file to the text area
-                for (String element : sourceLines) {
-                    addLineToPosition(textArea.getText().length());
-                    textArea.append(element + System.lineSeparator());
-                }
 
                 //clean the text area before inserting the lines of the new file
                 if (!textArea.getText().isEmpty()) {
@@ -157,6 +152,7 @@ public class ParseTreeInfoPanel extends JPanel {
 
                 // insert the contents of the file to the text area
                 for (final String element : sourceLines) {
+                    addLineToPosition(textArea.getText().length());
                     textArea.append(element + System.lineSeparator());
                 }
 


### PR DESCRIPTION
lines to inappropriate positions

Problem was pretty weird logic in filling textArea with new file content and assigning linesToPosition association between lines of code and position in text area. Before PR text area is appending once ( for the first time when text area is empty it is correct,but if not - new lines are appending at the end of old additionaly causing linesToPosition to be wrong) , clear text area and filling it once again. This PR just fix this poor behaviour moving adding lines after clearing old text area value.