### PR TITLE
Remove unnecessarily qualified statically imported elements. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -32,7 +32,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.SortedSet;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -92,7 +91,7 @@ public class UniquePropertiesCheckTest extends BaseFileSetCheckTestSupport {
         final int stringNumber =
                 UniquePropertiesCheck.getLineNumber(testStrings,
                         "some key");
-        Assert.assertEquals(0, stringNumber);
+        assertEquals(0, stringNumber);
     }
 
     /**
@@ -107,15 +106,15 @@ public class UniquePropertiesCheckTest extends BaseFileSetCheckTestSupport {
         final File file = new File(fileName);
         final SortedSet<LocalizedMessage> messages =
                 check.process(file, Collections.<String>emptyList());
-        Assert.assertEquals("Wrong messages count: " + messages.size(),
+        assertEquals("Wrong messages count: " + messages.size(),
                 1, messages.size());
         final LocalizedMessage message = messages.iterator().next();
         final String retrievedMessage = messages.iterator().next().getKey();
-        Assert.assertEquals("Message key '" + retrievedMessage
-                + "' is not valid", "unable.open.cause",
+        assertEquals("Message key '" + retrievedMessage
+                        + "' is not valid", "unable.open.cause",
                 retrievedMessage);
-        Assert.assertEquals("Message '" + message.getMessage()
-                + "' is not valid", message.getMessage(),
+        assertEquals("Message '" + message.getMessage()
+                        + "' is not valid", message.getMessage(),
                 getCheckMessage(IO_EXCEPTION_KEY, fileName, getFileNotFoundDetail(file)));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
@@ -78,7 +78,7 @@ public class ModifierOrderCheckTest
             TokenTypes.MODIFIERS,
             TokenTypes.OBJBLOCK,
         };
-        Assert.assertArrayEquals(expected, actual);
+        assertArrayEquals(expected, actual);
         Assert.assertNotSame(unexpectedEmptyArray, actual);
         Assert.assertNotSame(unexpectedArray, actual);
         Assert.assertNotNull(actual);
@@ -94,7 +94,7 @@ public class ModifierOrderCheckTest
             TokenTypes.MODIFIERS,
             TokenTypes.OBJBLOCK,
         };
-        Assert.assertArrayEquals(expected, actual);
+        assertArrayEquals(expected, actual);
         Assert.assertNotSame(unexpectedEmptyArray, actual);
         Assert.assertNotSame(unexpectedArray, actual);
         Assert.assertNotNull(actual);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
@@ -156,6 +156,6 @@ public class ConstantNameCheckTest
             TokenTypes.VARIABLE_DEF,
         };
         Assert.assertNotNull(actual);
-        Assert.assertArrayEquals(expected, actual);
+        assertArrayEquals(expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
@@ -24,7 +24,6 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitiali
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -72,7 +71,7 @@ public class EmptyForInitializerPadCheckTest
         int[] expected = new int[] {
             TokenTypes.FOR_INIT,
         };
-        Assert.assertArrayEquals(expected, actual);
+        assertArrayEquals(expected, actual);
     }
 
     /* Additional test for jacoco, since valueOf()


### PR DESCRIPTION
Fixes `UnnecessarilyQualifiedStaticallyImportedElement` inspection violations in test code.

Description:
>Reports any references to static members which are statically imported and also qualified with their containing class name. Because the elements are already statically imported such qualification is unnecessary and can be removed.