### PR TITLE
Do not use static field referenced by subclass. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
+import org.antlr.v4.runtime.Recognizer;
+
 import com.puppycrawl.tools.checkstyle.grammars.javadoc.JavadocParser;
 
 /**
@@ -1523,7 +1525,7 @@ public final class JavadocTokenTypes {
     /**
      * End Of File symbol
      */
-    public static final int EOF = JavadocParser.EOF;
+    public static final int EOF = Recognizer.EOF;
 
     private JavadocTokenTypes() {
     }


### PR DESCRIPTION
Fixes `StaticFieldReferenceOnSubclass` inspection violations.

Description:
>Reports static field accesses where the call is qualified by a subclass of the declaring class, rather than the declaring class itself. Java allows such qualification, but such accesses may be confusing, and may indicate a subtle confusion of inheritance and overriding.