### PR TITLE
Use constants for empty arrays. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigValidationTest.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigValidationTest.java
@@ -1,5 +1,7 @@
 package com.google.checkstyle.test.base;
 
+import static org.apache.commons.lang3.ArrayUtils.EMPTY_STRING_ARRAY;
+
 import java.io.File;
 import java.util.List;
 
@@ -22,6 +24,6 @@ public class ConfigValidationTest extends BaseCheckTestSupport {
         
         //runs over all input files;
         //as severity level is "warning", no errors expected
-        verify(c, files.toArray(new File[files.size()]), "", new String[0], null);
+        verify(c, files.toArray(new File[files.size()]), "", EMPTY_STRING_ARRAY, null);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static org.apache.commons.lang3.ArrayUtils.EMPTY_BYTE_ARRAY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -115,7 +116,7 @@ public class PackageNamesLoaderTest {
 
         final URLConnection mockConnection = Mockito.mock(URLConnection.class);
         when(mockConnection.getInputStream()).thenReturn(
-                new ByteArrayInputStream(new byte[]{}));
+                new ByteArrayInputStream(EMPTY_BYTE_ARRAY));
 
         URL url = getMockUrl(mockConnection);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
+import static org.apache.commons.lang3.ArrayUtils.EMPTY_BYTE_ARRAY;
+import static org.apache.commons.lang3.ArrayUtils.EMPTY_OBJECT_ARRAY;
 import static org.junit.Assert.assertEquals;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -74,7 +76,7 @@ public class LocalizedMessageTest {
         ClassLoader classloader = mock(ClassLoader.class);
         final URLConnection mockConnection = Mockito.mock(URLConnection.class);
         when(mockConnection.getInputStream()).thenReturn(
-                new ByteArrayInputStream(new byte[]{}));
+                new ByteArrayInputStream(EMPTY_BYTE_ARRAY));
 
         URL url = getMockUrl(mockConnection);
         String resource = "com/puppycrawl/tools/checkstyle/checks/coding/messages_en.properties";
@@ -139,7 +141,7 @@ public class LocalizedMessageTest {
 
     private static LocalizedMessage createSampleLocalizedMessage() {
         return new LocalizedMessage(0, "com.puppycrawl.tools.checkstyle.checks.coding.messages",
-                "empty.statement", new Object[]{}, "module", LocalizedMessage.class, null);
+                "empty.statement", EMPTY_OBJECT_ARRAY, "module", LocalizedMessage.class, null);
     }
 
     @After


### PR DESCRIPTION
Fixes some `ZeroLengthArrayInitialization` inspection violations.

Description:
>Reports on allocations of arrays with known lengths of zero. Since array lengths in Java are non-modifiable, it is almost always possible to share zero-length arrays, rather than repeatedly allocating new zero-length arrays. Such sharing may provide useful optimizations in program runtime or footprint. Note that this inspection does not report zero-length arrays allocated as static final fields, as it is assumed that those arrays are being used to implement array sharing.