### PR TITLE
Fix local variable name in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -409,9 +409,9 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
 
     @Test(expected = IllegalStateException.class)
     public void testVisitTokenSwitchReflection() throws Exception {
-        ImportOrderOption C = PowerMockito.mock(ImportOrderOption.class);
-        Whitebox.setInternalState(C, "name", "NEW_OPTION_FOR_UT");
-        Whitebox.setInternalState(C, "ordinal", 5);
+        ImportOrderOption importOrderOptionMock = PowerMockito.mock(ImportOrderOption.class);
+        Whitebox.setInternalState(importOrderOptionMock, "name", "NEW_OPTION_FOR_UT");
+        Whitebox.setInternalState(importOrderOptionMock, "ordinal", 5);
 
         DetailAST astImport = mockAST(TokenTypes.IMPORT, "import", "mockfile", 0, 0);
         DetailAST astIdent = mockAST(TokenTypes.IDENT, "myTestImport", "mockfile", 0, 0);


### PR DESCRIPTION
Fixes `LocalVariableNamingConvention` inspection violations in test code.

Description:
>Reports local variables whose names are either too short, too long, or do not follow the specified regular expression pattern.