### PR TITLE
Removed suppression for SwitchDensity rule from PMD, issue #973

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -162,12 +162,6 @@
       <property name="problemDepth" value="4"/>
     </properties>
   </rule>
-  <rule ref="rulesets/java/design.xml/SwitchDensity">
-    <properties>
-      <!-- till #973 -->
-      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='DeclarationOrderCheck']"/>
-    </properties>
-  </rule>
 
   <rule ref="rulesets/java/design.xml/SingularField">
     <properties>


### PR DESCRIPTION
@romani 
After you had committed  3eca04c940bcdf575c2f9009202a4145e9a82c15 the issue #973 was resolved.

So, I've removed suppression for SwitchDensity rule from PMD:
>SwitchDensity: A high ratio of statements to labels in a switch statement implies that the switch statement is doing too much work. Consider moving the statements into new methods, or creating subclasses based on the switch variable. 