### PR TITLE
Rename boolean methods to start with question word. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -157,7 +157,7 @@ final class PropertyCacheFile {
      * @param timestamp the timestamp of the file to check
      * @return whether the specified file has already been checked ok
      */
-    boolean inCache(String uncheckedFileName, long timestamp) {
+    boolean isInCache(String uncheckedFileName, long timestamp) {
         final String lastChecked = details.getProperty(uncheckedFileName);
         return lastChecked != null
             && lastChecked.equals(Long.toString(timestamp));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -186,7 +186,7 @@ public final class TreeWalker
         final String fileName = file.getPath();
         final long timestamp = file.lastModified();
         if (cache != null
-                && (cache.inCache(fileName, timestamp)
+                && (cache.isInCache(fileName, timestamp)
                     || !CommonUtils.fileExtensionMatches(file, getFileExtensions()))) {
             return;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
@@ -149,7 +149,7 @@ public abstract class AbstractDeclarationCollector extends Check {
         if (frame instanceof ClassFrame) {
             final DetailAST mods =
                     ast.findFirstToken(TokenTypes.MODIFIERS);
-            if (ScopeUtils.inInterfaceBlock(ast)
+            if (ScopeUtils.isInInterfaceBlock(ast)
                     || mods.branchContains(TokenTypes.LITERAL_STATIC)) {
                 ((ClassFrame) frame).addStaticMember(name);
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -174,7 +174,7 @@ public abstract class AbstractSuperCheck
      */
     private boolean isOverridingMethod(DetailAST ast) {
         if (ast.getType() != TokenTypes.METHOD_DEF
-            || ScopeUtils.inInterfaceOrAnnotationBlock(ast)) {
+            || ScopeUtils.isInInterfaceOrAnnotationBlock(ast)) {
             return false;
         }
         final DetailAST nameAST = ast.findFirstToken(TokenTypes.IDENT);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -121,7 +121,7 @@ public class ExplicitInitializationCheck extends Check {
         // do not check local variables and
         // fields declared in interface/annotations
         if (ScopeUtils.isLocalVariableDef(ast)
-            || ScopeUtils.inInterfaceOrAnnotationBlock(ast)) {
+            || ScopeUtils.isInInterfaceOrAnnotationBlock(ast)) {
             return true;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -180,10 +180,10 @@ public class FinalLocalVariableCheck extends Check {
                 break;
 
             case TokenTypes.PARAMETER_DEF:
-                if (!inLambda(ast)
+                if (!isInLambda(ast)
                         && !ast.branchContains(TokenTypes.FINAL)
-                        && !inAbstractOrNativeMethod(ast)
-                        && !ScopeUtils.inInterfaceBlock(ast)) {
+                        && !isInAbstractOrNativeMethod(ast)
+                        && !ScopeUtils.isInInterfaceBlock(ast)) {
                     insertVariable(ast);
                 }
                 break;
@@ -249,7 +249,7 @@ public class FinalLocalVariableCheck extends Check {
      * @param ast the AST to check.
      * @return true if ast is a descendant of an abstract or native method.
      */
-    private static boolean inAbstractOrNativeMethod(DetailAST ast) {
+    private static boolean isInAbstractOrNativeMethod(DetailAST ast) {
         boolean abstractOrNative = false;
         DetailAST parent = ast.getParent();
         while (parent != null && !abstractOrNative) {
@@ -269,7 +269,7 @@ public class FinalLocalVariableCheck extends Check {
      * @param paramDef {@link TokenTypes#PARAMETER_DEF parameter def}.
      * @return true if current param is lamda's param.
      */
-    private static boolean inLambda(DetailAST paramDef) {
+    private static boolean isInLambda(DetailAST paramDef) {
         return paramDef.getParent().getParent().getType() == TokenTypes.LAMBDA;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -276,7 +276,7 @@ public class HiddenFieldCheck
      * @param ast the variable token.
      */
     private void processVariable(DetailAST ast) {
-        if (!ScopeUtils.inInterfaceOrAnnotationBlock(ast)
+        if (!ScopeUtils.isInInterfaceOrAnnotationBlock(ast)
             && (ScopeUtils.isLocalVariableDef(ast)
                 || ast.getType() == TokenTypes.PARAMETER_DEF)) {
             // local variable or parameter. Does it shadow a field?
@@ -301,7 +301,7 @@ public class HiddenFieldCheck
      */
     private boolean isStaticOrOnstanceField(DetailAST ast, String name) {
         return frame.containsStaticField(name)
-                || !inStatic(ast) && frame.containsInstanceField(name);
+                || !isInStatic(ast) && frame.containsInstanceField(name);
     }
 
     /**
@@ -319,7 +319,7 @@ public class HiddenFieldCheck
      * @param ast the node to check.
      * @return true if ast is in a static method or a static block;
      */
-    private static boolean inStatic(DetailAST ast) {
+    private static boolean isInStatic(DetailAST ast) {
         DetailAST parent = ast.getParent();
         boolean inStatic = false;
 
@@ -389,7 +389,7 @@ public class HiddenFieldCheck
             final DetailAST typeAST = aMethodAST.findFirstToken(TokenTypes.TYPE);
             final String returnType = typeAST.getFirstChild().getText();
             if (typeAST.branchContains(TokenTypes.LITERAL_VOID)
-                    || setterCanReturnItsClass && frame.embeddedIn(returnType)) {
+                    || setterCanReturnItsClass && frame.isEmbeddedIn(returnType)) {
                 // this method has signature
                 //
                 //     void set${Name}(${anyType} ${name})
@@ -608,7 +608,7 @@ public class HiddenFieldCheck
          * @return true if current frame is embedded in class or enum
          * with name classOrNameName
          */
-        private boolean embeddedIn(String classOrEnumName) {
+        private boolean isEmbeddedIn(String classOrEnumName) {
             FieldFrame currentFrame = this;
             while (currentFrame != null) {
                 if (Objects.equals(currentFrame.frameName, classOrEnumName)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -213,7 +213,7 @@ public class MagicNumberCheck extends Check {
             return;
         }
 
-        if (inIgnoreList(ast)
+        if (isInIgnoreList(ast)
             || ignoreHashCodeMethod && isInHashCodeMethod(ast)) {
             return;
         }
@@ -273,7 +273,7 @@ public class MagicNumberCheck extends Check {
         }
 
         // implicit constant?
-        if (ScopeUtils.inInterfaceOrAnnotationBlock(varDefAST)
+        if (ScopeUtils.isInInterfaceOrAnnotationBlock(varDefAST)
             || varDefAST.getType() == TokenTypes.ENUM_CONSTANT_DEF) {
             return varDefAST;
         }
@@ -323,7 +323,7 @@ public class MagicNumberCheck extends Check {
      */
     private static boolean isInHashCodeMethod(DetailAST ast) {
         // if not in a code block, can't be in hashCode()
-        if (!ScopeUtils.inCodeBlock(ast)) {
+        if (!ScopeUtils.isInCodeBlock(ast)) {
             return false;
         }
 
@@ -360,7 +360,7 @@ public class MagicNumberCheck extends Check {
      * @return true if the number of ast is in the ignore list of this
      * check.
      */
-    private boolean inIgnoreList(DetailAST ast) {
+    private boolean isInIgnoreList(DetailAST ast) {
         double value = CheckUtils.parseDouble(ast.getText(), ast.getType());
         final DetailAST parent = ast.getParent();
         if (parent.getType() == TokenTypes.UNARY_MINUS) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -211,7 +211,7 @@ public class UnnecessaryParenthesesCheck extends Check {
         }
 
         // A literal (numeric or string) surrounded by parentheses.
-        if (surrounded && inTokenList(type, LITERALS)) {
+        if (surrounded && isInTokenList(type, LITERALS)) {
             parentToSkip = ast.getParent();
             if (type == TokenTypes.STRING_LITERAL) {
                 log(ast, MSG_STRING,
@@ -224,7 +224,7 @@ public class UnnecessaryParenthesesCheck extends Check {
         }
 
         // The rhs of an assignment surrounded by parentheses.
-        if (inTokenList(type, ASSIGNMENTS)) {
+        if (isInTokenList(type, ASSIGNMENTS)) {
             assignDepth++;
             final DetailAST last = ast.getLastChild();
             if (last.getType() == TokenTypes.RPAREN) {
@@ -265,7 +265,7 @@ public class UnnecessaryParenthesesCheck extends Check {
 
             parentToSkip = null;
         }
-        else if (inTokenList(type, ASSIGNMENTS)) {
+        else if (isInTokenList(type, ASSIGNMENTS)) {
             assignDepth--;
         }
 
@@ -307,7 +307,7 @@ public class UnnecessaryParenthesesCheck extends Check {
      * @return {@code true} if {@code type} was found in {@code
      *         tokens}.
      */
-    private static boolean inTokenList(int type, int... tokens) {
+    private static boolean isInTokenList(int type, int... tokens) {
         // NOTE: Given the small size of the two arrays searched, I'm not sure
         //       it's worth bothering with doing a binary search or using a
         //       HashMap to do the searches.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -82,7 +82,7 @@ public class DesignForExtensionCheck extends Check {
     @Override
     public void visitToken(DetailAST ast) {
         // nothing to do for Interfaces
-        if (ScopeUtils.inInterfaceOrAnnotationBlock(ast)) {
+        if (ScopeUtils.isInInterfaceOrAnnotationBlock(ast)) {
             return;
         }
         if (isPrivateOrFinalOrAbstract(ast)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -77,7 +77,7 @@ public class FinalClassCheck
             classes.push(new ClassDesc(isFinal, isAbstract));
         }
         // ctors in enums don't matter
-        else if (!ScopeUtils.inEnumBlock(ast)) {
+        else if (!ScopeUtils.isInEnumBlock(ast)) {
             final ClassDesc desc = classes.peek();
             if (modifiers.branchContains(TokenTypes.LITERAL_PRIVATE)) {
                 desc.reportPrivateCtor();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheck.java
@@ -67,7 +67,7 @@ public class InnerTypeLastCheck extends Check {
         else {
             DetailAST nextSibling = ast.getNextSibling();
             while (nextSibling != null) {
-                if (!ScopeUtils.inCodeBlock(ast)
+                if (!ScopeUtils.isInCodeBlock(ast)
                     && (nextSibling.getType() == TokenTypes.VARIABLE_DEF
                         || nextSibling.getType() == TokenTypes.METHOD_DEF)) {
                     log(nextSibling.getLineNo(), nextSibling.getColumnNo(),

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -452,7 +452,7 @@ public class VisibilityModifierCheck
      */
     private void visitVariableDef(DetailAST variableDef) {
         final boolean inInterfaceOrAnnotationBlock =
-                ScopeUtils.inInterfaceOrAnnotationBlock(variableDef);
+                ScopeUtils.isInInterfaceOrAnnotationBlock(variableDef);
 
         if (!inInterfaceOrAnnotationBlock && !hasIgnoreAnnotation(variableDef)) {
             final DetailAST varNameAST = variableDef.findFirstToken(TokenTypes.TYPE)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
@@ -112,13 +112,13 @@ public class RedundantImportCheck
         }
         else if (ast.getType() == TokenTypes.IMPORT) {
             final FullIdent imp = FullIdent.createFullIdentBelow(ast);
-            if (fromPackage(imp.getText(), "java.lang")) {
+            if (isFromPackage(imp.getText(), "java.lang")) {
                 log(ast.getLineNo(), ast.getColumnNo(), MSG_LANG,
                     imp.getText());
             }
             // imports from unnamed package are not allowed,
             // so we are checking SAME rule only for named packages
-            else if (pkgName != null && fromPackage(imp.getText(), pkgName)) {
+            else if (pkgName != null && isFromPackage(imp.getText(), pkgName)) {
                 log(ast.getLineNo(), ast.getColumnNo(), MSG_SAME,
                     imp.getText());
             }
@@ -155,7 +155,7 @@ public class RedundantImportCheck
      * @param pkg the package name
      * @return whether from the package
      */
-    private static boolean fromPackage(String importName, String pkg) {
+    private static boolean isFromPackage(String importName, String pkg) {
         // imports from unnamed package are not allowed:
         // http://docs.oracle.com/javase/specs/jls/se7/html/jls-7.html#jls-7.5
         // So '.' must be present in member name and we are not checking for it

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -540,7 +540,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
         final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
         final Scope declaredScope = ScopeUtils.getScopeFromMods(mods);
 
-        if (ScopeUtils.inInterfaceOrAnnotationBlock(ast)) {
+        if (ScopeUtils.isInInterfaceOrAnnotationBlock(ast)) {
             return Scope.PUBLIC;
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -159,7 +159,7 @@ public class JavadocStyleCheck
             return getFileContents().inPackageInfo();
         }
 
-        if (ScopeUtils.inCodeBlock(ast)) {
+        if (ScopeUtils.isInCodeBlock(ast)) {
             return false;
         }
 
@@ -174,7 +174,7 @@ public class JavadocStyleCheck
 
         final Scope customScope;
 
-        if (ScopeUtils.inInterfaceOrAnnotationBlock(ast)) {
+        if (ScopeUtils.isInInterfaceOrAnnotationBlock(ast)) {
             customScope = Scope.PUBLIC;
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -225,7 +225,7 @@ public class JavadocTypeCheck
         final Scope declaredScope = ScopeUtils.getScopeFromMods(mods);
         final Scope customScope;
 
-        if (ScopeUtils.inInterfaceOrAnnotationBlock(ast)) {
+        if (ScopeUtils.isInInterfaceOrAnnotationBlock(ast)) {
             customScope = Scope.PUBLIC;
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -132,7 +132,7 @@ public class JavadocVariableCheck
      * @return whether we should check a given node.
      */
     private boolean shouldCheck(final DetailAST ast) {
-        if (ScopeUtils.inCodeBlock(ast) || isIgnored(ast)) {
+        if (ScopeUtils.isInCodeBlock(ast) || isIgnored(ast)) {
             return false;
         }
 
@@ -144,7 +144,7 @@ public class JavadocVariableCheck
             final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
             final Scope declaredScope = ScopeUtils.getScopeFromMods(mods);
 
-            if (ScopeUtils.inInterfaceOrAnnotationBlock(ast)) {
+            if (ScopeUtils.isInInterfaceOrAnnotationBlock(ast)) {
                 customScope = Scope.PUBLIC;
             }
             else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
@@ -85,9 +85,9 @@ public class ConstantNameCheck
         final boolean isFinal = modifiersAST.branchContains(TokenTypes.FINAL);
 
         if (isStatic  && isFinal && shouldCheckInScope(modifiersAST)
-                || ScopeUtils.inAnnotationBlock(ast)
-                || ScopeUtils.inInterfaceOrAnnotationBlock(ast)
-                        && !ScopeUtils.inCodeBlock(ast)) {
+                || ScopeUtils.isInAnnotationBlock(ast)
+                || ScopeUtils.isInInterfaceOrAnnotationBlock(ast)
+                        && !ScopeUtils.isInCodeBlock(ast)) {
             // Handle the serialVersionUID and serialPersistentFields constants
             // which are used for Serialization. Cannot enforce rules on it. :-)
             final DetailAST nameAST = ast.findFirstToken(TokenTypes.IDENT);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheck.java
@@ -77,7 +77,7 @@ public class MemberNameCheck
             ast.findFirstToken(TokenTypes.MODIFIERS);
         final boolean isStatic = modifiersAST.branchContains(TokenTypes.LITERAL_STATIC);
 
-        return !isStatic && !ScopeUtils.inInterfaceOrAnnotationBlock(ast)
+        return !isStatic && !ScopeUtils.isInInterfaceOrAnnotationBlock(ast)
             && !ScopeUtils.isLocalVariableDef(ast)
                 && shouldCheckInScope(modifiersAST);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheck.java
@@ -79,6 +79,6 @@ public class StaticVariableNameCheck
         return isStatic
                 && !isFinal
                 && shouldCheckInScope(modifiersAST)
-                && !ScopeUtils.inInterfaceOrAnnotationBlock(ast);
+                && !ScopeUtils.isInInterfaceOrAnnotationBlock(ast);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
@@ -124,7 +124,7 @@ public class ParameterNumberCheck
     public void visitToken(DetailAST ast) {
         final DetailAST params = ast.findFirstToken(TokenTypes.PARAMETERS);
         final int count = params.getChildCount(TokenTypes.PARAMETER_DEF);
-        if (count > max && !ignoreNumberOfParameters(ast)) {
+        if (count > max && !shouldIgnoreNumberOfParameters(ast)) {
             final DetailAST name = ast.findFirstToken(TokenTypes.IDENT);
             log(name.getLineNo(), name.getColumnNo(), MSG_KEY, max, count);
         }
@@ -136,7 +136,7 @@ public class ParameterNumberCheck
      * @return true if this is overridden method and number of parameters should be ignored
      *         false otherwise
      */
-    private boolean ignoreNumberOfParameters(DetailAST ast) {
+    private boolean shouldIgnoreNumberOfParameters(DetailAST ast) {
         //if you override a method, you have no power over the number of parameters
         return ignoreOverriddenMethods
                 && (AnnotationUtility.containsAnnotation(ast, OVERRIDE)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtils.java
@@ -99,7 +99,7 @@ public final class ScopeUtils {
      * block
      * @return a {@code boolean} value
      */
-    public static boolean inInterfaceBlock(DetailAST aAST) {
+    public static boolean isInInterfaceBlock(DetailAST aAST) {
         boolean retVal = false;
 
         // Loop up looking for a containing interface block
@@ -130,7 +130,7 @@ public final class ScopeUtils {
      * block
      * @return a {@code boolean} value
      */
-    public static boolean inAnnotationBlock(DetailAST aAST) {
+    public static boolean isInAnnotationBlock(DetailAST aAST) {
         boolean retVal = false;
 
         // Loop up looking for a containing interface block
@@ -161,8 +161,8 @@ public final class ScopeUtils {
      * or annotation block
      * @return a {@code boolean} value
      */
-    public static boolean inInterfaceOrAnnotationBlock(DetailAST aAST) {
-        return inInterfaceBlock(aAST) || inAnnotationBlock(aAST);
+    public static boolean isInInterfaceOrAnnotationBlock(DetailAST aAST) {
+        return isInInterfaceBlock(aAST) || isInAnnotationBlock(aAST);
     }
 
     /**
@@ -172,7 +172,7 @@ public final class ScopeUtils {
      * block
      * @return a {@code boolean} value
      */
-    public static boolean inEnumBlock(DetailAST aAST) {
+    public static boolean isInEnumBlock(DetailAST aAST) {
         boolean retVal = false;
 
         // Loop up looking for a containing interface block
@@ -201,7 +201,7 @@ public final class ScopeUtils {
      * @param aAST the node to check
      * @return a {@code boolean} value
      */
-    public static boolean inCodeBlock(DetailAST aAST) {
+    public static boolean isInCodeBlock(DetailAST aAST) {
         boolean retVal = false;
 
         // Loop up looking for a containing code block

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -83,9 +83,9 @@ public class PropertyCacheFileTest {
         final String filePath = temporaryFolder.newFile().getPath();
         PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
         cache.put("myFile", 1);
-        assertTrue(cache.inCache("myFile", 1));
-        assertFalse(cache.inCache("myFile", 2));
-        assertFalse(cache.inCache("myFile1", 1));
+        assertTrue(cache.isInCache("myFile", 1));
+        assertFalse(cache.isInCache("myFile", 2));
+        assertFalse(cache.isInCache("myFile1", 1));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtilsTest.java
@@ -37,7 +37,7 @@ public class ScopeUtilsTest {
     @Test
     public void testInEnumOnRoot() throws ReflectiveOperationException {
         DetailAST ast = new DetailAST();
-        Assert.assertFalse(ScopeUtils.inEnumBlock(ast));
+        Assert.assertFalse(ScopeUtils.isInEnumBlock(ast));
     }
 
     @Test
@@ -48,7 +48,7 @@ public class ScopeUtilsTest {
         ast2.setType(TokenTypes.MODIFIERS);
         ast.addChild(ast2);
 
-        Assert.assertFalse(ScopeUtils.inEnumBlock(ast2));
+        Assert.assertFalse(ScopeUtils.isInEnumBlock(ast2));
     }
 
     @Test
@@ -62,7 +62,7 @@ public class ScopeUtilsTest {
         ast2.setType(TokenTypes.MODIFIERS);
         ast1.addChild(ast2);
 
-        Assert.assertTrue(ScopeUtils.inEnumBlock(ast2));
+        Assert.assertTrue(ScopeUtils.isInEnumBlock(ast2));
     }
 
     @Test
@@ -73,7 +73,7 @@ public class ScopeUtilsTest {
         ast2.setType(TokenTypes.MODIFIERS);
         ast.addChild(ast2);
 
-        Assert.assertFalse(ScopeUtils.inEnumBlock(ast2));
+        Assert.assertFalse(ScopeUtils.isInEnumBlock(ast2));
     }
 
     @Test
@@ -84,7 +84,7 @@ public class ScopeUtilsTest {
         ast2.setType(TokenTypes.MODIFIERS);
         ast.addChild(ast2);
 
-        Assert.assertFalse(ScopeUtils.inEnumBlock(ast2));
+        Assert.assertFalse(ScopeUtils.isInEnumBlock(ast2));
     }
 
     @Test
@@ -95,7 +95,7 @@ public class ScopeUtilsTest {
         ast2.setType(TokenTypes.MODIFIERS);
         ast.addChild(ast2);
 
-        Assert.assertFalse(ScopeUtils.inEnumBlock(ast2));
+        Assert.assertFalse(ScopeUtils.isInEnumBlock(ast2));
     }
 
     @Test


### PR DESCRIPTION
Fixes `BooleanMethodNameMustStartWithQuestion` inspection violations.

Description:
>Reports boolean methods whose names do not start with a question word. Boolean methods that override library methods are ignored by this inspection.