### PR TITLE
Unused method parameters should be removed. Issue #46

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
@@ -69,7 +69,7 @@ public final class Main {
         final JFrame testFrame = new JFrame("CheckStyle");
         final ParseTreeInfoPanel panel = new ParseTreeInfoPanel();
         testFrame.getContentPane().add(panel);
-        panel.openAst(ast, testFrame);
+        panel.openAst(ast);
         testFrame.setSize(1500, 800);
         testFrame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         testFrame.setVisible(true);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -41,12 +41,12 @@ import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 import javax.swing.filechooser.FileFilter;
 
-import antlr.ANTLRException;
-
 import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FileText;
+
+import antlr.ANTLRException;
 
 /**
  * Displays information about a parse tree.
@@ -106,7 +106,7 @@ public class ParseTreeInfoPanel extends JPanel {
 
     }
 
-    public void openAst(DetailAST parseTree, final Component parent) {
+    public void openAst(DetailAST parseTree) {
         parseTreeModel.setParseTree(parseTree);
         reloadAction.setEnabled(true);
 


### PR DESCRIPTION
We have one more warning on this line, but I think it is not good idea to remove parameter from public method in abstract class: https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java#L126
