### PR TITLE
Simplify throws list in test code. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule522typenames/TypeNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule522typenames/TypeNameTest.java
@@ -21,7 +21,7 @@ public class TypeNameTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void typeNameTest() throws IOException, Exception {
+    public void typeNameTest() throws Exception {
 
         Configuration checkConfig = builder.getCheckConfig("TypeName");
         String msgKey = "name.invalidPattern";

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
@@ -26,7 +26,7 @@ public class AbbreviationAsWordInNameTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void abbreviationAsWordInNameTest() throws IOException, Exception {
+    public void abbreviationAsWordInNameTest() throws Exception {
 
         int maxCapitalCount = 1;
         String msg = getCheckMessage(clazz, MSG_KEY, maxCapitalCount);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
@@ -204,7 +204,7 @@ public class UtilsTest {
     }
 
     @Test
-    public void testTokenValueIncorrect2() throws NoSuchMethodException, IllegalAccessException {
+    public void testTokenValueIncorrect2() throws Exception {
         Integer id = 0;
         String[] originalValue = null;
         Field fieldToken = null;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
-import java.net.URISyntaxException;
 
 import org.junit.Test;
 import org.xml.sax.Attributes;
@@ -44,7 +43,7 @@ public class ImportControlLoaderTest {
     }
 
     @Test(expected = CheckstyleException.class)
-    public void testWrongFormatURI() throws CheckstyleException, URISyntaxException {
+    public void testWrongFormatURI() throws Exception {
         final PkgControl root =
                 ImportControlLoader.load(
                         new URI("aaa://src/test/resources/com/puppycrawl/tools/checkstyle/imports/import-control_complete.xml"));
@@ -52,7 +51,7 @@ public class ImportControlLoaderTest {
     }
 
     @Test
-    public void testExtraElementInConfig() throws CheckstyleException, URISyntaxException {
+    public void testExtraElementInConfig() throws Exception {
         final PkgControl root =
                 ImportControlLoader.load(new File(
                         "src/test/resources/com/puppycrawl/tools/checkstyle/imports/import-control_WithNewElement.xml").toURI());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -69,8 +69,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testLoadFromURL()
-        throws CheckstyleException, InterruptedException {
+    public void testLoadFromURL() throws Exception {
         boolean online = isInternetReachable();
 
         Assume.assumeTrue(online);


### PR DESCRIPTION
Fixes `MultipleExceptionsDeclaredOnTestMethod` inspection violations.

Description:
>Reports JUnit test methods with more than one exception declared in the throws clause. Such a throws clause can be more concisely declared as `throws Exception`.