### PR TITLE
Review visibility and usages of protected fields. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -39,7 +39,6 @@ public abstract class BaseCheckTestSupport {
 
     protected final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     protected final PrintStream stream = new PrintStream(baos);
-    protected final Properties props = new Properties();
 
     public static DefaultConfiguration createCheckConfig(Class<?> clazz) {
         return new DefaultConfiguration(clazz.getName());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/comments/CompareTreesWithComments.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/comments/CompareTreesWithComments.java
@@ -7,7 +7,7 @@ import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 
 public class CompareTreesWithComments extends Check {
-    protected static DetailAST expectedTree;
+    static DetailAST expectedTree;
 
     @Override
     public boolean isCommentNodesRequired() {


### PR DESCRIPTION
Fixes `ProtectedField` inspection violations in test code.

Description:
>Reports protected instance variables. Constants (i.e. variables marked static and final) are not reported.