### PR TITLE
Remove unnecessary toString() call in test code. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -72,7 +72,7 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 				absoluteRootPath.lastIndexOf("src"));
 		for (File file : files) {
 			if (file.toString().endsWith(aFileName+".java")) {
-				return rootPath + file.toString();
+				return rootPath + file;
 			}
 		}
 		return null;


### PR DESCRIPTION
Fixes `UnnecessaryToStringCall` inspection violations in test code.

Description:
>Reports on any calls to toString() used in string concatenations and as arguments to the print() and println() methods of java.io.PrintWriter and java.io.PrintStream, the append() method of java.lang.StringBuilder and java.lang.StringBuffer or the trace(), debug(), info(), warn() and error() methods of org.slf4j.Logger. In these cases the conversion to string will be handled by the underlying library methods and an explicit call to toString() is no needed.
Note that without the toString() call the expression will have slightly different semantics (the string null will be used instead of throwing a NullPointerException).