### PR TITLE
Use String instead of constant in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckTest.java
@@ -57,7 +57,7 @@ public class AvoidNestedBlocksCheckTest
         throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(AvoidNestedBlocksCheck.class);
-        checkConfig.addAttribute("allowInSwitchCase", Boolean.TRUE.toString());
+        checkConfig.addAttribute("allowInSwitchCase", "true");
 
         final String[] expected = {
             "22:9: " + getCheckMessage(MSG_KEY_BLOCK_NESTED),


### PR DESCRIPTION
Fixes `NumericToString` inspection violations in test code.

Description:
>Reports any call of toString() on numeric objects. Such calls are usually incorrect in an internationalized environment.