### PR TITLE
Remove redundant no-arg constructor. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/DebugChecker.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DebugChecker.java
@@ -6,9 +6,6 @@
 package com.puppycrawl.tools.checkstyle;
 
 class DebugChecker extends Checker {
-    DebugChecker() {
-    }
-
     @Override
     public void fireAuditFinished() {
         super.fireAuditFinished();


### PR DESCRIPTION
Fixes `UnnecessaryConstructor` inspection violations.

Description:
>Reports unnecessary constructors. A constructor is unnecessary if it is the only constructor of a class, has no parameters, has the same access modifiers as its containing class, and does not perform any initialization except explicitly or implicitly calling the super class constructor without arguments. Such a constructor can be safely removed as it will be generated by the compiler even if not specified.