### PR TITLE
Use ignored results of calling methods in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck.MSG_KEY;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Assert;
@@ -85,7 +86,7 @@ public class TrailingCommentCheckTest extends BaseCheckTestSupport {
             Assert.fail();
         }
         catch (IllegalStateException ex) {
-            "visitToken() shouldn't be called.".equals(ex.getMessage());
+            assertEquals("visitToken() shouldn't be called.", ex.getMessage());
         }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck.MSG_KEY;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -102,7 +103,7 @@ public class UncommentedMainCheckTest
             Assert.fail();
         }
         catch (IllegalStateException ex) {
-            ast.toString().equals(ex.getMessage());
+            assertEquals(ast.toString(), ex.getMessage());
         }
 
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleTest.java
@@ -25,6 +25,7 @@ import static com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseSty
 import static com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING;
 import static com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 
@@ -263,7 +264,7 @@ public class AnnotationUseStyleTest extends BaseCheckTestSupport {
             check.setElementStyle("SHOULD_PRODUCE_ERROR");
         }
         catch (ConversionException ex) {
-            ex.getMessage().startsWith("unable to parse");
+            assertTrue(ex.getMessage().startsWith("unable to parse"));
             return;
         }
 


### PR DESCRIPTION
Fixes `IgnoreResultOfCall` inspection violations in test code.

Description:
>Reports any calls to specific methods where the result of that call is ignored. Both methods specified in the inspection's settings and methods annotated with org.jetbrains.annotations.Contract(pure=true) are checked. For many methods, ignoring the result is perfectly legitimate, but for some methods it is almost certainly an error. Examples of methods where ignoring the result of a call is likely to be an error include java.io.inputStream.read(), which returns the number of bytes actually read, any method on java.lang.String or java.math.BigInteger, as all of those methods are side-effect free and thus pointless if ignored.