### PR TITLE
Use relative alignment constants. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeInfoPanel.java
@@ -75,7 +75,7 @@ public class ParseTreeInfoPanel extends JPanel {
         parseTreeModel = new ParseTreeModel(null);
         final JTreeTable treeTable = new JTreeTable(parseTreeModel);
         final JScrollPane sp = new JScrollPane(treeTable);
-        add(sp, BorderLayout.NORTH);
+        add(sp, BorderLayout.PAGE_START);
 
         final JButton fileSelectionButton =
             new JButton(new FileSelectionAction());
@@ -93,7 +93,7 @@ public class ParseTreeInfoPanel extends JPanel {
         add(sp2, BorderLayout.CENTER);
 
         final JPanel p = new JPanel(new GridLayout(1, 2));
-        add(p, BorderLayout.SOUTH);
+        add(p, BorderLayout.PAGE_END);
         p.add(fileSelectionButton);
         p.add(reloadButton);
 


### PR DESCRIPTION
Fixes `AbsoluteAlignmentInUserInterface` inspection violations.

Description:
>Reports usages of absolute alignment constants from AWT and Swing. Internationalized applications should make use of relative alignment, because it respects locale component orientation settings.