### PR TITLE
Remove unnecessary constant array creation expressions. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -473,7 +473,7 @@ public class MainTest {
     public void testExistingDirectoryWithViolations() throws Exception {
 
         // we just reference there all violations
-        final String[][] outputValues = new String[][]{
+        final String[][] outputValues = {
             {"JavaNCSSCheckTestInput", "1", "84"},
         };
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
@@ -144,7 +144,7 @@ public class DetailASTTest {
                            final DetailAST prev,
                            final String filename,
                            final DetailAST root) {
-        Object[] params = new Object[] {
+        Object[] params = {
             node, parent, prev, filename, root,
         };
         String msg = MessageFormat.format(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfoTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfoTest.java
@@ -55,7 +55,7 @@ public class JavadocTagInfoTest {
      */
     @Test
     public void testTypeValues() {
-        JavadocTagInfo.Type[] expected = new JavadocTagInfo.Type[] {
+        JavadocTagInfo.Type[] expected = {
             JavadocTagInfo.Type.BLOCK,
             JavadocTagInfo.Type.INLINE,
         };
@@ -67,7 +67,7 @@ public class JavadocTagInfoTest {
     public void testAuthor() {
         final DetailAST ast = new DetailAST();
 
-        int[] validTypes = new int[] {
+        int[] validTypes = {
             TokenTypes.PACKAGE_DEF,
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
@@ -85,7 +85,7 @@ public class JavadocTagInfoTest {
 
     @Test
     public void testOthers() {
-        JavadocTagInfo[] tags = new JavadocTagInfo[] {
+        JavadocTagInfo[] tags = {
             JavadocTagInfo.CODE,
             JavadocTagInfo.DOC_ROOT,
             JavadocTagInfo.LINK,
@@ -102,7 +102,7 @@ public class JavadocTagInfoTest {
             final DetailAST ast = new DetailAST();
             ast.setParent(astParent);
 
-            int[] validTypes = new int[] {
+            int[] validTypes = {
                 TokenTypes.PACKAGE_DEF,
                 TokenTypes.CLASS_DEF,
                 TokenTypes.INTERFACE_DEF,
@@ -133,7 +133,7 @@ public class JavadocTagInfoTest {
         astParent.setType(TokenTypes.LITERAL_CATCH);
         ast.setParent(astParent);
 
-        int[] validTypes = new int[] {
+        int[] validTypes = {
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
@@ -164,7 +164,7 @@ public class JavadocTagInfoTest {
         astParent.setType(TokenTypes.LITERAL_CATCH);
         ast.setParent(astParent);
 
-        int[] validTypes = new int[] {
+        int[] validTypes = {
             TokenTypes.VARIABLE_DEF,
         };
         for (int type: validTypes) {
@@ -184,7 +184,7 @@ public class JavadocTagInfoTest {
     public void testException() {
         final DetailAST ast = new DetailAST();
 
-        int[] validTypes = new int[] {
+        int[] validTypes = {
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
         };
@@ -201,7 +201,7 @@ public class JavadocTagInfoTest {
     public void testThrows() {
         final DetailAST ast = new DetailAST();
 
-        int[] validTypes = new int[] {
+        int[] validTypes = {
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
         };
@@ -218,7 +218,7 @@ public class JavadocTagInfoTest {
     public void testVersions() {
         final DetailAST ast = new DetailAST();
 
-        int[] validTypes = new int[] {
+        int[] validTypes = {
             TokenTypes.PACKAGE_DEF,
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
@@ -238,7 +238,7 @@ public class JavadocTagInfoTest {
     public void testParam() {
         final DetailAST ast = new DetailAST();
 
-        int[] validTypes = new int[] {
+        int[] validTypes = {
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.METHOD_DEF,
@@ -263,7 +263,7 @@ public class JavadocTagInfoTest {
         astChild2.setType(TokenTypes.LITERAL_INT);
         astChild.setFirstChild(astChild2);
 
-        int[] validTypes = new int[] {
+        int[] validTypes = {
             TokenTypes.METHOD_DEF,
         };
         for (int type: validTypes) {
@@ -289,7 +289,7 @@ public class JavadocTagInfoTest {
         astChild2.setText("ObjectStreafield");
         astChild.setFirstChild(astChild2);
 
-        int[] validTypes = new int[] {
+        int[] validTypes = {
             TokenTypes.VARIABLE_DEF,
         };
         for (int type: validTypes) {
@@ -316,7 +316,7 @@ public class JavadocTagInfoTest {
         astChild.setText("writeObject");
         ast.setFirstChild(astChild);
 
-        String[] validNames = new String[] {
+        String[] validNames = {
             "writeObject",
             "readObject",
             "writeExternal",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ScopeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ScopeTest.java
@@ -65,7 +65,7 @@ public class ScopeTest {
 
     @Test
     public void testMixedCaseSpacesWithDifferentLocales() {
-        Locale[] differentLocales = new Locale[] {new Locale("TR", "tr") };
+        Locale[] differentLocales = {new Locale("TR", "tr") };
         Locale defaultLocale = Locale.getDefault();
         try {
             for (Locale differentLocale : differentLocales) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelTest.java
@@ -62,7 +62,7 @@ public class SeverityLevelTest {
 
     @Test
     public void testMixedCaseSpacesWithDifferentLocales() {
-        Locale[] differentLocales = new Locale[] {new Locale("TR", "tr") };
+        Locale[] differentLocales = {new Locale("TR", "tr") };
         Locale defaultLocale = Locale.getDefault();
         try {
             for (Locale differentLocale : differentLocales) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheckTest.java
@@ -34,7 +34,7 @@ public class ArrayTypeStyleCheckTest
     @Test
     public void testGetRequiredTokens() {
         ArrayTypeStyleCheck checkObj = new ArrayTypeStyleCheck();
-        int[] expected = new int[] {TokenTypes.ARRAY_DECLARATOR};
+        int[] expected = {TokenTypes.ARRAY_DECLARATOR};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -35,7 +35,7 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
     public void testGetRequiredTokens() {
         AvoidEscapedUnicodeCharactersCheck checkObj =
             new AvoidEscapedUnicodeCharactersCheck();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.STRING_LITERAL,
             TokenTypes.CHAR_LITERAL,
         };
@@ -183,7 +183,7 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
     public void testGetAcceptableTokens() {
         AvoidEscapedUnicodeCharactersCheck check = new AvoidEscapedUnicodeCharactersCheck();
         int[] actual = check.getAcceptableTokens();
-        int[] expected = new int[] {TokenTypes.STRING_LITERAL, TokenTypes.CHAR_LITERAL };
+        int[] expected = {TokenTypes.STRING_LITERAL, TokenTypes.CHAR_LITERAL };
         assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
@@ -34,7 +34,7 @@ public class OuterTypeFilenameCheckTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         OuterTypeFilenameCheck checkObj = new OuterTypeFilenameCheck();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
@@ -63,7 +63,7 @@ public class OuterTypeFilenameCheckTest extends BaseCheckTestSupport {
     public void testGetAcceptableTokens() {
         OuterTypeFilenameCheck check = new OuterTypeFilenameCheck();
         int[] actual = check.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -34,7 +34,7 @@ public class SuppressWarningsHolderTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         SuppressWarningsHolder checkObj = new SuppressWarningsHolder();
-        int[] expected = new int[] {TokenTypes.ANNOTATION};
+        int[] expected = {TokenTypes.ANNOTATION};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckTest.java
@@ -35,7 +35,7 @@ public class TodoCommentCheckTest
     @Test
     public void testGetRequiredTokens() {
         TodoCommentCheck checkObj = new TodoCommentCheck();
-        int[] expected = new int[] {TokenTypes.COMMENT_CONTENT};
+        int[] expected = {TokenTypes.COMMENT_CONTENT};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -45,7 +45,7 @@ public class TranslationCheckTest
         final String[] expected = {
             "0: " + getCheckMessage(MSG_KEY, "only.english"),
         };
-        final File[] propertyFiles = new File[] {
+        final File[] propertyFiles = {
             new File(getPath("messages_test_de.properties")),
             new File(getPath("messages_test.properties")),
         };
@@ -63,7 +63,7 @@ public class TranslationCheckTest
         final String[] expected = {
             "0: " + getCheckMessage(MSG_KEY, "only.english"),
         };
-        final File[] propertyFiles = new File[] {
+        final File[] propertyFiles = {
             new File(getPath("app-dev.properties")),
             new File(getPath("app-stage.properties")),
         };
@@ -79,7 +79,7 @@ public class TranslationCheckTest
         final DefaultConfiguration checkConfig = createCheckConfig(TranslationCheck.class);
         final String[] expected = {
         };
-        final File[] propertyFiles = new File[] {
+        final File[] propertyFiles = {
             new File(getPath("app-dev.properties")),
         };
         verify(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UpperEllCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UpperEllCheckTest.java
@@ -35,7 +35,7 @@ public class UpperEllCheckTest
     @Test
     public void testGetRequiredTokens() {
         UpperEllCheck checkObj = new UpperEllCheck();
-        int[] expected = new int[] {TokenTypes.NUM_LONG};
+        int[] expected = {TokenTypes.NUM_LONG};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
@@ -78,7 +78,7 @@ public class AnnotationLocationCheckTest extends BaseCheckTestSupport {
     public void testGetAcceptableTokens() {
         AnnotationLocationCheck constantNameCheckObj = new AnnotationLocationCheck();
         int[] actual = constantNameCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleTest.java
@@ -252,7 +252,7 @@ public class AnnotationUseStyleTest extends BaseCheckTestSupport {
     public void testGetAcceptableTokens() {
         AnnotationUseStyleCheck constantNameCheckObj = new AnnotationUseStyleCheck();
         int[] actual = constantNameCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {TokenTypes.ANNOTATION };
+        int[] expected = {TokenTypes.ANNOTATION };
         Assert.assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedTest.java
@@ -37,7 +37,7 @@ public class MissingDeprecatedTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         MissingDeprecatedCheck checkObj = new  MissingDeprecatedCheck();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.INTERFACE_DEF,
             TokenTypes.CLASS_DEF,
             TokenTypes.ANNOTATION_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationTest.java
@@ -46,7 +46,7 @@ public class PackageAnnotationTest extends BaseCheckTestSupport {
     public void testGetAcceptableTokens() {
         PackageAnnotationCheck constantNameCheckObj = new PackageAnnotationCheck();
         int[] actual = constantNameCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {TokenTypes.PACKAGE_DEF };
+        int[] expected = {TokenTypes.PACKAGE_DEF };
         Assert.assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckTest.java
@@ -34,7 +34,7 @@ public class AvoidNestedBlocksCheckTest
     @Test
     public void testGetRequiredTokens() {
         AvoidNestedBlocksCheck checkObj = new AvoidNestedBlocksCheck();
-        int[] expected = new int[] {TokenTypes.SLIST};
+        int[] expected = {TokenTypes.SLIST};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -71,7 +71,7 @@ public class AvoidNestedBlocksCheckTest
     public void testGetAcceptableTokens() {
         AvoidNestedBlocksCheck constantNameCheckObj = new AvoidNestedBlocksCheck();
         int[] actual = constantNameCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {TokenTypes.SLIST };
+        int[] expected = {TokenTypes.SLIST };
         assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
@@ -37,7 +37,7 @@ public class EmptyCatchBlockCheckTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         EmptyCatchBlockCheck checkObj = new EmptyCatchBlockCheck();
-        int[] expected = new int[] {TokenTypes.LITERAL_CATCH};
+        int[] expected = {TokenTypes.LITERAL_CATCH};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -75,7 +75,7 @@ public class EmptyCatchBlockCheckTest extends BaseCheckTestSupport {
     public void testGetAcceptableTokens() {
         EmptyCatchBlockCheck constantNameCheckObj = new EmptyCatchBlockCheck();
         int[] actual = constantNameCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {TokenTypes.LITERAL_CATCH };
+        int[] expected = {TokenTypes.LITERAL_CATCH };
         assertArrayEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -275,7 +275,7 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
     public void testGetAcceptableTokens() {
         LeftCurlyCheck check = new LeftCurlyCheck();
         int[] actual = check.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.INTERFACE_DEF,
             TokenTypes.CLASS_DEF,
             TokenTypes.ANNOTATION_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckTest.java
@@ -34,7 +34,7 @@ public class DesignForExtensionCheckTest
     @Test
     public void testGetRequiredTokens() {
         DesignForExtensionCheck checkObj = new DesignForExtensionCheck();
-        int[] expected = new int[] {TokenTypes.METHOD_DEF};
+        int[] expected = {TokenTypes.METHOD_DEF};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -34,7 +34,7 @@ public class FinalClassCheckTest
     @Test
     public void testGetRequiredTokens() {
         FinalClassCheck checkObj = new FinalClassCheck();
-        int[] expected = new int[]{TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF};
+        int[] expected = {TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheckTest.java
@@ -37,7 +37,7 @@ public class HideUtilityClassConstructorCheckTest
     public void testGetRequiredTokens() {
         HideUtilityClassConstructorCheck checkObj =
             new HideUtilityClassConstructorCheck();
-        int[] expected = new int[] {TokenTypes.CLASS_DEF};
+        int[] expected = {TokenTypes.CLASS_DEF};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheckTest.java
@@ -35,7 +35,7 @@ public class InnerTypeLastCheckTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         InnerTypeLastCheck checkObj = new InnerTypeLastCheck();
-        int[] expected = new int[] {TokenTypes.CLASS_DEF, TokenTypes.INTERFACE_DEF};
+        int[] expected = {TokenTypes.CLASS_DEF, TokenTypes.INTERFACE_DEF};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -44,7 +44,7 @@ public class VisibilityModifierCheckTest
     @Test
     public void testGetRequiredTokens() {
         VisibilityModifierCheck checkObj = new VisibilityModifierCheck();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.VARIABLE_DEF,
             TokenTypes.IMPORT,
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportTest.java
@@ -58,7 +58,7 @@ public class AvoidStarImportTest
         checkConfig.addAttribute("excludes",
             "java.io,java.lang,javax.swing.WindowConstants.*, javax.swing.WindowConstants");
         // allow the java.io/java.lang,javax.swing.WindowConstants star imports
-        final String[] expected2 = new String[] {
+        final String[] expected2 = {
             "7: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.imports.*"),
             "28: " + getCheckMessage(MSG_KEY, "java.io.File.*"),
         };
@@ -71,7 +71,7 @@ public class AvoidStarImportTest
         final DefaultConfiguration checkConfig = createCheckConfig(AvoidStarImportCheck.class);
         checkConfig.addAttribute("allowClassImports", "true");
         // allow all class star imports
-        final String[] expected2 = new String[] {
+        final String[] expected2 = {
             "25: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
             "26: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
             "28: " + getCheckMessage(MSG_KEY, "java.io.File.*"), };
@@ -84,7 +84,7 @@ public class AvoidStarImportTest
         final DefaultConfiguration checkConfig = createCheckConfig(AvoidStarImportCheck.class);
         checkConfig.addAttribute("allowStaticMemberImports", "true");
         // allow all static star imports
-        final String[] expected2 = new String[] {
+        final String[] expected2 = {
             "7: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.imports.*"),
             "9: " + getCheckMessage(MSG_KEY, "java.io.*"),
             "10: " + getCheckMessage(MSG_KEY, "java.lang.*"),
@@ -98,7 +98,7 @@ public class AvoidStarImportTest
         AvoidStarImportCheck testCheckObject =
                 new AvoidStarImportCheck();
         int[] actual = testCheckObject.getAcceptableTokens();
-        int[] expected = new int[]{TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
+        int[] expected = {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
         assertArrayEquals(expected, actual);
     }
 
@@ -107,7 +107,7 @@ public class AvoidStarImportTest
         AvoidStarImportCheck testCheckObject =
                 new AvoidStarImportCheck();
         int[] actual = testCheckObject.getRequiredTokens();
-        int[] expected = new int[]{TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
+        int[] expected = {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
 
         assertArrayEquals(expected, actual);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportTest.java
@@ -36,7 +36,7 @@ public class AvoidStaticImportTest
     @Test
     public void testGetRequiredTokesn() {
         AvoidStaticImportCheck checkObj = new AvoidStaticImportCheck();
-        int[] expected = new int[] {TokenTypes.STATIC_IMPORT};
+        int[] expected = {TokenTypes.STATIC_IMPORT};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -137,7 +137,7 @@ public class AvoidStaticImportTest
         AvoidStaticImportCheck testCheckObject =
                 new AvoidStaticImportCheck();
         int[] actual = testCheckObject.getAcceptableTokens();
-        int[] expected = new int[]{TokenTypes.STATIC_IMPORT};
+        int[] expected = {TokenTypes.STATIC_IMPORT};
 
         assertArrayEquals(expected, actual);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -50,7 +50,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         CustomImportOrderCheck checkObj = new CustomImportOrderCheck();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.IMPORT,
             TokenTypes.STATIC_IMPORT,
             TokenTypes.PACKAGE_DEF,
@@ -322,7 +322,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         CustomImportOrderCheck testCheckObject =
                 new CustomImportOrderCheck();
         int[] actual = testCheckObject.getAcceptableTokens();
-        int[] expected = new int[]{
+        int[] expected = {
             TokenTypes.IMPORT,
             TokenTypes.STATIC_IMPORT,
             TokenTypes.PACKAGE_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/GuardTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/GuardTest.java
@@ -44,7 +44,7 @@ public class GuardTest {
     @Test
     public void testAccessResultValues() {
         AccessResult[] actual = AccessResult.values();
-        AccessResult[] expected = new AccessResult[] {
+        AccessResult[] expected = {
             AccessResult.ALLOWED,
             AccessResult.DISALLOWED,
             AccessResult.UNKNOWN,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
@@ -35,7 +35,7 @@ public class IllegalImportCheckTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         IllegalImportCheck checkObj = new  IllegalImportCheck();
-        int[] expected = new int[] {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
+        int[] expected = {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -72,7 +72,7 @@ public class IllegalImportCheckTest extends BaseCheckTestSupport {
         IllegalImportCheck testCheckObject =
                 new IllegalImportCheck();
         int[] actual = testCheckObject.getAcceptableTokens();
-        int[] expected = new int[]{TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
+        int[] expected = {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
 
         assertArrayEquals(expected, actual);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -39,7 +39,7 @@ public class ImportControlCheckTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         ImportControlCheck checkObj = new ImportControlCheck();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.PACKAGE_DEF,
             TokenTypes.IMPORT,
             TokenTypes.STATIC_IMPORT,
@@ -162,7 +162,7 @@ public class ImportControlCheckTest extends BaseCheckTestSupport {
         ImportControlCheck testCheckObject =
                 new ImportControlCheck();
         int[] actual = testCheckObject.getAcceptableTokens();
-        int[] expected = new int[]{
+        int[] expected = {
             TokenTypes.PACKAGE_DEF,
             TokenTypes.IMPORT,
             TokenTypes.STATIC_IMPORT,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckTest.java
@@ -38,7 +38,7 @@ public class RedundantImportCheckTest
     @Test
     public void testGetRequiredTokens() {
         RedundantImportCheck checkObj = new RedundantImportCheck();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.IMPORT,
             TokenTypes.STATIC_IMPORT,
             TokenTypes.PACKAGE_DEF,
@@ -81,7 +81,7 @@ public class RedundantImportCheckTest
         RedundantImportCheck testCheckObject =
                 new RedundantImportCheck();
         int[] actual = testCheckObject.getAcceptableTokens();
-        int[] expected = new int[]{
+        int[] expected = {
             TokenTypes.IMPORT,
             TokenTypes.STATIC_IMPORT,
             TokenTypes.PACKAGE_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -106,7 +106,7 @@ public class UnusedImportsCheckTest extends BaseCheckTestSupport {
         UnusedImportsCheck testCheckObject =
                 new UnusedImportsCheck();
         int[] actual = testCheckObject.getRequiredTokens();
-        int[] expected = new int[]{
+        int[] expected = {
             TokenTypes.IDENT,
             TokenTypes.IMPORT,
             TokenTypes.STATIC_IMPORT,
@@ -131,7 +131,7 @@ public class UnusedImportsCheckTest extends BaseCheckTestSupport {
         UnusedImportsCheck testCheckObject =
                 new UnusedImportsCheck();
         int[] actual = testCheckObject.getAcceptableTokens();
-        int[] expected = new int[]{
+        int[] expected = {
             TokenTypes.IDENT,
             TokenTypes.IMPORT,
             TokenTypes.STATIC_IMPORT,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
@@ -33,14 +33,14 @@ public class AtclauseOrderCheckTest extends BaseCheckTestSupport {
     @Test
     public void testGetAcceptableTokens() {
         AtclauseOrderCheck checkObj = new AtclauseOrderCheck();
-        int[] expected = new int[] {TokenTypes.BLOCK_COMMENT_BEGIN};
+        int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN};
         assertArrayEquals(expected, checkObj.getAcceptableTokens());
     }
 
     @Test
     public void testGetRequiredTokens() {
         AtclauseOrderCheck checkObj = new AtclauseOrderCheck();
-        int[] expected = new int[] {TokenTypes.BLOCK_COMMENT_BEGIN};
+        int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -52,7 +52,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
         JavadocMethodCheck javadocMethodCheck = new JavadocMethodCheck();
 
         int[] actual = javadocMethodCheck.getAcceptableTokens();
-        int[] expected = new int[]{
+        int[] expected = {
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
@@ -44,7 +44,7 @@ public class JavadocParagraphCheckTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         JavadocParagraphCheck checkObj = new JavadocParagraphCheck();
-        int[] expected = new int[] {TokenTypes.BLOCK_COMMENT_BEGIN};
+        int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -42,7 +42,7 @@ public class JavadocStyleCheckTest
     public void testGetRequiredTokens() {
         JavadocStyleCheck javadocStyleCheck = new JavadocStyleCheck();
         int[] actual = javadocStyleCheck.getRequiredTokens();
-        int[] expected = new int[]{
+        int[] expected = {
             TokenTypes.INTERFACE_DEF,
             TokenTypes.CLASS_DEF,
             TokenTypes.ANNOTATION_DEF,
@@ -62,7 +62,7 @@ public class JavadocStyleCheckTest
         JavadocStyleCheck javadocStyleCheck = new JavadocStyleCheck();
 
         int[] actual = javadocStyleCheck.getAcceptableTokens();
-        int[] expected = new int[]{
+        int[] expected = {
             TokenTypes.INTERFACE_DEF,
             TokenTypes.CLASS_DEF,
             TokenTypes.ANNOTATION_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -35,7 +35,7 @@ public class JavadocTagContinuationIndentationCheckTest
     public void testGetRequiredTokens() {
         JavadocTagContinuationIndentationCheck checkObj =
             new JavadocTagContinuationIndentationCheck();
-        int[] expected = new int[] {TokenTypes.BLOCK_COMMENT_BEGIN };
+        int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN };
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagTest.java
@@ -45,7 +45,7 @@ public class JavadocTagTest {
     public void testJavadocTagTypeValues() {
         JavadocUtils.JavadocTagType[] enumConstants =
             JavadocUtils.JavadocTagType.values();
-        JavadocUtils.JavadocTagType[] expected = new JavadocUtils.JavadocTagType[] {
+        JavadocUtils.JavadocTagType[] expected = {
             JavadocUtils.JavadocTagType.BLOCK,
             JavadocUtils.JavadocTagType.INLINE,
             JavadocUtils.JavadocTagType.ALL,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -48,7 +48,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         JavadocTypeCheck javadocTypeCheck = new JavadocTypeCheck();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.INTERFACE_DEF,
             TokenTypes.CLASS_DEF,
             TokenTypes.ENUM_DEF,
@@ -62,7 +62,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
         JavadocTypeCheck javadocTypeCheck = new JavadocTypeCheck();
 
         int[] actual = javadocTypeCheck.getAcceptableTokens();
-        int[] expected = new int[]{
+        int[] expected = {
             TokenTypes.INTERFACE_DEF,
             TokenTypes.CLASS_DEF,
             TokenTypes.ENUM_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
@@ -38,7 +38,7 @@ public class JavadocVariableCheckTest
     public void testGetRequiredTokens() {
         JavadocVariableCheck javadocVariableCheck = new JavadocVariableCheck();
         int[] actual = javadocVariableCheck.getRequiredTokens();
-        int[] expected = new int[]{
+        int[] expected = {
             TokenTypes.VARIABLE_DEF,
         };
         assertArrayEquals(expected, actual);
@@ -49,7 +49,7 @@ public class JavadocVariableCheckTest
         JavadocVariableCheck javadocVariableCheck = new JavadocVariableCheck();
 
         int[] actual = javadocVariableCheck.getAcceptableTokens();
-        int[] expected = new int[]{
+        int[] expected = {
             TokenTypes.VARIABLE_DEF,
             TokenTypes.ENUM_CONSTANT_DEF,
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckTest.java
@@ -35,7 +35,7 @@ public class NonEmptyAtclauseDescriptionCheckTest
     public void testGetAcceptableTokens() {
         NonEmptyAtclauseDescriptionCheck checkObj =
             new NonEmptyAtclauseDescriptionCheck();
-        int[] expected = new int[] {TokenTypes.BLOCK_COMMENT_BEGIN};
+        int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN};
         assertArrayEquals(expected, checkObj.getAcceptableTokens());
     }
 
@@ -43,7 +43,7 @@ public class NonEmptyAtclauseDescriptionCheckTest
     public void testGetRequiredTokens() {
         NonEmptyAtclauseDescriptionCheck checkObj =
             new NonEmptyAtclauseDescriptionCheck();
-        int[] expected = new int[] {TokenTypes.BLOCK_COMMENT_BEGIN};
+        int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheckTest.java
@@ -33,14 +33,14 @@ public class SingleLineJavadocCheckTest extends BaseCheckTestSupport {
     @Test
     public void testAcceptableTokens() {
         SingleLineJavadocCheck checkObj = new SingleLineJavadocCheck();
-        int[] expected = new int[] {TokenTypes.BLOCK_COMMENT_BEGIN };
+        int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN };
         assertArrayEquals(expected, checkObj.getAcceptableTokens());
     }
 
     @Test
     public void testGetRequiredTokens() {
         SingleLineJavadocCheck checkObj = new SingleLineJavadocCheck();
-        int[] expected = new int[] {TokenTypes.BLOCK_COMMENT_BEGIN };
+        int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN };
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -42,7 +42,7 @@ public class SummaryJavadocCheckTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         SummaryJavadocCheck checkObj = new SummaryJavadocCheck();
-        int[] expected = new int[] {TokenTypes.BLOCK_COMMENT_BEGIN };
+        int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN };
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -83,7 +83,7 @@ public class ClassFanOutComplexityCheckTest extends BaseCheckTestSupport {
     public void testGetAcceptableTokens() {
         ClassFanOutComplexityCheck classFanOutComplexityCheckObj = new ClassFanOutComplexityCheck();
         int[] actual = classFanOutComplexityCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.PACKAGE_DEF,
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheckTest.java
@@ -57,7 +57,7 @@ public class CyclomaticComplexityCheckTest
     public void testGetAcceptableTokens() {
         CyclomaticComplexityCheck cyclomaticComplexityCheckObj = new CyclomaticComplexityCheck();
         int[] actual = cyclomaticComplexityCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.CTOR_DEF,
             TokenTypes.METHOD_DEF,
             TokenTypes.INSTANCE_INIT,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckTest.java
@@ -89,7 +89,7 @@ public class JavaNCSSCheckTest extends BaseCheckTestSupport {
     public void testGetAcceptableTokens() {
         JavaNCSSCheck javaNcssCheckObj = new JavaNCSSCheck();
         int[] actual = javaNcssCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.METHOD_DEF,
@@ -127,7 +127,7 @@ public class JavaNCSSCheckTest extends BaseCheckTestSupport {
     public void testGetRequiredTokens() {
         JavaNCSSCheck javaNcssCheckObj = new JavaNCSSCheck();
         int[] actual = javaNcssCheckObj.getRequiredTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.METHOD_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -92,7 +92,7 @@ public class NPathComplexityCheckTest extends BaseCheckTestSupport {
     public void testGetAcceptableTokens() {
         NPathComplexityCheck npathComplexityCheckObj = new NPathComplexityCheck();
         int[] actual = npathComplexityCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.CTOR_DEF,
             TokenTypes.METHOD_DEF,
             TokenTypes.STATIC_INIT,
@@ -116,7 +116,7 @@ public class NPathComplexityCheckTest extends BaseCheckTestSupport {
     public void testGetRequiredTokens() {
         NPathComplexityCheck npathComplexityCheckObj = new NPathComplexityCheck();
         int[] actual = npathComplexityCheckObj.getRequiredTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.CTOR_DEF,
             TokenTypes.METHOD_DEF,
             TokenTypes.INSTANCE_INIT,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
@@ -38,7 +38,7 @@ public class ModifierOrderCheckTest
     @Test
     public void testGetRequiredTokens() {
         ModifierOrderCheck checkObj = new ModifierOrderCheck();
-        int[] expected = new int[] {TokenTypes.MODIFIERS};
+        int[] expected = {TokenTypes.MODIFIERS};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -72,9 +72,9 @@ public class ModifierOrderCheckTest
     public void testGetDefaultTokens() {
         ModifierOrderCheck modifierOrderCheckObj = new ModifierOrderCheck();
         int[] actual = modifierOrderCheckObj.getDefaultTokens();
-        int[] expected = new int[] {TokenTypes.MODIFIERS};
-        int[] unexpectedEmptyArray = new int[] {};
-        int[] unexpectedArray = new int[] {
+        int[] expected = {TokenTypes.MODIFIERS};
+        int[] unexpectedEmptyArray = {};
+        int[] unexpectedArray = {
             TokenTypes.MODIFIERS,
             TokenTypes.OBJBLOCK,
         };
@@ -88,9 +88,9 @@ public class ModifierOrderCheckTest
     public void testGetAcceptableTokens() {
         ModifierOrderCheck modifierOrderCheckObj = new ModifierOrderCheck();
         int[] actual = modifierOrderCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {TokenTypes.MODIFIERS};
-        int[] unexpectedEmptyArray = new int[] {};
-        int[] unexpectedArray = new int[] {
+        int[] expected = {TokenTypes.MODIFIERS};
+        int[] unexpectedEmptyArray = {};
+        int[] unexpectedArray = {
             TokenTypes.MODIFIERS,
             TokenTypes.OBJBLOCK,
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierTest.java
@@ -107,7 +107,7 @@ public class RedundantModifierTest
     public void testGetAcceptableTokens() {
         RedundantModifierCheck redundantModifierCheckObj = new RedundantModifierCheck();
         int[] actual = redundantModifierCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.METHOD_DEF,
             TokenTypes.VARIABLE_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,
@@ -123,7 +123,7 @@ public class RedundantModifierTest
     public void testGetRequiredTokens() {
         RedundantModifierCheck redundantModifierCheckObj = new RedundantModifierCheck();
         int[] actual = redundantModifierCheckObj.getRequiredTokens();
-        int[] expected = new int[] {};
+        int[] expected = {};
         Assert.assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckTest.java
@@ -99,7 +99,7 @@ public class AbstractClassNameCheckTest extends BaseCheckTestSupport {
     public void testGetAcceptableTokens() {
         AbstractClassNameCheck classNameCheckObj = new AbstractClassNameCheck();
         int[] actual = classNameCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.CLASS_DEF,
         };
         Assert.assertArrayEquals(expected, actual);
@@ -109,7 +109,7 @@ public class AbstractClassNameCheckTest extends BaseCheckTestSupport {
     public void testGetRequiredTokens() {
         AbstractClassNameCheck classNameCheckObj = new AbstractClassNameCheck();
         int[] actual = classNameCheckObj.getRequiredTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.CLASS_DEF,
         };
         Assert.assertArrayEquals(expected, actual);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
@@ -39,7 +39,7 @@ public class ConstantNameCheckTest
     @Test
     public void testGetRequiredTokens() {
         ConstantNameCheck checkObj = new ConstantNameCheck();
-        int[] expected = new int[] {TokenTypes.VARIABLE_DEF};
+        int[] expected = {TokenTypes.VARIABLE_DEF};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -152,7 +152,7 @@ public class ConstantNameCheckTest
     public void testGetAcceptableTokens() {
         ConstantNameCheck constantNameCheckObj = new ConstantNameCheck();
         int[] actual = constantNameCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.VARIABLE_DEF,
         };
         Assert.assertNotNull(actual);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckTest.java
@@ -81,7 +81,7 @@ public class LocalFinalVariableNameCheckTest
     public void testGetAcceptableTokens() {
         LocalFinalVariableNameCheck localFinalVariableNameCheckObj = new LocalFinalVariableNameCheck();
         int[] actual = localFinalVariableNameCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.VARIABLE_DEF,
             TokenTypes.PARAMETER_DEF,
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheckTest.java
@@ -36,7 +36,7 @@ public class MemberNameCheckTest
     @Test
     public void testGetRequiredTokens() {
         MemberNameCheck checkObj = new MemberNameCheck();
-        int[] expected = new int[] {TokenTypes.VARIABLE_DEF};
+        int[] expected = {TokenTypes.VARIABLE_DEF};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -252,7 +252,7 @@ public class MemberNameCheckTest
     public void testGetAcceptableTokens() {
         MemberNameCheck memberNameCheckObj = new MemberNameCheck();
         int[] actual = memberNameCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.VARIABLE_DEF,
         };
         assertArrayEquals(expected, actual);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
@@ -35,7 +35,7 @@ public class MethodNameCheckTest
     @Test
     public void testGetRequiredTokens() {
         MethodNameCheck checkObj = new MethodNameCheck();
-        int[] expected = new int[] {TokenTypes.METHOD_DEF};
+        int[] expected = {TokenTypes.METHOD_DEF};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -150,7 +150,7 @@ public class MethodNameCheckTest
     public void testGetAcceptableTokens() {
         MethodNameCheck methodNameCheckObj = new MethodNameCheck();
         int[] actual = methodNameCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.METHOD_DEF,
         };
         assertArrayEquals(expected, actual);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheckTest.java
@@ -34,7 +34,7 @@ public class PackageNameCheckTest
     @Test
     public void testGetRequiredTokens() {
         PackageNameCheck checkObj = new PackageNameCheck();
-        int[] expected = new int[] {TokenTypes.PACKAGE_DEF};
+        int[] expected = {TokenTypes.PACKAGE_DEF};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -67,7 +67,7 @@ public class PackageNameCheckTest
     public void testGetAcceptableTokens() {
         PackageNameCheck packageNameCheckObj = new PackageNameCheck();
         int[] actual = packageNameCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.PACKAGE_DEF,
         };
         assertArrayEquals(expected, actual);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -34,7 +34,7 @@ public class ParameterNameCheckTest
     @Test
     public void testGetRequiredTokens() {
         ParameterNameCheck checkObj = new ParameterNameCheck();
-        int[] expected = new int[] {TokenTypes.PARAMETER_DEF};
+        int[] expected = {TokenTypes.PARAMETER_DEF};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -80,7 +80,7 @@ public class ParameterNameCheckTest
     public void testGetAcceptableTokens() {
         ParameterNameCheck parameterNameCheckObj = new ParameterNameCheck();
         int[] actual = parameterNameCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.PARAMETER_DEF,
         };
         assertArrayEquals(expected, actual);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheckTest.java
@@ -36,7 +36,7 @@ public class StaticVariableNameCheckTest
     @Test
     public void testGetRequiredTokens() {
         StaticVariableNameCheck checkObj = new StaticVariableNameCheck();
-        int[] excpected = new int[] {TokenTypes.VARIABLE_DEF};
+        int[] excpected = {TokenTypes.VARIABLE_DEF};
         assertArrayEquals(excpected, checkObj.getRequiredTokens());
     }
 
@@ -84,7 +84,7 @@ public class StaticVariableNameCheckTest
     public void testGetAcceptableTokens() {
         StaticVariableNameCheck staticVariableNameCheckObj = new StaticVariableNameCheck();
         int[] actual = staticVariableNameCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.VARIABLE_DEF,
         };
         assertArrayEquals(expected, actual);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeParameterNameTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeParameterNameTest.java
@@ -37,7 +37,7 @@ public class TypeParameterNameTest
     public void testGetInterfaceRequiredTokens() {
         InterfaceTypeParameterNameCheck checkObj =
             new InterfaceTypeParameterNameCheck();
-        int[] expected = new int[] {TokenTypes.TYPE_PARAMETER};
+        int[] expected = {TokenTypes.TYPE_PARAMETER};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -45,7 +45,7 @@ public class TypeParameterNameTest
     public void testGetMethodRequiredTokens() {
         MethodTypeParameterNameCheck checkObj =
             new MethodTypeParameterNameCheck();
-        int[] expected = new int[] {TokenTypes.TYPE_PARAMETER};
+        int[] expected = {TokenTypes.TYPE_PARAMETER};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -53,7 +53,7 @@ public class TypeParameterNameTest
     public void testGetClassRequiredTokens() {
         ClassTypeParameterNameCheck checkObj =
             new ClassTypeParameterNameCheck();
-        int[] expected = new int[] {TokenTypes.TYPE_PARAMETER};
+        int[] expected = {TokenTypes.TYPE_PARAMETER};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -162,7 +162,7 @@ public class TypeParameterNameTest
     public void testGetAcceptableTokens() {
         AbstractTypeParameterNameCheck typeParameterNameCheckObj = new ClassTypeParameterNameCheck();
         int[] actual = typeParameterNameCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.TYPE_PARAMETER,
         };
         assertArrayEquals(expected, actual);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/AnonInnerLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/AnonInnerLengthCheckTest.java
@@ -37,7 +37,7 @@ public class AnonInnerLengthCheckTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         AnonInnerLengthCheck checkObj = new AnonInnerLengthCheck();
-        int[] expected = new int[] {TokenTypes.LITERAL_NEW};
+        int[] expected = {TokenTypes.LITERAL_NEW};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -46,7 +46,7 @@ public class AnonInnerLengthCheckTest extends BaseCheckTestSupport {
         AnonInnerLengthCheck anonInnerLengthCheckObj =
                 new AnonInnerLengthCheck();
         int[] actual = anonInnerLengthCheckObj.getAcceptableTokens();
-        int[] expected = new int[]{TokenTypes.LITERAL_NEW};
+        int[] expected = {TokenTypes.LITERAL_NEW};
 
         assertArrayEquals(expected, actual);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheckTest.java
@@ -37,7 +37,7 @@ public class MethodCountCheckTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         MethodCountCheck checkObj = new MethodCountCheck();
-        int[] expected = new int[] {TokenTypes.METHOD_DEF};
+        int[] expected = {TokenTypes.METHOD_DEF};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckTest.java
@@ -33,7 +33,7 @@ public class OuterTypeNumberCheckTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         OuterTypeNumberCheck checkObj = new OuterTypeNumberCheck();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
@@ -44,7 +44,7 @@ public class EmptyForInitializerPadCheckTest
     @Test
     public void testGetRequiredTokens() {
         EmptyForInitializerPadCheck checkObj = new EmptyForInitializerPadCheck();
-        int[] expected = new int[] {TokenTypes.FOR_INIT};
+        int[] expected = {TokenTypes.FOR_INIT};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -69,7 +69,7 @@ public class EmptyForInitializerPadCheckTest
     public void testGetAcceptableTokens() {
         EmptyForInitializerPadCheck emptyForInitializerPadCheckObj = new EmptyForInitializerPadCheck();
         int[] actual = emptyForInitializerPadCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.FOR_INIT,
         };
         Assert.assertArrayEquals(expected, actual);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
@@ -42,7 +42,7 @@ public class EmptyForIteratorPadCheckTest
     @Test
     public void testGetRequiredTokens() {
         EmptyForIteratorPadCheck checkObj = new EmptyForIteratorPadCheck();
-        int[] expected = new int[] {TokenTypes.FOR_ITERATOR};
+        int[] expected = {TokenTypes.FOR_ITERATOR};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -69,7 +69,7 @@ public class EmptyForIteratorPadCheckTest
     public void testGetAcceptableTokens() {
         EmptyForIteratorPadCheck emptyForIteratorPadCheckObj = new EmptyForIteratorPadCheck();
         int[] actual = emptyForIteratorPadCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.FOR_ITERATOR,
         };
         assertArrayEquals(expected, actual);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -126,7 +126,7 @@ public class EmptyLineSeparatorCheckTest
     public void testGetAcceptableTokens() {
         EmptyLineSeparatorCheck emptyLineSeparatorCheckObj = new EmptyLineSeparatorCheck();
         int[] actual = emptyLineSeparatorCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.PACKAGE_DEF,
             TokenTypes.IMPORT,
             TokenTypes.CLASS_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -56,7 +56,7 @@ public class GenericWhitespaceCheckTest
     @Test
     public void testGetRequiredTokens() {
         GenericWhitespaceCheck checkObj = new GenericWhitespaceCheck();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.GENERIC_START,
             TokenTypes.GENERIC_END,
         };
@@ -135,7 +135,7 @@ public class GenericWhitespaceCheckTest
     public void testGetAcceptableTokens() {
         GenericWhitespaceCheck genericWhitespaceCheckObj = new GenericWhitespaceCheck();
         int[] actual = genericWhitespaceCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.GENERIC_START,
             TokenTypes.GENERIC_END,
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
@@ -128,7 +128,7 @@ public class MethodParamPadCheckTest
     public void testGetAcceptableTokens() {
         MethodParamPadCheck methodParamPadCheckObj = new MethodParamPadCheck();
         int[] actual = methodParamPadCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.CTOR_DEF,
             TokenTypes.LITERAL_NEW,
             TokenTypes.METHOD_CALL,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
@@ -64,7 +64,7 @@ public class SeparatorWrapCheckTest
     public void testGetDefaultTokens() {
         SeparatorWrapCheck separatorWrapCheckObj = new SeparatorWrapCheck();
         int[] actual = separatorWrapCheckObj.getDefaultTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.DOT,
             TokenTypes.COMMA,
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheckTest.java
@@ -79,7 +79,7 @@ public class TypecastParenPadCheckTest
     public void testGetAcceptableTokens() {
         TypecastParenPadCheck typecastParenPadCheckObj = new TypecastParenPadCheck();
         int[] actual = typecastParenPadCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.RPAREN,
             TokenTypes.TYPECAST,
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundTest.java
@@ -227,7 +227,7 @@ public class WhitespaceAroundTest
     public void testGetAcceptableTokens() {
         WhitespaceAroundCheck whitespaceAroundCheckObj = new WhitespaceAroundCheck();
         int[] actual = whitespaceAroundCheckObj.getAcceptableTokens();
-        int[] expected = new int[] {
+        int[] expected = {
             TokenTypes.ASSIGN,
             TokenTypes.BAND,
             TokenTypes.BAND_ASSIGN,


### PR DESCRIPTION
Fixes `UnnecessaryConstantArrayCreationExpression` inspection violations in test code.

Description:
>Reports any constant new array expression which can be replaced with an array initializer. Array initializers omit the type declaration because that is already specified by the declaration of the variable the expression is assigned to.