### PR TITLE
Fix typos in utlis package. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -276,7 +276,7 @@ public class IllegalInstantiationCheck
                 }
             }
             else {
-                if (CommonUtils.baseClassname(importArg).equals(className)
+                if (CommonUtils.baseClassName(importArg).equals(className)
                     && illegalClasses.contains(importArg)) {
                     illegalType = importArg;
                     break;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -103,7 +103,7 @@ public class UnusedImportsCheck extends Check {
     public void finishTree(DetailAST rootAST) {
         // loop over all the imports to see if referenced.
         for (final FullIdent imp : imports) {
-            if (!referenced.contains(CommonUtils.baseClassname(imp.getText()))) {
+            if (!referenced.contains(CommonUtils.baseClassName(imp.getText()))) {
                 log(imp.getLineNo(),
                     imp.getColumnNo(),
                     MSG_KEY, imp.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -74,7 +74,7 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
      */
     public static final String SUMMARY_JAVADOC = "summary.javaDoc";
     /**
-     * This regexp is used to convert multiline javdoc to single line without stars.
+     * This regexp is used to convert multiline javadoc to single line without stars.
      */
     private static final Pattern JAVADOC_MULTILINE_TO_SINGLELINE_PATTERN =
             Pattern.compile("\n[ ]+(\\*)|^[ ]+(\\*)");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtils.java
@@ -137,15 +137,15 @@ public final class CheckUtils {
      * @return {@code FullIdent} for given type.
      */
     public static FullIdent createFullType(DetailAST typeAST) {
-        final DetailAST arrayDeclAST =
+        final DetailAST arrayDeclaratorAST =
             typeAST.findFirstToken(TokenTypes.ARRAY_DECLARATOR);
         final FullIdent fullType;
 
-        if (arrayDeclAST == null) {
+        if (arrayDeclaratorAST == null) {
             fullType = createFullTypeNoArrays(typeAST);
         }
         else {
-            fullType = createFullTypeNoArrays(arrayDeclAST);
+            fullType = createFullTypeNoArrays(arrayDeclaratorAST);
         }
         return fullType;
     }
@@ -270,36 +270,36 @@ public final class CheckUtils {
 
     /**
      * Retrieves the names of the type parameters to the node.
-     * @param node the parameterised AST node
+     * @param node the parameterized AST node
      * @return a list of type parameter names
      */
     public static List<String> getTypeParameterNames(final DetailAST node) {
         final DetailAST typeParameters =
             node.findFirstToken(TokenTypes.TYPE_PARAMETERS);
 
-        final List<String> typeParanames = Lists.newArrayList();
+        final List<String> typeParameterNames = Lists.newArrayList();
         if (typeParameters != null) {
             final DetailAST typeParam =
                 typeParameters.findFirstToken(TokenTypes.TYPE_PARAMETER);
-            typeParanames.add(
-                typeParam.findFirstToken(TokenTypes.IDENT).getText());
+            typeParameterNames.add(
+                    typeParam.findFirstToken(TokenTypes.IDENT).getText());
 
             DetailAST sibling = typeParam.getNextSibling();
             while (sibling != null) {
                 if (sibling.getType() == TokenTypes.TYPE_PARAMETER) {
-                    typeParanames.add(
-                        sibling.findFirstToken(TokenTypes.IDENT).getText());
+                    typeParameterNames.add(
+                            sibling.findFirstToken(TokenTypes.IDENT).getText());
                 }
                 sibling = sibling.getNextSibling();
             }
         }
 
-        return typeParanames;
+        return typeParameterNames;
     }
 
     /**
      * Retrieves the type parameters to the node.
-     * @param node the parameterised AST node
+     * @param node the parameterized AST node
      * @return a list of type parameter names
      */
     public static List<DetailAST> getTypeParameters(final DetailAST node) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
@@ -188,7 +188,7 @@ public final class CommonUtils {
      *            the fully qualified name. Cannot be null
      * @return the base class name from a fully qualified name
      */
-    public static String baseClassname(String type) {
+    public static String baseClassName(String type) {
         final int i = type.lastIndexOf('.');
 
         if (i == -1) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
@@ -49,7 +49,7 @@ public final class JavadocUtils {
     private static final String[] TOKEN_VALUE_TO_NAME;
 
     /** Exception message for unknown JavaDoc token id. */
-    private static final String UNKNOWN_JAVADOC_TOKEN_ID_EXCEPTION_MESSAGE = "Unknown javdoc"
+    private static final String UNKNOWN_JAVADOC_TOKEN_ID_EXCEPTION_MESSAGE = "Unknown javadoc"
             + " token id. Given id: ";
 
     // Using reflection gets all token names and values from JavadocTokenTypes class
@@ -243,12 +243,12 @@ public final class JavadocUtils {
 
     /**
      * Get content of Javadoc comment.
-     * @param javdocCommentBegin
+     * @param javadocCommentBegin
      *        Javadoc comment AST
      * @return content of Javadoc comment.
      */
-    public static String getJavadocCommentContent(DetailAST javdocCommentBegin) {
-        final DetailAST commentContent = javdocCommentBegin.getFirstChild();
+    public static String getJavadocCommentContent(DetailAST javadocCommentBegin) {
+        final DetailAST commentContent = javadocCommentBegin.getFirstChild();
         return commentContent.getText().substring(1);
     }
 
@@ -398,7 +398,7 @@ public final class JavadocUtils {
     public static int getTokenId(String name) {
         final Integer id = TOKEN_NAME_TO_VALUE.get(name);
         if (id == null) {
-            throw new IllegalArgumentException("Unknown javdoc token name. Given name " + name);
+            throw new IllegalArgumentException("Unknown javadoc token name. Given name " + name);
         }
         return id;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtils.java
@@ -196,7 +196,7 @@ public final class ScopeUtils {
 
     /**
      * Returns whether the scope of a node is restricted to a code block.
-     * A code block is a method or constructor body, or a initialiser block.
+     * A code block is a method or constructor body, or a initializer block.
      *
      * @param aAST the node to check
      * @return a {@code boolean} value

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtils.java
@@ -152,9 +152,9 @@ public final class TokenUtils {
             throw new IllegalArgumentException(TOKEN_NAME_EXCEPTION_PREFIX + name);
         }
 
-        final String tokentypes =
+        final String tokenTypes =
             "com.puppycrawl.tools.checkstyle.api.tokentypes";
-        final ResourceBundle bundle = ResourceBundle.getBundle(tokentypes);
+        final ResourceBundle bundle = ResourceBundle.getBundle(tokenTypes);
         return bundle.getString(name);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
@@ -87,13 +87,13 @@ public class CommonUtilsTest {
     }
 
     @Test
-    public void testBaseClassnameForCanonicalName() {
-        assertEquals("List", CommonUtils.baseClassname("java.util.List"));
+    public void testBaseClassNameForCanonicalName() {
+        assertEquals("List", CommonUtils.baseClassName("java.util.List"));
     }
 
     @Test
-    public void testBaseClassnameForSimpleName() {
-        assertEquals("Set", CommonUtils.baseClassname("Set"));
+    public void testBaseClassNameForSimpleName() {
+        assertEquals("Set", CommonUtils.baseClassName("Set"));
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputJavadocStyleCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputJavadocStyleCheck.java
@@ -225,7 +225,7 @@ public class InputJavadocStyleCheck
     /** 
      */
     private static int ASDF = 0;
-    // should report empty javdoc
+    // should report empty javadoc
 
     /** @see java.lang.Object */
     public void method19()


### PR DESCRIPTION
Fixes some `SpellCheckingInspection` inspection violations.

Description:
>Spellchecker inspection helps locate typos and misspelling in your code, comments and literals.