### PR TITLE
Use only one exception on throws list for tests. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java
@@ -22,7 +22,7 @@ public class LineLengthTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void lineLengthTest() throws IOException, Exception {
+    public void lineLengthTest() throws Exception {
 
         final String[] expected = {
             "5: " + getCheckMessage(LineLengthCheck.class, "maxLineLen", 100, 112),

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/AvoidStarImportTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/AvoidStarImportTest.java
@@ -21,7 +21,7 @@ public class AvoidStarImportTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void starImportTest() throws IOException, Exception {
+    public void starImportTest() throws Exception {
 
         final String[] expected = {
             "3: Using the '.*' form of import should be avoided - java.io.*.",

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java
@@ -24,7 +24,7 @@ public class NoLineWrapTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void badLineWrapTest() throws IOException, Exception {
+    public void badLineWrapTest() throws Exception {
 
         final String[] expected = {
             "1: " + getCheckMessage(NoLineWrapCheck.class, "no.line.wrap", "package"),
@@ -39,7 +39,7 @@ public class NoLineWrapTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void goodLineWrapTest() throws IOException, Exception {
+    public void goodLineWrapTest() throws Exception {
 
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
@@ -51,7 +51,7 @@ public class NoLineWrapTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void goodLineLength() throws IOException, Exception {
+    public void goodLineLength() throws Exception {
 
         int maxLineLength = 100;
         final String[] expected = {

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
@@ -32,7 +32,7 @@ public class CustomImportOrderTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void customImportTest_1() throws IOException, Exception {
+    public void customImportTest_1() throws Exception {
         
         final String[] expected = {
             "4: " + getCheckMessage(clazz, msgLex, "java.awt.Button.ABORT", "java.io.File.createTempFile"),
@@ -56,7 +56,7 @@ public class CustomImportOrderTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void customImportTest_2() throws IOException, Exception {
+    public void customImportTest_2() throws Exception {
         
         final String[] expected = {
             "4: " + getCheckMessage(clazz, msgLex, "java.awt.Button.ABORT", "java.io.File.createTempFile"),
@@ -77,7 +77,7 @@ public class CustomImportOrderTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void customImportTest_3() throws IOException, Exception {
+    public void customImportTest_3() throws Exception {
         
         final String[] expected = {
                 "4: " + getCheckMessage(clazz, msgLex, "java.awt.Button.ABORT", "java.io.File.createTempFile"),
@@ -96,7 +96,7 @@ public class CustomImportOrderTest extends BaseCheckTestSupport{
         verify(checkConfig, filePath, expected, warnList);
     }
     @Test
-    public void validTest() throws IOException, Exception {
+    public void validTest() throws Exception {
         
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
         

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/OneTopLevelClassTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/OneTopLevelClassTest.java
@@ -23,7 +23,7 @@ public class OneTopLevelClassTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void badTest() throws IOException, Exception {
+    public void badTest() throws Exception {
         
         Class<OneTopLevelClassCheck> clazz = OneTopLevelClassCheck.class;
         String messageKey = "one.top.level.class";
@@ -45,7 +45,7 @@ public class OneTopLevelClassTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void goodTest() throws IOException, Exception {
+    public void goodTest() throws Exception {
         
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
         
@@ -57,7 +57,7 @@ public class OneTopLevelClassTest extends BaseCheckTestSupport{
     }
     
     @Test
-    public void bad2Test() throws IOException, Exception {
+    public void bad2Test() throws Exception {
     	
     	Class<OneTopLevelClassCheck> clazz = OneTopLevelClassCheck.class;
         String messageKey = "one.top.level.class";
@@ -74,7 +74,7 @@ public class OneTopLevelClassTest extends BaseCheckTestSupport{
     }
     
     @Test
-    public void bad3Test() throws IOException, Exception {
+    public void bad3Test() throws Exception {
         
     	Class<OneTopLevelClassCheck> clazz = OneTopLevelClassCheck.class;
         String messageKey = "one.top.level.class";

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/OverloadMethodsDeclarationOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/OverloadMethodsDeclarationOrderTest.java
@@ -22,7 +22,7 @@ public class OverloadMethodsDeclarationOrderTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void overloadMethodsTest() throws IOException, Exception {
+    public void overloadMethodsTest() throws Exception {
         
         Class<OverloadMethodsDeclarationOrderCheck> clazz = OverloadMethodsDeclarationOrderCheck.class;
         String messageKey = "overload.methods.declaration";

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3sourcefile/EmptyLineSeparatorTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3sourcefile/EmptyLineSeparatorTest.java
@@ -22,7 +22,7 @@ public class EmptyLineSeparatorTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void emptyLineSeparatorTest() throws IOException, Exception {
+    public void emptyLineSeparatorTest() throws Exception {
         
         Class<EmptyLineSeparatorCheck> clazz = EmptyLineSeparatorCheck.class;
         String messageKey = "empty.line.separator";

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyRightCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyRightCurlyTest.java
@@ -30,7 +30,7 @@ public class LeftCurlyRightCurlyTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void leftCurlyBracesTest() throws IOException, Exception {
+    public void leftCurlyBracesTest() throws Exception {
 
         final String[] expected = {
             "4:1: " + getCheckMessage(LeftCurlyCheck.class, MSG_KEY_LINE_PREVIOUS, "{", 1),
@@ -50,7 +50,7 @@ public class LeftCurlyRightCurlyTest extends BaseCheckTestSupport {
     }
     
     @Test
-    public void leftCurlyAnnotationsTest() throws IOException, Exception {
+    public void leftCurlyAnnotationsTest() throws Exception {
 
         final String[] expected = {
             "10:1: " + getCheckMessage(LeftCurlyCheck.class, MSG_KEY_LINE_PREVIOUS, "{", 1),
@@ -68,7 +68,7 @@ public class LeftCurlyRightCurlyTest extends BaseCheckTestSupport {
     }
     
     @Test
-    public void leftCurlyMethodsTest() throws IOException, Exception {
+    public void leftCurlyMethodsTest() throws Exception {
 
         final String[] expected = {
             "4:1: " + getCheckMessage(LeftCurlyCheck.class, MSG_KEY_LINE_PREVIOUS, "{", 1),

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java
@@ -22,7 +22,7 @@ public class EmptyLineSeparatorTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void emptyLineSeparatorTest() throws IOException, Exception {
+    public void emptyLineSeparatorTest() throws Exception {
         
         Class<EmptyLineSeparatorCheck> clazz = EmptyLineSeparatorCheck.class;
         String messageKey = "empty.line.separator";

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
@@ -22,7 +22,7 @@ public class WhitespaceAroundTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void whitespaceAroundBasicTest() throws IOException, Exception {
+    public void whitespaceAroundBasicTest() throws Exception {
         
         Configuration checkConfig = builder.getCheckConfig("WhitespaceAround");
         String msgPreceded = "ws.notPreceded";
@@ -58,7 +58,7 @@ public class WhitespaceAroundTest extends BaseCheckTestSupport{
     }
     
     @Test
-    public void whitespaceAroundGenericsTest() throws IOException, Exception {
+    public void whitespaceAroundGenericsTest() throws Exception {
         
         String msgPreceded = "ws.preceded";
         String msgFollowed = "ws.followed";
@@ -89,7 +89,7 @@ public class WhitespaceAroundTest extends BaseCheckTestSupport{
         verify(checkConfig, filePath, expected, warnList);
     }
     @Test
-    public void whitespaceAroundEmptyTypesCyclesTest() throws IOException, Exception {
+    public void whitespaceAroundEmptyTypesCyclesTest() throws Exception {
         
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
@@ -101,8 +101,7 @@ public class WhitespaceAroundTest extends BaseCheckTestSupport{
     }
     
     @Test
-    public void genericWhitespaceTest() throws IOException, Exception
-    {
+    public void genericWhitespaceTest() throws Exception {
         String msgPreceded = "ws.preceded";
         String msgFollowed = "ws.followed";
         String msgNotPreceded = "ws.notPreceded";

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4821onevariablepreline/MultipleVariableDeclarationsTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4821onevariablepreline/MultipleVariableDeclarationsTest.java
@@ -22,7 +22,7 @@ public class MultipleVariableDeclarationsTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void multipleVariableDeclarationsTest() throws IOException, Exception {
+    public void multipleVariableDeclarationsTest() throws Exception {
         
         String msgComma = getCheckMessage(MultipleVariableDeclarationsCheck.class, "multiple.variable.declarations.comma");
         String msg = getCheckMessage(MultipleVariableDeclarationsCheck.class, "multiple.variable.declarations");

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4843defaultcasepresent/MissingSwitchDefaultTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4843defaultcasepresent/MissingSwitchDefaultTest.java
@@ -22,7 +22,7 @@ public class MissingSwitchDefaultTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void missingSwitchDefaultTest() throws IOException, Exception {
+    public void missingSwitchDefaultTest() throws Exception {
         
         String msg = getCheckMessage(MissingSwitchDefaultCheck.class, "missing.switch.default");
 

--- a/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule62donotignoreexceptions/EmptyBlockTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule62donotignoreexceptions/EmptyBlockTest.java
@@ -22,7 +22,7 @@ public class EmptyBlockTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void emptyBlockTestCatch() throws IOException, Exception {
+    public void emptyBlockTestCatch() throws Exception {
         
         final String[] expected = {
             "29:17: " + getCheckMessage(EmptyBlockCheck.class, "block.empty", "finally"),

--- a/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule64finalizers/NoFinalizerTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule64finalizers/NoFinalizerTest.java
@@ -22,7 +22,7 @@ public class NoFinalizerTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void noFinalizerBasicTest() throws IOException, Exception {
+    public void noFinalizerBasicTest() throws Exception {
         
         String msg = getCheckMessage(NoFinalizerCheck.class, "avoid.finalizer.method");
 
@@ -38,7 +38,7 @@ public class NoFinalizerTest extends BaseCheckTestSupport{
     }
     
     @Test
-    public void noFinalizerExtendedTest() throws IOException, Exception {
+    public void noFinalizerExtendedTest() throws Exception {
         
         String msg = getCheckMessage(NoFinalizerCheck.class, "avoid.finalizer.method");
 


### PR DESCRIPTION
Fixes `MultipleExceptionsDeclaredOnTestMethod` inspection violation

Description:
>Reports JUnit test methods with more than one exception declared in the throws clause. Such a throws clause can be more concisely declared as `throws Exception`.