### PR TITLE
Remove unnecessary parentheses in test code. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
@@ -127,16 +127,16 @@ public class IndentationConfigurationBuilder extends ConfigurationBuilder
         if (match.matches()) {
             final int expectedLevel = Integer.parseInt(match.group(1));
 
-            return (expectedLevel == indentInComment) && !isWarnComment
-                    || (expectedLevel != indentInComment) && isWarnComment;
+            return expectedLevel == indentInComment && !isWarnComment
+                    || expectedLevel != indentInComment && isWarnComment;
         }
 
         match = NONSTRICT_LEVEL_COMMENT_REGEX.matcher(comment);
         if (match.matches()) {
             final int expectedMinimalIndent = Integer.parseInt(match.group(1));
 
-            return (indentInComment >= expectedMinimalIndent) && !isWarnComment
-                    || (indentInComment < expectedMinimalIndent) && isWarnComment;
+            return indentInComment >= expectedMinimalIndent && !isWarnComment
+                    || indentInComment < expectedMinimalIndent && isWarnComment;
         }
 
         throw new IllegalArgumentException();


### PR DESCRIPTION
Fixes `UnnecessaryParentheses` inspection violations in test code.

Description:
>Reports on any instance of unnecessary parentheses. Parentheses are considered unnecessary if the evaluation order of an expression remains unchanged if the parentheses are removed.