### PR TITLE
Remove calls to simple getters within classes. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -56,7 +56,7 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 	}
 
 	public Configuration getCheckConfig(String aCheckName) {
-		for (Configuration currentConfig : getConfiguration().getChildren()) {
+		for (Configuration currentConfig : configuration.getChildren()) {
 			if ("TreeWalker".equals(currentConfig.getName())) {
 				for (Configuration checkConfig : currentConfig.getChildren()) {
 					if (aCheckName.equals(checkConfig.getName())) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Check.java
@@ -170,7 +170,7 @@ public abstract class Check extends AbstractViolationReporter {
      * @return the file contents
      */
     public final String[] getLines() {
-        return getFileContents().getLines();
+        return fileContents.getLines();
     }
 
     /**
@@ -179,7 +179,7 @@ public abstract class Check extends AbstractViolationReporter {
      * @return the line from the file contents
      */
     public final String getLine(int index) {
-        return getFileContents().getLine(index);
+        return fileContents.getLine(index);
     }
 
     /**
@@ -245,7 +245,7 @@ public abstract class Check extends AbstractViolationReporter {
     public final void log(int lineNo, int colNo, String key,
             Object... args) {
         final int col = 1 + Utils.lengthExpandedTabs(
-            getLines()[lineNo - 1], colNo, getTabWidth());
+            getLines()[lineNo - 1], colNo, tabWidth);
         messages.add(
             new LocalizedMessage(
                 lineNo,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -110,7 +110,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
     public void addPreviousSibling(DetailAST ast) {
         if (ast != null) {
             ast.setParent(parent);
-            final DetailAST previousSiblingNode = getPreviousSibling();
+            final DetailAST previousSiblingNode = previousSibling;
 
             if (previousSiblingNode != null) {
                 ast.previousSibling = previousSiblingNode;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -257,7 +257,7 @@ public final class FileContents implements CommentListener {
      */
     @Deprecated
     public String getFilename() {
-        return getFileName();
+        return fileName;
     }
 
     /**
@@ -319,6 +319,6 @@ public final class FileContents implements CommentListener {
      * @return true if the package file.
      */
     public boolean inPackageInfo() {
-        return getFileName().endsWith("package-info.java");
+        return fileName.endsWith("package-info.java");
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
@@ -139,7 +139,7 @@ public final class FullIdent {
 
     @Override
     public String toString() {
-        return getText() + "[" + getLineNo() + "x" + getColumnNo() + "]";
+        return getText() + "[" + lineNo + "x" + columnNo + "]";
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java
@@ -56,11 +56,11 @@ public class LineColumn implements Comparable<LineColumn> {
 
     @Override
     public int compareTo(LineColumn lineColumn) {
-        if (getLine() == lineColumn.getLine()) {
-            return Integer.compare(getColumn(), lineColumn.getColumn());
+        if (line == lineColumn.line) {
+            return Integer.compare(column, lineColumn.column);
         }
         else {
-            return Integer.compare(getLine(), lineColumn.getLine());
+            return Integer.compare(line, lineColumn.line);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
@@ -136,8 +136,8 @@ public class JavadocNodeImpl implements DetailNode {
 
     @Override
     public String toString() {
-        return JavadocUtils.getTokenName(getType())
-                + "[" + getLineNumber() + "x" + getColumnNumber() + "]";
+        return JavadocUtils.getTokenName(type)
+                + "[" + lineNumber + "x" + columnNumber + "]";
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImplTest.java
@@ -38,4 +38,14 @@ public class JavadocNodeImplTest {
 
         assertEquals("CODE_LITERAL[1x2]", result);
     }
+
+    @Test
+    public void testGetColumnNumber() {
+        JavadocNodeImpl javadocNode = new JavadocNodeImpl();
+        javadocNode.setColumnNumber(1);
+
+        int result = javadocNode.getColumnNumber();
+
+        assertEquals(1, result);
+    }
 }


### PR DESCRIPTION
Fixes `CallToSimpleGetterInClass` inspection violations.

Description:
>Reports any calls to a simple property getter from within the property's class. A simple property getter is defined as one which simply returns the value of a field, and does no other calculation. Such simple getter calls may be safely inlined, at a small performance improvement. Some coding standards also suggest against the use of simple getters for code clarity reasons.