### PR TITLE
Remove unused field. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassMethodTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassMethodTypeParameterNameTest.java
@@ -15,7 +15,6 @@ public class ClassMethodTypeParameterNameTest extends BaseCheckTestSupport{
 
     private static final String MSG_KEY = "name.invalidPattern";
     private static ConfigurationBuilder builder;
-    private final String msgKey = "name.invalidPattern";
     private static Configuration configuration;
     private static String format;
 


### PR DESCRIPTION
Fixes `FieldMayBeStatic` inspection violations.

Description:
>Reports any instance variables which may safely be made static. A field may be static if it is declared final, and is initialized with a constant.