### PR TITLE
Remove test for default implementation of toString(). #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/FilterSetTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/FilterSetTest.java
@@ -73,12 +73,6 @@ public class FilterSetTest {
     }
 
     @Test
-    public void testToString() {
-        filter.addFilter(new IntMatchFilter(0));
-        assertNotNull("toString works", filter.toString());
-    }
-
-    @Test
     public void testGetFilters2() {
         FilterSet filterSet = new FilterSet();
         filterSet.addFilter(new SeverityMatchFilter());


### PR DESCRIPTION
Fixes `ObjectToString` inspection violations in test code.

Description:
>Reports any calls to .toString() which use the default implementation from java.lang.Object. The default implementation is rarely desired, but easy to use by accident. Calls to .toString() on objects of type java.lang.Object are ignored by this inspection.