### PR TITLE
Use serializable type of field in serializable class. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -63,7 +63,7 @@ public class ParseTreeInfoPanel extends JPanel {
     private final JTextArea textArea;
     private File lastDirectory;
     private File currentFile;
-    private final Action reloadAction;
+    private final ReloadAction reloadAction;
     private final List<Integer>   linesToPosition  = new ArrayList<>();
 
     /**


### PR DESCRIPTION
Fixes `NonSerializableFieldInSerializableClass` inspection violation.

Description:
>Reports non-Serializable fields in Serializable classes. Such fields will result in runtime exceptions if the object is serialized. Fields declared transient or static are not reported, nor are fields of classes which have defined a writeObject method. For purposes of this inspection, fields with java.util.Collection or java.util.Map types are assumed to be Serializable, unless the types they are declared to contain are non-Serializable.