### PR TITLE
Remove empty methods. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeModel.java
@@ -106,11 +106,6 @@ public class ParseTreeModel extends AbstractTreeTableModel {
     }
 
     @Override
-    public void setValueAt(Object aValue, Object node, int column) {
-        // No code, tree is read-only
-    }
-
-    @Override
     public Object getChild(Object parent, int index) {
         final DetailAST ast = (DetailAST) parent;
         int i = 0;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModel.java
@@ -71,14 +71,4 @@ public interface TreeTableModel extends TreeModel {
      * @return true if editable
      */
     boolean isCellEditable(Object node, int column);
-
-    /**
-     * Sets the value for node {@code node},
-     * at column number {@code column}.
-     *
-     * @param aValue the value to set
-     * @param node the node to set the value on
-     * @param column the column number
-     */
-    void setValueAt(Object aValue, Object node, int column);
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModelAdapter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModelAdapter.java
@@ -98,11 +98,6 @@ public class TreeTableModelAdapter extends AbstractTableModel {
         return treeTableModel.isCellEditable(nodeForRow(row), column);
     }
 
-    @Override
-    public void setValueAt(Object value, int row, int column) {
-        treeTableModel.setValueAt(value, nodeForRow(row), column);
-    }
-
     /**
      * Invokes fireTableDataChanged after all the pending events have been
      * processed. SwingUtilities.invokeLater is used to handle this.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -117,16 +117,5 @@ public class AutomaticBeanTest {
             throw new IllegalStateException(privateField);
         }
 
-        public void setName(String name) {
-        }
-
-        /**
-         * Just for code coverage
-         * @param childConf a child of this component's Configuration
-         */
-        @Override
-        protected void setupChild(Configuration childConf) throws CheckstyleException {
-            super.setupChild(childConf);
-        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/CheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/CheckTest.java
@@ -33,10 +33,6 @@ public class CheckTest {
                 return ArrayUtils.EMPTY_INT_ARRAY;
             }
 
-            @Override
-            public int[] getRequiredTokens() {
-                return super.getRequiredTokens();
-            }
         };
         // Eventually it will become clear abstract method
         Assert.assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, check.getRequiredTokens());
@@ -50,10 +46,6 @@ public class CheckTest {
                 return ArrayUtils.EMPTY_INT_ARRAY;
             }
 
-            @Override
-            public int[] getAcceptableTokens() {
-                return super.getAcceptableTokens();
-            }
         };
         // Eventually it will become clear abstract method
         Assert.assertArrayEquals(ArrayUtils.EMPTY_INT_ARRAY, check.getAcceptableTokens());


### PR DESCRIPTION
Fixes `EmptyMethod` inspection violations in test code.

Description:
>This inspection reports methods where:
- method is empty OR
- all implementations of interface method are empty OR
- method is empty itself and is overridden only by empty methods
Note that a method containing only the super() call and passing its own parameter is also considered empty.  This inspection is automatically suppressed for methods annotated with special annotations, for example, EJB annotations javax.ejb.Init and javax.ejb.Remove.