### PR TITLE
Remove unused assignments. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
@@ -59,7 +59,6 @@ public class RegexpHeaderCheckTest extends BaseFileSetCheckTestSupport {
         // check null passes
         RegexpHeaderCheck instance = new RegexpHeaderCheck();
         // check empty string passes
-        instance = new RegexpHeaderCheck();
         String header = "";
         instance.setHeader(header);
     }
@@ -71,7 +70,6 @@ public class RegexpHeaderCheckTest extends BaseFileSetCheckTestSupport {
     public void testSetHeaderSimple() {
         RegexpHeaderCheck instance = new RegexpHeaderCheck();
         // check valid header passes
-        instance = new RegexpHeaderCheck();
         String header = "abc.*";
         instance.setHeader(header);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -185,8 +185,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
         try {
             URL url = new URL("http://checkstyle.sourceforge.net/");
             HttpURLConnection urlConnect = (HttpURLConnection) url.openConnection();
-            @SuppressWarnings("unused")
-            Object objData = urlConnect.getContent();
+            urlConnect.getContent();
         }
         catch (IOException e) {
             return false;


### PR DESCRIPTION
Fixes `UnusedAssignment` inspection violations in test code.

Description:
>This inspection points out the cases where a variable value is never used after its assignment, i.e.:  
- the variable never gets read after assignment OR  
- the value is always overwritten with another assignment before the next variable read OR  
- the variable initializer is redundant (for one of the above two reasons) OR  
- the variable is never used.