### PR TITLE
Use compiled pattern instead of dynamic regexp. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import java.io.File;
+import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -31,6 +32,9 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * @author maxvetrenko
  */
 public class OuterTypeFilenameCheck extends Check {
+    /** Pattern matching any file extension with dot included */
+    private static final Pattern FILE_EXTENSION_PATTERN = Pattern.compile("\\.[^\\.]*$");
+
     /** Indicates whether the first token has been seen in the file. */
     private boolean seenFirstToken;
 
@@ -109,7 +113,7 @@ public class OuterTypeFilenameCheck extends Check {
     private String getFileName() {
         String fname = getFileContents().getFileName();
         fname = fname.substring(fname.lastIndexOf(File.separatorChar) + 1);
-        fname = fname.replaceAll("\\.[^\\.]*$", "");
+        fname = FILE_EXTENSION_PATTERN.matcher(fname).replaceAll("");
         return fname;
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -51,6 +51,11 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
     public static final String IO_EXCEPTION_KEY = "unable.open.cause";
 
     /**
+     * Pattern matching single space.
+     */
+    private static final Pattern SPACE_PATTERN = Pattern.compile(" ");
+
+    /**
      * Construct the check with default values.
      */
     public UniquePropertiesCheck() {
@@ -97,8 +102,8 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
      *         file, 0 is returned
      */
     protected static int getLineNumber(List<String> lines, String keyName) {
-        final String keyPatternString =
-                "^" + keyName.replace(" ", "\\\\ ") + "[\\s:=].*$";
+        final String keyPatternString = "^" + SPACE_PATTERN.matcher(keyName)
+                        .replaceAll(Matcher.quoteReplacement("\\\\ ")) + "[\\s:=].*$";
         final Pattern keyPattern = Pattern.compile(keyPatternString);
         int lineNumber = 1;
         final Matcher matcher = keyPattern.matcher("");


### PR DESCRIPTION
Fixes `DynamicRegexReplaceableByCompiledPattern` inspection violations.

Description:
>Reports calls to the regular expression methods of java.lang.String using constants arguments. Such calls may be profitably replaced with a private static final Pattern field so that the regular expression does not have to be compiled each time it is used.