### PR TITLE
Added 'validateAbstractClassNames' option for IllegalTypeCheck, issue #1805

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -62,9 +62,6 @@
     <suppress checks="." files=".*JavadocTokenTypes\.java"/>
     <suppress checks="." files=".*ParseTreeBuilder\.java"/>
 
-    <!-- Should be solved after fixing https://github.com/checkstyle/checkstyle/issues/1805 -->
-    <suppress checks="IllegalType" files=".*[\\/]src[\\/]test[\\/]|(AbstractTypeAwareCheck|TryHandler|SlistHandler|PrimordialHandler|MethodCallHandler|MemberDefHandler|IndentationCheck|IfHandler|HandlerFactory|CaseHandler|BlockParentHandler|AbstractExpressionHandler|JavadocMethodCheck|DetectorOptions)\.java"/>
-
     <!-- Till https://github.com/checkstyle/checkstyle/issues/1854 -->
     <suppress checks="TrailingComment" files="(InnerAssignmentCheck\.java|OperatorWrapCheck\.java|XMLLoggerTest\.java|AbbreviationAsWordInNameCheckTest\.java)"/>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -73,6 +73,10 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
  * will be ok.
  * </p>
  * <p>
+ * <b>validateAbstractClassNames</b> - controls whether to validate abstract class names.
+ * Default value is <b>false</b>
+ * </p>
+ * <p>
  * <b>ignoredMethodNames</b> - Methods that should not be checked.
  * </p>
  * <p>
@@ -139,12 +143,25 @@ public final class IllegalTypeCheck extends AbstractFormatCheck {
     /** Check methods and fields with only corresponding modifiers. */
     private List<Integer> memberModifiers;
 
+    /**
+     * Controls whether to validate abstract class names.
+     */
+    private boolean validateAbstractClassNames;
+
     /** Creates new instance of the check. */
     public IllegalTypeCheck() {
         super(DEFAULT_FORMAT);
         setIllegalClassNames(DEFAULT_ILLEGAL_TYPES);
         setLegalAbstractClassNames(DEFAULT_LEGAL_ABSTRACT_NAMES);
         setIgnoredMethodNames(DEFAULT_IGNORED_METHOD_NAMES);
+    }
+
+    /**
+     * Sets whether to validate abstract class names.
+     * @param validateAbstractClassNames whether abstract class names must be ignored.
+     */
+    public void setValidateAbstractClassNames(boolean validateAbstractClassNames) {
+        this.validateAbstractClassNames = validateAbstractClassNames;
     }
 
     @Override
@@ -305,7 +322,8 @@ public final class IllegalTypeCheck extends AbstractFormatCheck {
         final String shortName = className.substring(className.lastIndexOf('.') + 1);
         return illegalClassNames.contains(className)
                 || illegalClassNames.contains(shortName)
-                || !legalAbstractClassNames.contains(className)
+                || validateAbstractClassNames
+                    && !legalAbstractClassNames.contains(className)
                     && getRegexp().matcher(className).find();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -29,7 +29,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.TreeSet;
+import java.util.SortedSet;
 
 import org.junit.Test;
 
@@ -56,7 +56,7 @@ public class CheckerTest {
         checker.fireFileStarted("Some File Name");
         checker.fireFileFinished("Some File Name");
 
-        final TreeSet<LocalizedMessage> msgs = Sets.newTreeSet();
+        final SortedSet<LocalizedMessage> msgs = Sets.newTreeSet();
         msgs.add(new LocalizedMessage(0, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", msgs);
@@ -88,7 +88,7 @@ public class CheckerTest {
         assertTrue("Checker.fireFileFinished() doesn't call listener", auditAdapter.wasCalled());
 
         auditAdapter.resetListener();
-        final TreeSet<LocalizedMessage> msgs = Sets.newTreeSet();
+        final SortedSet<LocalizedMessage> msgs = Sets.newTreeSet();
         msgs.add(new LocalizedMessage(0, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", msgs);
@@ -125,7 +125,7 @@ public class CheckerTest {
         assertFalse("Checker.fireFileFinished() does call removed listener", auditAdapter.wasCalled());
 
         aa2.resetListener();
-        final TreeSet<LocalizedMessage> msgs = Sets.newTreeSet();
+        final SortedSet<LocalizedMessage> msgs = Sets.newTreeSet();
         msgs.add(new LocalizedMessage(0, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", msgs);
@@ -142,7 +142,7 @@ public class CheckerTest {
         checker.addFilter(filter);
 
         filter.resetFilter();
-        final TreeSet<LocalizedMessage> msgs = Sets.newTreeSet();
+        final SortedSet<LocalizedMessage> msgs = Sets.newTreeSet();
         msgs.add(new LocalizedMessage(0, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", msgs);
@@ -159,7 +159,7 @@ public class CheckerTest {
         checker.removeFilter(filter);
 
         f2.resetFilter();
-        final TreeSet<LocalizedMessage> msgs = Sets.newTreeSet();
+        final SortedSet<LocalizedMessage> msgs = Sets.newTreeSet();
         msgs.add(new LocalizedMessage(0, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", msgs);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -36,7 +36,6 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.util.Arrays;
 import java.util.Enumeration;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.junit.Test;
@@ -106,7 +105,7 @@ public class PackageNamesLoaderTest {
 
         Field field = PackageNamesLoader.class.getDeclaredField("packageNames");
         field.setAccessible(true);
-        LinkedHashSet<String> list = (LinkedHashSet<String>) field.get(loader);
+        Set<String> list = (Set<String>) field.get(loader);
         assertEquals("coding.", list.iterator().next());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -41,10 +41,29 @@ public class IllegalTypeCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
+    public void testValidateAbstractClassNamesSetToTrue() throws Exception {
+        checkConfig.addAttribute("validateAbstractClassNames", "true");
+        String[] expected = {
+            "27:5: " + getCheckMessage(MSG_KEY, "AbstractClass"),
+            "29:37: " + getCheckMessage(MSG_KEY, "AbstractClass"),
+            "33:12: " + getCheckMessage(MSG_KEY, "AbstractClass"),
+        };
+
+        verify(checkConfig, getPath("coding" + File.separator + "InputIllegalTypeAbstractClassNames.java"), expected);
+    }
+
+    @Test
+    public void testValidateAbstractClassNamesSetToFalse() throws Exception {
+        checkConfig.addAttribute("validateAbstractClassNames", "false");
+        String[] expected = {
+        };
+
+        verify(checkConfig, getPath("coding" + File.separator + "InputIllegalTypeAbstractClassNames.java"), expected);
+    }
+
+    @Test
     public void testDefaults() throws Exception {
         String[] expected = {
-            "6:13: " + getCheckMessage(MSG_KEY, "AbstractClass"),
-            "9:13: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.coding.InputIllegalType.AbstractClass"),
             "16:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
             "17:13: " + getCheckMessage(MSG_KEY, "TreeSet"),
         };
@@ -55,7 +74,7 @@ public class IllegalTypeCheckTest extends BaseCheckTestSupport {
     @Test
     public void testIgnoreMethodNames() throws Exception {
         checkConfig.addAttribute("ignoredMethodNames", "table2");
-
+        checkConfig.addAttribute("validateAbstractClassNames", "true");
         String[] expected = {
             "6:13: " + getCheckMessage(MSG_KEY, "AbstractClass"),
             "9:13: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.coding.InputIllegalType.AbstractClass"),
@@ -79,6 +98,7 @@ public class IllegalTypeCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testLegalAbstractClassNames() throws Exception {
+        checkConfig.addAttribute("validateAbstractClassNames", "true");
         checkConfig.addAttribute("legalAbstractClassNames", "AbstractClass");
 
         String[] expected = {
@@ -147,6 +167,7 @@ public class IllegalTypeCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testMemberModifiers() throws Exception {
+        checkConfig.addAttribute("validateAbstractClassNames", "true");
         checkConfig.addAttribute("memberModifiers", "LITERAL_PRIVATE, LITERAL_PROTECTED,"
                 + " LITERAL_STATIC");
         String[] expected = {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputIllegalTypeAbstractClassNames.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputIllegalTypeAbstractClassNames.java
@@ -1,0 +1,36 @@
+package com.puppycrawl.tools.checkstyle.coding;
+
+public class InputIllegalTypeAbstractClassNames {
+
+    abstract class AbstractClass {
+        abstract String getClassInfo();
+        abstract boolean isPerfectClass();
+    }
+
+    class MyNonAbstractClass extends AbstractClass {
+
+        boolean perfect = true;
+
+        private MyNonAbstractClass() {}
+
+        @Override
+        String getClassInfo() {
+            return "This is my non abstract class.";
+        }
+
+        @Override
+        boolean isPerfectClass() {
+            return perfect;
+        }
+    }
+
+    AbstractClass a = new MyNonAbstractClass();
+
+    public String getInnerClassInfo(AbstractClass clazz) {
+        return clazz.getClassInfo();
+    }
+
+    public AbstractClass newInnerClassInstance() {
+        return new MyNonAbstractClass();
+    }
+}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -1997,6 +1997,12 @@ if (&quot;something&quot;.equals(x))
             </td>
           </tr>
           <tr>
+            <td>validateAbstractClassNames</td>
+            <td>Whether to validate abstract class names</td>
+            <td>boolean</td>
+            <td>false</td>
+          </tr>
+          <tr>
             <td>illegalClassNames</td>
             <td>Classes that should not be used as types in variable
             declarations, return values or parameters</td>


### PR DESCRIPTION
@romani 
checkstyle-tester reported no violations/errors when I ran IllegalTypeCheck against checkstyle-6.10-SNAPSHOT with ```src/test/**/*``` as excludes.