### PR TITLE
Add argument to exception constructor invocation. #1555

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -154,7 +154,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
                     || indentInComment < expectedMinimalIndent && isWarnComment;
         }
 
-        throw new IllegalStateException();
+        throw new IllegalStateException("Comments are not consistent");
     }
 
     private static int getLineStart(String line, final int tabWidth) {


### PR DESCRIPTION
Fixes `NewExceptionWithoutArguments` inspection violation.

Description:
>Reports exception instance creation without any arguments specified. When an exception is constructed without arguments it contains no information about the fault that happened, which makes debugging needlessly hard.