### PR TITLE
Remove calls to simple setters within classes. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -600,7 +600,7 @@ public class CheckstyleAntTask extends Task {
 
         /** @param file set the property value from a File */
         public void setFile(File file) {
-            setValue(file.getAbsolutePath());
+            value = file.getAbsolutePath();
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.java
@@ -38,7 +38,7 @@ public abstract class AbstractNestedDepthCheck extends Check {
      * @param max default allowed nesting depth.
      */
     protected AbstractNestedDepthCheck(int max) {
-        setMax(max);
+        this.max = max;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
@@ -59,7 +59,7 @@ public final class MutableExceptionCheck extends AbstractFormatCheck {
     /** Creates new instance of the check. */
     public MutableExceptionCheck() {
         super(DEFAULT_FORMAT);
-        setExtendedClassNameFormat(DEFAULT_FORMAT);
+        extendedClassNameFormat = DEFAULT_FORMAT;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
@@ -71,7 +71,7 @@ public final class ThrowsCountCheck extends Check {
 
     /** Creates new instance of the check. */
     public ThrowsCountCheck() {
-        setMax(DEFAULT_MAX);
+        max = DEFAULT_MAX;
     }
 
     @Override


### PR DESCRIPTION
Fixes `CallToSimpleSetterInClass` inspection violations in test code.

Description:
>Reports any calls to a simple property setter from within the property's class. A simple property setter is defined as one which simply assigns the value of its parameter to a field, and does no other calculation. Such simple setter calls may be safely inlined, at a small performance improvement. Some coding standards also suggest against the use of simple setters for code clarity reasons.