### PR TITLE
Use multi-catch in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -486,10 +486,7 @@ public class ConfigurationLoaderTest {
             final Configuration[] children = config.getChildren();
             assertEquals(0, children[0].getChildren().length);
         }
-        catch (CheckstyleException ex) {
-            fail("unexpected exception");
-        }
-        catch (FileNotFoundException e) {
+        catch (CheckstyleException | FileNotFoundException ex) {
             fail("unexpected exception");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
@@ -233,10 +233,7 @@ public class UtilsTest {
             assertEquals("given id " + id, expected.getMessage());
 
         }
-        catch (IllegalAccessException e) {
-            fail();
-        }
-        catch (NoSuchFieldException e) {
+        catch (IllegalAccessException | NoSuchFieldException e) {
             fail();
         }
     }


### PR DESCRIPTION
Fixes `TryWithIdenticalCatches` inspection violations in test code.

Description:
>Reports identical catch sections in try blocks under JDK 7. A quickfix is available to collapse the sections into a multi-catch section.
This inspection only reports if the project or module is configured to use a language level of 7.0 or higher.