### PR TITLE
Encapsulate package-visible fields. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigValidationTest.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigValidationTest.java
@@ -15,7 +15,7 @@ public class ConfigValidationTest extends BaseCheckTestSupport {
     @Test
     public void testGoogleChecks() throws Exception {
         ConfigurationBuilder builder = new ConfigurationBuilder(new File("src/it/"));
-        final Configuration checkerConfig = builder.config;
+        final Configuration checkerConfig = builder.getConfiguration();
         final Checker checker = new Checker();
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(checkerConfig);

--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -25,16 +25,16 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 
 	private final List<File> files = new ArrayList<>();
 
-	Configuration config;
+	private final Configuration configuration;
 
-	URL url;
+	private final Pattern warnPattern = Utils.createPattern(".*[ ]*//[ ]*warn[ ]*|/[*]warn[*]/");
 
-	final Pattern warnPattern = Utils.createPattern(".*[ ]*//[ ]*warn[ ]*|/[*]warn[*]/");
+	private URL url;
 
 	public ConfigurationBuilder(File aROOT)
 			throws CheckstyleException {
 		root = aROOT;
-		config = getConfigurationFromXML(XML_NAME, System.getProperties());
+		configuration = getConfigurationFromXML(XML_NAME, System.getProperties());
 		listFiles(files, root, "java");
 	}
 
@@ -51,8 +51,12 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 		}
 	}
 
+	Configuration getConfiguration() {
+		return configuration;
+	}
+
 	public Configuration getCheckConfig(String aCheckName) {
-		for (Configuration currentConfig : config.getChildren()) {
+		for (Configuration currentConfig : getConfiguration().getChildren()) {
 			if ("TreeWalker".equals(currentConfig.getName())) {
 				for (Configuration checkConfig : currentConfig.getChildren()) {
 					if (aCheckName.equals(checkConfig.getName())) {


### PR DESCRIPTION
Fixes `PackageVisibleField` inspection violations.

Description:
>Reports package-visible instance variables. Constants (i.e. variables marked static and final) are not reported.