### PR TITLE
Remove unused array declarations. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -435,8 +435,6 @@ public class MainTest {
 
     @Test
     public void testCreateListener_IllegalStateException() throws Exception {
-        Class<?>[] param = new Class<?>[1];
-        param[0] = File.class;
         Method method = Main.class.getDeclaredMethod("createListener", String.class, String.class);
         method.setAccessible(true);
         try {
@@ -454,8 +452,6 @@ public class MainTest {
 
     @Test
     public void testCreateListenerWithLocation_IllegalStateException() throws Exception {
-        Class<?>[] param = new Class<?>[1];
-        param[0] = File.class;
         Method method = Main.class.getDeclaredMethod("createListener", String.class, String.class);
         method.setAccessible(true);
         String outDir = "myfolder123";
@@ -509,8 +505,6 @@ public class MainTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testListFiles_notFile() throws Exception {
-        Class<?>[] param = new Class<?>[1];
-        param[0] = File.class;
         Method method = Main.class.getDeclaredMethod("listFiles", File.class);
         method.setAccessible(true);
 
@@ -526,8 +520,6 @@ public class MainTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testListFiles_DirectoryWithNull() throws Exception {
-        Class<?>[] param = new Class<?>[1];
-        param[0] = File.class;
         Method method = Main.class.getDeclaredMethod("listFiles", File.class);
         method.setAccessible(true);
 


### PR DESCRIPTION
Fixes `MismatchedArrayReadWrite` inspection violations in test code.

Description:
>Reports any array fields or variables whose contents are read but not written, or written but not read. Such mismatched reads and writes are pointless, and probably indicate dead, incomplete or erroneous code.