### PR TITLE
Use EqualsVerifier to test equals methods. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilter.java
@@ -46,12 +46,12 @@ class IntMatchFilter implements IntFilter {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         return Integer.valueOf(matchValue).hashCode();
     }
 
     @Override
-    public boolean equals(Object object) {
+    public final boolean equals(Object object) {
         if (object instanceof IntMatchFilter) {
             final IntMatchFilter other = (IntMatchFilter) object;
             return matchValue == other.matchValue;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterTest.java
@@ -38,16 +38,6 @@ public class IntMatchFilterTest {
     }
 
     @Test
-    public void testEquals() {
-        final IntFilter filter = new IntMatchFilter(0);
-        final IntFilter filter2 = new IntMatchFilter(0);
-        final IntFilter filter3 = new IntMatchFilter(1);
-        assertEquals("0", filter, filter2);
-        assertFalse("0 != 1", filter.equals(filter3));
-        assertFalse("0 != this", filter.equals(this));
-    }
-
-    @Test
     public void testEqualsAndHashCode() {
         EqualsVerifier.forClass(IntMatchFilter.class).verify();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterTest.java
@@ -25,6 +25,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+
 /** Tests IntMatchFilter */
 public class IntMatchFilterTest {
     @Test
@@ -44,6 +46,11 @@ public class IntMatchFilterTest {
         assertFalse("0 != 1", filter.equals(filter3));
         assertFalse("0 != this", filter.equals(this));
         assertFalse("0 != null", filter.equals(null));
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(IntMatchFilter.class).verify();
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterTest.java
@@ -45,7 +45,6 @@ public class IntMatchFilterTest {
         assertEquals("0", filter, filter2);
         assertFalse("0 != 1", filter.equals(filter3));
         assertFalse("0 != this", filter.equals(this));
-        assertFalse("0 != null", filter.equals(null));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterTest.java
@@ -67,7 +67,6 @@ public class IntRangeFilterTest {
         assertFalse("[0,2] != [0,1]", filter.equals(filter3));
         assertFalse("[0,2] != [1,2]", filter.equals(filter4));
         assertFalse("[0,2] != this", filter.equals(this));
-        assertFalse("[0,2] != null", filter.equals(null));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterTest.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -55,18 +54,6 @@ public class IntRangeFilterTest {
         assertFalse("out", filter.accept(5));
         assertFalse("out", filter.accept(10));
         assertFalse("out", filter.accept(11));
-    }
-
-    @Test
-    public void testEquals() {
-        final IntFilter filter = new IntRangeFilter(0, 2);
-        final IntFilter filter2 = new IntRangeFilter(0, 2);
-        final IntFilter filter3 = new IntRangeFilter(0, 1);
-        final IntFilter filter4 = new IntRangeFilter(1, 2);
-        assertEquals("[0,2] == [0,2]", filter, filter2);
-        assertFalse("[0,2] != [0,1]", filter.equals(filter3));
-        assertFalse("[0,2] != [1,2]", filter.equals(filter4));
-        assertFalse("[0,2] != this", filter.equals(this));
     }
 
     @Test


### PR DESCRIPTION
Fixes `ObjectEqualsNull` inspection violations.

Description:
>Reports on calls to .equals() which have null as an argument. The semantics of such calls are almost certainly not what was intended.