### PR TITLE
Fix name for constants in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -39,7 +39,7 @@ import com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck;
 
 public class SuppressWarningsFilterTest
     extends BaseCheckTestSupport {
-    private static final String[] sAllMessages = {
+    private static final String[] ALL_MESSAGES = {
         "22:45: Name 'I' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         "24:17: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         "25:17: Name 'K' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
@@ -81,7 +81,7 @@ public class SuppressWarningsFilterTest
         String... aSuppressed) throws Exception {
         verify(createChecker(aFilterConfig),
             getPath("filters/InputSuppressWarningsFilter.java"),
-            removeSuppressed(sAllMessages, aSuppressed));
+            removeSuppressed(ALL_MESSAGES, aSuppressed));
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -49,7 +49,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class SuppressWithNearbyCommentFilterTest
     extends BaseCheckTestSupport {
-    private static final String[] sAllMessages = {
+    private static final String[] ALL_MESSAGES = {
         "14:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         "15:17: Name 'A2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         "16:59: Name 'A3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
@@ -200,7 +200,7 @@ public class SuppressWithNearbyCommentFilterTest
         throws Exception {
         verify(createChecker(filterConfig),
                getPath("filters/InputSuppressWithNearbyCommentFilter.java"),
-               removeSuppressed(sAllMessages, suppressed));
+               removeSuppressed(ALL_MESSAGES, suppressed));
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -49,7 +49,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class SuppressionCommentFilterTest
     extends BaseCheckTestSupport {
-    private static final String[] sAllMessages = {
+    private static final String[] ALL_MESSAGES = {
         "13:17: Name 'I' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         "16:17: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         "19:17: Name 'K' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
@@ -200,7 +200,7 @@ public class SuppressionCommentFilterTest
         throws Exception {
         verify(createChecker(aFilterConfig),
                getPath("filters/InputSuppressionCommentFilter.java"),
-               removeSuppressed(sAllMessages, aSuppressed));
+               removeSuppressed(ALL_MESSAGES, aSuppressed));
     }
 
     @Override


### PR DESCRIPTION
Fixes `ConstantNamingConvention` inspection violations in test code.

Description:
>Reports any constants whose names are either too short, too long, or do not follow the specified regular expression pattern. Constants are fields declared static final.