### PR TITLE
Remove unnecessary this in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -264,9 +264,8 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testAcceptNullFileContents() {
         final LocalizedMessage message =
-            new LocalizedMessage(1, 1,
-                "messages.properties", "key", null, SeverityLevel.ERROR, null,
-                this.getClass(), null);
+            new LocalizedMessage(1, 1, "messages.properties", "key", null, SeverityLevel.ERROR,
+                    null, getClass(), null);
         final AuditEvent auditEvent = new AuditEvent(this, "Test.java", message);
         SuppressWithNearbyCommentFilter filter = new SuppressWithNearbyCommentFilter();
         Assert.assertTrue(filter.accept(auditEvent));


### PR DESCRIPTION
Fixes `UnnecessaryThis` inspection violations in test code.

Description:
>Reports on any unnecessary uses of this in the code. Using this to disambiguate a code reference may easily become unnecessary via automatic refactorings, and is discouraged by many coding styles.