### PR TITLE
Use compiled pattern instead of dynamic regexp in checks. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -313,6 +313,9 @@ public class CustomImportOrderCheck extends Check {
     /** NON_GROUP group name. */
     private static final String NON_GROUP_RULE_GROUP = "NOT_ASSIGNED_TO_ANY_GROUP";
 
+    /** Pattern used to separate groups of imports */
+    private static final Pattern GROUP_SEPARATOR_PATTERN = Pattern.compile("\\s*###\\s*");
+
     /** RegExp for SAME_PACKAGE group imports */
     private String samePackageDomainsRegExp = "";
 
@@ -399,8 +402,7 @@ public class CustomImportOrderCheck extends Check {
      */
     public final void setCustomImportOrderRules(final String inputCustomImportOrder) {
         customImportOrderRules.clear();
-        for (String currentState : inputCustomImportOrder
-                .split("\\s*###\\s*")) {
+        for (String currentState : GROUP_SEPARATOR_PATTERN.split(inputCustomImportOrder)) {
             addRuleastoList(currentState);
         }
         customImportOrderRules.add(NON_GROUP_RULE_GROUP);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -72,6 +72,11 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
      * file.
      */
     public static final String SUMMARY_JAVADOC = "summary.javaDoc";
+    /**
+     * This regexp is used to convert multiline javdoc to single line without stars.
+     */
+    private static final Pattern JAVADOC_MULTILINE_TO_SINGLELINE_PATTERN =
+            Pattern.compile("\n[ ]+(\\*)|^[ ]+(\\*)");
 
     /**
      * Regular expression for forbidden summary fragments.
@@ -174,8 +179,8 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
      * @return true, if first sentence contains forbidden summary fragment.
      */
     private boolean containsForbiddenFragment(String firstSentence) {
-        // This regexp is used to convert multiline javdoc to single line without stars.
-        String javadocText = firstSentence.replaceAll("\n[ ]+(\\*)|^[ ]+(\\*)", " ");
+        String javadocText = JAVADOC_MULTILINE_TO_SINGLELINE_PATTERN
+                .matcher(firstSentence).replaceAll(" ");
         javadocText = CharMatcher.WHITESPACE.trimAndCollapseFrom(javadocText, ' ');
         return forbiddenSummaryFragments.matcher(javadocText).find();
     }


### PR DESCRIPTION
Fixes some `SpellDynamicRegexReplaceableByCompiledPattern` inspection violations.

Description:
>Reports calls to the regular expression methods of java.lang.String using constants arguments. Such calls may be profitably replaced with a private static final Pattern field so that the regular expression does not have to be compiled each time it is used.