### PR TITLE
Invert negated if-else. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -328,11 +328,11 @@ public class LeftCurlyCheck
                                        String braceLine) {
         // not on the same line
         if (startToken.getLineNo() + 1 == brace.getLineNo()) {
-            if (!Utils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
-                log(brace, MSG_KEY_LINE_NEW, "{", brace.getColumnNo() + 1);
+            if (Utils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
+                log(brace, MSG_KEY_LINE_PREVIOUS, "{", brace.getColumnNo() + 1);
             }
             else {
-                log(brace, MSG_KEY_LINE_PREVIOUS, "{", brace.getColumnNo() + 1);
+                log(brace, MSG_KEY_LINE_NEW, "{", brace.getColumnNo() + 1);
             }
         }
         else if (!Utils.whitespaceBefore(brace.getColumnNo(), braceLine)) {


### PR DESCRIPTION
Fixes `NegatedIfElse` inspection violations.

Description:
>Reports if statements which contain else branches and whose conditions are negated. Flipping the order of the if and else branches will usually increase the clarity of such statements.