### PR TITLE
Mark fields as final in test code. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -18,17 +18,17 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class ConfigurationBuilder extends BaseCheckTestSupport {
 
-	private File root;
+	private final File root;
 
-	private List<File> files = new ArrayList<>();
+	private final List<File> files = new ArrayList<>();
 
 	Configuration config;
 	
 	URL url;
 	
-	String xmlName = "/google_checks.xml";
+	final String xmlName = "/google_checks.xml";
 	
-	Pattern warnPattern = Utils.createPattern(".*[ ]*//[ ]*warn[ ]*|/[*]warn[*]/");
+	final Pattern warnPattern = Utils.createPattern(".*[ ]*//[ ]*warn[ ]*|/[*]warn[*]/");
 
 	public ConfigurationBuilder(File aROOT)
 			throws CheckstyleException, IOException {

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
@@ -15,10 +15,10 @@ import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
 public class CustomImportOrderTest extends BaseCheckTestSupport{
 
     static ConfigurationBuilder builder;
-    Class<CustomImportOrderCheck> clazz = CustomImportOrderCheck.class;
-    String msgSeparator = "custom.import.order.line.separator";
-    String msgLex = "custom.import.order.lex";
-    String msgOrder = "custom.import.order";
+    final Class<CustomImportOrderCheck> clazz = CustomImportOrderCheck.class;
+    final String msgSeparator = "custom.import.order.line.separator";
+    final String msgLex = "custom.import.order.lex";
+    final String msgOrder = "custom.import.order";
     String msgNongroup = "custom.import.order.nongroup.import";
 
     /** Shortcuts to make code more compact */

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java
@@ -15,7 +15,7 @@ public class PackageNameTest extends BaseCheckTestSupport{
 
 	private static ConfigurationBuilder builder;
 	private static Configuration checkConfig;
-	private String msgKey = "name.invalidPattern";
+	private final String msgKey = "name.invalidPattern";
 	private static String format;
 
 

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java
@@ -14,7 +14,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 public class MemberNameTest extends BaseCheckTestSupport{
 
 	private static ConfigurationBuilder builder;
-	private String msgKey = "name.invalidPattern";
+	private final String msgKey = "name.invalidPattern";
 	private static Configuration checkConfig;
 	private static String format;
 

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
@@ -14,7 +14,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 public class LocalVariableNameTest extends BaseCheckTestSupport{
 
 	private static ConfigurationBuilder builder;
-	private String msgKey = "name.invalidPattern";
+	private final String msgKey = "name.invalidPattern";
 	private static Configuration checkConfig;
 	private static String format;
 

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassMethodTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassMethodTypeParameterNameTest.java
@@ -14,7 +14,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 public class ClassMethodTypeParameterNameTest extends BaseCheckTestSupport{
 
     private static ConfigurationBuilder builder;
-    private String msgKey = "name.invalidPattern";
+    private final String msgKey = "name.invalidPattern";
     private static Configuration checkConfig;
     private static String format;
 

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
@@ -16,7 +16,7 @@ public class AbbreviationAsWordInNameTest extends BaseCheckTestSupport{
 
     private static final String MSG_KEY = "abbreviation.as.word";
     private static ConfigurationBuilder builder;
-    private Class<AbbreviationAsWordInNameCheck> clazz = AbbreviationAsWordInNameCheck.class;
+    private final Class<AbbreviationAsWordInNameCheck> clazz = AbbreviationAsWordInNameCheck.class;
     private static Configuration checkConfig;
     
     @BeforeClass

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -798,16 +798,16 @@ public class CustomImportOrderCheck extends Check {
      */
     private static class ImportDetails {
         /** Import full path */
-        private String importFullPath;
+        private final String importFullPath;
 
         /** Import line number */
-        private int lineNumber;
+        private final int lineNumber;
 
         /** Import group */
-        private String importGroup;
+        private final String importGroup;
 
         /** Is static import */
-        private boolean staticImport;
+        private final boolean staticImport;
 
         /**
          * @param importFullPath

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -46,7 +46,7 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
 public class MainTest {
     @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
     @Rule
     public final ExpectedSystemExit exit = ExpectedSystemExit.none();
     @Rule

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -48,7 +48,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 public class PropertyCacheFileTest {
 
     @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
     public void testNonAccessibleFile() throws IOException {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -44,7 +44,7 @@ import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck;
 
 public class TreeWalkerTest extends BaseCheckTestSupport {
-    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
     public void testProperFileExtension() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
@@ -37,7 +37,7 @@ import com.puppycrawl.tools.checkstyle.BaseFileSetCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
 public class RegexpMultilineCheckTest extends BaseFileSetCheckTestSupport {
-    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     private DefaultConfiguration checkConfig;
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -39,7 +39,7 @@ import com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck;
 
 public class SuppressWarningsFilterTest
     extends BaseCheckTestSupport {
-    private static String[] sAllMessages = {
+    private static final String[] sAllMessages = {
         "22:45: Name 'I' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         "24:17: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         "25:17: Name 'K' must match pattern '^[a-z][a-zA-Z0-9]*$'.",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -49,7 +49,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class SuppressWithNearbyCommentFilterTest
     extends BaseCheckTestSupport {
-    private static String[] sAllMessages = {
+    private static final String[] sAllMessages = {
         "14:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         "15:17: Name 'A2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         "16:59: Name 'A3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -49,7 +49,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class SuppressionCommentFilterTest
     extends BaseCheckTestSupport {
-    private static String[] sAllMessages = {
+    private static final String[] sAllMessages = {
         "13:17: Name 'I' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         "16:17: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         "19:17: Name 'K' must match pattern '^[a-z][a-zA-Z0-9]*$'.",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -57,7 +57,7 @@ import com.puppycrawl.tools.checkstyle.api.FilterSet;
 public class SuppressionsLoaderTest extends BaseCheckTestSupport {
 
     @Rule
-    public ExpectedException thrown = ExpectedException.none();
+    public final ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testNoSuppressions()


### PR DESCRIPTION
Fixes `CanBeFinal` inspection violations in test code.

Description:
>This inspection reports all fields, methods or classes, found in the specified inspection scope, that may have a final modifier added to their declarations.