### PR TITLE
Create new instance using constructor in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -339,7 +339,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         try {
             Class<?> clazz = Class.forName(
                     "com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck");
-            Object t = clazz.newInstance();
+            Object t = clazz.getConstructor().newInstance();
             Method method = clazz.getDeclaredMethod("getFullImportIdent", DetailAST.class);
             method.setAccessible(true);
             actual = method.invoke(t, (DetailAST) null);


### PR DESCRIPTION
Fixes `ClassNewInstance` inspection violations in test code.

Description:
>Reports any calls to java.lang.Class.newInstance(). The newInstance method propagates any exception thrown by the no-arg constructor, including checked exceptions. Use of this method effectively bypasses the compile-time exception checking that would otherwise be performed by the compiler. Replacing such a method call with a call to the java.lang.reflect.Constructor.newInstance() method avoids this problem by wrapping any exception thrown by the constructor in a java.lang.reflect.InvocationTargetException.