### PR TITLE
Remove redundant throws. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -32,14 +32,14 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 	final Pattern warnPattern = Utils.createPattern(".*[ ]*//[ ]*warn[ ]*|/[*]warn[*]/");
 
 	public ConfigurationBuilder(File aROOT)
-			throws CheckstyleException, IOException {
+			throws CheckstyleException {
 		root = aROOT;
 		config = getConfigurationFromXML(xmlName, System.getProperties());
 		listFiles(files, root, "java");
 	}
 
 	private static Configuration getConfigurationFromXML(String aConfigName,
-			Properties aProps) throws CheckstyleException {
+			Properties aProps) {
 		try {
 			return ConfigurationLoader.loadConfiguration(aConfigName,
 					new PropertiesExpander(aProps));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DebugChecker.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DebugChecker.java
@@ -8,7 +8,7 @@ package com.puppycrawl.tools.checkstyle;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
 class DebugChecker extends Checker {
-    public DebugChecker() throws CheckstyleException {
+    public DebugChecker() {
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControlRegExpTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControlRegExpTest.java
@@ -30,7 +30,7 @@ public class PkgControlRegExpTest {
     private final PkgControl pcCommon = new PkgControl(pcRoot, "common");
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         pcRoot.addGuard(new Guard(false, false, ".*\\.(spring|lui)framework", false, true));
         pcRoot.addGuard(new Guard(false, false, "org\\.hibernate", false, true));
         pcRoot.addGuard(new Guard(true, false, "org\\.(apache|lui)\\.commons", false, true));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControlTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControlTest.java
@@ -30,7 +30,7 @@ public class PkgControlTest {
     private final PkgControl pcCommon = new PkgControl(pcRoot, "common");
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         pcRoot.addGuard(new Guard(false, false, "org.springframework", false, false));
         pcRoot.addGuard(new Guard(false, false, "org.hibernate", false, false));
         pcRoot.addGuard(new Guard(true, false, "org.apache.commons", false, false));


### PR DESCRIPTION
Fixes `RedundantThrows` inspection violations in test code.

Description:
>This inspection reports exceptions that are declared in a method's signature but never thrown by the method itself or its implementations/derivatives.