### PR TITLE
Remove duplicates in throws lists. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigValidationTest.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigValidationTest.java
@@ -1,7 +1,6 @@
 package com.google.checkstyle.test.base;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 import org.junit.Test;
@@ -11,7 +10,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class ConfigValidationTest extends BaseCheckTestSupport {
     @Test
-    public void testGoogleChecks() throws IOException, Exception {
+    public void testGoogleChecks() throws Exception {
         ConfigurationBuilder builder = new ConfigurationBuilder(new File("src/it/"));
         final Configuration checkerConfig = builder.config;
         final Checker c = new Checker();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/GeneratedJava14LexerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/GeneratedJava14LexerTest.java
@@ -1,7 +1,6 @@
 package com.puppycrawl.tools.checkstyle.grammars;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assume;
@@ -18,7 +17,7 @@ import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 public class GeneratedJava14LexerTest
     extends BaseCheckTestSupport {
     @Test
-    public void testUnexpectedChar() throws IOException, Exception {
+    public void testUnexpectedChar() throws Exception {
         Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS); // Encoding problems can occur in Windows
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
@@ -29,7 +28,7 @@ public class GeneratedJava14LexerTest
     }
     
     @Test
-    public void testSemicolonBetweenImports() throws IOException, Exception {
+    public void testSemicolonBetweenImports() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
         final String[] expected = {


### PR DESCRIPTION
Fixes `DuplicateThrows` inspection violations in test code.

Description:
>This inspection reports duplicate exceptions in a method throws list.