### PR TITLE
Fix typos in xdocs. #1555

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 # Eclipse-CS Checkstyle Plug-In IDE configuration files
 .checkstyle
  
-#Netbeans project files
+#NetBeans project files
 nbactions.xml
 nb-configuration.xml
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -97,7 +97,7 @@
       <item name="Contributing" href="contributing.html"/>
       <item name="Beginning Development" href="beginning_development.html">
         <item name="Eclipse IDE" href="eclipse.html"/>
-        <item name="Netbeans IDE" href="netbeans.html"/>
+        <item name="NetBeans IDE" href="netbeans.html"/>
         <item name="IntelliJ IDE" href="idea.html"/>
       </item>
       <item name="Javadoc" href="apidocs/index.html"/>

--- a/src/xdocs/beginning_development.xml
+++ b/src/xdocs/beginning_development.xml
@@ -45,7 +45,7 @@ git clone git@github.com:you_user_name/checkstyle.git
       <p>
         Here you can find instructions of importing and debugging the project for IDEs:<br/>
         <a href="eclipse.html">Eclipse IDE</a><br/>
-        <a href="netbeans.html">Netbeans IDE</a><br/>
+        <a href="netbeans.html">NetBeans IDE</a><br/>
         <a href="idea.html">IntelliJ Idea IDE</a><br/>
       </p>
 

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -238,7 +238,7 @@
       <tr>
         <td><a href="config_design.html#FinalClass">FinalClass</a></td>
         <td>
-          Checks that class which has only private ctors
+          Checks that class which has only private constructors
         is declared as final.</td>
       </tr>
       <tr>

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -1146,7 +1146,7 @@ class MyClass {
             See <a href="http://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.14">FOR statement</a> specification for more details.
           </p>
         <p>
-            Such loop would be supressed:
+            Such loop would be suppressed:
         </p>
         <source>
             for (int i = 0; i &lt; 10;) {

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -316,7 +316,7 @@
             Do not be ashamed to have complexity level 15 or even higher,
             but keep it below 20 to catch really bad designed code automatically.
             <br/>Please use Suppression to avoid violations on cases that could not be split in few
-            methods without damanging readability of code or incapsulation.
+            methods without damaging readability of code or encapsulation.
             <br/>
         </p>
       </subsection>
@@ -427,7 +427,7 @@ class CC {
           avoid problem of Cyclomatic complexity metric like nesting level within a function.
         </p>
         <p>
-          Metic wsa described at <a href="http://dl.acm.org/citation.cfm?id=42379">"NPATH: a measure of execution pathcomplexity and its applications"</a>. If you need detaled description of algorithm, please read that article,
+          Metric was described at <a href="http://dl.acm.org/citation.cfm?id=42379">"NPATH: a measure of execution pathcomplexity and its applications"</a>. If you need detaled description of algorithm, please read that article,
           it is well written and have number of examples and details.
         </p>
 

--- a/src/xdocs/eclipse.xml
+++ b/src/xdocs/eclipse.xml
@@ -72,7 +72,7 @@
 
     <section name="Organize Imports">
       <p>
-        One of the Checkstyle checks we run on our own code require sertain order of import
+        One of the Checkstyle checks we run on our own code require certain order of import
         statements. Few changes in IDE settings are required to help your IDE do it automatically.<br/>
         To change settings of "Organize Imports" feature (Kepler, Luna &amp; Mars, other versions
         are likely to work the same way), please go to Window -> Preferences in menu.<br/>

--- a/src/xdocs/idea.xml
+++ b/src/xdocs/idea.xml
@@ -10,7 +10,7 @@
   </properties>
 
   <head>
-    <title>Importing and debugging in IntellIJ IDE</title>
+    <title>Importing and debugging in IntelliJ IDE</title>
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"/>
     <script type="text/javascript" src="js/anchors.js"/>
     <script type="text/javascript" src="js/google-analytics.js"/>

--- a/src/xdocs/netbeans.xml
+++ b/src/xdocs/netbeans.xml
@@ -5,12 +5,12 @@
   xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 http://maven.apache.org/xsd/xdoc-2.0.xsd">
 
   <properties>
-    <title>Importing and debugging in Netbeans IDE</title>
+    <title>Importing and debugging in NetBeans IDE</title>
     <author>Checkstyle Development Team</author>
   </properties>
 
   <head>
-    <title>Importing and debugging in Netbeans IDE</title>
+    <title>Importing and debugging in NetBeans IDE</title>
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"/>
     <script type="text/javascript" src="js/anchors.js"/>
     <script type="text/javascript" src="js/google-analytics.js"/>

--- a/src/xdocs/running.xml
+++ b/src/xdocs/running.xml
@@ -32,7 +32,7 @@
 
       <p>
         Note that there are <a href="index.html#Related_Tools">loads of
-        plug-ins</a> for all the IDE's out there.
+        plug-ins</a> for all the IDEs out there.
       </p>
     </section>
   </body>

--- a/src/xdocs/writingchecks.xml.vm
+++ b/src/xdocs/writingchecks.xml.vm
@@ -482,7 +482,7 @@ java -classpath mycompanychecks.jar;checkstyle-${projectVersion}-all.jar \
         This means that you cannot implement some of the code inspection
         features that are available in advanced IDEs like <a
         href="http://www.jetbrains.com/idea/">IntelliJ IDEA</a>,
-        <a href="http://findbugs.sourceforge.net/">Findbug</a>,
+        <a href="http://findbugs.sourceforge.net/">FindBugs</a>,
         <a href="http://pmd.sourceforge.net/">PMD</a>,
         <a href="http://www.sonarqube.org/">Sonarqube</a>. 
       </p>
@@ -560,7 +560,7 @@ public class LimitImplementationFiles extends AbstractFileSetCheck
       </p>
       <p>
         There are virtually no limits what you can do in
-        FileSetChecks, but please do not be creazy.
+        FileSetChecks, but please do not be crazy.
       </p>
 
     </section>


### PR DESCRIPTION
Fixes some `SpellCheckingInspection` inspection violations.

Description:
>Spellchecker inspection helps locate typos and misspelling in your code, comments and literals, and fix them in one click.