### PR TITLE
Remove unnecessary cast expression. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -210,7 +210,7 @@ public class ConfigurationLoaderTest {
         final Configuration[] children = config.getChildren();
         final Configuration[] grandchildren = children[0].getChildren();
 
-        assertTrue(((DefaultConfiguration) grandchildren[0]).getMessages()
+        assertTrue(grandchildren[0].getMessages()
             .containsKey("name.invalidPattern"));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -350,7 +350,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         }
 
         String expected = "";
-        assertEquals(expected, (String) actual);
+        assertEquals(expected, actual);
     }
 
     @Test


### PR DESCRIPTION
Fixes `RedundantCast` inspection violations in test code.

Description:
>This inspection reports unnecessary cast expressions.