### PR TITLE
Remove call to printStackTrace() in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -345,7 +345,6 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
             actual = m.invoke(t, (DetailAST) null);
         }
         catch (Exception e) {
-            e.printStackTrace();
             actual = null;
         }
 


### PR DESCRIPTION
Fixes `ThrowablePrintStackTrace` inspection violations in test code.

Description:
>Reports any calls to Throwable.printStackTrace() without arguments. Such statements are often used for temporary debugging, and should probably be either removed from production code, or replaced with a more robust logging facility.