### PR TITLE
Fix various typos. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -185,7 +185,7 @@ public abstract class AbstractClassCouplingCheck extends Check {
     }
 
     /**
-     * Incapsulates information about class coupling.
+     * Encapsulates information about class coupling.
      *
      * @author <a href="mailto:simon@redhillconsulting.com.au">Simon Harris</a>
      * @author o_sukhodolsky

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -313,7 +313,7 @@ public class JavaNCSSCheck extends Check {
     private static boolean isVariableDefCountable(DetailAST ast) {
         boolean countable = false;
 
-        //count variable defs only if they are direct child to a slist or
+        //count variable definitions only if they are direct child to a slist or
         // object block
         final int parentType = ast.getParent().getType();
 
@@ -323,7 +323,7 @@ public class JavaNCSSCheck extends Check {
 
             //is countable if no previous sibling is found or
             //the sibling is no COMMA.
-            //This is done because multiple assignment on one line are countes
+            //This is done because multiple assignment on one line are counted
             // as 1
             countable = prevSibling == null
                     || prevSibling.getType() != TokenTypes.COMMA;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -330,7 +330,7 @@ public class AbbreviationAsWordInNameCheck extends Check {
      * @param str name
      * @param beginIndex begin index
      * @param endIndex end index
-     * @return true is abbreviation is bigger that requierd and not in ignore list
+     * @return true is abbreviation is bigger that required and not in ignore list
      */
     private String getAbbreviationIfIllegal(String str, int beginIndex, int endIndex) {
         String result = null;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.java
@@ -65,7 +65,7 @@ public abstract class AbstractTypeParameterNameCheck
     }
 
     /**
-     * This method must be overriden to specify the
+     * This method must be overridden to specify the
      * location of the type parameter to check.
      *
      * @return {@code TokenTypes.CLASS_DEF }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
@@ -37,7 +37,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * The default is false (it is not allowed).  It is legal in Java to have
  * method with the same name as a class.  As long as a return type is specified
  * it is a method and not a constructor which it could be easily confused as.
- * <h3>Does not check-style the name of an overriden methods</h3> because the developer does not
+ * <h3>Does not check-style the name of an overridden methods</h3> because the developer does not
  * have a choice in renaming such methods.
  *
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
@@ -221,7 +221,7 @@ public class RegexpCheck extends AbstractFormatCheck {
     }
 
     /**
-     * Check if we can stop valiation
+     * Check if we can stop validation
      * @param ignore flag
      * @return true is we can continue
      */
@@ -234,7 +234,7 @@ public class RegexpCheck extends AbstractFormatCheck {
      * Detect ignore situation
      * @param startLine position of line
      * @param text file text
-     * @param start line colun
+     * @param start line column
      * @return true is that need to be ignored
      */
     private boolean isIgnore(int startLine, FileText text, LineColumn start) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java
@@ -46,10 +46,10 @@ class SinglelineDetector {
      */
     public void processLines(List<String> lines) {
         resetState();
-        int lineno = 0;
+        int lineNo = 0;
         for (String line : lines) {
-            lineno++;
-            checkLine(lineno, line, options.getPattern().matcher(line), 0);
+            lineNo++;
+            checkLine(lineNo, line, options.getPattern().matcher(line), 0);
         }
         finish();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
@@ -225,7 +225,7 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testTypeNamesForThreePermitedCapitalLettersWithOverridenMethod() throws Exception {
+    public void testTypeNamesForThreePermitedCapitalLettersWithOverriddenMethod() throws Exception {
 
         final DefaultConfiguration checkConfig = createCheckConfig(AbbreviationAsWordInNameCheck.class);
         final int expectedCapitalCount = 3;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
@@ -132,7 +132,7 @@ public class MethodNameCheckTest
     }
 
     @Test
-    public void testOverridenMethods() throws Exception {
+    public void testOverriddenMethods() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MethodNameCheck.class);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheckTest.java
@@ -37,8 +37,8 @@ public class StaticVariableNameCheckTest
     @Test
     public void testGetRequiredTokens() {
         StaticVariableNameCheck checkObj = new StaticVariableNameCheck();
-        int[] excpected = {TokenTypes.VARIABLE_DEF};
-        assertArrayEquals(excpected, checkObj.getRequiredTokens());
+        int[] expected = {TokenTypes.VARIABLE_DEF};
+        assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
@@ -123,7 +123,7 @@ public class ExecutableStatementCountCheckTest
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testVisitTokenWhithWrongTokenType() {
+    public void testVisitTokenWithWrongTokenType() {
         ExecutableStatementCountCheck checkObj =
             new ExecutableStatementCountCheck();
         DetailAST ast = new DetailAST();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
@@ -62,7 +62,7 @@ public class MethodLengthCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testcountEmpty() throws Exception {
+    public void testCountEmpty() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MethodLengthCheck.class);
         checkConfig.addAttribute("max", "19");


### PR DESCRIPTION
Fixes some `SpellCheckingInspection` inspection violations.

Description:
>Spellchecker inspection helps locate typos and misspelling in your code, comments and literals, and fix them in one click.