### PR TITLE
Fixed PMD violation 'ConfusingTernary' (partial fix), issue #974

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -299,13 +299,13 @@ public final class Main {
         // setup the output stream
         OutputStream out;
         boolean closeOutputStream;
-        if (outputLocation != null) {
-            out = new FileOutputStream(outputLocation);
-            closeOutputStream = true;
-        }
-        else {
+        if (outputLocation == null) {
             out = System.out;
             closeOutputStream = false;
+        }
+        else {
+            out = new FileOutputStream(outputLocation);
+            closeOutputStream = true;
         }
 
         // setup a listener

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
@@ -213,11 +213,11 @@ public abstract class AbstractDeclarationCollector extends Check {
      * @return LexicalFrame containing declaration or null
      */
     private LexicalFrame findFrame(String name) {
-        if (current != null) {
-            return current.getIfContains(name);
+        if (current == null) {
+            return null;
         }
         else {
-            return null;
+            return current.getIfContains(name);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -252,16 +252,15 @@ public class AvoidEscapedUnicodeCharactersCheck
         final DetailAST variableDef = getVariableDef(ast);
         DetailAST semi;
 
-        if (variableDef != null) {
-
+        if (variableDef == null) {
+            semi = getSemi(ast);
+        }
+        else {
             semi = variableDef.getNextSibling();
 
             if (semi.getType() != TokenTypes.SEMI) {
                 semi = variableDef.getLastChild();
             }
-        }
-        else {
-            semi = getSemi(ast);
         }
 
         boolean result = false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -214,13 +214,13 @@ public class SuppressWarningsHolder
             final DetailAST nextAST = targetAST.getNextSibling();
             final int lastLine;
             final int lastColumn;
-            if (nextAST != null) {
-                lastLine = nextAST.getLineNo();
-                lastColumn = nextAST.getColumnNo() - 1;
-            }
-            else {
+            if (nextAST == null) {
                 lastLine = Integer.MAX_VALUE;
                 lastColumn = Integer.MAX_VALUE;
+            }
+            else {
+                lastLine = nextAST.getLineNo();
+                lastColumn = nextAST.getColumnNo() - 1;
             }
 
             // add suppression entries for listed checks

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
@@ -219,8 +219,8 @@ public final class MissingDeprecatedCheck extends Check {
             if (multilineCont.find()) {
                 reindex = lines.length;
                 final String lFin = multilineCont.group(1);
-                if (!lFin.equals(NEXT_TAG)
-                    && !lFin.equals(END_JAVADOC)) {
+                if (lFin.equals(NEXT_TAG) || lFin.equals(END_JAVADOC)) {
+                    log(currentLine, MSG_KEY_JAVADOC_MISSING);
                     if (foundBefore) {
                         log(currentLine, MSG_KEY_JAVADOC_DUPLICATE_TAG,
                             JavadocTagInfo.DEPRECATED.getText());
@@ -228,7 +228,6 @@ public final class MissingDeprecatedCheck extends Check {
                     found = true;
                 }
                 else {
-                    log(currentLine, MSG_KEY_JAVADOC_MISSING);
                     if (foundBefore) {
                         log(currentLine, MSG_KEY_JAVADOC_DUPLICATE_TAG,
                             JavadocTagInfo.DEPRECATED.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -158,12 +158,12 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
                 warningHolder.findFirstToken(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
         DetailAST warning;
 
-        if (token != null) {
-            // case like '@SuppressWarnings(value = UNUSED)'
-            warning = token.findFirstToken(TokenTypes.EXPR);
+        if (token == null) {
+            warning = warningHolder.findFirstToken(TokenTypes.EXPR);
         }
         else {
-            warning = warningHolder.findFirstToken(TokenTypes.EXPR);
+            // case like '@SuppressWarnings(value = UNUSED)'
+            warning = token.findFirstToken(TokenTypes.EXPR);
         }
 
         //rare case with empty array ex: @SuppressWarnings({})
@@ -254,13 +254,13 @@ public class SuppressWarningsCheck extends AbstractFormatCheck {
             annotation.findFirstToken(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
         final DetailAST annArrayInit;
 
-        if (annValuePair != null) {
+        if (annValuePair == null) {
             annArrayInit =
-                annValuePair.findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
+                annotation.findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
         }
         else {
             annArrayInit =
-                annotation.findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
+                annValuePair.findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
         }
 
         if (annArrayInit != null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -301,14 +301,14 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
                 break;
             case TokenTypes.LITERAL_IF:
                 nextToken = ast.findFirstToken(TokenTypes.LITERAL_ELSE);
-                if (nextToken != null) {
-                    lcurly = nextToken.getPreviousSibling();
-                    rcurly = lcurly.getLastChild();
-                }
-                else {
+                if (nextToken == null) {
                     shouldCheckLastRcurly = true;
                     nextToken = getNextToken(ast);
                     lcurly = ast.getLastChild();
+                    rcurly = lcurly.getLastChild();
+                }
+                else {
+                    lcurly = nextToken.getPreviousSibling();
                     rcurly = lcurly.getLastChild();
                 }
                 break;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -248,7 +248,16 @@ public class DeclarationOrderCheck extends Check {
     private void processModifiers(DetailAST ast) {
 
         final ScopeState state = scopeStates.peek();
-        if (ast.findFirstToken(TokenTypes.LITERAL_STATIC) != null) {
+        if (ast.findFirstToken(TokenTypes.LITERAL_STATIC) == null) {
+            if (state.currentScopeState > STATE_INSTANCE_VARIABLE_DEF) {
+                log(ast, MSG_INSTANCE);
+            }
+            else if (state.currentScopeState == STATE_STATIC_VARIABLE_DEF) {
+                state.declarationAccess = Scope.PUBLIC;
+                state.currentScopeState = STATE_INSTANCE_VARIABLE_DEF;
+            }
+        }
+        else {
             if (state.currentScopeState > STATE_STATIC_VARIABLE_DEF) {
                 if (!ignoreModifiers
                     || state.currentScopeState > STATE_INSTANCE_VARIABLE_DEF) {
@@ -257,15 +266,6 @@ public class DeclarationOrderCheck extends Check {
             }
             else {
                 state.currentScopeState = STATE_STATIC_VARIABLE_DEF;
-            }
-        }
-        else {
-            if (state.currentScopeState > STATE_INSTANCE_VARIABLE_DEF) {
-                log(ast, MSG_INSTANCE);
-            }
-            else if (state.currentScopeState == STATE_STATIC_VARIABLE_DEF) {
-                state.declarationAccess = Scope.PUBLIC;
-                state.currentScopeState = STATE_INSTANCE_VARIABLE_DEF;
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -324,13 +324,13 @@ public final class ModifiedControlVariableCheck extends Check {
      */
     private void leaveForDef(DetailAST ast) {
         final DetailAST forInitAST = ast.findFirstToken(TokenTypes.FOR_INIT);
-        if (forInitAST != null) {
-            final Set<String> variablesManagedByForLoop = getVariablesManagedByForLoop(ast);
-            popCurrentVariables(variablesManagedByForLoop.size());
-        }
-        else {
+        if (forInitAST == null) {
             // this is for-each loop, just pop veriables
             getCurrentVariables().pop();
+        }
+        else {
+            final Set<String> variablesManagedByForLoop = getVariablesManagedByForLoop(ast);
+            popCurrentVariables(variablesManagedByForLoop.size());
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -92,12 +92,11 @@ public class MultipleStringLiteralsCheck extends Check {
      *         if unable to create Pattern object
      */
     public final void setIgnoreStringsRegexp(String ignoreStringsRegexp) {
-        if (ignoreStringsRegexp != null
-            && !ignoreStringsRegexp.isEmpty()) {
-            pattern = Utils.createPattern(ignoreStringsRegexp);
+        if (ignoreStringsRegexp == null || ignoreStringsRegexp.isEmpty()) {
+            pattern = null;
         }
         else {
-            pattern = null;
+            pattern = Utils.createPattern(ignoreStringsRegexp);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
@@ -169,13 +169,13 @@ public final class OneStatementPerLineCheck extends Check {
      */
     private static boolean isMultilineStatement(DetailAST ast) {
         final boolean multiline;
-        if (ast.getPreviousSibling() != null) {
+        if (ast.getPreviousSibling() == null) {
+            multiline = false;
+        }
+        else {
             final DetailAST prevSibling = ast.getPreviousSibling();
             multiline = prevSibling.getLineNo() != ast.getLineNo()
                 && ast.getParent() != null;
-        }
-        else {
-            multiline = false;
         }
         return multiline;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -517,11 +517,11 @@ public class VariableDeclarationUsageDistanceCheck extends Check {
                         exprWithVariableUsage = blockWithVariableUsage.getFirstChild();
                 }
                 currentScopeAst = exprWithVariableUsage;
-                if (exprWithVariableUsage != null) {
-                    variableUsageAst = exprWithVariableUsage;
+                if (exprWithVariableUsage == null) {
+                    variableUsageAst = blockWithVariableUsage;
                 }
                 else {
-                    variableUsageAst = blockWithVariableUsage;
+                    variableUsageAst = exprWithVariableUsage;
                 }
             }
             // If variable usage exists in different scopes, then distance =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
@@ -164,11 +164,11 @@ public final class ThrowsCountCheck extends Check {
     private static String getAnnotationName(DetailAST annotation) {
         final DetailAST dotAst = annotation.findFirstToken(TokenTypes.DOT);
         String name;
-        if (dotAst != null) {
-            name = dotAst.findFirstToken(TokenTypes.IDENT).getText();
+        if (dotAst == null) {
+            name = annotation.findFirstToken(TokenTypes.IDENT).getText();
         }
         else {
-            name = annotation.findFirstToken(TokenTypes.IDENT).getText();
+            name = dotAst.findFirstToken(TokenTypes.IDENT).getText();
         }
         return name;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -101,16 +101,16 @@ final class ImportControlLoader extends AbstractLoader {
             final String pkg = atts.getValue("pkg");
             final boolean regex = atts.getValue("regex") != null;
             final Guard g;
-            if (pkg != null) {
-                final boolean exactMatch =
-                        atts.getValue("exact-match") != null;
-                g = new Guard(isAllow, isLocalOnly, pkg, exactMatch, regex);
-            }
-            else {
+            if (pkg == null) {
                 // handle class names which can be normal class names or regular
                 // expressions
                 final String clazz = safeGet(atts, "class");
                 g = new Guard(isAllow, isLocalOnly, clazz, regex);
+            }
+            else {
+                final boolean exactMatch =
+                    atts.getValue("exact-match") != null;
+                g = new Guard(isAllow, isLocalOnly, pkg, exactMatch, regex);
             }
 
             final PkgControl pc = stack.peek();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -270,7 +270,10 @@ public class BlockParentHandler extends AbstractExpressionHandler {
             checkRCurly();
         }
         final DetailAST listChild = getListChild();
-        if (listChild != null) {
+        if (listChild == null) {
+            checkNonlistChild();
+        }
+        else {
             // NOTE: switch statements usually don't have curlys
             if (!hasCurlys() || !areOnSameLine(getLCurly(), getRCurly())) {
                 checkChildren(listChild,
@@ -279,9 +282,6 @@ public class BlockParentHandler extends AbstractExpressionHandler {
                               true,
                               childrenMayNest());
             }
-        }
-        else {
-            checkNonlistChild();
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ForHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ForHandler.java
@@ -49,7 +49,13 @@ public class ForHandler extends BlockParentHandler {
             new IndentLevel(getLevel(), getBasicOffset());
         final DetailAST init = getMainAst().findFirstToken(TokenTypes.FOR_INIT);
 
-        if (init != null) {
+        if (init == null) {
+            // for each
+            final DetailAST forEach =
+                getMainAst().findFirstToken(TokenTypes.FOR_EACH_CLAUSE);
+            checkExpressionSubtree(forEach, expected, false, false);
+        }
+        else {
             checkExpressionSubtree(init, expected, false, false);
 
             final DetailAST cond =
@@ -59,12 +65,6 @@ public class ForHandler extends BlockParentHandler {
             final DetailAST iter =
                 getMainAst().findFirstToken(TokenTypes.FOR_ITERATOR);
             checkExpressionSubtree(iter, expected, false, false);
-        }
-        // for each
-        else {
-            final DetailAST forEach =
-                getMainAst().findFirstToken(TokenTypes.FOR_EACH_CLAUSE);
-            checkExpressionSubtree(forEach, expected, false, false);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
@@ -186,11 +186,11 @@ public class WriteTagCheck
                 tagCount += 1;
                 final int contentStart = matcher.start(1);
                 final String content = s.substring(contentStart);
-                if (tagFormatRE != null && !tagFormatRE.matcher(content).find()) {
-                    log(lineNo + i - comment.length, TAG_FORMAT, tag, tagFormat);
+                if (tagFormatRE == null || tagFormatRE.matcher(content).find()) {
+                    logTag(lineNo + i - comment.length, tag, content);
                 }
                 else {
-                    logTag(lineNo + i - comment.length, tag, content);
+                    log(lineNo + i - comment.length, TAG_FORMAT, tag, tagFormat);
                 }
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressElement.java
@@ -102,11 +102,11 @@ public class SuppressElement
      */
     public void setLines(String lines) {
         linesCSV = lines;
-        if (lines != null) {
-            lineFilter = new CSVFilter(lines);
+        if (lines == null) {
+            lineFilter = null;
         }
         else {
-            lineFilter = null;
+            lineFilter = new CSVFilter(lines);
         }
     }
 
@@ -117,11 +117,11 @@ public class SuppressElement
      */
     public void setColumns(String columns) {
         columnsCSV = columns;
-        if (columns != null) {
-            columnFilter = new CSVFilter(columns);
+        if (columns == null) {
+            columnFilter = null;
         }
         else {
-            columnFilter = null;
+            columnFilter = new CSVFilter(columns);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -313,13 +313,13 @@ public class SuppressWithNearbyCommentFilter
             try {
                 format = expandFrocomment(text, filter.checkFormat, filter.commentRegexp);
                 tagCheckRegexp = Pattern.compile(format);
-                if (filter.messageFormat != null) {
-                    format = expandFrocomment(
-                         text, filter.messageFormat, filter.commentRegexp);
-                    tagMessageRegexp = Pattern.compile(format);
+                if (filter.messageFormat == null) {
+                    tagMessageRegexp = null;
                 }
                 else {
-                    tagMessageRegexp = null;
+                    format = expandFrocomment(
+                        text, filter.messageFormat, filter.commentRegexp);
+                    tagMessageRegexp = Pattern.compile(format);
                 }
                 format = expandFrocomment(
                     text, filter.influenceFormat, filter.commentRegexp);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -339,29 +339,29 @@ public class SuppressionCommentFilter
                     format =
                         expandFromCoont(text, filter.checkFormat, filter.onRegexp);
                     tagCheckRegexp = Pattern.compile(format);
-                    if (filter.messageFormat != null) {
+                    if (filter.messageFormat == null) {
+                        tagMessageRegexp = null;
+                    }
+                    else {
                         format =
                             expandFromCoont(text, filter.messageFormat, filter.onRegexp);
                         tagMessageRegexp = Pattern.compile(format);
-                    }
-                    else {
-                        tagMessageRegexp = null;
                     }
                 }
                 else {
                     format =
                         expandFromCoont(text, filter.checkFormat, filter.offRegexp);
                     tagCheckRegexp = Pattern.compile(format);
-                    if (filter.messageFormat != null) {
+                    if (filter.messageFormat == null) {
+                        tagMessageRegexp = null;
+                    }
+                    else {
                         format =
                             expandFromCoont(
                                 text,
                                 filter.messageFormat,
                                 filter.offRegexp);
                         tagMessageRegexp = Pattern.compile(format);
-                    }
-                    else {
-                        tagMessageRegexp = null;
                     }
                 }
             }


### PR DESCRIPTION
@romani 
There are 6 PMD's violations after fix:

```
[INFO] PMD Failure: com.puppycrawl.tools.checkstyle.ConfigurationLoader:361 Rule:ConfusingTernary Priority:3 Avoid if (x != y) ..; else ..;.
[INFO] PMD Failure: com.puppycrawl.tools.checkstyle.api.DetailAST:115 Rule:ConfusingTernary Priority:3 Avoid if (x != y) ..; else ..;.
[INFO] PMD Failure: com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck:229 Rule:ConfusingTernary Priority:3 Avoid if (x != y) ..; else ..;.
[INFO] PMD Failure: com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck:196 Rule:ConfusingTernary Priority:3 Avoid if (x != y) ..; else ..;.
[INFO] PMD Failure: com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck:468 Rule:ConfusingTernary Priority:3 Avoid if (x != y) ..; else ..;.
[INFO] PMD Failure: com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser:104 Rule:ConfusingTernary Priority:3 Avoid if (x != y) ..; else ..;.
```
Those  classes require more detailed analysis of boolean expressions.

