### PR TITLE
Remove usage of null as argument to varagrs in test code. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigValidationTest.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigValidationTest.java
@@ -1,5 +1,6 @@
 package com.google.checkstyle.test.base;
 
+import static org.apache.commons.lang3.ArrayUtils.EMPTY_INTEGER_OBJECT_ARRAY;
 import static org.apache.commons.lang3.ArrayUtils.EMPTY_STRING_ARRAY;
 
 import java.io.File;
@@ -24,6 +25,7 @@ public class ConfigValidationTest extends BaseCheckTestSupport {
         
         //runs over all input files;
         //as severity level is "warning", no errors expected
-        verify(checker, files.toArray(new File[files.size()]), "", EMPTY_STRING_ARRAY, null);
+        verify(checker, files.toArray(new File[files.size()]), "",
+                EMPTY_STRING_ARRAY, EMPTY_INTEGER_OBJECT_ARRAY);
     }
 }


### PR DESCRIPTION
Fixes `NullArgumentToVariableArgMethod` inspection violations in test code.

Description:
>Reports any calls to a variable-argument method which has a null in the variable-argument position (e.g System.out.printf("%s", null) ). Such a null argument may be confusing, as it is not wrapped as a single-element array, as may be expected.