### PR TITLE
Remove explicit array creation. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -196,7 +196,7 @@ public class CheckerTest {
         c.setModuleFactory(factory);
 
         c.setFileExtensions((String[]) null);
-        c.setFileExtensions(new String[]{".java", "xml"});
+        c.setFileExtensions(".java", "xml");
 
         try {
             c.setCharset("UNKNOW-CHARSET");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
@@ -33,7 +33,7 @@ public class FileContentsTest {
     @SuppressWarnings("deprecation")
     public void testDeprecatedCtor() {
         // just to make UT coverage 100%
-        FileContents o = new FileContents("filename.java", new String[]{"1", "2"});
+        FileContents o = new FileContents("filename.java", "1", "2");
         o.getFilename();
     }
 


### PR DESCRIPTION
Fixes `RedundantArrayCreation` inspection violations in test code.

Description:
>This inspection reports unnecessary creation of array expression to be passed as an argument to varargs parameter.