### PR TITLE
Mark method as static. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -190,7 +190,7 @@ public final class FileText extends AbstractList<String> {
      * @return File's text
      * @throws IOException Unable to open or read the file
      */
-    private String readFile(final File inputFile, final CharsetDecoder decoder)
+    private static String readFile(final File inputFile, final CharsetDecoder decoder)
             throws IOException {
         final StringBuilder buf = new StringBuilder();
         final FileInputStream stream = new FileInputStream(inputFile);


### PR DESCRIPTION
Fixes `MethodMayBeStatic` inspection violation introduced in recent commit.

Description:
>Reports any methods which may safely be made static. A method may be static if it is not synchronized, it does not reference any of its class' non static methods and non static fields and is not overridden in a sub class.