### PR TITLE
Issue #1566: Class 'AbstractCellEditor' must be declared as 'abstract'

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/AbstractCellEditor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/AbstractCellEditor.java
@@ -37,7 +37,7 @@ import javax.swing.event.EventListenerList;
  *
  * @author Philip Milne
  */
-public class AbstractCellEditor implements CellEditor {
+public abstract class AbstractCellEditor implements CellEditor {
 
     /**
      * A list of event listeners for the cell editor.


### PR DESCRIPTION
The rest of such violations are in our `suppressions.xml`:
```xml
    <!-- Can not change API -->
    <suppress checks="AbstractClassNameCheck"
              files="Check.java"/>

    <!-- 'Abstract' pattern is used to show it is checking for abstract class name -->
    <suppress checks="AbstractClassNameCheck"
              files="AbstractClassNameCheck.java"/>
```