### PR TITLE
Rename unused catch parameters. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -148,7 +148,7 @@ public abstract class BaseCheckTestSupport {
         Properties pr = new Properties();
         try {
             pr.load(getClass().getResourceAsStream("messages.properties"));
-        } catch (IOException e) {
+        } catch (IOException ignored) {
             return null;
         }
         return format(pr.getProperty(messageKey), arguments);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -428,7 +428,7 @@ public class MainTest {
             assertTrue(e.getCause().getMessage().startsWith("Unable to load properties from file '"));
             assertTrue(e.getCause().getMessage().endsWith(":invalid'."));
         }
-        catch (Exception e) {
+        catch (Exception ignored) {
             fail();
         }
     }
@@ -447,7 +447,7 @@ public class MainTest {
             assertTrue(e.getCause() instanceof IllegalStateException);
             assertTrue(e.getCause().getMessage().startsWith("Invalid output format. Found"));
         }
-        catch (Exception e) {
+        catch (Exception ignored) {
             fail();
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -113,7 +113,7 @@ public class PropertyCacheFileTest {
             assertTrue(e.getCause().getCause() instanceof NoSuchAlgorithmException);
             assertEquals("Unable to calculate hashcode.", e.getCause().getMessage());
         }
-        catch (Exception e) {
+        catch (Exception ignored) {
             fail();
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
@@ -186,7 +186,7 @@ public class UtilsTest {
         try {
             Utils.getIntFromField(field, 0);
         }
-        catch (IllegalStateException expected) {
+        catch (IllegalStateException ignored) {
             // expected
         }
     }
@@ -233,10 +233,10 @@ public class UtilsTest {
             assertEquals("given id " + id, expected.getMessage());
 
         }
-        catch (IllegalAccessException e) {
+        catch (IllegalAccessException ignored) {
             fail();
         }
-        catch (NoSuchFieldException e) {
+        catch (NoSuchFieldException ignored) {
             fail();
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -53,7 +53,7 @@ public class FileTextTest {
                      + "checkstyle/imports/import-control_complete.xml"), charsetName);
             assertEquals(o.getCharset().name(), charsetName);
         }
-        catch (UnsupportedEncodingException e) {
+        catch (UnsupportedEncodingException ignored) {
             fail();
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/ClassResolverTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/ClassResolverTest.java
@@ -43,7 +43,7 @@ public class ClassResolverTest {
             cr.resolve("who.will.win.the.world.cup", "");
             fail("Should not resolve class");
         }
-        catch (ClassNotFoundException e) {
+        catch (ClassNotFoundException ignored) {
             // expected
         }
         cr.resolve("java.lang.String", "");
@@ -54,7 +54,7 @@ public class ClassResolverTest {
             cr.resolve("ChoiceFormat", "");
             fail();
         }
-        catch (ClassNotFoundException e) {
+        catch (ClassNotFoundException ignored) {
             // expected
         }
 
@@ -69,7 +69,7 @@ public class ClassResolverTest {
             cr.resolve("two.nil.england", "");
             fail();
         }
-        catch (ClassNotFoundException e) {
+        catch (ClassNotFoundException ignored) {
             // expected
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -160,7 +160,7 @@ public class FinalLocalVariableCheckTest
             check.visitToken(lambdaAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ignored) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
@@ -175,7 +175,7 @@ public class IllegalInstantiationCheckTest
             check.visitToken(lambdaAst);
             Assert.fail();
         }
-        catch (IllegalArgumentException e) {
+        catch (IllegalArgumentException ignored) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -182,7 +182,7 @@ public class IllegalTypeCheckTest extends BaseCheckTestSupport {
             check.visitToken(classDefAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ignored) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
@@ -89,7 +89,7 @@ public class ModifiedControlVariableCheckTest
             check.visitToken(classDefAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ignored) {
             // it is OK
         }
 
@@ -97,7 +97,7 @@ public class ModifiedControlVariableCheckTest
             check.leaveToken(classDefAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ignored) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
@@ -66,7 +66,7 @@ public class ParameterAssignmentCheckTest extends BaseCheckTestSupport {
             check.visitToken(classDefAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ignored) {
             // it is OK
         }
 
@@ -74,7 +74,7 @@ public class ParameterAssignmentCheckTest extends BaseCheckTestSupport {
             check.leaveToken(classDefAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ignored) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
@@ -117,7 +117,7 @@ public class ReturnCountCheckTest extends BaseCheckTestSupport {
             check.visitToken(classDefAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ignored) {
             // it is OK
         }
 
@@ -125,7 +125,7 @@ public class ReturnCountCheckTest extends BaseCheckTestSupport {
             check.leaveToken(classDefAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ignored) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
@@ -232,7 +232,7 @@ public class VariableDeclarationUsageDistanceCheckTest extends
             createChecker(checkConfig);
             verify(checkConfig, getPath("coding/InputVariableDeclarationUsageDistanceCheck.java"), expected);
         }
-        catch (Exception ex) {
+        catch (Exception ignored) {
             //Exception is not expected
             fail();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
@@ -83,7 +83,7 @@ public class MutableExceptionCheckTest extends BaseCheckTestSupport {
             obj.visitToken(ast);
             fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ignored) {
             //expected
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -53,7 +53,7 @@ public class HeaderCheckTest extends BaseFileSetCheckTestSupport {
             };
             verify(checkConfig, getPath("InputRegexpHeader1.java"), expected);
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException ignored) {
             // Exception is not expected
             fail();
         }
@@ -68,7 +68,7 @@ public class HeaderCheckTest extends BaseFileSetCheckTestSupport {
             createChecker(checkConfig);
             fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException ignored) {
             // expected exception
         }
     }
@@ -83,7 +83,7 @@ public class HeaderCheckTest extends BaseFileSetCheckTestSupport {
             createChecker(checkConfig);
             fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException ignored) {
             // expected exception
         }
     }
@@ -97,7 +97,7 @@ public class HeaderCheckTest extends BaseFileSetCheckTestSupport {
             createChecker(checkConfig);
             fail("Checker creation should not succeed with invalid headerFile");
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException ignored) {
             // expected exception
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
@@ -88,7 +88,7 @@ public class RegexpHeaderCheckTest extends BaseFileSetCheckTestSupport {
             instance.setHeader(header);
             fail(String.format("%s should have been thrown", ConversionException.class));
         }
-        catch (ConversionException ex) {
+        catch (ConversionException ignored) {
             // expected
         }
     }
@@ -102,7 +102,7 @@ public class RegexpHeaderCheckTest extends BaseFileSetCheckTestSupport {
             };
             verify(checkConfig, getPath("InputRegexpHeader1.java"), expected);
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException ignored) {
             // Exception is not expected
             fail();
         }
@@ -116,7 +116,7 @@ public class RegexpHeaderCheckTest extends BaseFileSetCheckTestSupport {
             createChecker(checkConfig);
             fail("Checker creation should not succeed with invalid headerFile");
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException ignored) {
             // expected exception
         }
     }
@@ -164,7 +164,7 @@ public class RegexpHeaderCheckTest extends BaseFileSetCheckTestSupport {
             createChecker(checkConfig);
             fail("Checker creation should not succeed when regexp spans multiple lines");
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException ignored) {
             // expected exception
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -504,7 +504,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
             verify(checkConfig, getPath("imports" + File.separator
                 + "InputCustomImportOrder.java"), expected);
         }
-        catch (Exception ex) {
+        catch (Exception ignored) {
             // Exception is not expected
             fail();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -110,7 +110,7 @@ public class ImportControlCheckTest extends BaseCheckTestSupport {
                     + "InputImportControl.java"), expected);
             fail("should fail");
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException ignored) {
             //donothng
         }
     }
@@ -126,7 +126,7 @@ public class ImportControlCheckTest extends BaseCheckTestSupport {
                     + "InputImportControl.java"), expected);
             fail("should fail");
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException ignored) {
             //donothing
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -105,7 +105,7 @@ public class SummaryJavadocCheckTest extends BaseCheckTestSupport {
             createChecker(checkConfig);
             verify(checkConfig, getPath("javadoc/InputIncorrectSummaryJavaDocCheck.java"), expected);
         }
-        catch (Exception ex) {
+        catch (Exception ignored) {
             //Exception is not expected
             fail();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
@@ -66,7 +66,7 @@ public class ClassDataAbstractionCouplingCheckTest extends BaseCheckTestSupport 
                 getPath("metrics" + File.separator + "ClassCouplingCheckTestInput.java"),
                 expected);
         }
-        catch (Exception ex) {
+        catch (Exception ignored) {
             //Exception is not expected
             fail();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -73,7 +73,7 @@ public class ClassFanOutComplexityCheckTest extends BaseCheckTestSupport {
                 getPath("metrics" + File.separator + "ClassCouplingCheckTestInput.java"),
                 expected);
         }
-        catch (Exception ex) {
+        catch (Exception ignored) {
             //Exception is not expected
             fail();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckTest.java
@@ -79,7 +79,7 @@ public class JavaNCSSCheckTest extends BaseCheckTestSupport {
             verify(checkConfig, getPath("metrics" + File.separator
                 + "JavaNCSSCheckTestInput.java"), expected);
         }
-        catch (Exception ex) {
+        catch (Exception ignored) {
             // Exception is not expected
             fail();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -82,7 +82,7 @@ public class NPathComplexityCheckTest extends BaseCheckTestSupport {
             createChecker(checkConfig);
             verify(checkConfig, getPath("ComplexityCheckTestInput.java"), expected);
         }
-        catch (Exception ex) {
+        catch (Exception ignored) {
             // Exception is not expected
             fail();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
@@ -53,7 +53,7 @@ public class ConstantNameCheckTest
             createChecker(checkConfig);
             fail();
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException ignored) {
             // expected exception
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
@@ -153,7 +153,7 @@ public class ExecutableStatementCountCheckTest
             createChecker(checkConfig);
             verify(checkConfig, getPath("ExecutableStatementCountInput.java"), expected);
         }
-        catch (Exception ex) {
+        catch (Exception ignored) {
             //Exception is not expected
             fail();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
@@ -74,7 +74,7 @@ public class FileLengthCheckTest
             createChecker(checkConfig);
             fail("Should indicate illegal args");
         }
-        catch (CheckstyleException ex) {
+        catch (CheckstyleException ignored) {
             // Expected Exception because of illegal argument for "max"
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -188,7 +188,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
             @SuppressWarnings("unused")
             Object objData = urlConnect.getContent();
         }
-        catch (IOException e) {
+        catch (IOException ignored) {
             return false;
         }
         return true;


### PR DESCRIPTION
Fixes `UnusedCatchParameter` inspection violations in test code.

Description:
>Reports any catch parameters that are unused in their corresponding blocks. This inspection will not report any catch parameters named "ignore" or "ignored". Conversely this inspection will warn on any catch parameters named "ignore" or "ignored" that are actually used.