### PR TITLE
Remove unnecessary this keyword. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java
@@ -62,7 +62,7 @@ class HtmlTag {
         this.position = position;
         this.text = text;
         this.closedTag = closedTag;
-        this.incompleteTag = incomplete;
+        incompleteTag = incomplete;
     }
 
     /**


### PR DESCRIPTION
Fixes `UnnecessaryThis` inspection violations.

Description:
>Reports on any unnecessary uses of this in the code. Using this to disambiguate a code reference may easily become unnecessary via automatic refactorings, and is discouraged by many coding styles.