### PR TITLE
Inline calls to simple getters. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -251,7 +251,7 @@ public final class ConfigurationLoader {
                 new ConfigurationLoader(overridePropsResolver,
                                         omitIgnoredModules);
             loader.parseInputSource(configSource);
-            return loader.getConfiguration();
+            return loader.configuration;
         }
         catch (final SAXParseException e) {
             throw new CheckstyleException("unable to parse configuration stream"
@@ -261,14 +261,6 @@ public final class ConfigurationLoader {
         catch (final ParserConfigurationException | IOException | SAXException e) {
             throw new CheckstyleException("unable to parse configuration stream", e);
         }
-    }
-
-    /**
-     * Returns the configuration in the last file parsed.
-     * @return Configuration object
-     */
-    private Configuration getConfiguration() {
-        return configuration;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -67,7 +67,7 @@ public final class DefaultConfiguration implements Configuration {
     public String getAttribute(String attributeName) throws CheckstyleException {
         if (!attributeMap.containsKey(attributeName)) {
             throw new CheckstyleException(
-                    "missing key '" + attributeName + "' in " + getName());
+                    "missing key '" + attributeName + "' in " + name);
         }
         return attributeMap.get(attributeName);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -76,15 +76,6 @@ public final class PackageNamesLoader
         super(DTD_PUBLIC_ID, DTD_RESOURCE_NAME);
     }
 
-    /**
-     * Returns the set of fully qualified package names this
-     * this loader processed.
-     * @return the set of package names
-     */
-    private Set<String> getPackageNames() {
-        return packageNames;
-    }
-
     @Override
     public void startElement(String namespaceURI,
                              String localName,
@@ -162,7 +153,7 @@ public final class PackageNamesLoader
                 }
             }
 
-            result = namesLoader.getPackageNames();
+            result = namesLoader.packageNames;
 
         }
         catch (IOException e) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -321,7 +321,7 @@ public abstract class AbstractTypeAwareCheck extends Check {
                     final FullIdent name =
                         FullIdent.createFullIdentBelow(bounds);
                     final AbstractClassInfo ci =
-                        createClassInfo(new Token(name), getCurrentClassName());
+                        createClassInfo(new Token(name), currentClassName);
                     paramsMap.put(alias, ci);
                 }
             }
@@ -436,14 +436,10 @@ public abstract class AbstractTypeAwareCheck extends Check {
             this.surroundingClass = surroundingClass;
             this.check = check;
         }
-        /** @return if class is loadable ot not. */
-        private boolean isLoadable() {
-            return loadable;
-        }
 
         @Override
         public Class<?> getClazz() {
-            if (isLoadable() && classObj == null) {
+            if (loadable && classObj == null) {
                 setClazz(check.tryLoadClass(getName(), surroundingClass));
             }
             return classObj;
@@ -543,8 +539,8 @@ public abstract class AbstractTypeAwareCheck extends Check {
 
         @Override
         public String toString() {
-            return "Token[" + getText() + "(" + getLineNo()
-                + "x" + getColumnNo() + ")]";
+            return "Token[" + text + "(" + lineNo
+                + "x" + columnNo + ")]";
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -550,14 +550,6 @@ public class HiddenFieldCheck
         }
 
         /**
-         * Is this frame for static inner type.
-         * @return is this field frame for static inner type.
-         */
-        boolean isStaticType() {
-            return staticType;
-        }
-
-        /**
          * Adds an instance field to this FieldFrame.
          * @param field  the name of the instance field.
          */
@@ -581,7 +573,7 @@ public class HiddenFieldCheck
         public boolean containsInstanceField(String field) {
             return instanceFields.contains(field)
                     || parent != null
-                    && !isStaticType()
+                    && !staticType
                     && parent.containsInstanceField(field);
 
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -92,7 +92,7 @@ public class IllegalTokenTextCheck
     public void visitToken(DetailAST ast) {
         final String text = ast.getText();
         if (getRegexp().matcher(text).find()) {
-            String customMessage = getMessage();
+            String customMessage = message;
             if (customMessage.isEmpty()) {
                 customMessage = MSG_KEY;
             }
@@ -116,15 +116,6 @@ public class IllegalTokenTextCheck
         else {
             this.message = message;
         }
-    }
-
-    /**
-     * Getter for message property.
-     * @return custom message which should be used
-     * to report about violations.
-     */
-    public String getMessage() {
-        return message;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
@@ -94,14 +94,6 @@ public final class ThrowsCountCheck extends Check {
     }
 
     /**
-     * Getter for max property.
-     * @return maximum allowed throws statements.
-     */
-    public int getMax() {
-        return max;
-    }
-
-    /**
      * Sets whether private methods must be ignored.
      * @param ignorePrivateMethods whether private methods must be ignored.
      */
@@ -136,9 +128,9 @@ public final class ThrowsCountCheck extends Check {
                 && !isOverriding(ast)) {
             // Account for all the commas!
             final int count = (ast.getChildCount() + 1) / 2;
-            if (count > getMax()) {
+            if (count > max) {
                 log(ast.getLineNo(),  ast.getColumnNo(), MSG_KEY,
-                    count, getMax());
+                    count, max);
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -309,11 +309,6 @@ public class VisibilityModifierCheck
     private final List<String> immutableClassShortNames =
             getClassShortNames(DEFAULT_IMMUTABLE_TYPES);
 
-    /** @return whether protected members are allowed */
-    public boolean isProtectedAllowed() {
-        return protectedAllowed;
-    }
-
     /**
      * Set the list of ignore annotations.
      * @param annotationNames array of ignore annotations canonical names.
@@ -328,11 +323,6 @@ public class VisibilityModifierCheck
      */
     public void setProtectedAllowed(boolean protectedAllowed) {
         this.protectedAllowed = protectedAllowed;
-    }
-
-    /** @return whether package visible members are allowed */
-    public boolean isPackageAllowed() {
-        return packageAllowed;
     }
 
     /**
@@ -353,13 +343,6 @@ public class VisibilityModifierCheck
     public void setPublicMemberPattern(String pattern) {
         publicMemberPattern = Utils.createPattern(pattern);
         publicMemberFormat = pattern;
-    }
-
-    /**
-     * @return the regexp for public members to ignore.
-     */
-    private Pattern getPublicMemberRegexp() {
-        return publicMemberPattern;
     }
 
     /**
@@ -533,8 +516,8 @@ public class VisibilityModifierCheck
         if (!"private".equals(variableScope)) {
             result =
                 isStaticFinalVariable(variableDef)
-                || isPackageAllowed() && "package".equals(variableScope)
-                || isProtectedAllowed() && "protected".equals(variableScope)
+                || packageAllowed && "package".equals(variableScope)
+                || protectedAllowed && "protected".equals(variableScope)
                 || isIgnoredPublicMember(variableName, variableScope)
                    || allowPublicImmutableFields
                       && isImmutableFieldDefinedInFinalClass(variableDef);
@@ -561,7 +544,7 @@ public class VisibilityModifierCheck
      */
     private boolean isIgnoredPublicMember(String variableName, String variableScope) {
         return "public".equals(variableScope)
-            && getPublicMemberRegexp().matcher(variableName).find();
+            && publicMemberPattern.matcher(variableName).find();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControl.java
@@ -57,7 +57,7 @@ class PkgControl {
      */
     PkgControl(final PkgControl parent, final String subPkg) {
         this.parent = parent;
-        fullPackage = parent.getFullPackage() + "." + subPkg;
+        fullPackage = parent.fullPackage + "." + subPkg;
         parent.children.add(this);
     }
 
@@ -85,7 +85,7 @@ class PkgControl {
         // Check if we are a match.
         // This algormithm should be improved to check for a trailing "."
         // or nothing following.
-        if (!forPkg.startsWith(getFullPackage())) {
+        if (!forPkg.startsWith(fullPackage)) {
             return null;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -477,7 +477,7 @@ public abstract class AbstractExpressionHandler {
      */
     protected final void findSubtreeLines(LineSet lines, DetailAST tree,
         boolean allowNesting) {
-        if (getIndentCheck().getHandlerFactory().isHandledType(tree.getType())) {
+        if (indentCheck.getHandlerFactory().isHandledType(tree.getType())) {
             return;
         }
 
@@ -551,7 +551,7 @@ public abstract class AbstractExpressionHandler {
      * @return value of basicOffset property of {@code IndentationCheck}
      */
     protected final int getBasicOffset() {
-        return getIndentCheck().getBasicOffset();
+        return indentCheck.getBasicOffset();
     }
 
     /**
@@ -560,7 +560,7 @@ public abstract class AbstractExpressionHandler {
      *         of {@code IndentationCheck}
      */
     protected final int getBraceAdjustment() {
-        return getIndentCheck().getBraceAdjustment();
+        return indentCheck.getBraceAdjustment();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.java
@@ -70,11 +70,6 @@ public abstract class AbstractComplexityCheck
         };
     }
 
-    /** @return the maximum threshold allowed */
-    public final int getMax() {
-        return max;
-    }
-
     /**
      * Set the maximum threshold allowed.
      *
@@ -153,7 +148,7 @@ public abstract class AbstractComplexityCheck
      * @param by the amount to increment by
      */
     protected final void incrementCurrentValue(BigInteger by) {
-        currentValue = getCurrentValue().add(by);
+        currentValue = currentValue.add(by);
     }
 
     /** Push the current value on the stack */
@@ -181,7 +176,7 @@ public abstract class AbstractComplexityCheck
      * @param ast the token representing the method definition
      */
     private void leaveMethodDef(DetailAST ast) {
-        final BigInteger bigIntegerMax = BigInteger.valueOf(getMax());
+        final BigInteger bigIntegerMax = BigInteger.valueOf(max);
         if (currentValue.compareTo(bigIntegerMax) > 0) {
             log(ast, getMessageID(), currentValue, bigIntegerMax);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
@@ -171,21 +171,13 @@ class DetectorOptions {
     }
 
     /**
-     * Whether to ignore case when matching.
-     * @return whether to ignore case when matching.
-     */
-    public boolean isIgnoreCase() {
-        return ignoreCase;
-    }
-
-    /**
      * The pattern to use when matching.
      * @return the pattern to use when matching.
      */
     public Pattern getPattern() {
         int options = compileFlags;
 
-        if (isIgnoreCase()) {
+        if (ignoreCase) {
             options |= Pattern.CASE_INSENSITIVE;
         }
         return Pattern.compile(format, options);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
@@ -134,17 +134,6 @@ public class RegexpCheck extends AbstractFormatCheck {
     }
 
     /**
-     * Getter for message property.
-     * I'm not sure if this gets used by anything outside,
-     * I just included it because GenericIllegalRegexp had it,
-     * it's being used in logMessage() so it's covered in EMMA.
-     * @return custom message to be used in report.
-     */
-    public String getMessage() {
-        return message;
-    }
-
-    /**
      * Sets if matches within comments should be ignored.
      * @param ignoreComments True if comments should be ignored.
      */
@@ -275,7 +264,7 @@ public class RegexpCheck extends AbstractFormatCheck {
     private void logMessage(int lineNumber) {
         String msg;
 
-        if (getMessage().isEmpty()) {
+        if (message.isEmpty()) {
             msg = getFormat();
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -351,21 +351,6 @@ public class SuppressWithNearbyCommentFilter
             }
         }
 
-        /** @return the text of the tag. */
-        public String getText() {
-            return text;
-        }
-
-        /** @return the line number of the first suppressed line. */
-        public int getFirstLine() {
-            return firstLine;
-        }
-
-        /** @return the line number of the last suppressed line. */
-        public int getLastLine() {
-            return lastLine;
-        }
-
         /**
          * Compares the position of this tag in the file
          * with the position of another tag.
@@ -457,8 +442,8 @@ public class SuppressWithNearbyCommentFilter
 
         @Override
         public final String toString() {
-            return "Tag[lines=[" + getFirstLine() + " to " + getLastLine()
-                + "]; text='" + getText() + "']";
+            return "Tag[lines=[" + firstLine + " to " + lastLine
+                + "]; text='" + text + "']";
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -372,11 +372,6 @@ public class SuppressionCommentFilter
             }
         }
 
-        /** @return the text of the tag. */
-        public String getText() {
-            return text;
-        }
-
         /** @return the line number of the tag in the source file. */
         public int getLine() {
             return line;
@@ -484,8 +479,8 @@ public class SuppressionCommentFilter
 
         @Override
         public final String toString() {
-            return "Tag[line=" + getLine() + "; col=" + getColumn()
-                + "; on=" + isOn() + "; text='" + getText() + "']";
+            return "Tag[line=" + line + "; col=" + column
+                + "; on=" + on + "; text='" + text + "']";
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -77,14 +77,6 @@ public final class SuppressionsLoader
         super(createIdToResourceNameMap());
     }
 
-    /**
-     * Returns the loaded filter chain.
-     * @return the loaded filter chain.
-     */
-    public FilterSet getFilterChain() {
-        return filterChain;
-    }
-
     @Override
     public void startElement(String namespaceURI,
                              String localName,
@@ -180,7 +172,7 @@ public final class SuppressionsLoader
             final SuppressionsLoader suppressionsLoader =
                 new SuppressionsLoader();
             suppressionsLoader.parseInputSource(source);
-            return suppressionsLoader.getFilterChain();
+            return suppressionsLoader.filterChain;
         }
         catch (final FileNotFoundException e) {
             throw new CheckstyleException(UNABLE_TO_FIND_ERROR_MESSAGE + sourceName, e);


### PR DESCRIPTION
Fixes `CallToSimpleGetterInClass` inspection violations.

Description:
>Reports any calls to a simple property getter from within the property's class. A simple property getter is defined as one which simply returns the value of a field, and does no other calculation. Such simple getter calls may be safely inlined, at a small performance improvement. Some coding standards also suggest against the use of simple getters for code clarity reasons.