### PR TITLE
Fix typos in import and java8 packages. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -95,7 +95,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * Use the separator '###' between rules.
  * </p>
  * <p>
- * To set RegExps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
+ * To set Regexps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
  * thirdPartyPackageRegExp and standardPackageRegExp options.
  * </p>
  *
@@ -185,7 +185,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *        {@code
  *&lt;module name=&quot;CustomImportOrder&quot;/&gt;
  *        }
- * <p>To set RegExps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
+ * <p>To set Regexps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
  *         thirdPartyPackageRegExp and standardPackageRegExp options.</p>
  * <pre>
  * {@code
@@ -403,7 +403,7 @@ public class CustomImportOrderCheck extends Check {
     public final void setCustomImportOrderRules(final String inputCustomImportOrder) {
         customImportOrderRules.clear();
         for (String currentState : GROUP_SEPARATOR_PATTERN.split(inputCustomImportOrder)) {
-            addRuleastoList(currentState);
+            addRulesToList(currentState);
         }
         customImportOrderRules.add(NON_GROUP_RULE_GROUP);
     }
@@ -590,7 +590,7 @@ public class CustomImportOrderCheck extends Check {
         return matchesStaticImportGroup(isStatic, currentGroup)
                 || matchesSamePackageImportGroup(isStatic, importPath, currentGroup)
                 || matchesSpecialImportsGroup(isStatic, importPath, currentGroup)
-                || matchesStandartImportGroup(isStatic, importPath, currentGroup)
+                || matchesStandardImportGroup(isStatic, importPath, currentGroup)
                 || matchesThirdPartyImportGroup(isStatic, importPath, currentGroup);
     }
 
@@ -634,7 +634,7 @@ public class CustomImportOrderCheck extends Check {
      *        current group.
      * @return true, if the import is placed in the standard group.
      */
-    private boolean matchesStandartImportGroup(boolean isStatic,
+    private boolean matchesStandardImportGroup(boolean isStatic,
         String currentImport, String currentGroup) {
         return !isStatic && STANDARD_JAVA_PACKAGE_RULE_GROUP.equals(currentGroup)
                 && standardPackageRegExp.matcher(currentImport).find();
@@ -733,7 +733,7 @@ public class CustomImportOrderCheck extends Check {
      * @param ruleStr
      *        String with rule.
      */
-    private void addRuleastoList(String ruleStr) {
+    private void addRulesToList(String ruleStr) {
         if (STATIC_RULE_GROUP.equals(ruleStr)
                 || THIRD_PARTY_PACKAGE_RULE_GROUP.equals(ruleStr)
                 || STANDARD_JAVA_PACKAGE_RULE_GROUP.equals(ruleStr)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -130,7 +130,7 @@ public class ImportControlCheck extends Check {
     }
 
     /**
-     * Set the pnameter for the file containing the import control
+     * Set the name for the file containing the import control
      * configuration. It will cause the file to be loaded.
      * @param name the name of the file to load.
      * @throws ConversionException on error loading the file.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -91,14 +91,14 @@ final class ImportControlLoader extends AbstractLoader {
     public void startElement(final String namespaceURI,
                              final String locqName,
                              final String qName,
-                             final Attributes atts)
+                             final Attributes attributes)
         throws SAXException {
         if ("import-control".equals(qName)) {
-            final String pkg = safeGet(atts, PKG_ATTRIBUTE_NAME);
+            final String pkg = safeGet(attributes, PKG_ATTRIBUTE_NAME);
             stack.push(new PkgControl(pkg));
         }
         else if (SUBPACKAGE_ELEMENT_NAME.equals(qName)) {
-            final String name = safeGet(atts, "name");
+            final String name = safeGet(attributes, "name");
             stack.push(new PkgControl(stack.peek(), name));
         }
         else if (ALLOW_ELEMENT_NAME.equals(qName) || "disallow".equals(qName)) {
@@ -106,19 +106,19 @@ final class ImportControlLoader extends AbstractLoader {
             // May have "exact-match" for "pkg"
             // May have "local-only"
             final boolean isAllow = ALLOW_ELEMENT_NAME.equals(qName);
-            final boolean isLocalOnly = atts.getValue("local-only") != null;
-            final String pkg = atts.getValue(PKG_ATTRIBUTE_NAME);
-            final boolean regex = atts.getValue("regex") != null;
+            final boolean isLocalOnly = attributes.getValue("local-only") != null;
+            final String pkg = attributes.getValue(PKG_ATTRIBUTE_NAME);
+            final boolean regex = attributes.getValue("regex") != null;
             final Guard g;
             if (pkg != null) {
                 final boolean exactMatch =
-                        atts.getValue("exact-match") != null;
+                        attributes.getValue("exact-match") != null;
                 g = new Guard(isAllow, isLocalOnly, pkg, exactMatch, regex);
             }
             else {
                 // handle class names which can be normal class names or regular
                 // expressions
-                final String clazz = safeGet(atts, "class");
+                final String clazz = safeGet(attributes, "class");
                 g = new Guard(isAllow, isLocalOnly, clazz, regex);
             }
 
@@ -189,14 +189,14 @@ final class ImportControlLoader extends AbstractLoader {
     /**
      * Utility to safely get an attribute. If it does not exist an exception
      * is thrown.
-     * @param atts collect to get attribute from.
+     * @param attributes collect to get attribute from.
      * @param name name of the attribute to get.
      * @return the value of the attribute.
      * @throws SAXException if the attribute does not exist.
      */
-    private static String safeGet(final Attributes atts, final String name)
+    private static String safeGet(final Attributes attributes, final String name)
         throws SAXException {
-        final String retVal = atts.getValue(name);
+        final String retVal = attributes.getValue(name);
         if (retVal == null) {
             throw new SAXException("missing attribute " + name);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -74,7 +74,7 @@ public class UnusedImportsCheck extends Check {
 
     /** Flag to indicate when time to start collecting references. */
     private boolean collect;
-    /** Flag whether to process Javdoc comments. */
+    /** Flag whether to process Javadoc comments. */
     private boolean processJavadoc;
 
     /** Set of the imports. */
@@ -172,7 +172,7 @@ public class UnusedImportsCheck extends Check {
         else {
             collect = true;
             if (processJavadoc) {
-                collectReferecesFromJavadoc(ast);
+                collectReferencesFromJavadoc(ast);
             }
         }
     }
@@ -220,12 +220,12 @@ public class UnusedImportsCheck extends Check {
      * Collects references made in Javadoc comments.
      * @param ast node to inspect for Javadoc
      */
-    private void collectReferecesFromJavadoc(DetailAST ast) {
+    private void collectReferencesFromJavadoc(DetailAST ast) {
         final FileContents contents = getFileContents();
         final int lineNo = ast.getLineNo();
         final TextBlock cmt = contents.getJavadocBefore(lineNo);
         if (cmt != null) {
-            referenced.addAll(collectReferecesFromJavadoc(cmt));
+            referenced.addAll(collectReferencesFromJavadoc(cmt));
         }
     }
 
@@ -235,10 +235,10 @@ public class UnusedImportsCheck extends Check {
      * @param cmt The javadoc block to parse
      * @return a set of classes referenced in the javadoc block
      */
-    private static Set<String> collectReferecesFromJavadoc(TextBlock cmt) {
+    private static Set<String> collectReferencesFromJavadoc(TextBlock cmt) {
         final Set<String> references = new HashSet<>();
         // process all the @link type tags
-        // INLINEs inside BLOCKs get hidden when using ALL
+        // INLINE tags inside BLOCKs get hidden when using ALL
         for (final JavadocTag tag
                 : getValidTags(cmt, JavadocUtils.JavadocTagType.INLINE)) {
             if (tag.canReferenceImports()) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportTest.java
@@ -34,7 +34,7 @@ public class AvoidStaticImportTest
     extends BaseCheckTestSupport {
 
     @Test
-    public void testGetRequiredTokesn() {
+    public void testGetRequiredTokens() {
         AvoidStaticImportCheck checkObj = new AvoidStaticImportCheck();
         int[] expected = {TokenTypes.STATIC_IMPORT};
         assertArrayEquals(expected, checkObj.getRequiredTokens());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -112,7 +112,7 @@ public class ImportControlCheckTest extends BaseCheckTestSupport {
             fail("should fail");
         }
         catch (CheckstyleException ex) {
-            //donothng
+            //do nothng
         }
     }
 
@@ -128,7 +128,7 @@ public class ImportControlCheckTest extends BaseCheckTestSupport {
             fail("should fail");
         }
         catch (CheckstyleException ex) {
-            //donothing
+            //do nothing
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/DefaultMethodsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/DefaultMethodsTest.java
@@ -28,7 +28,7 @@ import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 
-public class DefaulMethodsTest extends BaseCheckTestSupport {
+public class DefaultMethodsTest extends BaseCheckTestSupport {
 
     @Test
     public void testCanParse()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/LambdaTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/LambdaTest.java
@@ -91,7 +91,7 @@ public class LambdaTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testWithOneArgWIthoutTypeOneLineBody()
+    public void testWithOneArgWithoutTypeOneLineBody()
         throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
@@ -103,7 +103,7 @@ public class LambdaTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testWithOneArgWIthoutTypeFullBody()
+    public void testWithOneArgWithoutTypeFullBody()
         throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
@@ -139,7 +139,7 @@ public class LambdaTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testWithOneArgWIthoutParenthesesWithoutTypeOneLineBody()
+    public void testWithOneArgWithoutParenthesesWithoutTypeOneLineBody()
         throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
@@ -151,7 +151,7 @@ public class LambdaTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testWithOneArgWIthoutParenthesesWithoutTypeFullBody()
+    public void testWithOneArgWithoutParenthesesWithoutTypeFullBody()
         throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);


### PR DESCRIPTION
Fixes some `SpellCheckingInspection` inspection violations.

Description:
>Spellchecker inspection helps locate typos and misspelling in your code, comments and literals.