### PR TITLE
Use explicit charset in test code. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -12,6 +12,7 @@ import java.io.LineNumberReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -114,7 +115,7 @@ public abstract class BaseCheckTestSupport {
         final ByteArrayInputStream bais =
                 new ByteArrayInputStream(baos.toByteArray());
         final LineNumberReader lnr =
-                new LineNumberReader(new InputStreamReader(bais));
+                new LineNumberReader(new InputStreamReader(bais, StandardCharsets.UTF_8));
 
         for (int i = 0; i < expected.length; i++) {
             final String expectedResult = messageFileName + ":" + expected[i];

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -220,7 +221,7 @@ public class XMLLoggerTest {
         final ByteArrayInputStream inStream =
             new ByteArrayInputStream(bytes);
         final BufferedReader reader =
-            new BufferedReader(new InputStreamReader(inStream));
+            new BufferedReader(new InputStreamReader(inStream, StandardCharsets.UTF_8));
         final List<String> lineList = Lists.newArrayList();
         while (true) {
             final String line = reader.readLine();


### PR DESCRIPTION
Fixes some `ImplicitDefaultCharsetUsage` inspection violations.

Description:
>Reports method and constructor calls which implicitly use the platform's default charset. These can produce different results on (e.g. foreign language) systems that use a different default charset, resulting in unexpected behaviour.