### PR TITLE
Fix various typos in Java code. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -119,7 +119,7 @@ public class GenericWhitespaceCheck extends Check {
 
     @Override
     public void beginTree(DetailAST rootAST) {
-        // Reset for each tree, just incase there are errors in preceeding
+        // Reset for each tree, just increase there are errors in preceding
         // trees.
         depth = 0;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
@@ -151,9 +151,9 @@ public class MethodParamPadCheck
     }
 
     /**
-     * Control whether whitespace is flagged at linebreaks.
+     * Control whether whitespace is flagged at line breaks.
      * @param allowLineBreaks whether whitespace should be
-     * flagged at linebreaks.
+     * flagged at line breaks.
      */
     public void setAllowLineBreaks(boolean allowLineBreaks) {
         this.allowLineBreaks = allowLineBreaks;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -178,7 +178,7 @@ public class NoWhitespaceAfterCheck extends Check {
             typeOrIdent = arrayDeclarator.getParent().getFirstChild();
         }
         else if (isMultiDimensionalArray(arrayDeclarator)) {
-            if (isCstyleMultiDimensionalArrayDeclaration(arrayDeclarator)) {
+            if (isCStyleMultiDimensionalArrayDeclaration(arrayDeclarator)) {
                 if (arrayDeclarator.getParent().getType() != TokenTypes.ARRAY_DECLARATOR) {
                     typeOrIdent = getArrayIdentifier(arrayDeclarator);
                 }
@@ -192,7 +192,7 @@ public class NoWhitespaceAfterCheck extends Check {
             }
         }
         else {
-            if (isCstyleArrayDeclaration(arrayDeclarator)) {
+            if (isCStyleArrayDeclaration(arrayDeclarator)) {
                 typeOrIdent = getArrayIdentifier(arrayDeclarator);
             }
             else {
@@ -258,9 +258,9 @@ public class NoWhitespaceAfterCheck extends Check {
     }
 
     /**
-     * Control whether whitespace is flagged at linebreaks.
+     * Control whether whitespace is flagged at line breaks.
      * @param allowLineBreaks whether whitespace should be
-     * flagged at linebreaks.
+     * flagged at line breaks.
      */
     public void setAllowLineBreaks(boolean allowLineBreaks) {
         this.allowLineBreaks = allowLineBreaks;
@@ -281,7 +281,7 @@ public class NoWhitespaceAfterCheck extends Check {
      * @param arrayDeclaration {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR}
      * @return true if array is declared in C style
      */
-    private static boolean isCstyleArrayDeclaration(DetailAST arrayDeclaration) {
+    private static boolean isCStyleArrayDeclaration(DetailAST arrayDeclaration) {
         boolean result = false;
         final DetailAST identifier = getArrayIdentifier(arrayDeclaration);
         if (identifier != null) {
@@ -298,13 +298,13 @@ public class NoWhitespaceAfterCheck extends Check {
      * @param arrayDeclaration {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR}
      * @return true if multidimensional array is declared in C style.
      */
-    private static boolean isCstyleMultiDimensionalArrayDeclaration(DetailAST arrayDeclaration) {
+    private static boolean isCStyleMultiDimensionalArrayDeclaration(DetailAST arrayDeclaration) {
         boolean result = false;
         DetailAST parentArrayDeclaration = arrayDeclaration;
         while (parentArrayDeclaration != null) {
             if (parentArrayDeclaration.getParent() != null
                     && parentArrayDeclaration.getParent().getType() == TokenTypes.TYPE) {
-                result = isCstyleArrayDeclaration(parentArrayDeclaration);
+                result = isCStyleArrayDeclaration(parentArrayDeclaration);
             }
             parentArrayDeclaration = parentArrayDeclaration.getParent();
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/PadOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/PadOption.java
@@ -35,7 +35,7 @@ public enum PadOption {
 
     /**
      * Represents mandatory spacing following a left parenthesis
-     * and preceeing a right one.
+     * and preceding a right one.
      */
     SPACE
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
@@ -159,7 +159,7 @@ public class ParenPadCheck extends AbstractParenPadCheck {
      */
     private void visitLiteralFor(DetailAST ast) {
         DetailAST parenAst = ast.findFirstToken(TokenTypes.LPAREN);
-        if (!isPreceedsEmptyForInit(parenAst)) {
+        if (!isPrecedingEmptyForInit(parenAst)) {
             processLeft(parenAst);
         }
         parenAst = ast.findFirstToken(TokenTypes.RPAREN);
@@ -269,9 +269,9 @@ public class ParenPadCheck extends AbstractParenPadCheck {
 
     /**
      * @param ast the token to check
-     * @return whether a token preceeds an empty for initializer
+     * @return whether a token precedes an empty for initializer
      */
-    private static boolean isPreceedsEmptyForInit(DetailAST ast) {
+    private static boolean isPrecedingEmptyForInit(DetailAST ast) {
         boolean result = false;
         final DetailAST parent = ast.getParent();
         //Only traditional for statements are examined, not for-each statements

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -366,7 +366,7 @@ public class WhitespaceAroundCheck extends Check {
             // Check for "return;"
             && !(currentType == TokenTypes.LITERAL_RETURN
                 && ast.getFirstChild().getType() == TokenTypes.SEMI)
-            && !isAnnonimousInnerClassEnd(currentType, nextChar)) {
+            && !isAnonymousInnerClassEnd(currentType, nextChar)) {
 
             log(ast.getLineNo(), ast.getColumnNo() + ast.getText().length(),
                     WS_NOT_FOLLOWED, ast.getText());
@@ -379,7 +379,7 @@ public class WhitespaceAroundCheck extends Check {
      * @param nextChar next symbol
      * @return true is that is end of anon inner class
      */
-    private static boolean isAnnonimousInnerClassEnd(int currentType, char nextChar) {
+    private static boolean isAnonymousInnerClassEnd(int currentType, char nextChar) {
         return currentType == TokenTypes.RCURLY
             && (nextChar == ')'
                 || nextChar == ';'
@@ -417,7 +417,7 @@ public class WhitespaceAroundCheck extends Check {
             return true;
         }
 
-        // Checks if empty methods, ctors or loops are allowed.
+        // Checks if empty methods, constructors or loops are allowed.
         if (isEmptyBlock(ast, parentType)) {
             return true;
         }
@@ -461,7 +461,7 @@ public class WhitespaceAroundCheck extends Check {
 
     /**
      * Is array initialization
-     * @param currentType curret token
+     * @param currentType current token
      * @param parentType parent token
      * @return true is current token inside array initialization
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -311,18 +311,18 @@ public class SuppressWithNearbyCommentFilter
             //Does not intern Patterns with Utils.getPattern()
             String format = "";
             try {
-                format = expandFrocomment(text, filter.checkFormat, filter.commentRegexp);
+                format = expandFromComment(text, filter.checkFormat, filter.commentRegexp);
                 tagCheckRegexp = Pattern.compile(format);
                 if (filter.messageFormat != null) {
-                    format = expandFrocomment(
-                         text, filter.messageFormat, filter.commentRegexp);
+                    format = expandFromComment(
+                            text, filter.messageFormat, filter.commentRegexp);
                     tagMessageRegexp = Pattern.compile(format);
                 }
                 else {
                     tagMessageRegexp = null;
                 }
-                format = expandFrocomment(
-                    text, filter.influenceFormat, filter.commentRegexp);
+                format = expandFromComment(
+                        text, filter.influenceFormat, filter.commentRegexp);
                 int influence;
                 try {
                     if (Utils.startsWithChar(format, '+')) {
@@ -423,7 +423,7 @@ public class SuppressWithNearbyCommentFilter
          * @param regexp the parsed expander.
          * @return the expanded string
          */
-        private static String expandFrocomment(
+        private static String expandFromComment(
             String comment,
             String stringToExpand,
             Pattern regexp) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -106,7 +106,7 @@ public class SuppressionCommentFilter
     private WeakReference<FileContents> fileContentsReference = new WeakReference<>(null);
 
     /**
-     * Constructs a SuppressionCoontFilter.
+     * Constructs a SuppressionCommentFilter.
      * Initializes comment on, comment off, and check formats
      * to defaults.
      */
@@ -233,10 +233,10 @@ public class SuppressionCommentFilter
             tagSuppressions(contents.getCppComments().values());
         }
         if (checkC) {
-            final Collection<List<TextBlock>> cCoonts = contents
+            final Collection<List<TextBlock>> cComments = contents
                     .getCComments().values();
-            for (List<TextBlock> eleont : cCoonts) {
-                tagSuppressions(eleont);
+            for (List<TextBlock> element : cComments) {
+                tagSuppressions(element);
             }
         }
         Collections.sort(tags);
@@ -292,7 +292,7 @@ public class SuppressionCommentFilter
 
     /**
      * A Tag holds a suppression comment and its location, and determines
-     * whether the supression turns checkstyle reporting on or off.
+     * whether the suppression turns checkstyle reporting on or off.
      * @author Rick Giles
      */
     public static class Tag

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -118,7 +118,7 @@ public final class SuppressionsLoader
 
     /**
      * Returns the suppression filters in a specified file.
-     * @param filename name of the suppresssions file.
+     * @param filename name of the suppressions file.
      * @return the filter chain of suppression elements specified in the file.
      * @throws CheckstyleException if an error occurs.
      */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -138,7 +138,7 @@ public class EmptyLineSeparatorCheckTest
     }
 
     @Test
-    public void testPrePreviousLineEmpiness() throws Exception {
+    public void testPrePreviousLineEmptiness() throws Exception {
         DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
         checkConfig.addAttribute("allowMultipleEmptyLines", "false");
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -267,7 +267,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testloadSuppressionsURISyntaxException() throws Exception {
+    public void testLoadSuppressionsURISyntaxException() throws Exception {
         URL configUrl = mock(URL.class);
 
         when(configUrl.toURI()).thenThrow(URISyntaxException.class);


### PR DESCRIPTION
Fixes some `SpellCheckingInspection` inspection violations.

Description:
>Spellchecker inspection helps locate typos and misspelling in your code, comments and literals, and fix them in one click.