### PR TITLE
Remove unnecessary local variables. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -49,6 +49,9 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
  *
  **/
 public final class Main {
+    /** Exit code returned when excecution finishes with {@link CheckstyleException}*/
+    private static final int EXIT_WITH_CHECKSTYLE_EXCEPTION_CODE = -2;
+
     /** Don't create instance of this class, use {@link #main(String[])} method instead. */
     private Main() {
     }
@@ -107,8 +110,7 @@ public final class Main {
             printUsage();
         }
         catch (CheckstyleException e) {
-            final int exitWithCheckstyleException = -2;
-            exitStatus = exitWithCheckstyleException;
+            exitStatus = EXIT_WITH_CHECKSTYLE_EXCEPTION_CODE;
             errorCounter = 1;
             System.out.println(e.getMessage());
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -313,11 +313,10 @@ public abstract class AbstractTypeAwareCheck extends Check {
              child != null;
              child = child.getNextSibling()) {
             if (child.getType() == TokenTypes.TYPE_PARAMETER) {
-                final DetailAST param = child;
                 final String alias =
-                    param.findFirstToken(TokenTypes.IDENT).getText();
+                    child.findFirstToken(TokenTypes.IDENT).getText();
                 final DetailAST bounds =
-                    param.findFirstToken(TokenTypes.TYPE_UPPER_BOUNDS);
+                    child.findFirstToken(TokenTypes.TYPE_UPPER_BOUNDS);
                 if (bounds != null) {
                     final FullIdent name =
                         FullIdent.createFullIdentBelow(bounds);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
@@ -159,9 +159,7 @@ public final class OneStatementPerLineCheck extends Check {
      */
     private static boolean isOnTheSameLine(DetailAST ast, int lastStatementEnd,
                                            int forStatementEnd) {
-        final boolean onTheSameLine =
-            lastStatementEnd == ast.getLineNo() && forStatementEnd != ast.getLineNo();
-        return onTheSameLine;
+        return lastStatementEnd == ast.getLineNo() && forStatementEnd != ast.getLineNo();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -49,9 +49,7 @@ public abstract class BaseCheckTestSupport {
     protected final Properties props = new Properties();
 
     public static DefaultConfiguration createCheckConfig(Class<?> clazz) {
-        final DefaultConfiguration checkConfig =
-                new DefaultConfiguration(clazz.getName());
-        return checkConfig;
+        return new DefaultConfiguration(clazz.getName());
     }
 
     protected Checker createChecker(Configuration checkConfig)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -185,8 +185,7 @@ public class PackageNamesLoaderTest {
                 return connection;
             }
         };
-        final URL url = new URL("http://foo.bar", "foo.bar", 80, "", handler);
-        return url;
+        return new URL("http://foo.bar", "foo.bar", 80, "", handler);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
@@ -108,8 +108,7 @@ public class LocalizedMessageTest {
                 return connection;
             }
         };
-        final URL url = new URL("http://foo.bar", "foo.bar", 80, "", handler);
-        return url;
+        return new URL("http://foo.bar", "foo.bar", 80, "", handler);
     }
 
     @Test


### PR DESCRIPTION
Fixes `UnnecessaryLocalVariable` inspection violation.

Description:
>Reports unnecessary local variables, which add nothing to the comprehensibility of a method. Variables caught include local variables which are immediately returned, local variables that are immediately assigned to another variable and then not used, and local variables which always have the same value as another local variable or parameter.