### PR TITLE
Remove declared error that should not occur. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
@@ -163,7 +163,7 @@ public class ClassResolver {
             safeLoad(name);
             return true;
         }
-        catch (final ClassNotFoundException | NoClassDefFoundError ignored) {
+        catch (final ClassNotFoundException ignored) {
             return false;
         }
     }
@@ -174,10 +174,8 @@ public class ClassResolver {
      * @param name name of the class to load
      * @return the {@code Class} for the specified class
      * @throws ClassNotFoundException if an error occurs
-     * @throws NoClassDefFoundError if an error occurs
      */
-    public Class<?> safeLoad(String name)
-        throws ClassNotFoundException, NoClassDefFoundError {
+    public Class<?> safeLoad(String name) throws ClassNotFoundException {
         // The next line will load the class using the specified class
         // loader. The magic is having the "false" parameter. This means the
         // class will not be initialised. Very, very important.


### PR DESCRIPTION
Fixes `ErrorRethrown` inspection violations.

Description:
>Reports try statements which catch java.lang.Error or any subclass and which do not rethrow the error. Statements which catch java.lang.ThreadDeath are not reported by this inspection.