### PR TITLE
Fix always inverted boolean methods. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -214,15 +214,15 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
             violation = MSG_KEY_LINE_SAME;
         }
         else if (bracePolicy == RightCurlyOption.ALONE
-                && !isAloneOnLine(details)
-                && !isEmptyBody(lcurly)) {
+                && isNotAloneOnLine(details)
+                && isNotEmptyBody(lcurly)) {
             violation = MSG_KEY_LINE_ALONE;
         }
         else if (bracePolicy == RightCurlyOption.ALONE_OR_SINGLELINE
-                && !isAloneOnLine(details)
+                && isNotAloneOnLine(details)
                 && !isSingleLineBlock(details)
                 && !isAnonInnerClassInit(lcurly)
-                && !isEmptyBody(lcurly)) {
+                && isNotEmptyBody(lcurly)) {
             violation = MSG_KEY_LINE_ALONE;
         }
         else if (shouldStartLine) {
@@ -237,16 +237,16 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
     }
 
     /**
-     * Checks whether right curly is alone on a line.
+     * Checks whether right curly is not alone on a line.
      * @param details for validation.
-     * @return true if right curly is alone on a line.
+     * @return true if right curly is not alone on a line.
      */
-    private static boolean isAloneOnLine(Details details) {
+    private static boolean isNotAloneOnLine(Details details) {
         final DetailAST rcurly = details.rcurly;
         final DetailAST lcurly = details.lcurly;
         final DetailAST nextToken = details.nextToken;
-        return rcurly.getLineNo() != lcurly.getLineNo()
-            && rcurly.getLineNo() != nextToken.getLineNo();
+        return rcurly.getLineNo() == lcurly.getLineNo()
+                || rcurly.getLineNo() == nextToken.getLineNo();
     }
 
     /**
@@ -358,11 +358,11 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
     }
 
     /**
-     * Checks if definition body is empty.
+     * Checks if definition body is not empty.
      * @param lcurly left curly.
-     * @return true if definition body is empty.
+     * @return true if definition body is not empty.
      */
-    private static boolean isEmptyBody(DetailAST lcurly) {
+    private static boolean isNotEmptyBody(DetailAST lcurly) {
         boolean result = false;
         if (lcurly.getParent().getType() == TokenTypes.OBJBLOCK) {
             if (lcurly.getNextSibling().getType() == TokenTypes.RCURLY) {
@@ -372,7 +372,7 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
         else if (lcurly.getFirstChild().getType() == TokenTypes.RCURLY) {
             result = true;
         }
-        return result;
+        return !result;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -141,7 +141,7 @@ public class CommentsIndentationCheck extends Check {
         if (nextStatement != null
             && nextStatement.getType() != TokenTypes.RCURLY
             && !isTrailingSingleLineComment(singleLineComment)
-            && !areSameLevelIndented(singleLineComment, prevStatement, nextStatement)) {
+            && areNotSameLevelIndented(singleLineComment, prevStatement, nextStatement)) {
 
             log(singleLineComment.getLineNo(), MSG_KEY_SINGLE, nextStatement.getLineNo(),
                 singleLineComment.getColumnNo(), nextStatement.getColumnNo());
@@ -192,7 +192,7 @@ public class CommentsIndentationCheck extends Check {
 
     /**
      * Checks if comment and next code statement
-     * (or previous code stmt like <b>case</b> in switch block) are indented at the same level,
+     * (or previous code stmt like <b>case</b> in switch block) are not indented at the same level,
      * e.g.:
      * <p>
      * <pre>
@@ -211,10 +211,10 @@ public class CommentsIndentationCheck extends Check {
      * @param singleLineComment {@link TokenTypes#SINGLE_LINE_COMMENT single line comment}.
      * @param prevStmt previous code statement.
      * @param nextStmt next code statement.
-     * @return true if comment and next code statement are indented at the same level.
+     * @return true if comment and next code statement are not indented at the same level.
      */
-    private static boolean areSameLevelIndented(DetailAST singleLineComment,
-                                                DetailAST prevStmt, DetailAST nextStmt) {
+    private static boolean areNotSameLevelIndented(DetailAST singleLineComment,
+            DetailAST prevStmt, DetailAST nextStmt) {
         boolean result;
         if (prevStmt == null) {
             result = singleLineComment.getColumnNo() == nextStmt.getColumnNo();
@@ -223,7 +223,7 @@ public class CommentsIndentationCheck extends Check {
             result = singleLineComment.getColumnNo() == nextStmt.getColumnNo()
                 || singleLineComment.getColumnNo() == prevStmt.getColumnNo();
         }
-        return result;
+        return !result;
     }
 
     /**
@@ -261,7 +261,7 @@ public class CommentsIndentationCheck extends Check {
         if (nextStatement != null
             && nextStatement.getType() != TokenTypes.RCURLY
             && !isTrailingBlockComment(blockComment)
-            && !areSameLevelIndented(blockComment, prevStatement, nextStatement)) {
+            && areNotSameLevelIndented(blockComment, prevStatement, nextStatement)) {
 
             log(blockComment.getLineNo(), MSG_KEY_BLOCK, nextStatement.getLineNo(),
                 blockComment.getColumnNo(), nextStatement.getColumnNo());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -146,7 +146,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
     private boolean hasJavadocTags(DetailNode javadocRoot) {
         final DetailNode javadocTagSection =
                 JavadocUtils.findFirstToken(javadocRoot, JavadocTokenTypes.JAVADOC_TAG);
-        return javadocTagSection != null && !isTagIgnored(javadocTagSection);
+        return javadocTagSection != null && isTagNotIgnored(javadocTagSection);
     }
 
     /**
@@ -163,7 +163,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
                 JavadocUtils.findFirstToken(javadocRoot, JavadocTokenTypes.JAVADOC_INLINE_TAG);
         boolean foundTag = false;
         while (javadocTagSection != null) {
-            if (!isTagIgnored(javadocTagSection)) {
+            if (isTagNotIgnored(javadocTagSection)) {
                 foundTag = true;
                 break;
             }
@@ -174,12 +174,12 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
     }
 
     /**
-     * Checks if list of ignored tags contains javadocTagSection's javadoc tag.
+     * Checks if list of ignored tags doesn't contain javadocTagSection's javadoc tag.
      *
      * @param javadocTagSection to check javadoc tag in.
-     * @return true, if ignoredTags contains javadocTagSection's javadoc tag.
+     * @return true, if ignoredTags doesn't contain javadocTagSection's javadoc tag.
      */
-    private boolean isTagIgnored(DetailNode javadocTagSection) {
-        return ignoredTags.contains(JavadocUtils.getTagName(javadocTagSection));
+    private boolean isTagNotIgnored(DetailNode javadocTagSection) {
+        return !ignoredTags.contains(JavadocUtils.getTagName(javadocTagSection));
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
@@ -124,13 +124,13 @@ public final class BooleanExpressionComplexityCheck extends Check {
                 visitExpr();
                 break;
             case TokenTypes.BOR:
-                if (!isPipeOperator(ast) && !isPassedInParameter(ast)) {
+                if (!isPipeOperator(ast) && isNotPassedInParameter(ast)) {
                     context.visitBooleanOperator();
                 }
                 break;
             case TokenTypes.BAND:
             case TokenTypes.BXOR:
-                if (!isPassedInParameter(ast)) {
+                if (isNotPassedInParameter(ast)) {
                     context.visitBooleanOperator();
                 }
                 break;
@@ -144,13 +144,13 @@ public final class BooleanExpressionComplexityCheck extends Check {
     }
 
     /**
-     * Checks if logical operator is part of constructor or method call.
+     * Checks that logical operator is not part of constructor or method call.
      * @param logicalOperator logical operator
-     * @return true if logical operator is part of constructor or method call
+     * @return true if logical operator is not part of constructor or method call
      */
-    private static boolean isPassedInParameter(DetailAST logicalOperator) {
-        return logicalOperator.getParent().getType() == TokenTypes.EXPR
-            && logicalOperator.getParent().getParent().getType() == TokenTypes.ELIST;
+    private static boolean isNotPassedInParameter(DetailAST logicalOperator) {
+        return logicalOperator.getParent().getType() != TokenTypes.EXPR
+                || logicalOperator.getParent().getParent().getType() != TokenTypes.ELIST;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -227,7 +227,7 @@ public class EmptyLineSeparatorCheck extends Check {
                     processPackage(ast, nextToken);
                     break;
                 default:
-                    if (nextToken.getType() != TokenTypes.RCURLY && !hasEmptyLineAfter(ast)) {
+                    if (nextToken.getType() != TokenTypes.RCURLY && hasNoEmptyLineAfter(ast)) {
                         log(nextToken.getLineNo(), MSG_SHOULD_BE_SEPARATED, nextToken.getText());
                     }
                     if (hasNotAllowedTwoEmptyLinesBefore(ast)) {
@@ -246,7 +246,7 @@ public class EmptyLineSeparatorCheck extends Check {
         if (ast.getLineNo() > 1 && !hasEmptyLineBefore(ast)) {
             log(ast.getLineNo(), MSG_SHOULD_BE_SEPARATED, ast.getText());
         }
-        if (!hasEmptyLineAfter(ast)) {
+        if (hasNoEmptyLineAfter(ast)) {
             log(nextToken.getLineNo(), MSG_SHOULD_BE_SEPARATED, nextToken.getText());
         }
         if (hasNotAllowedTwoEmptyLinesBefore(ast)) {
@@ -261,7 +261,7 @@ public class EmptyLineSeparatorCheck extends Check {
      * @param astType token Type
      */
     private void processImport(DetailAST ast, DetailAST nextToken, int astType) {
-        if (astType != nextToken.getType() && !hasEmptyLineAfter(ast)) {
+        if (astType != nextToken.getType() && hasNoEmptyLineAfter(ast)) {
             log(nextToken.getLineNo(), MSG_SHOULD_BE_SEPARATED, nextToken.getText());
         }
         if (hasNotAllowedTwoEmptyLinesBefore(ast)) {
@@ -275,7 +275,7 @@ public class EmptyLineSeparatorCheck extends Check {
      * @param nextToken next Token
      */
     private void processVariableDef(DetailAST ast, DetailAST nextToken) {
-        if (isTypeField(ast) && !hasEmptyLineAfter(ast)) {
+        if (isTypeField(ast) && hasNoEmptyLineAfter(ast)) {
             if (allowNoEmptyLineBetweenFields
                 && nextToken.getType() != TokenTypes.VARIABLE_DEF
                 && nextToken.getType() != TokenTypes.RCURLY) {
@@ -321,16 +321,16 @@ public class EmptyLineSeparatorCheck extends Check {
     }
 
     /**
-     * Checks if token have empty line after.
+     * Checks if token have no empty line after.
      * @param token token.
-     * @return true if token have empty line after.
+     * @return true if token have no empty line after.
      */
-    private static boolean hasEmptyLineAfter(DetailAST token) {
+    private static boolean hasNoEmptyLineAfter(DetailAST token) {
         DetailAST lastToken = token.getLastChild().getLastChild();
         if (lastToken == null) {
             lastToken = token.getLastChild();
         }
-        return token.getNextSibling().getLineNo() - lastToken.getLineNo() > 1;
+        return token.getNextSibling().getLineNo() - lastToken.getLineNo() <= 1;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java
@@ -93,14 +93,14 @@ public class WhitespaceAfterCheck
         final String line = getLine(ast.getLineNo() - 1);
         if (ast.getType() == TokenTypes.TYPECAST) {
             final DetailAST targetAST = ast.findFirstToken(TokenTypes.RPAREN);
-            if (!isFollowedByWhitespace(targetAST, line)) {
+            if (isNotFollowedByWhitespace(targetAST, line)) {
                 log(targetAST.getLineNo(),
                     targetAST.getColumnNo() + targetAST.getText().length(),
                     WS_TYPECAST);
             }
         }
         else {
-            if (!isFollowedByWhitespace(ast, line)) {
+            if (isNotFollowedByWhitespace(ast, line)) {
                 final Object[] message = {ast.getText()};
                 log(ast.getLineNo(),
                     ast.getColumnNo() + ast.getText().length(),
@@ -111,12 +111,12 @@ public class WhitespaceAfterCheck
     }
 
     /**
-     * checks whether token is followed by a whitespace.
+     * checks whether token is not followed by a whitespace.
      * @param targetAST Ast token.
      * @param line The line associated with the ast token.
-     * @return true if ast token is followed by a whitespace.
+     * @return true if ast token is not followed by a whitespace.
      */
-    private static boolean isFollowedByWhitespace(DetailAST targetAST, String line) {
+    private static boolean isNotFollowedByWhitespace(DetailAST targetAST, String line) {
         final int after =
             targetAST.getColumnNo() + targetAST.getText().length();
         boolean followedByWhitespace = true;
@@ -127,6 +127,6 @@ public class WhitespaceAfterCheck
                 || targetAST.getType() == TokenTypes.SEMI
                     && (charAfter == ';' || charAfter == ')');
         }
-        return followedByWhitespace;
+        return !followedByWhitespace;
     }
 }


### PR DESCRIPTION
Fixes `BooleanMethodIsAlwaysInverted` inspection violation.

Description:
>Reports methods with a boolean return type, which are only used in a negated context. Because this inspection requires global code analysis it is only available for Analyze|Inspect Code or Analyze|Run Inspection by Name and it will not report in the editor.
For example:

    class C {
      boolean inverted() {
        return true;
      }

      void f() {
        if (!inverted()) {
          return;
        }
      }
      boolean member = !inverted();
    }