### PR TITLE
Mark field as final. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -25,7 +25,7 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 
 	private final List<File> files = new ArrayList<>();
 
-	Configuration config;
+	final Configuration config;
 
 	URL url;
 


### PR DESCRIPTION
Fixes `CanBeFinal` inspection violations.

Description:
>This inspection reports all fields, methods or classes, found in the specified inspection scope, that may have a final modifier added to their declarations.