### PR TITLE
Specify charset used in test code. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -12,6 +12,7 @@ import java.io.LineNumberReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -130,7 +131,7 @@ public abstract class BaseCheckTestSupport
         final ByteArrayInputStream bais =
             new ByteArrayInputStream(baos.toByteArray());
         final LineNumberReader lnr =
-            new LineNumberReader(new InputStreamReader(bais));
+            new LineNumberReader(new InputStreamReader(bais, StandardCharsets.UTF_8));
 
         for (int i = 0; i < aExpected.length; i++) {
             final String expected = aMessageFileName + ":" + aExpected[i];

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
@@ -204,7 +205,7 @@ public class WriteTagCheckTest extends BaseCheckTestSupport {
         final ByteArrayInputStream bais =
             new ByteArrayInputStream(baos.toByteArray());
         final LineNumberReader lnr =
-            new LineNumberReader(new InputStreamReader(bais));
+            new LineNumberReader(new InputStreamReader(bais, StandardCharsets.UTF_8));
 
         for (int i = 0; i < expected.length; i++) {
             final String expectedResult = messageFileName + ":" + expected[i];


### PR DESCRIPTION
Fixes `ImplicitDefaultCharsetUsage` inspection violations.

Description:
>Reports method and constructor calls which implicitly use the platform's default charset. These can produce different results on (e.g. foreign language) systems that use a different default charset, resulting in unexpected behaviour.