### PR TITLE
Rename variables with unused exceptions. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -164,7 +164,7 @@ public abstract class BaseCheckTestSupport
         try {
             pr.load(aClass.getResourceAsStream("messages.properties"));
         }
-        catch (IOException e) {
+        catch (IOException ignored) {
             return null;
         }
         return pr.getProperty(messageKey);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -46,16 +46,9 @@ public class FileTextTest {
 
     @Test
     public void testSupportedCharset() throws IOException {
-        // just to make UT coverage 100%
-        try {
-            String charsetName = "ISO-8859-1";
-            FileText o = new FileText(new File("src/test/resources/com/puppycrawl/tools/"
-                     + "checkstyle/imports/import-control_complete.xml"), charsetName);
-            assertEquals(o.getCharset().name(), charsetName);
-        }
-        catch (UnsupportedEncodingException e) {
-            fail();
-        }
-
+        String charsetName = "ISO-8859-1";
+        FileText o = new FileText(new File("src/test/resources/com/puppycrawl/tools/"
+                 + "checkstyle/imports/import-control_complete.xml"), charsetName);
+        assertEquals(o.getCharset().name(), charsetName);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import static com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck.MSG_KEY;
 import static com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck.MSG_KEY_EXT;
-import static org.junit.Assert.fail;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -228,13 +227,7 @@ public class VariableDeclarationUsageDistanceCheckTest extends
             "542: " + getCheckMessage(MSG_KEY_EXT, "parentId", 4, 3),
         };
 
-        try {
-            createChecker(checkConfig);
-            verify(checkConfig, getPath("coding/InputVariableDeclarationUsageDistanceCheck.java"), expected);
-        }
-        catch (Exception ex) {
-            //Exception is not expected
-            fail();
-        }
+        createChecker(checkConfig);
+        verify(checkConfig, getPath("coding/InputVariableDeclarationUsageDistanceCheck.java"), expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
@@ -95,15 +95,9 @@ public class RegexpHeaderCheckTest extends BaseFileSetCheckTestSupport {
     @Test
     public void testDefaultConfiguration() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(RegexpHeaderCheck.class);
-        try {
-            createChecker(checkConfig);
-            final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-            verify(checkConfig, getPath("InputRegexpHeader1.java"), expected);
-        }
-        catch (CheckstyleException ex) {
-            // Exception is not expected
-            fail();
-        }
+        createChecker(checkConfig);
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputRegexpHeader1.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -343,7 +343,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
             method.setAccessible(true);
             actual = method.invoke(t, (DetailAST) null);
         }
-        catch (Exception e) {
+        catch (Exception ignored) {
             actual = null;
         }
 
@@ -498,14 +498,8 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
             createCheckConfig(CustomImportOrderCheck.class);
         String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
-        try {
-            createChecker(checkConfig);
-            verify(checkConfig, getPath("imports" + File.separator
-                + "InputCustomImportOrder.java"), expected);
-        }
-        catch (Exception ex) {
-            // Exception is not expected
-            fail();
-        }
+        createChecker(checkConfig);
+        verify(checkConfig, getPath("imports" + File.separator
+            + "InputCustomImportOrder.java"), expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -26,7 +26,6 @@ import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCh
 import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.MSG_ORDER;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.lang.reflect.Method;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck.SUMMARY_FIRST_SENTENCE;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck.SUMMARY_JAVADOC;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.fail;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Before;
@@ -100,13 +99,7 @@ public class SummaryJavadocCheckTest extends BaseCheckTestSupport {
             "103: " + getCheckMessage(SUMMARY_FIRST_SENTENCE),
         };
 
-        try {
-            createChecker(checkConfig);
-            verify(checkConfig, getPath("javadoc/InputIncorrectSummaryJavaDocCheck.java"), expected);
-        }
-        catch (Exception ex) {
-            //Exception is not expected
-            fail();
-        }
+        createChecker(checkConfig);
+        verify(checkConfig, getPath("javadoc/InputIncorrectSummaryJavaDocCheck.java"), expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks.metrics;
 
 import static com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck.MSG_KEY;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 
@@ -59,16 +58,10 @@ public class ClassDataAbstractionCouplingCheckTest extends BaseCheckTestSupport 
             createCheckConfig(ClassDataAbstractionCouplingCheck.class);
         String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
-        try {
-            createChecker(checkConfig);
-            verify(checkConfig,
-                getPath("metrics" + File.separator + "ClassCouplingCheckTestInput.java"),
-                expected);
-        }
-        catch (Exception ex) {
-            //Exception is not expected
-            fail();
-        }
+        createChecker(checkConfig);
+        verify(checkConfig,
+            getPath("metrics" + File.separator + "ClassCouplingCheckTestInput.java"),
+            expected);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks.metrics;
 
 import static com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck.MSG_KEY;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 
@@ -66,16 +65,10 @@ public class ClassFanOutComplexityCheckTest extends BaseCheckTestSupport {
             createCheckConfig(ClassFanOutComplexityCheck.class);
         String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
-        try {
-            createChecker(checkConfig);
-            verify(checkConfig,
-                getPath("metrics" + File.separator + "ClassCouplingCheckTestInput.java"),
-                expected);
-        }
-        catch (Exception ex) {
-            //Exception is not expected
-            fail();
-        }
+        createChecker(checkConfig);
+        verify(checkConfig,
+            getPath("metrics" + File.separator + "ClassCouplingCheckTestInput.java"),
+            expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckTest.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks.metrics;
 import static com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck.MSG_CLASS;
 import static com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck.MSG_FILE;
 import static com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck.MSG_METHOD;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 
@@ -74,15 +73,9 @@ public class JavaNCSSCheckTest extends BaseCheckTestSupport {
         DefaultConfiguration checkConfig = createCheckConfig(JavaNCSSCheck.class);
         String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
-        try {
-            createChecker(checkConfig);
-            verify(checkConfig, getPath("metrics" + File.separator
-                + "JavaNCSSCheckTestInput.java"), expected);
-        }
-        catch (Exception ex) {
-            // Exception is not expected
-            fail();
-        }
+        createChecker(checkConfig);
+        verify(checkConfig, getPath("metrics" + File.separator
+            + "JavaNCSSCheckTestInput.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks.metrics;
 
 import static com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck.MSG_KEY;
-import static org.junit.Assert.fail;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Assert;
@@ -77,14 +76,8 @@ public class NPathComplexityCheckTest extends BaseCheckTestSupport {
             createCheckConfig(NPathComplexityCheck.class);
         String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
-        try {
-            createChecker(checkConfig);
-            verify(checkConfig, getPath("ComplexityCheckTestInput.java"), expected);
-        }
-        catch (Exception ex) {
-            // Exception is not expected
-            fail();
-        }
+        createChecker(checkConfig);
+        verify(checkConfig, getPath("ComplexityCheckTestInput.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks.sizes;
 
 import static com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck.MSG_KEY;
-import static org.junit.Assert.fail;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
@@ -148,13 +147,7 @@ public class ExecutableStatementCountCheckTest
             createCheckConfig(ExecutableStatementCountCheck.class);
         String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
-        try {
-            createChecker(checkConfig);
-            verify(checkConfig, getPath("ExecutableStatementCountInput.java"), expected);
-        }
-        catch (Exception ex) {
-            //Exception is not expected
-            fail();
-        }
+        createChecker(checkConfig);
+        verify(checkConfig, getPath("ExecutableStatementCountInput.java"), expected);
     }
 }


### PR DESCRIPTION
Fixes `UnusedCatchParameter` inspection violations.

Description:
>Reports any catch parameters that are unused in their corresponding blocks. This inspection will not report any catch parameters named "ignore" or "ignored". Conversely this inspection will warn on any catch parameters named "ignore" or "ignored" that are actually used.