### PR TITLE
Add arguments to created exceptions. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
@@ -139,7 +139,7 @@ public class IndentationConfigurationBuilder extends ConfigurationBuilder
                     || indentInComment < expectedMinimalIndent && isWarnComment;
         }
 
-        throw new IllegalArgumentException();
+        throw new IllegalArgumentException("Cannot determine if commit is consistent");
     }
 
     private static int getLineStart(String line, final int tabWidth)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounter.java
@@ -38,7 +38,7 @@ public final class SeverityLevelCounter implements AuditListener {
      */
     public SeverityLevelCounter(SeverityLevel level) {
         if (level == null) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("'level' cannot be null");
         }
         this.level = level;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/UtilsTest.java
@@ -288,7 +288,7 @@ public class UtilsTest {
 
             @Override
             public void close() throws IOException {
-                throw new IOException();
+                throw new IOException("Test IOException");
             }
         });
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounterTest.java
@@ -35,7 +35,7 @@ public class SeverityLevelCounterTest {
         final SeverityLevelCounter counter = new SeverityLevelCounter(SeverityLevel.ERROR);
         final AuditEvent event = new AuditEvent(this, "ATest.java", null);
         assertEquals(0, counter.getCount());
-        counter.addException(event, new IllegalStateException());
+        counter.addException(event, new IllegalStateException("Test IllegalStateException"));
         assertEquals(1, counter.getCount());
     }
 
@@ -44,7 +44,7 @@ public class SeverityLevelCounterTest {
         final SeverityLevelCounter counter = new SeverityLevelCounter(SeverityLevel.WARNING);
         final AuditEvent event = new AuditEvent(this, "ATest.java", null);
         assertEquals(0, counter.getCount());
-        counter.addException(event, new IllegalStateException());
+        counter.addException(event, new IllegalStateException("Test IllegalStateException"));
         assertEquals(0, counter.getCount());
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -154,7 +154,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
                     || indentInComment < expectedMinimalIndent && isWarnComment;
         }
 
-        throw new IllegalArgumentException();
+        throw new IllegalStateException();
     }
 
     private static int getLineStart(String line, final int tabWidth) {


### PR DESCRIPTION
Fixes `NewExceptionWithoutArguments` inspection violations.

Description:
>Reports exception instance creation without any arguments specified. When an exception is constructed without arguments it contains no information about the fault that happened, which makes debugging needlessly hard.