### PR TITLE
Add missing locale to String case conversions in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.apache.commons.io.FileUtils;
@@ -406,7 +407,7 @@ public class MainTest {
         Method method = Main.class.getDeclaredMethod("loadProperties", param);
         method.setAccessible(true);
         try {
-            if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
+            if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows")) {
                 // https://support.microsoft.com/en-us/kb/177506 but this only for NTFS
                 // WindowsServer 2012 use Resilient File System (ReFS), so any name is ok
                 File file = new File(File.separator + ":invalid");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -136,7 +136,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         final TreeWalker treeWalker = new TreeWalker();
         treeWalker.configure(new DefaultConfiguration("default config"));
         if (System.getProperty("os.name")
-                        .toLowerCase().startsWith("windows")) {
+                        .toLowerCase(Locale.ENGLISH).startsWith("windows")) {
             // https://support.microsoft.com/en-us/kb/177506 but this only for NTFS
             // WindowsServer 2012 use Resilient File System (ReFS), so any name is ok
             File file = new File("C\\:invalid");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheckTest.java
@@ -23,6 +23,7 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacter
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck.FILE_CONTAINS_TAB;
 
 import java.io.File;
+import java.util.Locale;
 
 import org.junit.Test;
 
@@ -79,7 +80,7 @@ public class FileTabCharacterCheckTest
         final String path = getPath("Claira");
         String exceptionMessage = " (No such file or directory)";
         if (System.getProperty("os.name")
-                .toLowerCase().startsWith("windows")) {
+                .toLowerCase(Locale.ENGLISH).startsWith("windows")) {
             exceptionMessage = " (The system cannot find the file specified)";
         }
 


### PR DESCRIPTION
Fixes `StringToUpperWithoutLocale` inspection violations in test code.

Description:
>Reports any call of toUpperCase() or toLowerCase() on String objects which do not specify a java.util.Locale. Such calls are usually incorrect in an internationalized environment.