### PR TITLE
Remove usage of prohibited exceptions in test code. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
@@ -61,7 +61,7 @@ public class IndentationConfigurationBuilder extends ConfigurationBuilder
                     final int actualIndent = getLineStart(line, tabWidth);
 
                     if (actualIndent != indentInComment) {
-                        throw new RuntimeException(String.format(
+                        throw new IllegalStateException(String.format(
                                         "File \"%1$s\" has incorrect indentation in comment."
                                                         + "Line %2$d: comment:%3$d, actual:%4$d.",
                                         aFileName,
@@ -75,14 +75,14 @@ public class IndentationConfigurationBuilder extends ConfigurationBuilder
                     }
 
                     if (!isCommentConsistent(comment)) {
-                        throw new RuntimeException(String.format(
+                        throw new IllegalStateException(String.format(
                                         "File \"%1$s\" has inconsistent comment on line %2$d",
                                         aFileName,
                                         lineNumber));
                     }
                 }
                 else if (NONEMPTY_LINE_REGEX.matcher(line).matches()) {
-                    throw new RuntimeException(String.format(
+                    throw new IllegalStateException(String.format(
                                     "File \"%1$s\" has no indentation comment or its format "
                                                     + "malformed. Error on line: %2$d(%3$s)",
                                     aFileName,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -131,7 +131,7 @@ public class UniquePropertiesCheckTest extends BaseFileSetCheckTestSupport {
         try {
             final InputStream stream = new FileInputStream(file);
             stream.close();
-            throw new Exception("File " + file.getPath() + " should not exist");
+            throw new IllegalStateException("File " + file.getPath() + " should not exist");
         }
         catch (FileNotFoundException ex) {
             return ex.getLocalizedMessage();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -79,7 +79,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
                     final int actualIndent = getLineStart(line, tabWidth);
 
                     if (actualIndent != indentInComment) {
-                        throw new RuntimeException(String.format(
+                        throw new IllegalStateException(String.format(
                                         "File \"%1$s\" has incorrect indentation in comment."
                                                         + "Line %2$d: comment:%3$d, actual:%4$d.",
                                         aFileName,
@@ -93,14 +93,14 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
                     }
 
                     if (!isCommentConsistent(comment)) {
-                        throw new RuntimeException(String.format(
+                        throw new IllegalStateException(String.format(
                                         "File \"%1$s\" has inconsistent comment on line %2$d",
                                         aFileName,
                                         lineNumber));
                     }
                 }
                 else if (NONEMPTY_LINE_REGEX.matcher(line).matches()) {
-                    throw new RuntimeException(String.format(
+                    throw new IllegalStateException(String.format(
                                     "File \"%1$s\" has no indentation comment or its format "
                                                     + "malformed. Error on line: %2$d",
                                     aFileName,


### PR DESCRIPTION
Fixes `BadExceptionThrown` inspection violations in test code.

Description:
>Reports throw statements which throw inappropriate exceptions. One use of this inspection would be to warn of throw statements which throw overly generic exceptions (e.g. java.lang.Exception or java.io.IOException).