### PR TITLE
Use constants for empty arrays of zero length. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -193,8 +193,11 @@ public class ImportOrderCheck
     /** The special wildcard that catches all remaining groups. */
     private static final String WILDCARD_GROUP_NAME = "*";
 
+    /** Empty array of pattern type needed to initlialize check */
+    private static final Pattern[] EMPTY_PATTERN_ARRAY = new Pattern[0];
+
     /** List of import groups specified by the user. */
-    private Pattern[] groups = new Pattern[0];
+    private Pattern[] groups = EMPTY_PATTERN_ARRAY;
     /** Require imports in group be separated. */
     private boolean separated;
     /** Require imports in group. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
@@ -33,6 +33,11 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtils;
  */
 public class JavadocNodeImpl implements DetailNode {
     /**
+     * Empty array of {@link DetailNode} type.
+     */
+    private static final DetailNode[] EMPTY_DETAIL_NODE_ARRAY = new DetailNode[0];
+
+    /**
      * Node index among parent's children
      */
     private int index;
@@ -90,7 +95,7 @@ public class JavadocNodeImpl implements DetailNode {
     @Override
     public DetailNode[] getChildren() {
         if (children == null) {
-            return new DetailNode[0];
+            return EMPTY_DETAIL_NODE_ARRAY.clone();
         }
         else {
             return Arrays.copyOf(children, children.length);


### PR DESCRIPTION
Fixes `ZeroLengthArrayInitialization` inspection violations.

Description:
>Reports on allocations of arrays with known lengths of zero. Since array lengths in Java are non-modifiable, it is almost always possible to share zero-length arrays, rather than repeatedly allocating new zero-length arrays. Such sharing may provide useful optimizations in program runtime or footprint. Note that this inspection does not report zero-length arrays allocated as static final fields, as it is assumed that those arrays are being used to implement array sharing.