### PR TITLE
Decrease scope of variables. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule485annotations/AnnotationLocationTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule485annotations/AnnotationLocationTest.java
@@ -25,11 +25,11 @@ public class AnnotationLocationTest extends BaseCheckTestSupport{
     public void annotationTest() throws IOException, Exception {
         
         Class<AnnotationLocationCheck> clazz = AnnotationLocationCheck.class;
-        String msgLocation = "annotation.location";
-        String msgLocationAlone = "annotation.location.alone";
         getCheckMessage(clazz, "annotation.location.alone");
         Configuration checkConfig = builder.getCheckConfig("AnnotationLocation");
 
+        String msgLocationAlone = "annotation.location.alone";
+        String msgLocation = "annotation.location";
         final String[] expected = {
             "3: " + getCheckMessage(clazz, msgLocationAlone, "MyAnnotation1"),
             "20: " + getCheckMessage(clazz, msgLocation, "MyAnnotation1", "8", "4"),

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
@@ -168,8 +168,6 @@ public class EmptyBlockCheck
      * @return whether the SLIST token contains any text.
      */
     protected boolean hasText(final DetailAST slistAST) {
-        boolean retVal = false;
-
         final DetailAST rightCurly = slistAST.findFirstToken(TokenTypes.RCURLY);
         final DetailAST rcurlyAST;
 
@@ -184,6 +182,7 @@ public class EmptyBlockCheck
         final int rcurlyLineNo = rcurlyAST.getLineNo();
         final int rcurlyColNo = rcurlyAST.getColumnNo();
         final String[] lines = getLines();
+        boolean retVal = false;
         if (slistLineNo == rcurlyLineNo) {
             // Handle braces on the same line
             final String txt = lines[slistLineNo - 1]

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
@@ -250,10 +250,9 @@ public final class MethodCountCheck extends Check {
          */
         int value(Scope scope) {
             final Integer value = counts.get(scope);
-            final int defaultValue = 0;
 
             if (value == null) {
-                return defaultValue;
+                return 0;
             }
             else {
                 return value;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
@@ -60,8 +60,8 @@ public class RegexpMultilineCheckTest extends BaseFileSetCheckTestSupport {
     public void testMessageProperty()
         throws Exception {
         final String illegal = "System\\.(out)|(err)\\.print(ln)?\\(";
-        final String message = "Bad line :(";
         checkConfig.addAttribute("format", illegal);
+        final String message = "Bad line :(";
         checkConfig.addAttribute("message", message);
         final String[] expected = {
             "69: " + message,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -214,10 +214,10 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
             loaderClass.getDeclaredMethod("loadSuppressions", InputSource.class, String.class);
         loadSuppressions.setAccessible(true);
 
-        String sourceName = "suppressions_none.xml";
         InputSource inputSource = new InputSource();
 
         thrown.expect(CheckstyleException.class);
+        String sourceName = "suppressions_none.xml";
         thrown.expectMessage("Unable to read " + sourceName);
 
         loadSuppressions.invoke(loaderClass, inputSource, sourceName);
@@ -269,10 +269,10 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
     @SuppressWarnings("unchecked")
     public void testloadSuppressionsURISyntaxException() throws Exception {
         URL configUrl = mock(URL.class);
-        String fileName = "suppressions_none.xml";
 
         when(configUrl.toURI()).thenThrow(URISyntaxException.class);
         mockStatic(SuppressionsLoader.class, Mockito.CALLS_REAL_METHODS);
+        String fileName = "suppressions_none.xml";
         when(SuppressionsLoader.class.getResource(fileName)).thenReturn(configUrl);
 
         try {


### PR DESCRIPTION
Fixes `TooBroadScope` inspection violations.

Description:
>Reports any variable declarations of which the scope can be narrowed. Especially useful for "Pascal style" declarations at the start of a method, but variables with too broad a scope are also often left over after refactorings.