### PR TITLE
Fix confusing variable names. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -61,16 +61,16 @@ public abstract class BaseCheckTestSupport
         throws Exception
     {
         final DefaultConfiguration dc = createCheckerConfig(aCheckConfig);
-        final Checker c = new Checker();
+        final Checker checker = new Checker();
         // make sure the tests always run with english error messages
         // so the tests don't fail in supported locales like german
         final Locale locale = Locale.ENGLISH;
-        c.setLocaleCountry(locale.getCountry());
-        c.setLocaleLanguage(locale.getLanguage());
-        c.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
-        c.configure(dc);
-        c.addListener(new BriefLogger(stream));
-        return c;
+        checker.setLocaleCountry(locale.getCountry());
+        checker.setLocaleLanguage(locale.getLanguage());
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.configure(dc);
+        checker.addListener(new BriefLogger(stream));
+        return checker;
     }
 
     protected DefaultConfiguration createCheckerConfig(Configuration aConfig)

--- a/src/it/java/com/google/checkstyle/test/base/ConfigValidationTest.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigValidationTest.java
@@ -13,15 +13,15 @@ public class ConfigValidationTest extends BaseCheckTestSupport {
     public void testGoogleChecks() throws Exception {
         ConfigurationBuilder builder = new ConfigurationBuilder(new File("src/it/"));
         final Configuration checkerConfig = builder.config;
-        final Checker c = new Checker();
-        c.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
-        c.configure(checkerConfig);
-        c.addListener(new BriefLogger(stream));
+        final Checker checker = new Checker();
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.configure(checkerConfig);
+        checker.addListener(new BriefLogger(stream));
 
         final List<File> files = builder.getFiles();
         
         //runs over all input files;
         //as severity level is "warning", no errors expected
-        verify(c, files.toArray(new File[files.size()]), "", new String[0], null);
+        verify(checker, files.toArray(new File[files.size()]), "", new String[0], null);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -55,16 +55,16 @@ public abstract class BaseCheckTestSupport {
     protected Checker createChecker(Configuration checkConfig)
             throws Exception {
         final DefaultConfiguration dc = createCheckerConfig(checkConfig);
-        final Checker c = new Checker();
+        final Checker checker = new Checker();
         // make sure the tests always run with default error messages (language-invariant)
         // so the tests don't fail in supported locales like German
         final Locale locale = Locale.ROOT;
-        c.setLocaleCountry(locale.getCountry());
-        c.setLocaleLanguage(locale.getLanguage());
-        c.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
-        c.configure(dc);
-        c.addListener(new BriefLogger(stream));
-        return c;
+        checker.setLocaleCountry(locale.getCountry());
+        checker.setLocaleLanguage(locale.getLanguage());
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.configure(dc);
+        checker.addListener(new BriefLogger(stream));
+        return checker;
     }
 
     protected DefaultConfiguration createCheckerConfig(Configuration config) {
@@ -93,22 +93,22 @@ public abstract class BaseCheckTestSupport {
         verify(createChecker(aConfig), fileName, fileName, expected);
     }
 
-    protected void verify(Checker c, String fileName, String... expected)
+    protected void verify(Checker checker, String fileName, String... expected)
             throws Exception {
-        verify(c, fileName, fileName, expected);
+        verify(checker, fileName, fileName, expected);
     }
 
-    protected void verify(Checker c,
+    protected void verify(Checker checker,
                           String processedFilename,
                           String messageFileName,
                           String... expected)
             throws Exception {
-        verify(c,
+        verify(checker,
                 new File[]{new File(processedFilename)},
                 messageFileName, expected);
     }
 
-    protected void verify(Checker c,
+    protected void verify(Checker checker,
                           File[] processedFiles,
                           String messageFileName,
                           String... expected)
@@ -116,7 +116,7 @@ public abstract class BaseCheckTestSupport {
         stream.flush();
         final List<File> theFiles = Lists.newArrayList();
         Collections.addAll(theFiles, processedFiles);
-        final int errs = c.process(theFiles);
+        final int errs = checker.process(theFiles);
 
         // process each of the lines
         final ByteArrayInputStream bais =
@@ -132,7 +132,7 @@ public abstract class BaseCheckTestSupport {
 
         assertEquals("unexpected output: " + lnr.readLine(),
                 expected.length, errs);
-        c.destroy();
+        checker.destroy();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -258,8 +258,8 @@ public class XMLLoggerTest {
         private static final long serialVersionUID = 1L;
 
         @Override
-        public void printStackTrace(PrintWriter s) {
-            s.print("stackTrace");
+        public void printStackTrace(PrintWriter printWriter) {
+            printWriter.print("stackTrace");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -337,12 +337,12 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
     public void testGetFullImportIdent() {
         Object actual;
         try {
-            Class<?> c = Class.forName(
+            Class<?> clazz = Class.forName(
                     "com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck");
-            Object t = c.newInstance();
-            Method m = c.getDeclaredMethod("getFullImportIdent", DetailAST.class);
-            m.setAccessible(true);
-            actual = m.invoke(t, (DetailAST) null);
+            Object t = clazz.newInstance();
+            Method method = clazz.getDeclaredMethod("getFullImportIdent", DetailAST.class);
+            method.setAccessible(true);
+            actual = method.invoke(t, (DetailAST) null);
         }
         catch (Exception e) {
             e.printStackTrace();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
@@ -69,9 +69,9 @@ public class ImportControlLoaderTest {
                 }
             };
         try {
-            Class<?> c = Class.forName(
+            Class<?> clazz = Class.forName(
                     "com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader");
-            Method privateMethod = c.getDeclaredMethod("safeGet", Attributes.class, String.class);
+            Method privateMethod = clazz.getDeclaredMethod("safeGet", Attributes.class, String.class);
             privateMethod.setAccessible(true);
             privateMethod.invoke(null, attr, "you_cannot_find_me");
         }
@@ -89,9 +89,9 @@ public class ImportControlLoaderTest {
     public void testLoadThrowsException() throws InvocationTargetException {
         InputSource source = new InputSource();
         try {
-            Class<?> c = Class.forName(
+            Class<?> clazz = Class.forName(
                     "com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader");
-            Method privateMethod = c.getDeclaredMethod("load", InputSource.class, URI.class);
+            Method privateMethod = clazz.getDeclaredMethod("load", InputSource.class, URI.class);
             privateMethod.setAccessible(true);
             privateMethod.invoke(null, source, new File(
                     "src/test/resources/com/puppycrawl/tools/checkstyle/imports/import-control_complete.xml").toURI());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -192,7 +192,7 @@ public class WriteTagCheckTest extends BaseCheckTestSupport {
     }
 
     @Override
-    protected void verify(Checker c,
+    protected void verify(Checker checker,
                           File[] processedFiles,
                           String messageFileName,
                           String... expected)
@@ -200,7 +200,7 @@ public class WriteTagCheckTest extends BaseCheckTestSupport {
         stream.flush();
         final List<File> theFiles = Lists.newArrayList();
         Collections.addAll(theFiles, processedFiles);
-        final int errs = c.process(theFiles);
+        final int errs = checker.process(theFiles);
 
         // process each of the lines
         final ByteArrayInputStream bais =
@@ -217,6 +217,6 @@ public class WriteTagCheckTest extends BaseCheckTestSupport {
         assertTrue("unexpected output: " + lnr.readLine(),
                    expected.length >= errs);
 
-        c.destroy();
+        checker.destroy();
     }
 }


### PR DESCRIPTION
Fixes `StandardVariableNames` inspection violations in test code.

Description:
>Reports on any variables with 'standard' names which are of unexpected types. Such names may be confusing. Standard names and types are as follows:
- i, j, k, m, n - int
- f - float
- d - double
- b - byte
- c, ch - char
- l - long
- s, str - String