### PR TITLE
Issue #1566: Fix for 'Don't use trailing comments' (partial)

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ScopeUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ScopeUtils.java
@@ -42,7 +42,8 @@ public final class ScopeUtils {
      * @return a {@code Scope} value
      */
     public static Scope getScopeFromMods(DetailAST aMods) {
-        Scope retVal = Scope.PACKAGE; // default scope
+        // default scope
+        Scope retVal = Scope.PACKAGE;
         for (AST token = aMods.getFirstChild(); token != null
                 && retVal == Scope.PACKAGE;
                 token = token.getNextSibling()) {
@@ -83,7 +84,8 @@ public final class ScopeUtils {
             }
             else if (type == TokenTypes.LITERAL_NEW) {
                 retVal = Scope.ANONINNER;
-                break; //because Scope.ANONINNER is not in any other Scope
+                // because Scope.ANONINNER is not in any other Scope
+                break;
             }
         }
 
@@ -114,7 +116,7 @@ public final class ScopeUtils {
                 || type == TokenTypes.ENUM_DEF
                 || type == TokenTypes.ANNOTATION_DEF
                 || type == TokenTypes.LITERAL_NEW) {
-                break; // in a class, enum or annotation
+                break;
             }
         }
 
@@ -143,7 +145,7 @@ public final class ScopeUtils {
                 || type == TokenTypes.ENUM_DEF
                 || type == TokenTypes.INTERFACE_DEF
                 || type == TokenTypes.LITERAL_NEW) {
-                break; // in a class, enum or interface
+                break;
             }
 
         }
@@ -185,7 +187,7 @@ public final class ScopeUtils {
                 || type == TokenTypes.ANNOTATION_DEF
                 || type == TokenTypes.CLASS_DEF
                 || type == TokenTypes.LITERAL_NEW) {
-                break; // in an interface, annotation or class
+                break;
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -524,7 +524,7 @@ public final class TreeWalker
 
             CommonHiddenStreamToken tokenBefore = curNode.getHiddenBefore();
             DetailAST currentSibling = curNode;
-            while (tokenBefore != null) { // threat multiple comments
+            while (tokenBefore != null) {
                 final DetailAST newCommentNode =
                          createCommentAstFromToken(tokenBefore);
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -195,7 +195,9 @@ public class XMLLogger
         }
 
         if (ent.charAt(1) == '#') {
-            int prefixLength = 2; // "&#"
+            // prefix is "&#"
+            int prefixLength = 2;
+
             int radix = BASE_10;
             if (ent.charAt(2) == 'x') {
                 prefixLength++;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
@@ -48,7 +48,7 @@ public abstract class Check extends AbstractViolationReporter {
     private LocalizedMessages messages;
 
     /** The tab width for column reporting */
-    private int tabWidth = DEFAULT_TAB_WIDTH; // meaningful default
+    private int tabWidth = DEFAULT_TAB_WIDTH;
 
     /**
      * The class loader to load external classes. Not initialised as this must

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -66,7 +66,9 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
     public void initialize(Token tok) {
         super.initialize(tok);
         lineNo = tok.getLine();
-        columnNo = tok.getColumn() - 1; // expect columns to start @ 0
+
+        // expect columns to start @ 0
+        columnNo = tok.getColumn() - 1;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -517,7 +517,7 @@ public final class JavadocTokenTypes {
      * }
      * </pre>
      */
-    public static final int JAVADOC_INLINE_TAG_END = JavadocParser.JAVADOC_INLINE_TAG_END; // '}'
+    public static final int JAVADOC_INLINE_TAG_END = JavadocParser.JAVADOC_INLINE_TAG_END;
 
     /**
      * '@code' literal in {&#64;code} Javadoc inline tag.
@@ -1423,11 +1423,17 @@ public final class JavadocTokenTypes {
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
     /////////////////////// SINGLETON HTML TAGS  //////////////////////////////////////////////////
+    /**
+     * Parent node for all singleton html tags.
+     */
     public static final int SINGLETON_ELEMENT = JavadocParser.RULE_singletonElement
-            + RULE_TYPES_OFFSET; // parent node for all singleton tags
+            + RULE_TYPES_OFFSET;
 
+    /**
+     * Non-special singleton html tag.
+     */
     public static final int SINGLETON_TAG = JavadocParser.RULE_singletonTag
-            + RULE_TYPES_OFFSET; // non-special singleton tag
+            + RULE_TYPES_OFFSET;
 
     public static final int AREA_TAG = JavadocParser.RULE_areaTag + RULE_TYPES_OFFSET;
     public static final int AREA_HTML_TAG_NAME = JavadocParser.AREA_HTML_TAG_NAME;
@@ -1469,27 +1475,55 @@ public final class JavadocTokenTypes {
     public static final int PARAM_HTML_TAG_NAME = JavadocParser.PARAM_HTML_TAG_NAME;
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
-    // HTML comments
     public static final int HTML_COMMENT = JavadocParser.RULE_htmlComment
             + RULE_TYPES_OFFSET
             + RULE_TYPES_OFFSET;
-    public static final int HTML_COMMENT_START = JavadocParser.HTML_COMMENT_START; // <!---
-    public static final int HTML_COMMENT_END = JavadocParser.HTML_COMMENT_END; // -->
 
-    public static final int CDATA = JavadocParser.CDATA; // '<![CDATA[...]]>'
+    /**
+     * HTML comment start symbol '&lt;!--'.
+     */
+    public static final int HTML_COMMENT_START = JavadocParser.HTML_COMMENT_START;
+
+    /**
+     * HTML comment end symbol '--&gt;'.
+     */
+    public static final int HTML_COMMENT_END = JavadocParser.HTML_COMMENT_END;
+
+    /**
+     * &lt;![CDATA[...]]&gt; block.
+     */
+    public static final int CDATA = JavadocParser.CDATA;
 
     //--------------------------------------------------------------------------------------------//
     //------------------        OTHER          ---------------------------------------------------//
     //--------------------------------------------------------------------------------------------//
 
     public static final int LEADING_ASTERISK = JavadocParser.LEADING_ASTERISK;
-    public static final int NEWLINE = JavadocParser.NEWLINE; // \n
-    public static final int CHAR = JavadocParser.CHAR; // any symbol
-    public static final int WS = JavadocParser.WS; // whitespace, \t
-    public static final int TEXT = JavadocParser.RULE_text
-            + RULE_TYPES_OFFSET; // CHAR and WS sequence
 
-    public static final int EOF = JavadocParser.EOF; // end of file
+    /**
+     * Newline symbol - '\n'.
+     */
+    public static final int NEWLINE = JavadocParser.NEWLINE;
+
+    /**
+     * Any other symbol.
+     */
+    public static final int CHAR = JavadocParser.CHAR;
+
+    /**
+     * Whitespace or tab ('\t') symbol.
+     */
+    public static final int WS = JavadocParser.WS;
+
+    /**
+     * CHAR and WS sequence.
+     */
+    public static final int TEXT = JavadocParser.RULE_text + RULE_TYPES_OFFSET;
+
+    /**
+     * End Of File symbol
+     */
+    public static final int EOF = JavadocParser.EOF;
 
     private JavadocTokenTypes() {
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/CheckUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/CheckUtils.java
@@ -334,7 +334,9 @@ public final class CheckUtils {
         // Check the name matches format setX...
         final DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
         final String name = type.getNextSibling().getText();
-        if (!name.matches("^set[A-Z].*")) { // Depends on JDK 1.4
+
+        // Depends on JDK 1.4
+        if (!name.matches("^set[A-Z].*")) {
             return false;
         }
 
@@ -380,7 +382,9 @@ public final class CheckUtils {
         // check that the format isX is only used with a boolean type.
         final DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
         final String name = type.getNextSibling().getText();
-        if (!name.matches("^(is|get)[A-Z].*")) { // Depends on JDK 1.4
+
+        // Depends on JDK 1.4
+        if (!name.matches("^(is|get)[A-Z].*")) {
             return false;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
@@ -104,7 +104,7 @@ public class EqualsHashCodeCheck
         else if (type.getFirstChild().getType() == TokenTypes.LITERAL_INT
                 && "hashCode".equals(methodName.getText())
                 && modifiers.branchContains(TokenTypes.LITERAL_PUBLIC)
-                && parameters.getFirstChild() == null) { // no params
+                && parameters.getFirstChild() == null) {
             objBlockWithHashCode.add(ast.getParent());
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -69,7 +69,8 @@ public class IllegalTokenTextCheck
      * Instantiates a new instance.
      */
     public IllegalTokenTextCheck() {
-        super("$^"); // the empty language
+        // the empty language
+        super("$^");
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -354,7 +354,8 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
                             }
                         }
                     }
-                    else { // is not method call
+                    else {
+                        // is not method call
                         result = false;
                     }
                     break;
@@ -416,7 +417,8 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
                             if (isVariableInOperatorExpr(currentAst, variableIdentAst)) {
                                 dist++;
                             }
-                            else { // variable usage is in inner scope
+                            else {
+                                // variable usage is in inner scope
                                 // reset counters, because we can't determine distance
                                 dist = 0;
                             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -76,7 +76,8 @@ public class FinalClassCheck
             final boolean isAbstract = modifiers.branchContains(TokenTypes.ABSTRACT);
             classes.push(new ClassDesc(isFinal, isAbstract));
         }
-        else if (!ScopeUtils.inEnumBlock(ast)) { //ctors in enums don't matter
+        // ctors in enums don't matter
+        else if (!ScopeUtils.inEnumBlock(ast)) {
             final ClassDesc desc = classes.peek();
             if (modifiers.branchContains(TokenTypes.LITERAL_PRIVATE)) {
                 desc.reportPrivateCtor();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -78,7 +78,7 @@ public class HideUtilityClassConstructorCheck extends Check {
 
         // figure out if class extends java.lang.object directly
         // keep it simple for now and get a 99% solution
-        final boolean extendsJLO = // J.Lo even made it into in our sources :-)
+        final boolean extendsJLO =
             ast.findFirstToken(TokenTypes.EXTENDS_CLAUSE) == null;
 
         final boolean isUtilClass = extendsJLO && hasMethodOrField

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
@@ -95,7 +95,7 @@ public class HeaderCheck extends AbstractHeaderCheck {
             for (int i = 0; i < getHeaderLines().size(); i++) {
                 if (!isMatch(i, lines.get(i))) {
                     log(i + 1, MSG_MISMATCH, getHeaderLines().get(i));
-                    break; // stop checking
+                    break;
                 }
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -88,7 +88,7 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck {
                 if (!isMatch) {
                     log(i + 1, "header.mismatch", getHeaderLines().get(
                             headerLineNo));
-                    break; // stop checking
+                    break;
                 }
                 if (!isMultiLine(headerLineNo)) {
                     headerLineNo++;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/Guard.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/Guard.java
@@ -78,7 +78,9 @@ class Guard {
         this.regExp = regExp;
         pkgName = null;
         this.className = className;
-        exactMatch = true; // not used.
+
+        // not used
+        exactMatch = true;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -239,7 +239,8 @@ public class ImportOrderCheck
             // if the pkg name is the wildcard, make it match zero chars
             // from any name, so it will always be used as last resort.
             if (WILDCARD_GROUP_NAME.equals(pkg)) {
-                grp = Pattern.compile(""); // matches any package
+                // matches any package
+                grp = Pattern.compile("");
             }
             else if (Utils.startsWithChar(pkg, '/')) {
                 if (!Utils.endsWithChar(pkg, '/')) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
@@ -88,8 +88,10 @@ public class HandlerFactory {
     private void register(int type, Class<?> handlerClass) {
         final Constructor<?> ctor = Utils.getConstructor(handlerClass,
                 IndentationCheck.class,
-                DetailAST.class, // current AST
-                AbstractExpressionHandler.class // parent
+                // current AST
+                DetailAST.class,
+                // parent
+                AbstractExpressionHandler.class
         );
         typeHandlers.put(type, ctor);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -389,7 +389,8 @@ public class JavadocStyleCheck
         }
 
         // Identify any tags left on the stack.
-        String lastFound = ""; // Skip multiples, like <b>...<b>
+        // Skip multiples, like <b>...<b>
+        String lastFound = "";
         final List<String> typeParameters = CheckUtils.getTypeParameterNames(ast);
         for (final HtmlTag htag : htmlStack) {
             if (!isSingleTag(htag)
@@ -426,7 +427,8 @@ public class JavadocStyleCheck
         }
 
         // Output the unterminated tags, if any
-        String lastFound = ""; // Skip multiples, like <b>..<b>
+        // Skip multiples, like <b>..<b>
+        String lastFound = "";
         for (final HtmlTag htag : unclosedTags) {
             lastOpenTag = htag;
             if (lastOpenTag.getId().equals(lastFound)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocUtils.java
@@ -131,13 +131,17 @@ public final class JavadocUtils {
                 final Pattern commentPattern = Pattern.compile("^\\s*(?:/\\*{2,}|\\*+)\\s*(.*)");
                 final Matcher commentMatcher = commentPattern.matcher(s);
                 final String commentContents;
-                final int commentOffset; // offset including comment characters
+
+                // offset including comment characters
+                final int commentOffset;
+
                 if (commentMatcher.find()) {
                     commentContents = commentMatcher.group(1);
                     commentOffset = commentMatcher.start(1) - 1;
                 }
                 else {
-                    commentContents = s; // No leading asterisks, still valid
+                    // No leading asterisks, still valid
+                    commentContents = s;
                     commentOffset = 0;
                 }
                 final Pattern tagPattern = Pattern.compile(".*?\\{@(\\p{Alpha}+)\\s+(.*?)\\}");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
@@ -117,7 +117,8 @@ public class MethodNameCheck
     public void visitToken(DetailAST ast) {
         if (!AnnotationUtility.containsAnnotation(ast, OVERRIDE)
             && !AnnotationUtility.containsAnnotation(ast, CANONICAL_OVERRIDE)) {
-            super.visitToken(ast); // Will check the name against the format.
+            // Will check the name against the format.
+            super.visitToken(ast);
         }
 
         if (!allowClassName) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
@@ -116,7 +116,8 @@ public class RegexpCheck extends AbstractFormatCheck {
      * Instantiates an new RegexpCheck.
      */
     public RegexpCheck() {
-        super("$^", Pattern.MULTILINE); // the empty language
+        // the empty language
+        super("$^", Pattern.MULTILINE);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java
@@ -101,7 +101,7 @@ class SinglelineDetector {
                 // check if the expression is on the rest of the line
                 checkLine(lineno, line, matcher, endCol);
             }
-            return; // end processing here
+            return;
         }
 
         currentMatches++;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -195,7 +195,8 @@ public class SuppressWithNearbyCommentFilter
     @Override
     public boolean accept(AuditEvent event) {
         if (event.getLocalizedMessage() == null) {
-            return true;        // A special event.
+            // A special event
+            return true;
         }
 
         // Lazy update. If the first event for the current file, update file

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -182,7 +182,8 @@ public class SuppressionCommentFilter
     @Override
     public boolean accept(AuditEvent event) {
         if (event.getLocalizedMessage() == null) {
-            return true;        // A special event.
+            // A special event
+            return true;
         }
 
         // Lazy update. If the first event for the current file, update file

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/FileDrop.java
@@ -170,7 +170,9 @@ class FileDrop {
 
         // See if any of the flavors are a file list
         int i = 0;
-        while (!ok && i < flavors.length) {   // Is the flavor a file list?
+
+        // Is the flavor a file list?
+        while (!ok && i < flavors.length) {
             if (flavors[i].equals(DataFlavor.javaFileListFlavor)) {
                 ok = true;
             }


### PR DESCRIPTION
I don't think these violations have to be fixed:
1) http://rdiachenko.github.io/site-src/xref/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.html#L114
2) http://rdiachenko.github.io/site-src/xref/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.html#L117

Removing those comments or moving them to the new line makes code less readable.