### PR TITLE
Rename variable in anonymous class hiding other variable. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -422,10 +422,10 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
         ImportOrderCheck check = new ImportOrderCheck() {
             @Override
             public ImportOrderOption getAbstractOption() {
-                ImportOrderOption C = PowerMockito.mock(ImportOrderOption.class);
-                Whitebox.setInternalState(C, "name", "NEW_OPTION_FOR_UT");
-                Whitebox.setInternalState(C, "ordinal", 5);
-                return C;
+                ImportOrderOption importOrderOption = PowerMockito.mock(ImportOrderOption.class);
+                Whitebox.setInternalState(importOrderOption, "name", "NEW_OPTION_FOR_UT");
+                Whitebox.setInternalState(importOrderOption, "ordinal", 5);
+                return importOrderOption;
                 }
         };
         // expecting IllegalStateException


### PR DESCRIPTION
Fixes `AnonymousClassVariableHidesContainingMethodVariable` inspection violations in test code.

Description:
>Reports anonymous class variables being named identically to variables of a containing method or lambda expression. Such a variable name may be confusing.