### PR TITLE
Remove unnecessary local variables. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -48,9 +48,7 @@ public abstract class BaseCheckTestSupport
 
     public static DefaultConfiguration createCheckConfig(Class<?> aClazz)
     {
-        final DefaultConfiguration checkConfig =
-            new DefaultConfiguration(aClazz.getName());
-        return checkConfig;
+        return new DefaultConfiguration(aClazz.getName());
     }
 
     protected Checker createChecker(Configuration aCheckConfig)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
@@ -226,8 +226,7 @@ public class InnerAssignmentCheck
             DetailAST current = ast;
             for (int anElement : element) {
                 current = current.getParent();
-                final int expectedType = anElement;
-                if (current.getType() == expectedType) {
+                if (current.getType() == anElement) {
                     found = true;
                 }
                 else {


### PR DESCRIPTION
Fixes `UnnecessaryLocalVariable` inspection violations.

Description:
>Reports unnecessary local variables, which add nothing to the comprehensibility of a method. Variables caught include local variables which are immediately returned, local variables that are immediately assigned to another variable and then not used, and local variables which always have the same value as another local variable or parameter.