### PR TITLE
Remove unchecked exceptions from throws clauses in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressElementTest.java
@@ -23,8 +23,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.regex.PatternSyntaxException;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,8 +36,7 @@ public class SuppressElementTest {
     private SuppressElement filter;
 
     @Before
-    public void setUp()
-        throws PatternSyntaxException {
+    public void setUp() {
         filter = new SuppressElement("Test");
         filter.setChecks("Test");
     }
@@ -162,7 +159,7 @@ public class SuppressElementTest {
     }
 
     @Test
-    public void testEquals() throws PatternSyntaxException {
+    public void testEquals() {
         final SuppressElement filter2 = new SuppressElement("Test");
         filter2.setChecks("Test");
         assertEquals("filter, filter2", filter, filter2);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -31,7 +31,6 @@ import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.regex.PatternSyntaxException;
 
 import org.junit.Assume;
 import org.junit.Rule;
@@ -118,7 +117,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
 
     @Test
     public void testMultipleSuppression()
-        throws CheckstyleException, PatternSyntaxException {
+        throws CheckstyleException {
         final FilterSet fc =
             SuppressionsLoader.loadSuppressions(
                     "src/test/resources/com/puppycrawl/tools/checkstyle/suppressions_multiple.xml");


### PR DESCRIPTION
Fixes `ThrowsRuntimeException` inspection violations in test code.

Description:
>Reports declarations of unchecked exceptions (RuntimeException and its subclasses) in the throws clause of a method. Declaration of unchecked exceptions are not required and may be removed or moved to a Javadoc @throws tag.