### PR TITLE
Return unmodifiable collection from class in test code. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -6,6 +6,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.regex.Pattern;
@@ -95,7 +96,7 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 	}
 
 	public List<File> getFiles() {
-            return files;
+            return Collections.unmodifiableList(files);
 	}
 
 	public Integer[] getLinesWithWarn(String aFileName) throws IOException {


### PR DESCRIPTION
Fixes `ReturnOfCollectionField` inspection violations in test code.

Description:
>Reports any attempt to return an array or Collection field from a method. Since the array or Collection may have its contents modified by the calling method, this construct may result in an object having its state modified unexpectedly. While occasionally useful for performance reasons, this construct is inherently bug-prone.