### PR TITLE
Use same parameter names in overridden methods. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -430,14 +430,14 @@ public final class ConfigurationLoader {
         }
 
         @Override
-        public void startElement(String namespaceURI,
+        public void startElement(String uri,
                                  String localName,
                                  String qName,
-                                 Attributes atts)
+                                 Attributes attributes)
             throws SAXException {
             if (qName.equals(MODULE)) {
                 //create configuration
-                final String name = atts.getValue(NAME);
+                final String name = attributes.getValue(NAME);
                 final DefaultConfiguration conf =
                     new DefaultConfiguration(name);
 
@@ -458,13 +458,13 @@ public final class ConfigurationLoader {
                 //extract value and name
                 final String value;
                 try {
-                    value = replaceProperties(atts.getValue(VALUE),
-                        overridePropsResolver, atts.getValue(DEFAULT));
+                    value = replaceProperties(attributes.getValue(VALUE),
+                        overridePropsResolver, attributes.getValue(DEFAULT));
                 }
                 catch (final CheckstyleException ex) {
                     throw new SAXException(ex);
                 }
-                final String name = atts.getValue(NAME);
+                final String name = attributes.getValue(NAME);
 
                 //add to attributes of configuration
                 final DefaultConfiguration top =
@@ -473,8 +473,8 @@ public final class ConfigurationLoader {
             }
             else if (qName.equals(MESSAGE)) {
                 //extract key and value
-                final String key = atts.getValue(KEY);
-                final String value = atts.getValue(VALUE);
+                final String key = attributes.getValue(KEY);
+                final String value = attributes.getValue(VALUE);
 
                 //add to messages of configuration
                 final DefaultConfiguration top = configStack.peek();
@@ -488,7 +488,7 @@ public final class ConfigurationLoader {
         }
 
         @Override
-        public void endElement(String namespaceURI,
+        public void endElement(String uri,
                                String localName,
                                String qName) {
             if (qName.equals(MODULE)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -77,13 +77,13 @@ public final class PackageNamesLoader
     }
 
     @Override
-    public void startElement(String namespaceURI,
+    public void startElement(String uri,
                              String localName,
                              String qName,
-                             Attributes atts) {
+                             Attributes attributes) {
         if ("package".equals(qName)) {
             //push package name, name is mandatory attribute with not empty value by DTD
-            final String name = atts.getValue("name");
+            final String name = attributes.getValue("name");
             packageStack.push(name);
         }
     }
@@ -106,7 +106,7 @@ public final class PackageNamesLoader
     }
 
     @Override
-    public void endElement(String namespaceURI,
+    public void endElement(String uri,
                            String localName,
                            String qName) {
         if ("package".equals(qName)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
@@ -46,7 +46,7 @@ public final class PropertiesExpander
     }
 
     @Override
-    public String resolve(String propertyName) {
-        return properties.getProperty(propertyName);
+    public String resolve(String name) {
+        return properties.getProperty(name);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
@@ -65,7 +65,7 @@ public class OuterTypeFilenameCheck extends Check {
     }
 
     @Override
-    public void beginTree(DetailAST ast) {
+    public void beginTree(DetailAST rootAST) {
         fileName = getFileName();
         seenFirstToken = false;
         validFirst = false;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseFileSetCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseFileSetCheckTestSupport.java
@@ -5,9 +5,9 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 public class BaseFileSetCheckTestSupport extends BaseCheckTestSupport {
     @Override
     protected DefaultConfiguration createCheckerConfig(
-        Configuration aCheckConfig) {
+        Configuration config) {
         final DefaultConfiguration dc = new DefaultConfiguration("root");
-        dc.addChild(aCheckConfig);
+        dc.addChild(config);
         return dc;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -182,7 +182,7 @@ public class PackageNamesLoaderTest {
     public static URL getMockUrl(final URLConnection connection) throws IOException {
         final URLStreamHandler handler = new URLStreamHandler() {
             @Override
-            protected URLConnection openConnection(final URL arg0) {
+            protected URLConnection openConnection(final URL url) {
                 return connection;
             }
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/FileSetCheckLifecycleTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/FileSetCheckLifecycleTest.java
@@ -41,9 +41,9 @@ public class FileSetCheckLifecycleTest
     extends BaseCheckTestSupport {
     @Override
     protected DefaultConfiguration createCheckerConfig(
-        Configuration checkConfig) {
+        Configuration config) {
         final DefaultConfiguration dc = new DefaultConfiguration("root");
-        dc.addChild(checkConfig);
+        dc.addChild(config);
         return dc;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -33,9 +33,9 @@ public class NewlineAtEndOfFileCheckTest
     extends BaseCheckTestSupport {
     @Override
     protected DefaultConfiguration createCheckerConfig(
-        Configuration checkConfig) {
+        Configuration config) {
         final DefaultConfiguration dc = new DefaultConfiguration("root");
-        dc.addChild(checkConfig);
+        dc.addChild(config);
         return dc;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -34,9 +34,9 @@ public class TranslationCheckTest
     extends BaseCheckTestSupport {
     @Override
     protected DefaultConfiguration createCheckerConfig(
-        Configuration checkConfig) {
+        Configuration config) {
         final DefaultConfiguration dc = new DefaultConfiguration("root");
-        dc.addChild(checkConfig);
+        dc.addChild(config);
         return dc;
     }
 


### PR DESCRIPTION
Fixes some `ParameterNameDiffersFromOverriddenParameter` inspection violations.

Description:
>Reports parameters that have different names from the corresponding parameters in the methods they override. While legal in Java, such inconsistent names may be confusing, and lessen the documentation benefits of good naming practices.