### PR TITLE
Inline simple setters. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -96,7 +96,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
             ((DetailAST) ast).setParent(parent);
         }
         if (ast != null) {
-            ((DetailAST) ast).setPreviousSibling(this);
+            ((DetailAST) ast).previousSibling = this;
         }
     }
 
@@ -111,7 +111,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
             final DetailAST previousSiblingNode = getPreviousSibling();
 
             if (previousSiblingNode != null) {
-                ast.setPreviousSibling(previousSiblingNode);
+                ast.previousSibling = previousSiblingNode;
                 previousSiblingNode.setNextSibling(ast);
             }
             else if (parent != null) {
@@ -119,7 +119,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
             }
 
             ast.setNextSibling(this);
-            setPreviousSibling(ast);
+            previousSibling = ast;
         }
     }
 
@@ -135,20 +135,12 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
 
             if (nextSibling != null) {
                 ast.setNextSibling(nextSibling);
-                nextSibling.setPreviousSibling(ast);
+                nextSibling.previousSibling = ast;
             }
 
-            ast.setPreviousSibling(this);
+            ast.previousSibling = this;
             setNextSibling(ast);
         }
-    }
-
-    /**
-     * Sets previous sibling.
-     * @param ast a previous sibling
-     */
-    void setPreviousSibling(DetailAST ast) {
-        previousSibling = ast;
     }
 
     @Override
@@ -188,7 +180,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
         final DetailAST nextSibling = getNextSibling();
         if (nextSibling != null) {
             nextSibling.setParent(parent);
-            nextSibling.setPreviousSibling(this);
+            nextSibling.previousSibling = this;
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
@@ -59,7 +59,7 @@ public final class ReturnCountCheck extends AbstractFormatCheck {
     /** Creates new instance of the checks. */
     public ReturnCountCheck() {
         super("^equals$");
-        setMax(DEFAULT_MAX);
+        this.max = DEFAULT_MAX;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
@@ -54,7 +54,7 @@ public final class ExecutableStatementCountCheck
 
     /** Constructs a {@code ExecutableStatementCountCheck}. */
     public ExecutableStatementCountCheck() {
-        setMax(DEFAULT_MAX);
+        this.max = DEFAULT_MAX;
     }
 
     @Override


### PR DESCRIPTION
Fixes `CallToSimpleSetterInClass` inspection violations.

Description:
>Reports any calls to a simple property setter from within the property's class. A simple property setter is defined as one which simply assigns the value of its parameter to a field, and does no other calculation. Such simple setter calls may be safely inlined, at a small performance improvement. Some coding standards also suggest against the use of simple setters for code clarity reasons.