### PR TITLE
Indentation fix for pom.xml. Issue #46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -846,7 +846,7 @@
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>${maven.jacoco.plugin.version}</version>
         <configuration>
-            <dataFile>${project.build.directory}/jacoco/jacoco.exec</dataFile>
+          <dataFile>${project.build.directory}/jacoco/jacoco.exec</dataFile>
           <excludes>
             <exclude>com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask*.class</exclude>
             <exclude>com/puppycrawl/tools/checkstyle/doclets/*.class</exclude>


### PR DESCRIPTION
Proper indentation is a simple and effective way to improve the code's readability. Consistent indentation among the developers on a team also reduces the differences that are committed to source control systems, making code reviews easier.

By default this rule checks that each block of code is indented but not the size of this indent. The parameter "indentSize" allows the expected indent size to be defined. Only the first line of a badly indented section is reported.


I'm not sure about other violations. If anything left after #1882 I'll fix it next time