### PR TITLE
Remove call to default toString() implementation. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -295,7 +295,8 @@ public final class TreeWalker
             for (final int token : check.getRequiredTokens()) {
                 if (Arrays.binarySearch(defaultTokens, token) < 0) {
                     final String message = String.format("Token \"%s\" from required tokens was"
-                            + " not found in default tokens list in check %s", token, check);
+                            + " not found in default tokens list in check %s",
+                            token, check.getClass().getName());
                     throw new CheckstyleException(message);
                 }
             }


### PR DESCRIPTION
Fixes `ObjectToString` inspection violations.

Description:
>Reports any calls to .toString() which use the default implementation from java.lang.Object. The default implementation is rarely desired, but easy to use by accident. Calls to .toString() on objects of type java.lang.Object are ignored by this inspection.