### PR TITLE
Update EqualsVerifier to 1.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>1.7.3</version>
+      <version>1.7.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Version 1.7.4

You can now …
* …avoid adding prefab values for
 * JavaFX (Java 8 only),
 * javax.naming.Reference.
* …avoid exceptions thrown from SBT.
* …get better reporting on subclasses of versioned entities.