### PR TITLE
Fix too broad scope of variables. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -99,10 +99,10 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 	}
 
 	public Integer[] getLinesWithWarn(String aFileName) throws IOException {
-		int lineNumber = 1;
-	    List<Integer> result = new ArrayList<>();
+		List<Integer> result = new ArrayList<>();
 	    try(BufferedReader br = new BufferedReader(new FileReader(aFileName))) {
-	        while (true) {
+			int lineNumber = 1;
+			while (true) {
 	            String line = br.readLine();
 	            if (line == null) {
 	                break;

--- a/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
@@ -50,9 +50,9 @@ public class IndentationConfigurationBuilder extends ConfigurationBuilder
                     final int tabWidth)
                     throws IOException
     {
-        int lineNumber = 1;
         List<Integer> result = new ArrayList<>();
         try (BufferedReader br = new BufferedReader(new FileReader(aFileName))) {
+            int lineNumber = 1;
             for (String line = br.readLine(); line != null; line = br.readLine()) {
                 Matcher match = LINE_WITH_COMMENT_REGEX.matcher(line);
                 if (match.matches()) {
@@ -112,9 +112,7 @@ public class IndentationConfigurationBuilder extends ConfigurationBuilder
         final int indentInComment = getIndentFromComment(comment);
         final boolean isWarnComment = isWarnComment(comment);
 
-        Matcher match;
-
-        match = MULTILEVEL_COMMENT_REGEX.matcher(comment);
+        Matcher match = MULTILEVEL_COMMENT_REGEX.matcher(comment);
         if (match.matches()) {
             final String[] levels = match.group(1).split(",");
             final String indentInCommentStr = String.valueOf(indentInComment);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -487,9 +487,9 @@ public class MainTest {
                 String expectedPath = currentPath
                         + "/src/test/resources/com/puppycrawl/tools/checkstyle/metrics/"
                         .replace("/", File.separator);
-                String format = "%s.java:%s: warning: File length is %s lines (max allowed is 80).";
                 StringBuilder sb = new StringBuilder();
                 sb.append("Starting audit..." + System.getProperty("line.separator"));
+                String format = "%s.java:%s: warning: File length is %s lines (max allowed is 80).";
                 for (String[] outputValue : outputValues) {
                     String line = String.format(format,
                             expectedPath + outputValue[0], outputValue[1],

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -47,8 +47,8 @@ public class FileTextTest {
     @Test
     public void testSupportedCharset() throws IOException {
         // just to make UT coverage 100%
-        String charsetName = "ISO-8859-1";
         try {
+            String charsetName = "ISO-8859-1";
             FileText o = new FileText(new File("src/test/resources/com/puppycrawl/tools/"
                      + "checkstyle/imports/import-control_complete.xml"), charsetName);
             assertEquals(o.getCharset().name(), charsetName);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
@@ -72,12 +72,12 @@ public class LocalizedMessageTest {
     public void testBundleReload_UrlNotNull() throws IOException {
 
         ClassLoader classloader = mock(ClassLoader.class);
-        String resource = "com/puppycrawl/tools/checkstyle/checks/coding/messages_en.properties";
         final URLConnection mockConnection = Mockito.mock(URLConnection.class);
         when(mockConnection.getInputStream()).thenReturn(
                 new ByteArrayInputStream(new byte[]{}));
 
         URL url = getMockUrl(mockConnection);
+        String resource = "com/puppycrawl/tools/checkstyle/checks/coding/messages_en.properties";
         when(classloader.getResource(resource)).thenReturn(url);
 
         LocalizedMessage.UTF8Control cntrl = new LocalizedMessage.UTF8Control();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import static org.junit.Assert.assertArrayEquals;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -185,7 +184,6 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
         AvoidEscapedUnicodeCharactersCheck check = new AvoidEscapedUnicodeCharactersCheck();
         int[] actual = check.getAcceptableTokens();
         int[] expected = new int[] {TokenTypes.STRING_LITERAL, TokenTypes.CHAR_LITERAL };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertArrayEquals;
 
 import java.io.File;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -70,7 +69,6 @@ public class OuterTypeFilenameCheckTest extends BaseCheckTestSupport {
             TokenTypes.ENUM_DEF,
             TokenTypes.ANNOTATION_DEF,
         };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
@@ -24,7 +24,6 @@ import static com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocati
 import static org.junit.Assert.assertArrayEquals;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -96,7 +95,6 @@ public class AnnotationLocationCheckTest extends BaseCheckTestSupport {
             TokenTypes.DOT,
             TokenTypes.ANNOTATION_FIELD_DEF,
             };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleTest.java
@@ -253,7 +253,6 @@ public class AnnotationUseStyleTest extends BaseCheckTestSupport {
         AnnotationUseStyleCheck constantNameCheckObj = new AnnotationUseStyleCheck();
         int[] actual = constantNameCheckObj.getAcceptableTokens();
         int[] expected = new int[] {TokenTypes.ANNOTATION };
-        Assert.assertNotNull(actual);
         Assert.assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationTest.java
@@ -47,7 +47,6 @@ public class PackageAnnotationTest extends BaseCheckTestSupport {
         PackageAnnotationCheck constantNameCheckObj = new PackageAnnotationCheck();
         int[] actual = constantNameCheckObj.getAcceptableTokens();
         int[] expected = new int[] {TokenTypes.PACKAGE_DEF };
-        Assert.assertNotNull(actual);
         Assert.assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckTest.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 import static com.puppycrawl.tools.checkstyle.checks.blocks.AvoidNestedBlocksCheck.MSG_KEY_BLOCK_NESTED;
 import static org.junit.Assert.assertArrayEquals;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -73,7 +72,6 @@ public class AvoidNestedBlocksCheckTest
         AvoidNestedBlocksCheck constantNameCheckObj = new AvoidNestedBlocksCheck();
         int[] actual = constantNameCheckObj.getAcceptableTokens();
         int[] expected = new int[] {TokenTypes.SLIST };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 
 import static org.junit.Assert.assertArrayEquals;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -77,7 +76,6 @@ public class EmptyCatchBlockCheckTest extends BaseCheckTestSupport {
         EmptyCatchBlockCheck constantNameCheckObj = new EmptyCatchBlockCheck();
         int[] actual = constantNameCheckObj.getAcceptableTokens();
         int[] expected = new int[] {TokenTypes.LITERAL_CATCH };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -295,7 +294,6 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
             TokenTypes.LITERAL_ELSE,
             TokenTypes.LITERAL_FOR,
             TokenTypes.STATIC_INIT, };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
@@ -83,8 +83,8 @@ public class RegexpHeaderCheckTest extends BaseFileSetCheckTestSupport {
     public void testSetHeader() {
         // check invalid header passes
         RegexpHeaderCheck instance = new RegexpHeaderCheck();
-        String header = "^/**\\n * Licensed to the Apache Software Foundation (ASF)";
         try {
+            String header = "^/**\\n * Licensed to the Apache Software Foundation (ASF)";
             instance.setHeader(header);
             fail(String.format("%s should have been thrown", ConversionException.class));
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -68,9 +68,9 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
     protected static Integer[] getLinesWithWarnAndCheckComments(String aFileName,
                     final int tabWidth)
                     throws IOException {
-        int lineNumber = 1;
         List<Integer> result = new ArrayList<>();
         try (BufferedReader br = new BufferedReader(new FileReader(aFileName))) {
+            int lineNumber = 1;
             for (String line = br.readLine(); line != null; line = br.readLine()) {
                 Matcher match = LINE_WITH_COMMENT_REGEX.matcher(line);
                 if (match.matches()) {
@@ -126,9 +126,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
         final int indentInComment = getIndentFromComment(comment);
         final boolean isWarnComment = isWarnComment(comment);
 
-        Matcher match;
-
-        match = MULTILEVEL_COMMENT_REGEX.matcher(comment);
+        Matcher match = MULTILEVEL_COMMENT_REGEX.matcher(comment);
         if (match.matches()) {
             final String[] levels = match.group(1).split(",");
             final String indentInCommentStr = String.valueOf(indentInComment);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
@@ -100,15 +100,15 @@ public class AtclauseOrderCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testIncorrectCustom() throws Exception {
-        final String tagOrder = "[@since, @version, @param, @return, @throws, @exception,"
-                + " @deprecated, @see, @serial, @serialField, @serialData, @author]";
-        final String customOrder = " @since,  @version, @param,@return,@throws, @exception,"
-                + "@deprecated, @see,@serial,   @serialField,  @serialData,@author";
 
         DefaultConfiguration checkConfig = createCheckConfig(AtclauseOrderCheck.class);
         checkConfig.addAttribute("target", "CLASS_DEF");
+        final String customOrder = " @since,  @version, @param,@return,@throws, @exception,"
+                + "@deprecated, @see,@serial,   @serialField,  @serialData,@author";
         checkConfig.addAttribute("tagOrder", customOrder);
 
+        final String tagOrder = "[@since, @version, @param, @return, @throws, @exception,"
+                + " @deprecated, @see, @serial, @serialField, @serialData, @author]";
         final String[] expected = {
             "113: " + getCheckMessage(MSG_KEY, tagOrder),
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheckTest.java
@@ -72,7 +72,6 @@ public class CyclomaticComplexityCheckTest
             TokenTypes.LAND,
             TokenTypes.LOR,
         };
-        Assert.assertNotNull(actual);
         Assert.assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierTest.java
@@ -116,7 +116,6 @@ public class RedundantModifierTest
             TokenTypes.CLASS_DEF,
             TokenTypes.ENUM_DEF,
         };
-        Assert.assertNotNull(actual);
         Assert.assertArrayEquals(expected, actual);
     }
 
@@ -125,7 +124,6 @@ public class RedundantModifierTest
         RedundantModifierCheck redundantModifierCheckObj = new RedundantModifierCheck();
         int[] actual = redundantModifierCheckObj.getRequiredTokens();
         int[] expected = new int[] {};
-        Assert.assertNotNull(actual);
         Assert.assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckTest.java
@@ -102,7 +102,6 @@ public class AbstractClassNameCheckTest extends BaseCheckTestSupport {
         int[] expected = new int[] {
             TokenTypes.CLASS_DEF,
         };
-        Assert.assertNotNull(actual);
         Assert.assertArrayEquals(expected, actual);
     }
 
@@ -113,7 +112,6 @@ public class AbstractClassNameCheckTest extends BaseCheckTestSupport {
         int[] expected = new int[] {
             TokenTypes.CLASS_DEF,
         };
-        Assert.assertNotNull(actual);
         Assert.assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckTest.java
@@ -23,7 +23,6 @@ import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MS
 import static org.junit.Assert.assertArrayEquals;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -86,7 +85,6 @@ public class LocalFinalVariableNameCheckTest
             TokenTypes.VARIABLE_DEF,
             TokenTypes.PARAMETER_DEF,
         };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheckTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertArrayEquals;
 
 import java.io.File;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -256,7 +255,6 @@ public class MemberNameCheckTest
         int[] expected = new int[] {
             TokenTypes.VARIABLE_DEF,
         };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
@@ -23,7 +23,6 @@ import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MS
 import static com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck.MSG_KEY;
 import static org.junit.Assert.assertArrayEquals;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -154,7 +153,6 @@ public class MethodNameCheckTest
         int[] expected = new int[] {
             TokenTypes.METHOD_DEF,
         };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheckTest.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks.naming;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 import static org.junit.Assert.assertArrayEquals;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -71,7 +70,6 @@ public class PackageNameCheckTest
         int[] expected = new int[] {
             TokenTypes.PACKAGE_DEF,
         };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks.naming;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 import static org.junit.Assert.assertArrayEquals;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -84,7 +83,6 @@ public class ParameterNameCheckTest
         int[] expected = new int[] {
             TokenTypes.PARAMETER_DEF,
         };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheckTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertArrayEquals;
 
 import java.io.File;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -88,7 +87,6 @@ public class StaticVariableNameCheckTest
         int[] expected = new int[] {
             TokenTypes.VARIABLE_DEF,
         };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeParameterNameTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeParameterNameTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertArrayEquals;
 
 import java.io.File;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -166,7 +165,6 @@ public class TypeParameterNameTest
         int[] expected = new int[] {
             TokenTypes.TYPE_PARAMETER,
         };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheckTest.java
@@ -128,13 +128,13 @@ public class RegexpCheckTest extends BaseCheckTestSupport {
     @Test
     public void testIllegalFailAboveErrorLimit() throws Exception {
         final String illegal = "^import";
-        final String error = "The error limit has been exceeded, "
-            + "the check is aborting, there may be more unreported errors.";
         final DefaultConfiguration checkConfig =
             createCheckConfig(RegexpCheck.class);
         checkConfig.addAttribute("format", illegal);
         checkConfig.addAttribute("illegalPattern", "true");
         checkConfig.addAttribute("errorLimit", "3");
+        final String error = "The error limit has been exceeded, "
+                + "the check is aborting, there may be more unreported errors.";
         final String[] expected = {
             "7: " + getCheckMessage(MSG_ILLEGAL_REGEXP, illegal),
             "8: " + getCheckMessage(MSG_ILLEGAL_REGEXP, illegal),
@@ -147,11 +147,11 @@ public class RegexpCheckTest extends BaseCheckTestSupport {
     public void testMessagePropertyGood()
         throws Exception {
         final String illegal = "System\\.(out)|(err)\\.print(ln)?\\(";
-        final String message = "Bad line :(";
         final DefaultConfiguration checkConfig =
             createCheckConfig(RegexpCheck.class);
         checkConfig.addAttribute("format", illegal);
         checkConfig.addAttribute("illegalPattern", "true");
+        final String message = "Bad line :(";
         checkConfig.addAttribute("message", message);
         final String[] expected = {
             "69: " + getCheckMessage(MSG_ILLEGAL_REGEXP, message),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheckTest.java
@@ -50,8 +50,8 @@ public class RegexpSinglelineCheckTest extends BaseFileSetCheckTestSupport {
     public void testMessageProperty()
         throws Exception {
         final String illegal = "System\\.(out)|(err)\\.print(ln)?\\(";
-        final String message = "Bad line :(";
         checkConfig.addAttribute("format", illegal);
+        final String message = "Bad line :(";
         checkConfig.addAttribute("message", message);
         final String[] expected = {
             "69: " + message,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheckTest.java
@@ -58,8 +58,8 @@ public class RegexpSinglelineJavaCheckTest extends BaseCheckTestSupport {
     public void testMessageProperty()
         throws Exception {
         final String illegal = "System\\.(out)|(err)\\.print(ln)?\\(";
-        final String message = "Bad line :(";
         checkConfig.addAttribute("format", illegal);
+        final String message = "Bad line :(";
         checkConfig.addAttribute("message", message);
         final String[] expected = {
             "69: " + message,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
@@ -72,7 +72,6 @@ public class EmptyForInitializerPadCheckTest
         int[] expected = new int[] {
             TokenTypes.FOR_INIT,
         };
-        Assert.assertNotNull(actual);
         Assert.assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
@@ -23,7 +23,6 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIterator
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck.WS_NOT_FOLLOWED;
 import static org.junit.Assert.assertArrayEquals;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -73,7 +72,6 @@ public class EmptyForIteratorPadCheckTest
         int[] expected = new int[] {
             TokenTypes.FOR_ITERATOR,
         };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -24,7 +24,6 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparat
 import static org.junit.Assert.assertArrayEquals;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -139,7 +138,6 @@ public class EmptyLineSeparatorCheckTest
             TokenTypes.CTOR_DEF,
             TokenTypes.VARIABLE_DEF,
         };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertArrayEquals;
 import java.io.File;
 import java.util.Map;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -140,7 +139,6 @@ public class GenericWhitespaceCheckTest
             TokenTypes.GENERIC_START,
             TokenTypes.GENERIC_END,
         };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
@@ -25,7 +25,6 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCh
 import static org.junit.Assert.assertArrayEquals;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -136,7 +135,6 @@ public class MethodParamPadCheckTest
             TokenTypes.METHOD_DEF,
             TokenTypes.SUPER_CTOR_CALL,
         };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
@@ -68,7 +68,6 @@ public class SeparatorWrapCheckTest
             TokenTypes.DOT,
             TokenTypes.COMMA,
         };
-        Assert.assertNotNull(actual);
         Assert.assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheckTest.java
@@ -83,7 +83,6 @@ public class TypecastParenPadCheckTest
             TokenTypes.RPAREN,
             TokenTypes.TYPECAST,
         };
-        Assert.assertNotNull(actual);
         Assert.assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundTest.java
@@ -24,7 +24,6 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAround
 import static org.junit.Assert.assertArrayEquals;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -281,7 +280,6 @@ public class WhitespaceAroundTest
             TokenTypes.TYPE_EXTENSION_AND,
             TokenTypes.WILDCARD_TYPE,
         };
-        Assert.assertNotNull(actual);
         assertArrayEquals(expected, actual);
     }
 }


### PR DESCRIPTION
Additionally, obsolete assertions were removed.

Fixes `TooBroadScope` inspection violations.

Description:
>Reports any variable declarations of which the scope can be narrowed. Especially useful for "Pascal style" declarations at the start of a method, but variables with too broad a scope are also often left over after refactorings.