### PR TITLE
Remove calls to simple getters withing classes. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -69,12 +69,12 @@ public abstract class AbstractFileSetCheck
     @Override
     public final SortedSet<LocalizedMessage> process(File file,
                                                    List<String> lines) {
-        getMessageCollector().reset();
+        messageCollector.reset();
         // Process only what interested in
         if (Utils.fileExtensionMatches(file, fileExtensions)) {
             processFiltered(file, lines);
         }
-        return getMessageCollector().getMessages();
+        return messageCollector.getMessages();
     }
 
     @Override
@@ -148,16 +148,16 @@ public abstract class AbstractFileSetCheck
     @Override
     public final void log(int lineNo, int colNo, String key,
             Object... args) {
-        getMessageCollector().add(
-            new LocalizedMessage(lineNo,
-                                 colNo,
-                                 getMessageBundle(),
-                                 key,
-                                 args,
-                                 getSeverityLevel(),
-                                 getId(),
-                                 getClass(),
-                                 getCustomMessages().get(key)));
+        messageCollector.add(
+                new LocalizedMessage(lineNo,
+                        colNo,
+                        getMessageBundle(),
+                        key,
+                        args,
+                        getSeverityLevel(),
+                        getId(),
+                        getClass(),
+                        getCustomMessages().get(key)));
     }
 
     /**
@@ -167,9 +167,9 @@ public abstract class AbstractFileSetCheck
      * @param fileName the audited file
      */
     protected final void fireErrors(String fileName) {
-        final SortedSet<LocalizedMessage> errors = getMessageCollector()
+        final SortedSet<LocalizedMessage> errors = messageCollector
                 .getMessages();
-        getMessageCollector().reset();
+        messageCollector.reset();
         getMessageDispatcher().fireErrors(fileName, errors);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTagInfo.java
@@ -354,8 +354,8 @@ public enum JavadocTagInfo {
             new ImmutableMap.Builder<>();
 
         for (final JavadocTagInfo tag : JavadocTagInfo.values()) {
-            textToTagBuilder.put(tag.getText(), tag);
-            nameToTagBuilder.put(tag.getName(), tag);
+            textToTagBuilder.put(tag.text, tag);
+            nameToTagBuilder.put(tag.name, tag);
         }
 
         TEXT_TO_TAG = textToTagBuilder.build();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -350,14 +350,14 @@ public final class LocalizedMessage
 
     @Override
     public int compareTo(LocalizedMessage other) {
-        int result = Integer.compare(getLineNo(), other.getLineNo());
+        int result = Integer.compare(lineNo, other.lineNo);
 
-        if (getLineNo() == other.getLineNo()) {
-            if (getColumnNo() == other.getColumnNo()) {
+        if (lineNo == other.lineNo) {
+            if (columnNo == other.columnNo) {
                 result = getMessage().compareTo(other.getMessage());
             }
             else {
-                result = Integer.compare(getColumnNo(), other.getColumnNo());
+                result = Integer.compare(columnNo, other.columnNo);
             }
         }
         return result;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
@@ -85,14 +85,6 @@ public final class ExecutableStatementCountCheck
     }
 
     /**
-     * Gets the maximum threshold.
-     * @return the maximum threshold.
-     */
-    public int getMax() {
-        return max;
-    }
-
-    /**
      * Sets the maximum threshold.
      * @param max the maximum threshold.
      */
@@ -156,9 +148,9 @@ public final class ExecutableStatementCountCheck
      */
     private void leaveMemberDef(DetailAST ast) {
         final int count = context.getCount();
-        if (count > getMax()) {
+        if (count > max) {
             log(ast.getLineNo(), ast.getColumnNo(),
-                    MSG_KEY, count, getMax());
+                    MSG_KEY, count, max);
         }
         context = contextStack.pop();
     }


### PR DESCRIPTION
Fixes `CallToSimpleGetterInClass` inspection violations.

Description:
>Reports any calls to a simple property getter from within the property's class. A simple property getter is defined as one which simply returns the value of a field, and does no other calculation. Such simple getter calls may be safely inlined, at a small performance improvement. Some coding standards also suggest against the use of simple getters for code clarity reasons.