### PR TITLE
Mark fields as private static final in test code. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
@@ -15,11 +15,11 @@ import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
 
 public class CustomImportOrderTest extends BaseCheckTestSupport{
 
+    private static final String MSG_SEPARATOR = "custom.import.order.line.separator";
+    private static final String MSG_LEX = "custom.import.order.lex";
+    private static final String MSG_ORDER = "custom.import.order";
     static ConfigurationBuilder builder;
     final Class<CustomImportOrderCheck> clazz = CustomImportOrderCheck.class;
-    final String msgSeparator = "custom.import.order.line.separator";
-    final String msgLex = "custom.import.order.lex";
-    final String msgOrder = "custom.import.order";
     String msgNongroup = "custom.import.order.nongroup.import";
 
     /** Shortcuts to make code more compact */
@@ -35,17 +35,17 @@ public class CustomImportOrderTest extends BaseCheckTestSupport{
     public void customImportTest_1() throws IOException, Exception {
         
         final String[] expected = {
-            "4: " + getCheckMessage(clazz, msgLex, "java.awt.Button.ABORT", "java.io.File.createTempFile"),
-            "7: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.awt.Button"),
-            "8: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.awt.Frame"),
-            "9: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.awt.Dialog"),
-            "10: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.awt.event.ActionEvent"),
-            "11: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "javax.swing.JComponent"),
-            "12: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "javax.swing.JTable"),
-            "13: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.io.File"),
-            "14: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.io.IOException"),
-            "15: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.io.InputStream"),
-            "16: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.io.Reader"),
+            "4: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Button.ABORT", "java.io.File.createTempFile"),
+            "7: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.awt.Button"),
+            "8: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.awt.Frame"),
+            "9: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.awt.Dialog"),
+            "10: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.awt.event.ActionEvent"),
+            "11: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "javax.swing.JComponent"),
+            "12: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "javax.swing.JTable"),
+            "13: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.io.File"),
+            "14: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.io.IOException"),
+            "15: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.io.InputStream"),
+            "16: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.io.Reader"),
         };
         
         Configuration checkConfig = builder.getCheckConfig("CustomImportOrder");
@@ -59,14 +59,14 @@ public class CustomImportOrderTest extends BaseCheckTestSupport{
     public void customImportTest_2() throws IOException, Exception {
         
         final String[] expected = {
-            "4: " + getCheckMessage(clazz, msgLex, "java.awt.Button.ABORT", "java.io.File.createTempFile"),
-            "7: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.util.List"),
-            "8: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.util.StringTokenizer"),
-            "9: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.util.*"),
-            "10: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.util.concurrent.AbstractExecutorService"),
-            "11: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.util.concurrent.*"),
-            "14: " + getCheckMessage(clazz, msgSeparator, "com.sun.xml.internal.xsom.impl.scd.Iterators"),
-            "16: " + getCheckMessage(clazz, msgOrder, SPECIAL, STD, "com.google.common.reflect.*"),
+            "4: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Button.ABORT", "java.io.File.createTempFile"),
+            "7: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.List"),
+            "8: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.StringTokenizer"),
+            "9: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.*"),
+            "10: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.concurrent.AbstractExecutorService"),
+            "11: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.concurrent.*"),
+            "14: " + getCheckMessage(clazz, MSG_SEPARATOR, "com.sun.xml.internal.xsom.impl.scd.Iterators"),
+            "16: " + getCheckMessage(clazz, MSG_ORDER, SPECIAL, STD, "com.google.common.reflect.*"),
         };
 
         Configuration checkConfig = builder.getCheckConfig("CustomImportOrder");
@@ -80,13 +80,13 @@ public class CustomImportOrderTest extends BaseCheckTestSupport{
     public void customImportTest_3() throws IOException, Exception {
         
         final String[] expected = {
-                "4: " + getCheckMessage(clazz, msgLex, "java.awt.Button.ABORT", "java.io.File.createTempFile"),
-                "8: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.util.StringTokenizer"),
-                "9: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.util.*"),
-                "10: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.util.concurrent.AbstractExecutorService"),
-                "11: " + getCheckMessage(clazz, msgOrder, STD, SPECIAL, "java.util.concurrent.*"),
-                "14: " + getCheckMessage(clazz, msgSeparator, "com.sun.xml.internal.xsom.impl.scd.Iterators"),
-                "16: " + getCheckMessage(clazz, msgOrder, SPECIAL, STD, "com.google.common.reflect.*"),
+                "4: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Button.ABORT", "java.io.File.createTempFile"),
+                "8: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.StringTokenizer"),
+                "9: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.*"),
+                "10: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.concurrent.AbstractExecutorService"),
+                "11: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.concurrent.*"),
+                "14: " + getCheckMessage(clazz, MSG_SEPARATOR, "com.sun.xml.internal.xsom.impl.scd.Iterators"),
+                "16: " + getCheckMessage(clazz, MSG_ORDER, SPECIAL, STD, "com.google.common.reflect.*"),
         };
 
         Configuration checkConfig = builder.getCheckConfig("CustomImportOrder");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java
@@ -14,9 +14,9 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class PackageNameTest extends BaseCheckTestSupport{
 
+	private static final String MSG_KEY = "name.invalidPattern";
 	private static ConfigurationBuilder builder;
 	private static Configuration checkConfig;
-	private final String msgKey = "name.invalidPattern";
 	private static String format;
 
 
@@ -44,7 +44,7 @@ public class PackageNameTest extends BaseCheckTestSupport{
 
         String packagePath =
                 "com.google.checkstyle.test.chapter5naming.rule521packageNamesCamelCase";
-        String msg = getCheckMessage(checkConfig.getMessages(), msgKey, packagePath, format);
+        String msg = getCheckMessage(checkConfig.getMessages(), MSG_KEY, packagePath, format);
 
         final String[] expected = {
             "1:9: " + msg,
@@ -61,7 +61,7 @@ public class PackageNameTest extends BaseCheckTestSupport{
 
 
         String packagePath = "com.google.checkstyle.test.chapter5naming.rule521_packagenames";
-        String msg = getCheckMessage(checkConfig.getMessages(), msgKey, packagePath, format);
+        String msg = getCheckMessage(checkConfig.getMessages(), MSG_KEY, packagePath, format);
 
         final String[] expected = {
             "1:9: " + msg,
@@ -78,7 +78,7 @@ public class PackageNameTest extends BaseCheckTestSupport{
 
 
         String packagePath = "com.google.checkstyle.test.chapter5naming.rule521$packagenames";
-        String msg = getCheckMessage(checkConfig.getMessages(), msgKey, packagePath, format);
+        String msg = getCheckMessage(checkConfig.getMessages(), MSG_KEY, packagePath, format);
 
         final String[] expected = {
             "1:9: " + msg,

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java
@@ -14,7 +14,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 public class MemberNameTest extends BaseCheckTestSupport{
 
 	private static ConfigurationBuilder builder;
-	private final String msgKey = "name.invalidPattern";
+	private static final String MSG_KEY = "name.invalidPattern";
 	private static Configuration checkConfig;
 	private static String format;
 
@@ -29,19 +29,19 @@ public class MemberNameTest extends BaseCheckTestSupport{
     public void memberNameTest() throws Exception {
 
         final String[] expected = {
-            "5:16: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mPublic", format),
-            "6:19: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mProtected", format),
-            "7:9: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mPackage", format),
-            "8:17: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mPrivate", format),
-            "10:16: " + getCheckMessage(checkConfig.getMessages(), msgKey, "_public", format),
-            "11:19: " + getCheckMessage(checkConfig.getMessages(), msgKey, "prot_ected", format),
-            "12:9: " + getCheckMessage(checkConfig.getMessages(), msgKey, "package_", format),
-            "13:17: " + getCheckMessage(checkConfig.getMessages(), msgKey, "priva$te", format),
-            "20:9: " + getCheckMessage(checkConfig.getMessages(), msgKey, "ABC", format),
-            "21:15: " + getCheckMessage(checkConfig.getMessages(), msgKey, "C_D_E", format),
-            "23:16: " + getCheckMessage(checkConfig.getMessages(), msgKey, "$mPublic", format),
-            "24:19: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mPro$tected", format),
-            "25:9: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mPackage$", format),
+            "5:16: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mPublic", format),
+            "6:19: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mProtected", format),
+            "7:9: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mPackage", format),
+            "8:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mPrivate", format),
+            "10:16: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_public", format),
+            "11:19: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "prot_ected", format),
+            "12:9: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "package_", format),
+            "13:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "priva$te", format),
+            "20:9: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "ABC", format),
+            "21:15: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "C_D_E", format),
+            "23:16: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$mPublic", format),
+            "24:19: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mPro$tected", format),
+            "25:9: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mPackage$", format),
         };
 
         String filePath = builder.getFilePath("MemberNameInput_Basic");
@@ -54,38 +54,38 @@ public class MemberNameTest extends BaseCheckTestSupport{
     public void simpleTest() throws Exception {
 
         final String[] expected = {
-            "12:17: " + getCheckMessage(checkConfig.getMessages(), msgKey, "bad$Static", format),
-            "17:17: " + getCheckMessage(checkConfig.getMessages(), msgKey, "bad_Member", format),
-            "19:17: " + getCheckMessage(checkConfig.getMessages(), msgKey, "m", format),
-            "21:19: " + getCheckMessage(checkConfig.getMessages(), msgKey, "m_M", format),
-            "24:19: " + getCheckMessage(checkConfig.getMessages(), msgKey, "m$nts", format),
-            "35:9: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mTest1", format),
-            "37:16: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mTest2", format),
-            "39:16: " + getCheckMessage(checkConfig.getMessages(), msgKey, "$mTest2", format),
-            "41:16: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mTes$t2", format),
-            "43:16: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mTest2$", format),
-            "77:21: " + getCheckMessage(checkConfig.getMessages(), msgKey, "bad$Static", format),
-            "79:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "sum_Created", format),
-            "82:21: " + getCheckMessage(checkConfig.getMessages(), msgKey, "bad_Member", format),
-            "84:21: " + getCheckMessage(checkConfig.getMessages(), msgKey, "m", format),
-            "86:23: " + getCheckMessage(checkConfig.getMessages(), msgKey, "m_M", format),
-            "89:23: " + getCheckMessage(checkConfig.getMessages(), msgKey, "m$nts", format),
-            "93:13: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mTest1", format),
-            "95:20: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mTest2", format),
-            "97:20: " + getCheckMessage(checkConfig.getMessages(), msgKey, "$mTest2", format),
-            "99:20: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mTes$t2", format),
-            "101:20: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mTest2$", format),
-            "107:25: " + getCheckMessage(checkConfig.getMessages(), msgKey, "bad$Static", format),
-            "109:25: " + getCheckMessage(checkConfig.getMessages(), msgKey, "sum_Created", format),
-            "112:25: " + getCheckMessage(checkConfig.getMessages(), msgKey, "bad_Member", format),
-            "114:25: " + getCheckMessage(checkConfig.getMessages(), msgKey, "m", format),
-            "116:25: " + getCheckMessage(checkConfig.getMessages(), msgKey, "m_M", format),
-            "119:27: " + getCheckMessage(checkConfig.getMessages(), msgKey, "m$nts", format),
-            "123:25: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mTest1", format),
-            "125:25: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mTest2", format),
-            "127:25: " + getCheckMessage(checkConfig.getMessages(), msgKey, "$mTest2", format),
-            "129:25: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mTes$t2", format),
-            "131:25: " + getCheckMessage(checkConfig.getMessages(), msgKey, "mTest2$", format),
+            "12:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bad$Static", format),
+            "17:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bad_Member", format),
+            "19:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m", format),
+            "21:19: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m_M", format),
+            "24:19: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m$nts", format),
+            "35:9: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest1", format),
+            "37:16: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest2", format),
+            "39:16: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$mTest2", format),
+            "41:16: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTes$t2", format),
+            "43:16: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest2$", format),
+            "77:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bad$Static", format),
+            "79:22: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "sum_Created", format),
+            "82:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bad_Member", format),
+            "84:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m", format),
+            "86:23: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m_M", format),
+            "89:23: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m$nts", format),
+            "93:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest1", format),
+            "95:20: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest2", format),
+            "97:20: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$mTest2", format),
+            "99:20: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTes$t2", format),
+            "101:20: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest2$", format),
+            "107:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bad$Static", format),
+            "109:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "sum_Created", format),
+            "112:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bad_Member", format),
+            "114:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m", format),
+            "116:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m_M", format),
+            "119:27: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m$nts", format),
+            "123:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest1", format),
+            "125:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest2", format),
+            "127:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$mTest2", format),
+            "129:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTes$t2", format),
+            "131:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest2$", format),
         };
 
         String filePath = builder.getFilePath("MemberNameInput_Simple");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
@@ -13,8 +13,8 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class LocalVariableNameTest extends BaseCheckTestSupport{
 
+	private static final String MSG_KEY = "name.invalidPattern";
 	private static ConfigurationBuilder builder;
-	private final String msgKey = "name.invalidPattern";
 	private static Configuration checkConfig;
 	private static String format;
 
@@ -29,17 +29,17 @@ public class LocalVariableNameTest extends BaseCheckTestSupport{
     public void localVariableNameTest() throws Exception {
 
         final String[] expected = {
-            "26:13: " + getCheckMessage(checkConfig.getMessages(), msgKey, "a", format),
-            "27:13: " + getCheckMessage(checkConfig.getMessages(), msgKey, "aA", format),
-            "28:13: " + getCheckMessage(checkConfig.getMessages(), msgKey, "a1_a", format),
-            "29:13: " + getCheckMessage(checkConfig.getMessages(), msgKey, "A_A", format),
-            "30:13: " + getCheckMessage(checkConfig.getMessages(), msgKey, "aa2_a", format),
-            "31:13: " + getCheckMessage(checkConfig.getMessages(), msgKey, "_a", format),
-            "32:13: " + getCheckMessage(checkConfig.getMessages(), msgKey, "_aa", format),
-            "33:13: " + getCheckMessage(checkConfig.getMessages(), msgKey, "aa_", format),
-            "34:13: " + getCheckMessage(checkConfig.getMessages(), msgKey, "aaa$aaa", format),
-            "35:13: " + getCheckMessage(checkConfig.getMessages(), msgKey, "$aaaaaa", format),
-            "36:13: " + getCheckMessage(checkConfig.getMessages(), msgKey, "aaaaaa$", format),
+            "26:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "a", format),
+            "27:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aA", format),
+            "28:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "a1_a", format),
+            "29:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "A_A", format),
+            "30:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aa2_a", format),
+            "31:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_a", format),
+            "32:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_aa", format),
+            "33:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aa_", format),
+            "34:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aaa$aaa", format),
+            "35:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$aaaaaa", format),
+            "36:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aaaaaa$", format),
         };
 
         String filePath = builder.getFilePath("LocalVariableNameInput_Simple");
@@ -52,13 +52,13 @@ public class LocalVariableNameTest extends BaseCheckTestSupport{
     public void oneCharTest() throws Exception {
 
         final String[] expected = {
-            "15:13: " + getCheckMessage(checkConfig.getMessages(), msgKey, "i", format),
-            "21:17: " + getCheckMessage(checkConfig.getMessages(), msgKey, "I_ndex", format),
-            "45:17: " + getCheckMessage(checkConfig.getMessages(), msgKey, "i_ndex", format),
-            "49:17: " + getCheckMessage(checkConfig.getMessages(), msgKey, "ii_i1", format),
-            "53:17: " + getCheckMessage(checkConfig.getMessages(), msgKey, "$index", format),
-            "57:17: " + getCheckMessage(checkConfig.getMessages(), msgKey, "in$dex", format),
-            "61:17: " + getCheckMessage(checkConfig.getMessages(), msgKey, "index$", format),
+            "15:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "i", format),
+            "21:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "I_ndex", format),
+            "45:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "i_ndex", format),
+            "49:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "ii_i1", format),
+            "53:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$index", format),
+            "57:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "in$dex", format),
+            "61:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "index$", format),
         };
 
         String filePath = builder.getFilePath("LocalVariableNameInput_OneCharVarName");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassMethodTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassMethodTypeParameterNameTest.java
@@ -13,8 +13,8 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class ClassMethodTypeParameterNameTest extends BaseCheckTestSupport{
 
+    private static final String MSG_KEY = "name.invalidPattern";
     private static ConfigurationBuilder builder;
-    private final String msgKey = "name.invalidPattern";
     private static Configuration checkConfig;
     private static String format;
 
@@ -29,9 +29,9 @@ public class ClassMethodTypeParameterNameTest extends BaseCheckTestSupport{
     public void testClassDefault() throws Exception {
 
         final String[] expected = {
-            "5:31: " + getCheckMessage(checkConfig.getMessages(), msgKey, "t", format),
-            "13:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "foo", format),
-            "27:24: " + getCheckMessage(checkConfig.getMessages(), msgKey, "$foo", format),
+            "5:31: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "t", format),
+            "13:14: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "foo", format),
+            "27:24: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$foo", format),
         };
 
         String filePath = builder.getFilePath("ClassTypeParameterNameInput");
@@ -46,12 +46,12 @@ public class ClassMethodTypeParameterNameTest extends BaseCheckTestSupport{
         Configuration checkConfig = builder.getCheckConfig("MethodTypeParameterName");
 
         final String[] expected = {
-            "9:6: " + getCheckMessage(checkConfig.getMessages(), msgKey, "e_e", format),
-            "19:6: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Tfo$o2T", format),
-            "23:6: " + getCheckMessage(checkConfig.getMessages(), msgKey, "foo_", format),
-            "28:10: " + getCheckMessage(checkConfig.getMessages(), msgKey, "_abc", format),
-            "37:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "T$", format),
-            "42:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "EE", format),
+            "9:6: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "e_e", format),
+            "19:6: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "Tfo$o2T", format),
+            "23:6: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "foo_", format),
+            "28:10: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_abc", format),
+            "37:14: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "T$", format),
+            "42:14: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "EE", format),
         };
 
 


### PR DESCRIPTION
Fixes `FieldMayBeStatic` inspection violations in test code.

Description:
>Reports any instance variables which may safely be made static. A field may be static if it is declared final, and is initialized with a constant