### PR TITLE
Use constant for empty array initialization. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AllChecksWithDefaultConfigTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AllChecksWithDefaultConfigTest.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
@@ -40,7 +41,7 @@ public class AllChecksWithDefaultConfigTest extends BaseCheckTestSupport {
         final Set<Class<?>> checkstyleChecks = getCheckstyleChecks();
         final String inputFilePath = "src/test/resources-noncompilable/"
             + "com/puppycrawl/tools/checkstyle/InputDefaultConfig.java";
-        final String[] expected = {};
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
         for (Class<?> check : checkstyleChecks) {
             final DefaultConfiguration checkConfig = createCheckConfig(check);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -292,8 +292,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         final DefaultConfiguration checkConfig =
             createCheckConfig(RequiredTokenIsNotInDefaultsCheck.class);
         final String pathToEmptyFile = temporaryFolder.newFile("file.java").getPath();
-        final String[] expected = {
-        };
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
         try {
             verify(checkConfig, pathToEmptyFile, expected);
@@ -309,8 +308,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         final DefaultConfiguration checkConfig =
             createCheckConfig(RequiredTokenIsEmptyIntArray.class);
         final String pathToEmptyFile = temporaryFolder.newFile("file.java").getPath();
-        final String[] expected = {
-        };
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
         try {
             verify(checkConfig, pathToEmptyFile, expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -32,6 +32,7 @@ import java.io.PrintWriter;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -105,7 +106,7 @@ public class XMLLoggerTest {
         final XMLLogger logger = new XMLLogger(outStream, true);
         logger.auditStarted(null);
         logger.auditFinished(null);
-        final String[] expectedLines = {};
+        final String[] expectedLines = ArrayUtils.EMPTY_STRING_ARRAY;
         verifyLines(expectedLines);
     }
 
@@ -116,7 +117,7 @@ public class XMLLoggerTest {
         logger.auditStarted(null);
         logger.auditFinished(null);
         outStream.close();
-        final String[] expectedLines = {};
+        final String[] expectedLines = ArrayUtils.EMPTY_STRING_ARRAY;
         verifyLines(expectedLines);
     }
 
@@ -189,7 +190,7 @@ public class XMLLoggerTest {
         final AuditEvent ev = new AuditEvent(this, "Test.java", message);
         logger.addError(ev);
         logger.auditFinished(null);
-        final String[] expectedLines = {};
+        final String[] expectedLines = ArrayUtils.EMPTY_STRING_ARRAY;
         verifyLines(expectedLines);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -55,7 +56,7 @@ public class SuppressWarningsFilterTest
     @Test
     public void testNone() throws Exception {
         final DefaultConfiguration filterConfig = null;
-        final String[] suppressed = {};
+        final String[] suppressed = ArrayUtils.EMPTY_STRING_ARRAY;
         verifySuppressed(filterConfig, suppressed);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Locale;
 
 import org.apache.commons.beanutils.ConversionException;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -81,8 +82,7 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testNone() throws Exception {
         final DefaultConfiguration filterConfig = null;
-        final String[] suppressed = {
-        };
+        final String[] suppressed = ArrayUtils.EMPTY_STRING_ARRAY;
         verifySuppressed(filterConfig, suppressed);
     }
 
@@ -239,8 +239,7 @@ public class SuppressWithNearbyCommentFilterTest
         final DefaultConfiguration filterConfig =
             createFilterConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("influenceFormat", "a");
-        final String[] suppressed = {
-        };
+        final String[] suppressed = ArrayUtils.EMPTY_STRING_ARRAY;
         verifySuppressed(filterConfig, suppressed);
     }
 
@@ -249,8 +248,7 @@ public class SuppressWithNearbyCommentFilterTest
         final DefaultConfiguration filterConfig =
             createFilterConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("checkFormat", "a[l");
-        final String[] suppressed = {
-        };
+        final String[] suppressed = ArrayUtils.EMPTY_STRING_ARRAY;
         verifySuppressed(filterConfig, suppressed);
     }
 
@@ -286,8 +284,7 @@ public class SuppressWithNearbyCommentFilterTest
         filterConfig.addAttribute("commentFormat", "SUPPRESS CHECKSTYLE (\\w+)");
         filterConfig.addAttribute("checkFormat", "IllegalCatchCheck");
         filterConfig.addAttribute("messageFormat", "^$1 ololo*$");
-        final String[] suppressed = {
-        };
+        final String[] suppressed = ArrayUtils.EMPTY_STRING_ARRAY;
         verifySuppressed(filterConfig, suppressed);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Locale;
 
 import org.apache.commons.beanutils.ConversionException;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -72,8 +73,7 @@ public class SuppressionCommentFilterTest
     @Test
     public void testNone() throws Exception {
         final DefaultConfiguration filterConfig = null;
-        final String[] suppressed = {
-        };
+        final String[] suppressed = ArrayUtils.EMPTY_STRING_ARRAY;
         verifySuppressed(filterConfig, suppressed);
     }
 
@@ -253,8 +253,7 @@ public class SuppressionCommentFilterTest
         final DefaultConfiguration filterConfig =
             createFilterConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("checkFormat", "e[l");
-        final String[] suppressed = {
-        };
+        final String[] suppressed = ArrayUtils.EMPTY_STRING_ARRAY;
         verifySuppressed(filterConfig, suppressed);
     }
 
@@ -263,8 +262,7 @@ public class SuppressionCommentFilterTest
         final DefaultConfiguration filterConfig =
             createFilterConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("messageFormat", "e[l");
-        final String[] suppressed = {
-        };
+        final String[] suppressed = ArrayUtils.EMPTY_STRING_ARRAY;
         verifySuppressed(filterConfig, suppressed);
     }
 


### PR DESCRIPTION
Fixes `ZeroLengthArrayInitialization` inspection violations.

Description:
>Reports on allocations of arrays with known lengths of zero. Since array lengths in Java are non-modifiable, it is almost always possible to share zero-length arrays, rather than repeatedly allocating new zero-length arrays. Such sharing may provide useful optimizations in program runtime or footprint. Note that this inspection does not report zero-length arrays allocated as static final fields, as it is assumed that those arrays are being used to implement array sharing.