### PR TITLE
Use field that was unused and remove suppression. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -97,7 +97,6 @@ public class AutomaticBeanTest {
         }
     }
 
-    @SuppressWarnings("unused")
     private static class TestBean extends AutomaticBean {
 
         private String privateField;
@@ -115,7 +114,7 @@ public class AutomaticBeanTest {
         }
 
         public void setExceptionalMethod(String value) {
-            throw new IllegalStateException(wrong);
+            throw new IllegalStateException(privateField);
         }
 
         public void setName(String name) {


### PR DESCRIPTION
Fixes `SuppressionAnnotation` inspection violations in test code.

Description:
>Reports any inspection suppression comments or annotations.