### PR TITLE
Fix typos in code and Javadoc. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
@@ -40,10 +40,10 @@ public class IndentationConfigurationBuilder extends ConfigurationBuilder
     private static final Pattern MULTILEVEL_COMMENT_REGEX =
                     Pattern.compile("//indent:\\d+ exp:(\\d+(,\\d+)+?)( warn)?");
 
-    private static final Pattern SINGLELEVEL_COMMENT_REGEX =
+    private static final Pattern SINGLE_LEVEL_COMMENT_REGEX =
                     Pattern.compile("//indent:\\d+ exp:(\\d+)( warn)?");
 
-    private static final Pattern NONSTRICT_LEVEL_COMMENT_REGEX =
+    private static final Pattern NON_STRICT_LEVEL_COMMENT_REGEX =
                     Pattern.compile("//indent:\\d+ exp:>=(\\d+)( warn)?");
 
     protected static Integer[] getLinesWithWarnAndCheckComments(String aFileName,
@@ -123,7 +123,7 @@ public class IndentationConfigurationBuilder extends ConfigurationBuilder
                     || !containsActualLevel && isWarnComment;
         }
 
-        match = SINGLELEVEL_COMMENT_REGEX.matcher(comment);
+        match = SINGLE_LEVEL_COMMENT_REGEX.matcher(comment);
         if (match.matches()) {
             final int expectedLevel = Integer.parseInt(match.group(1));
 
@@ -131,7 +131,7 @@ public class IndentationConfigurationBuilder extends ConfigurationBuilder
                     || expectedLevel != indentInComment && isWarnComment;
         }
 
-        match = NONSTRICT_LEVEL_COMMENT_REGEX.matcher(comment);
+        match = NON_STRICT_LEVEL_COMMENT_REGEX.matcher(comment);
         if (match.matches()) {
             final int expectedMinimalIndent = Integer.parseInt(match.group(1));
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -133,7 +133,7 @@ public class CheckstyleAntTask extends Task {
     }
 
     /**
-     * Sets the maximum number of warings allowed. Default is
+     * Sets the maximum number of warnings allowed. Default is
      * {@link Integer#MAX_VALUE}.
      * @param maxWarnings the maximum number of warnings allowed.
      */
@@ -142,7 +142,7 @@ public class CheckstyleAntTask extends Task {
     }
 
     /**
-     * Adds uset of files (nested fileset attribute).
+     * Adds set of files (nested fileset attribute).
      * @param fS the file set to add
      */
     public void addFileset(FileSet fS) {
@@ -167,7 +167,7 @@ public class CheckstyleAntTask extends Task {
 
     /**
      * Set the class path.
-     * @param classpath the path to locate cluses
+     * @param classpath the path to locate classes
      */
     public void setClasspath(Path classpath) {
         if (this.classpath == null) {
@@ -186,7 +186,7 @@ public class CheckstyleAntTask extends Task {
         createClasspath().setRefid(classpathRef);
     }
 
-    /** @return a created path for locating cluses */
+    /** @return a created path for locating classes */
     public Path createClasspath() {
         if (classpath == null) {
             classpath = new Path(getProject());
@@ -606,17 +606,17 @@ public class CheckstyleAntTask extends Task {
 
     /** Represents a custom listener. */
     public static class Listener {
-        /** Classname of the listener class */
-        private String classname;
+        /** Class name of the listener class */
+        private String className;
 
-        /** @return the classname */
+        /** @return the class name */
         public String getClassname() {
-            return classname;
+            return className;
         }
 
-        /** @param classname set the classname */
-        public void setClassname(String classname) {
-            this.classname = classname;
+        /** @param name set the class name */
+        public void setClassname(String name) {
+            className = name;
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
@@ -62,7 +62,7 @@ public class EmptyForInitializerPadCheck
     public static final String MSG_NOT_PRECEDED = "ws.notPreceded";
 
     /**
-     * Sets the paren pad otion to nospace.
+     * Sets the paren pad option to nospace.
      */
     public EmptyForInitializerPadCheck() {
         super(PadOption.NOSPACE, PadOption.class);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
@@ -62,7 +62,7 @@ public class EmptyForIteratorPadCheck
     public static final String WS_NOT_FOLLOWED = "ws.notFollowed";
 
     /**
-     * Sets the paren pad otion to nospace.
+     * Sets the paren pad option to nospace.
      */
     public EmptyForIteratorPadCheck() {
         super(PadOption.NOSPACE, PadOption.class);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -29,8 +29,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <p>
  * Checks that there is no whitespace after a token.
  * More specifically, it checks that it is not followed by whitespace,
- * or (if linebreaks are allowed) all characters on the line after are
- * whitespace. To forbid linebreaks afer a token, set property
+ * or (if line breaks are allowed) all characters on the line after are
+ * whitespace. To forbid line breaks after a token, set property
  * allowLineBreaks to false.
  * </p>
   * <p> By default the check will check the following operators:
@@ -51,7 +51,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  * &lt;module name="NoWhitespaceAfter"/&gt;
  * </pre>
- * <p> An example of how to configure the check to forbid linebreaks after
+ * <p> An example of how to configure the check to forbid line breaks after
  * a {@link TokenTypes#DOT DOT} token is:
  * </p>
  * <pre>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/AbstractTreeTableModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/AbstractTreeTableModel.java
@@ -55,7 +55,7 @@ public abstract class AbstractTreeTableModel implements TreeTableModel {
     }
 
     //
-    // Default implmentations for methods in the TreeModel interface.
+    // Default implementations for methods in the TreeModel interface.
     //
 
     @Override
@@ -198,7 +198,7 @@ public abstract class AbstractTreeTableModel implements TreeTableModel {
     }
 
     //
-    // Default impelmentations for methods in the TreeTableModel interface.
+    // Default implementations for methods in the TreeTableModel interface.
     //
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java
@@ -135,7 +135,7 @@ class ListToTreeSelectionModelWrapper extends DefaultTreeSelectionModel {
 
     /**
      * Class responsible for calling updateSelectedPathsFromSelectedRows
-     * when the selection of the list changse.
+     * when the selection of the list changes.
      */
     class ListSelectionHandler implements ListSelectionListener {
         @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -63,7 +63,7 @@ public class PackageObjectFactoryTest {
     }
 
     @Test
-    public void testMakeObectFromList()
+    public void testMakeObjectFromList()
         throws CheckstyleException {
         factory.addPackage("com.");
         final Checker checker =
@@ -73,10 +73,10 @@ public class PackageObjectFactoryTest {
     }
 
     @Test
-    public void testMakeObectNoClass() {
+    public void testMakeObjectNoClass() {
         try {
             factory.createModule("NoClass");
-            fail("Instantiated non-existant class");
+            fail("Instantiated non-existent class");
         }
         catch (CheckstyleException ex) {
             assertEquals("CheckstyleException.message",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckTest.java
@@ -34,7 +34,7 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
- * Testcase for the JavaNCSS-Check.
+ * Test case for the JavaNCSS-Check.
  *
  * @author Lars Ködderitzsch
  */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
@@ -33,7 +33,7 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     private String warningMessage;
 
     @Test
-    public void testTypeNamesForThreePermitedCapitalLetters() throws Exception {
+    public void testTypeNamesForThreePermittedCapitalLetters() throws Exception {
 
         final DefaultConfiguration checkConfig = createCheckConfig(AbbreviationAsWordInNameCheck.class);
         final int expectedCapitalCount = 3;
@@ -54,7 +54,7 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testTypeNamesForFourPermitedCapitalLetters() throws Exception {
+    public void testTypeNamesForFourPermittedCapitalLetters() throws Exception {
 
         final int expectedCapitalCount = 4;
         warningMessage = getCheckMessage(MSG_KEY, expectedCapitalCount);
@@ -72,7 +72,7 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testTypeNamesForFivePermitedCapitalLetters() throws Exception {
+    public void testTypeNamesForFivePermittedCapitalLetters() throws Exception {
 
         final int expectedCapitalCount = 5;
         warningMessage = getCheckMessage(MSG_KEY, expectedCapitalCount);
@@ -225,7 +225,7 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testTypeNamesForThreePermitedCapitalLettersWithOverridenMethod() throws Exception {
+    public void testTypeNamesForThreePermittedCapitalLettersWithOverridenMethod() throws Exception {
 
         final DefaultConfiguration checkConfig = createCheckConfig(AbbreviationAsWordInNameCheck.class);
         final int expectedCapitalCount = 3;
@@ -244,7 +244,7 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testTypeNamesForZeroPermitedCapitalLetter() throws Exception {
+    public void testTypeNamesForZeroPermittedCapitalLetter() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(AbbreviationAsWordInNameCheck.class);
         final int expectedCapitalCount = 0;


### PR DESCRIPTION
Fixes some `SpellCheckingInspection` inspection violations.

Description:
>Spellchecker inspection helps locate typos and misspelling in your code, comments and literals, and fix them in one click.