### PR TITLE
Use unchecked exception in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -253,7 +253,7 @@ public class XMLLoggerTest {
         assertEquals("last line.", "</checkstyle>", lines[lines.length - 1]);
     }
 
-    private static class TestException extends Exception {
+    private static class TestException extends RuntimeException {
 
         private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
Fixes `CheckedExceptionClass` inspection violations in test code.

Description:
>Reports checked exception classes (i.e. subclasses of Exception which are not also subclasses of RuntimeException). Certain coding standards require that all user-defined exception classes be unchecked.