### PR TITLE
Rename boolean methods to start with question word. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -332,7 +332,7 @@ public abstract class AbstractExpressionHandler {
     private void checkSingleLine(int lineNum, IndentLevel indentLevel) {
         final String line = indentCheck.getLine(lineNum - 1);
         final int start = getLineStart(line);
-        if (indentLevel.greaterThan(start)) {
+        if (indentLevel.isGreaterThan(start)) {
             logChildError(lineNum, start, indentLevel);
         }
     }
@@ -354,8 +354,8 @@ public abstract class AbstractExpressionHandler {
         // at the correct indention level; otherwise, it is an only an
         // error if this statement starts the line and it is less than
         // the correct indentation level
-        if (mustMatch && !indentLevel.accept(start)
-                || !mustMatch && colNum == start && indentLevel.greaterThan(start)) {
+        if (mustMatch && !indentLevel.isAcceptable(start)
+                || !mustMatch && colNum == start && indentLevel.isGreaterThan(start)) {
             logChildError(lineNum, start, indentLevel);
         }
     }
@@ -507,7 +507,7 @@ public abstract class AbstractExpressionHandler {
              modifier != null;
              modifier = modifier.getNextSibling()) {
             if (startsLine(modifier)
-                && !getLevel().accept(expandedTabsColumnNo(modifier))) {
+                && !getLevel().isAcceptable(expandedTabsColumnNo(modifier))) {
                 logError(modifier, "modifier",
                     expandedTabsColumnNo(modifier));
             }
@@ -577,7 +577,7 @@ public abstract class AbstractExpressionHandler {
         // the rcurly can either be at the correct indentation,
         // or not first on the line ...
         final int rparenLevel = expandedTabsColumnNo(rparen);
-        if (getLevel().accept(rparenLevel) || !startsLine(rparen)) {
+        if (getLevel().isAcceptable(rparenLevel) || !startsLine(rparen)) {
             return;
         }
 
@@ -598,7 +598,7 @@ public abstract class AbstractExpressionHandler {
         // the rcurly can either be at the correct indentation, or on the
         // same line as the lcurly
         if (lparen == null
-            || getLevel().accept(expandedTabsColumnNo(lparen))
+            || getLevel().isAcceptable(expandedTabsColumnNo(lparen))
             || !startsLine(lparen)) {
             return;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
@@ -78,12 +78,12 @@ public class ArrayInitHandler extends BlockParentHandler {
     }
 
     @Override
-    protected boolean rcurlyMustStart() {
+    protected boolean shouldStartWithRCurly() {
         return false;
     }
 
     @Override
-    protected boolean childrenMayNest() {
+    protected boolean canChildrenBeNested() {
         return true;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -93,10 +93,10 @@ public class BlockParentHandler extends AbstractExpressionHandler {
         final DetailAST toplevel = getToplevelAST();
 
         if (toplevel == null
-            || getLevel().accept(expandedTabsColumnNo(toplevel)) || hasLabelBefore()) {
+            || getLevel().isAcceptable(expandedTabsColumnNo(toplevel)) || hasLabelBefore()) {
             return;
         }
-        if (!toplevelMustStartLine() && !startsLine(toplevel)) {
+        if (!shouldTopLevelStartLine() && !startsLine(toplevel)) {
             return;
         }
         logError(toplevel, "", expandedTabsColumnNo(toplevel));
@@ -117,7 +117,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
      *
      * @return true
      */
-    protected boolean toplevelMustStartLine() {
+    protected boolean shouldTopLevelStartLine() {
         return true;
     }
 
@@ -158,7 +158,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
         final DetailAST lcurly = getLCurly();
         final int lcurlyPos = expandedTabsColumnNo(lcurly);
 
-        if (curlyLevel().accept(lcurlyPos) || !startsLine(lcurly)) {
+        if (curlyLevel().isAcceptable(lcurlyPos) || !startsLine(lcurly)) {
             return;
         }
 
@@ -179,7 +179,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
      *
      * @return true
      */
-    protected boolean rcurlyMustStart() {
+    protected boolean shouldStartWithRCurly() {
         return true;
     }
 
@@ -188,7 +188,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
      *
      * @return false
      */
-    protected boolean childrenMayNest() {
+    protected boolean canChildrenBeNested() {
         return false;
     }
 
@@ -202,8 +202,8 @@ public class BlockParentHandler extends AbstractExpressionHandler {
         final DetailAST rcurly = getRCurly();
         final int rcurlyPos = expandedTabsColumnNo(rcurly);
 
-        if (curlyLevel().accept(rcurlyPos)
-            || !rcurlyMustStart() && !startsLine(rcurly)
+        if (curlyLevel().isAcceptable(rcurlyPos)
+            || !shouldStartWithRCurly() && !startsLine(rcurly)
             || areOnSameLine(rcurly, lcurly)) {
             return;
         }
@@ -277,7 +277,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
                               getCheckedChildren(),
                               getChildrenExpectedLevel(),
                               true,
-                              childrenMayNest());
+                              canChildrenBeNested());
             }
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CatchHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CatchHandler.java
@@ -42,7 +42,7 @@ public class CatchHandler extends BlockParentHandler {
     }
 
     @Override
-    protected boolean toplevelMustStartLine() {
+    protected boolean shouldTopLevelStartLine() {
         return false;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java
@@ -71,7 +71,7 @@ public class ClassDefHandler extends BlockParentHandler {
         if (modifiers.getChildCount() == 0) {
             final DetailAST ident = getMainAst().findFirstToken(TokenTypes.IDENT);
             final int lineStart = getLineStart(ident);
-            if (!getLevel().accept(lineStart)) {
+            if (!getLevel().isAcceptable(lineStart)) {
                 logError(ident, "ident", lineStart);
             }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/FinallyHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/FinallyHandler.java
@@ -41,7 +41,7 @@ public class FinallyHandler extends BlockParentHandler {
     }
 
     @Override
-    protected boolean toplevelMustStartLine() {
+    protected boolean shouldTopLevelStartLine() {
         return false;
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentLevel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentLevel.java
@@ -67,7 +67,7 @@ public class IndentLevel {
      * @return true if given indentation is acceptable,
      *         false otherwise.
      */
-    public boolean accept(int indent) {
+    public boolean isAcceptable(int indent) {
         return levels.get(indent);
     }
 
@@ -76,7 +76,7 @@ public class IndentLevel {
      * @return true if {@code indent} less then minimal of
      *         acceptable indentation levels, false otherwise.
      */
-    public boolean greaterThan(int indent) {
+    public boolean isGreaterThan(int indent) {
         return levels.nextSetBit(0) > indent;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
@@ -67,7 +67,7 @@ public class MemberDefHandler extends AbstractExpressionHandler {
     protected void checkModifiers() {
         final DetailAST modifier = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
         if (startsLine(modifier)
-            && !getLevel().accept(expandedTabsColumnNo(modifier))) {
+            && !getLevel().isAcceptable(expandedTabsColumnNo(modifier))) {
             logError(modifier, "modifier", expandedTabsColumnNo(modifier));
         }
     }
@@ -79,7 +79,7 @@ public class MemberDefHandler extends AbstractExpressionHandler {
         final DetailAST type = getMainAst().findFirstToken(TokenTypes.TYPE);
         final DetailAST ident = AbstractExpressionHandler.getFirstToken(type);
         final int columnNo = expandedTabsColumnNo(ident);
-        if (startsLine(ident) && !getLevel().accept(columnNo)) {
+        if (startsLine(ident) && !getLevel().isAcceptable(columnNo)) {
             logError(ident, "type", columnNo);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
@@ -52,7 +52,7 @@ public class MethodDefHandler extends BlockParentHandler {
     protected void checkModifiers() {
         final DetailAST modifier = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
         if (startsLine(modifier)
-            && !getLevel().accept(expandedTabsColumnNo(modifier))) {
+            && !getLevel().isAcceptable(expandedTabsColumnNo(modifier))) {
             logError(modifier, "modifier", expandedTabsColumnNo(modifier));
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
@@ -95,7 +95,7 @@ public class ObjectBlockHandler extends BlockParentHandler {
         final IndentLevel level = curlyLevel();
         level.addAcceptedIndent(level.getFirstIndentLevel() + getLineWrappingIndentation());
 
-        if (!level.accept(rcurlyPos) && startsLine(rcurly)) {
+        if (!level.isAcceptable(rcurlyPos) && startsLine(rcurly)) {
             logError(rcurly, "rcurly", rcurlyPos, curlyLevel());
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/PackageDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/PackageDefHandler.java
@@ -44,7 +44,7 @@ public class PackageDefHandler extends AbstractExpressionHandler {
     @Override
     public void checkIndentation() {
         final int columnNo = expandedTabsColumnNo(getMainAst());
-        if (!getLevel().accept(columnNo)) {
+        if (!getLevel().isAcceptable(columnNo)) {
             logError(getMainAst(), "", columnNo);
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/StaticInitHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/StaticInitHandler.java
@@ -41,7 +41,7 @@ public class StaticInitHandler extends BlockParentHandler {
     }
 
     @Override
-    protected boolean toplevelMustStartLine() {
+    protected boolean shouldTopLevelStartLine() {
         return false;
     }
 }


### PR DESCRIPTION
Fixes some `BooleanMethodNameMustStartWithQuestion` inspection violations.

Description:
>Reports boolean methods whose names do not start with a question word. Boolean methods that override library methods are ignored by this inspection