### PR TITLE
Rename negatively named boolean variable. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -341,14 +341,14 @@ public class ImportOrderCheck
         }
 
         final boolean isStaticAndNotLastImport = isStatic && !lastImportStatic;
-        final boolean isNotStaticAndLastImport = !isStatic && lastImportStatic;
+        final boolean isLastImportAndNonStatic = lastImportStatic && !isStatic;
         final ImportOrderOption abstractOption = getAbstractOption();
 
         // using set of IF instead of SWITCH to analyze Enum options to satisfy coverage.
         // https://github.com/checkstyle/checkstyle/issues/1387
         if (abstractOption == ImportOrderOption.TOP) {
 
-            if (isNotStaticAndLastImport) {
+            if (isLastImportAndNonStatic) {
                 lastGroup = Integer.MIN_VALUE;
                 lastImport = "";
             }
@@ -361,7 +361,7 @@ public class ImportOrderCheck
                 lastGroup = Integer.MIN_VALUE;
                 lastImport = "";
             }
-            doVisitToken(ident, isStatic, isNotStaticAndLastImport);
+            doVisitToken(ident, isStatic, isLastImportAndNonStatic);
 
         }
         else if (abstractOption == ImportOrderOption.ABOVE) {
@@ -370,7 +370,7 @@ public class ImportOrderCheck
 
         }
         else if (abstractOption == ImportOrderOption.UNDER) {
-            doVisitToken(ident, isStatic, isNotStaticAndLastImport);
+            doVisitToken(ident, isStatic, isLastImportAndNonStatic);
 
         }
         else if (abstractOption == ImportOrderOption.INFLOW) {


### PR DESCRIPTION
Fixes `NegativelyNamedBooleanVariable` inspection violation.

Description:
>Reports negatively named variables, for example 'disabled', 'hidden', 'isNotChanged'. It is usually more clear to invert the boolean value and remove the negation from the name.