### PR TITLE
Remove unnecessary this keyword. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Comment.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Comment.java
@@ -52,9 +52,9 @@ public class Comment implements TextBlock {
         this.text = new String[text.length];
         System.arraycopy(text, 0, this.text, 0, this.text.length);
         startLineNo = lastLine - this.text.length + 1;
-        this.endLineNo = lastLine;
-        this.startColNo = firstCol;
-        this.endColNo = lastCol;
+        endLineNo = lastLine;
+        startColNo = firstCol;
+        endColNo = lastCol;
     }
 
     @Override


### PR DESCRIPTION
Fixes `UnnecessaryThis` inspection violations.

Description:
>Reports on any unnecessary uses of this in the code. Using this to disambiguate a code reference may easily become unnecessary via automatic refactorings, and is discouraged by many coding styles.