### PR TITLE
fixed problem with lexical order in CustomImportOrder #1469

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -460,24 +460,25 @@ public class CustomImportOrderCheck extends Check {
         final ImportDetails firstImport = importToGroupList.get(0);
         String currentGroup = getImportGroup(firstImport.isStaticImport(),
                 firstImport.getImportFullPath());
-        int groupNumber = customImportOrderRules.indexOf(currentGroup);
-        String previousImport = null;
+        int currentGroupNumber = customImportOrderRules.indexOf(currentGroup);
+        String previousImportFromCurrentGroup = null;
 
         for (ImportDetails importObject : importToGroupList) {
             final String importGroup = importObject.getImportGroup();
-            final String fullImportIdent = importObject.importFullPath;
+            final String fullImportIdent = importObject.getImportFullPath();
 
             if (!importGroup.equals(currentGroup)) {
-                if (customImportOrderRules.size() > groupNumber + 1) {
-                    final String nextGroup = getNextImportGroup(groupNumber + 1);
+                //not the last group, last one is always NON_GROUP
+                if (customImportOrderRules.size() > currentGroupNumber + 1) {
+                    final String nextGroup = getNextImportGroup(currentGroupNumber + 1);
                     if (importGroup.equals(nextGroup)) {
                         if (separateLineBetweenGroups
                                 && !hasEmptyLineBefore(importObject.getLineNumber())) {
-                            log(importObject.getLineNumber(), MSG_LINE_SEPARATOR,
-                                    fullImportIdent);
+                            log(importObject.getLineNumber(), MSG_LINE_SEPARATOR, fullImportIdent);
                         }
                         currentGroup = nextGroup;
-                        groupNumber = customImportOrderRules.indexOf(nextGroup);
+                        currentGroupNumber = customImportOrderRules.indexOf(nextGroup);
+                        previousImportFromCurrentGroup = fullImportIdent;
                     }
                     else {
                         logWrongImportGroupOrder(importObject.getLineNumber(),
@@ -489,14 +490,17 @@ public class CustomImportOrderCheck extends Check {
                             importGroup, currentGroup, fullImportIdent);
                 }
             }
-            else if (sortImportsInGroupAlphabetically
-                    && previousImport != null
-                    && matchesImportGroup(importObject.isStaticImport(),
-                            fullImportIdent, currentGroup)
-                    && compareImports(fullImportIdent, previousImport) < 0) {
-                log(importObject.getLineNumber(), MSG_LEX, fullImportIdent, previousImport);
+            else {
+                if (sortImportsInGroupAlphabetically
+                    && previousImportFromCurrentGroup != null
+                    && compareImports(fullImportIdent, previousImportFromCurrentGroup) < 0) {
+                    log(importObject.getLineNumber(), MSG_LEX,
+                            fullImportIdent, previousImportFromCurrentGroup);
+                }
+                else {
+                    previousImportFromCurrentGroup = fullImportIdent;
+                }
             }
-            previousImport = fullImportIdent;
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -70,6 +70,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
             "4: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT", "java.io.File.createTempFile"),
+            "5: " + getCheckMessage(MSG_LEX, "java.awt.print.Paper.*", "java.io.File.createTempFile"),
             "8: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.awt.Button"),
             "9: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.awt.Frame"),
             "10: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.awt.Dialog"),
@@ -101,8 +102,12 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
             "4: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT", "java.io.File.createTempFile"),
+            "5: " + getCheckMessage(MSG_LEX, "java.awt.print.Paper.*", "java.io.File.createTempFile"),
             "10: " + getCheckMessage(MSG_LEX, "java.awt.Dialog", "java.awt.Frame"),
             "15: " + getCheckMessage(MSG_LEX, "java.io.File", "javax.swing.JTable"),
+            "16: " + getCheckMessage(MSG_LEX, "java.io.IOException", "javax.swing.JTable"),
+            "17: " + getCheckMessage(MSG_LEX, "java.io.InputStream", "javax.swing.JTable"),
+            "18: " + getCheckMessage(MSG_LEX, "java.io.Reader", "javax.swing.JTable"),
             "22: " + getCheckMessage(MSG_LEX, "com.google.common.collect.*", "com.puppycrawl.tools.*"),
         };
 
@@ -123,8 +128,12 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
             "4: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT", "java.io.File.createTempFile"),
+            "5: " + getCheckMessage(MSG_LEX, "java.awt.print.Paper.*", "java.io.File.createTempFile"),
             "10: " + getCheckMessage(MSG_LEX, "java.awt.Dialog", "java.awt.Frame"),
             "15: " + getCheckMessage(MSG_LEX, "java.io.File", "javax.swing.JTable"),
+            "16: " + getCheckMessage(MSG_LEX, "java.io.IOException", "javax.swing.JTable"),
+            "17: " + getCheckMessage(MSG_LEX, "java.io.InputStream", "javax.swing.JTable"),
+            "18: " + getCheckMessage(MSG_LEX, "java.io.Reader", "javax.swing.JTable"),
             "20: " + getCheckMessage(MSG_ORDER, SAME, THIRD, "com.puppycrawl.tools.*"),
             "22: " + getCheckMessage(MSG_NONGROUP_IMPORT, "com.google.common.collect.*"),
             "23: " + getCheckMessage(MSG_LINE_SEPARATOR, "org.junit.*"),
@@ -143,11 +152,15 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
                 "STANDARD_JAVA_PACKAGE");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
+            "4: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT", "java.io.File.createTempFile"),
             "7: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD, "java.util.List"),
             "8: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD, "java.util.StringTokenizer"),
             "9: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD, "java.util.*"),
             "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD, "java.util.concurrent.AbstractExecutorService"),
             "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD, "java.util.concurrent.*"),
+            "13: " + getCheckMessage(MSG_LEX, "com.puppycrawl.tools.*", "javax.swing.WindowConstants.*"),
+            "14: " + getCheckMessage(MSG_LEX, "com.*", "javax.swing.WindowConstants.*"),
+            "16: " + getCheckMessage(MSG_LEX, "com.google.common.base.*", "javax.swing.WindowConstants.*"),
         };
 
         verify(checkConfig, getPath("imports" + File.separator
@@ -163,11 +176,14 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
                 "STATIC###SAME_PACKAGE(3)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
+            "5: " + getCheckMessage(MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
             "6: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
             "7: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "java.awt.Button.ABORT"),
             "8: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "javax.swing.WindowConstants.*"),
+            "9: " + getCheckMessage(MSG_LEX, "com.puppycrawl.tools.*", "java.util.StringTokenizer"),
             "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.AbstractExecutorService"),
             "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "java.io.File.createTempFile"),
+            "12: " + getCheckMessage(MSG_LEX, "com.*", "java.util.StringTokenizer"),
         };
 
         verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
@@ -185,11 +201,14 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
                 "STATIC###SAME_PACKAGE(3)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
+            "5: " + getCheckMessage(MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
             "6: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
             "7: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "java.awt.Button.ABORT"),
             "8: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "javax.swing.WindowConstants.*"),
+            "9: " + getCheckMessage(MSG_LEX, "com.puppycrawl.tools.*", "java.util.StringTokenizer"),
             "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.AbstractExecutorService"),
             "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "java.io.File.createTempFile"),
+            "12: " + getCheckMessage(MSG_LEX, "com.*", "java.util.StringTokenizer"),
         };
 
         verify(checkConfig, new File("src/test/resources-noncompilable/com/puppycrawl/tools/"
@@ -207,6 +226,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
             "4: " + getCheckMessage(MSG_LEX, "java.io.File.createTempFile", "javax.swing.WindowConstants.*"),
+            "8: " + getCheckMessage(MSG_LEX, "com.*", "com.puppycrawl.tools.*"),
         };
 
         verify(checkConfig, getPath("imports" + File.separator
@@ -508,4 +528,5 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
             fail();
         }
     }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackage.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackage.java
@@ -2,15 +2,23 @@
 package java.util.concurrent;
 import com.google.common.*;
 import java.util.StringTokenizer;
-import java.util.*;
-import java.util.concurrent.*;
-import static java.awt.Button.ABORT;
-import static javax.swing.WindowConstants.*;
-import com.puppycrawl.tools.*;
-import java.util.concurrent.AbstractExecutorService;
-import static java.io.File.createTempFile;
-import com.*;
+import java.util.*; //warn, LEX, should be before "java.util.StringTokenizer"
+import java.util.concurrent.*; //warn, ORDER, should be on SAME_PACKAGE, now NOT_ASSIGNED
+import static java.awt.Button.ABORT; //warn, ORDER, should be on STATIC, now NOT_ASSIGNED
+import static javax.swing.WindowConstants.*; //warn, ORDER, should be on STATIC, now NOT_ASSIGNED
+import com.puppycrawl.tools.*; //warn, LEX, should be before "java.util.StringTokenizer"
+import java.util.concurrent.AbstractExecutorService; //warn, ORDER, should be on SAME_PACKAGE, now NOT_ASSIGNED
+import static java.io.File.createTempFile; //warn, ORDER, should be on STATIC, now NOT_ASSIGNED
+import com.*; //warn, LEX, should be before "java.util.StringTokenizer"
 import org.apache.*;
 
 public class InputCustomImportOrderSamePackage {
 }
+/*
+test: testStaticSamePackage()
+configuration:
+        checkConfig.addAttribute("thirdPartyPackageRegExp", "org.");
+        checkConfig.addAttribute("customImportOrderRules",
+                "STATIC###SAME_PACKAGE(3)");
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
+*/

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackage2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderSamePackage2.java
@@ -1,12 +1,18 @@
 //Moved to noncompilable because UT requires imports from the same package
 package java.util.concurrent;
 import java.util.regex.Pattern;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.StringTokenizer;
-import java.util.*;
-import java.util.concurrent.AbstractExecutorService;
-import java.util.concurrent.*;
+import java.util.List; //warn, LEX, should be before "java.util.regex.Pattern"
+import java.util.regex.Matcher; //warn, LEX, should be before "java.util.regex.Pattern"
+import java.util.StringTokenizer; //warn, LEX, should be before "java.util.regex.Pattern"
+import java.util.*;  //warn, LEX, should be before "java.util.regex.Pattern"
+import java.util.concurrent.AbstractExecutorService; //warn, ORDER, should be on SAME_PACKAGE, now NOT_ASSIGNED
+import java.util.concurrent.*; //warn, ORDER, should be on SAME_PACKAGE, now NOT_ASSIGNED
 
 public class InputCustomImportOrderSamePackage2 {
 }
+/*
+test: testOnlySamePackage()
+configuration:
+        checkConfig.addAttribute("customImportOrderRules", "SAME_PACKAGE(3)");
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
+*/

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderThirdPartyAndSpecial.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrderThirdPartyAndSpecial.java
@@ -8,11 +8,20 @@ import org.apache.commons.io.ByteOrderMark;
 
 import static sun.tools.util.ModifierFilter.ALL_ACCESS;
 
-import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtCompatible; //warn, ORDER, should be on THIRD_PARTY_PACKAGE, now SPECIAL_IMPORTS
 
 import antlr.*;
+import antlr.CommonASTWithHiddenTokens;
+import antlr.Token;
+import antlr.collections.AST;
 
 public class InputCustomImportOrderThirdPartyAndSpecial
 {
-
 }
+/*
+test: testThirdPartyAndSpecialImports()
+configuration:
+        checkConfig.addAttribute("specialImportsRegExp", "antlr.*");
+        checkConfig.addAttribute("customImportOrderRules",
+                "SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STATIC###SPECIAL_IMPORTS");
+*/


### PR DESCRIPTION
Fixed issues in #1469 
Now lexical order works only within a group, renamed few variables to better illustrate that.

Following additional improvement was done: previously violation was raised only for first lexical error in a group, in some cases after fixing this violation and rerunning the check user may see lexical violations for imports after fixed one. Now trying to raise these violations immediately.
Consider scenario below:
```java
import java.util.StringTokenizer; //#1
import java.util.*; //#2
import java.util.Arrays; //#3
```
Config: STANDARD_JAVA_PACKAGE
We had only one message:`'java.util.*' should be before 'java.util.StringTokenizer'`
Once user moves *#*2 to the very beginning and reruns validation, error message will be: `'java.util.Arrays' should be before 'java.util.StringTokenizer'`
It happens because check always compared to previous import. In this situation *#*2>*#*1 is  and *#*3>*#*2.
We can detect this situation immediately, if we compare *#*3 to last correct import from the same group (*#*1).

There are good examples in the end of Bazel reports below.

Reports:
on GUAWA to indicate no changes on good project: [before](https://ivanov-alex.github.io/i1469/target_guawa_messages/site/checkstyle.html), [after](https://ivanov-alex.github.io/i1469/target_guawa_lexic/site/checkstyle.html), [comparison](https://www.diffchecker.com/ich8fuuo)
on Bazel: [before](https://ivanov-alex.github.io/i1469/target_bazel_messages/site/checkstyle.html), [after](https://ivanov-alex.github.io/i1469/target_bazel_lexic/site/checkstyle.html), [comparison](https://www.diffchecker.com/tygxobe1)
on Checkstyle & Sevntu_Checkstyle: [before](https://ivanov-alex.github.io/i1469/target_checkstyle_messages/site/checkstyle.html), [after](https://ivanov-alex.github.io/i1469/target_checkstyle_lexic/site/checkstyle.html), [comparison](https://www.diffchecker.com/x4hkm2wt)
Please note that there are no violations on Checkstyle (only on Sevntu): one more sign that there are no unexpected effects for existing projects.
