### PR TITLE
replace deprecated method in HiddenCheckField

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -23,7 +23,6 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.ScopeUtils;
 import com.puppycrawl.tools.checkstyle.Utils;
@@ -619,7 +618,7 @@ public class HiddenFieldCheck
         private boolean embeddedIn(String classOrEnumName) {
             FieldFrame currentFrame = this;
             while (currentFrame != null) {
-                if (Objects.equal(currentFrame.frameName, classOrEnumName)) {
+                if (java.util.Objects.equals(currentFrame.frameName, classOrEnumName)) {
                     return true;
                 }
                 currentFrame = currentFrame.parent;


### PR DESCRIPTION
From [18.0 API Docs](http://google.github.io/guava/releases/18.0/api/docs/com/google/common/base/Objects.html#equal%28java.lang.Object,%20java.lang.Object%29):
> Note for Java 7 and later: This method should be treated as deprecated; use Objects.equals(java.lang.Object, java.lang.Object) instead.

As we now support only Java 7+, this should be replaced.