### PR TITLE
Fix typos in blocks, headers and filters packages. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -226,7 +226,7 @@ public class LeftCurlyCheck
      * Skip lines that only contain {@code TokenTypes.ANNOTATION}s.
      * If the received {@code DetailAST}
      * has annotations within its modifiers then first token on the line
-     * of the first token afer all annotations is return. This might be
+     * of the first token after all annotations is return. This might be
      * an annotation.
      * Otherwise, the received {@code DetailAST} is returned.
      * @param ast {@code DetailAST}.
@@ -237,29 +237,29 @@ public class LeftCurlyCheck
         if (modifiers == null) {
             return ast;
         }
-        DetailAST lastAnnot = findLastAnnotation(modifiers);
-        if (lastAnnot == null) {
+        DetailAST lastAnnotation = findLastAnnotation(modifiers);
+        if (lastAnnotation == null) {
             // There are no annotations.
             return ast;
         }
         final DetailAST tokenAfterLast;
 
-        if (lastAnnot.getNextSibling() == null) {
+        if (lastAnnotation.getNextSibling() == null) {
             tokenAfterLast = modifiers.getNextSibling();
         }
         else {
-            tokenAfterLast = lastAnnot.getNextSibling();
+            tokenAfterLast = lastAnnotation.getNextSibling();
         }
 
-        if (tokenAfterLast.getLineNo() > lastAnnot.getLineNo()) {
+        if (tokenAfterLast.getLineNo() > lastAnnotation.getLineNo()) {
             return tokenAfterLast;
         }
-        final int lastAnnotLineNumber = lastAnnot.getLineNo();
-        while (lastAnnot.getPreviousSibling() != null
-               && lastAnnot.getPreviousSibling().getLineNo() == lastAnnotLineNumber) {
-            lastAnnot = lastAnnot.getPreviousSibling();
+        final int lastAnnotationLineNumber = lastAnnotation.getLineNo();
+        while (lastAnnotation.getPreviousSibling() != null
+               && lastAnnotation.getPreviousSibling().getLineNo() == lastAnnotationLineNumber) {
+            lastAnnotation = lastAnnotation.getPreviousSibling();
         }
-        return lastAnnot;
+        return lastAnnotation;
     }
 
     /**
@@ -301,7 +301,7 @@ public class LeftCurlyCheck
             }
             else if (startToken.getLineNo() != brace.getLineNo()) {
 
-                validateNewLinePosion(brace, startToken, braceLine);
+                validateNewLinePosition(brace, startToken, braceLine);
 
             }
         }
@@ -309,7 +309,7 @@ public class LeftCurlyCheck
 
     /**
      * Validate EOL case
-     * @param brace brase AST
+     * @param brace brace AST
      * @param braceLine line content
      */
     private void validateEol(DetailAST brace, String braceLine) {
@@ -327,8 +327,7 @@ public class LeftCurlyCheck
      * @param startToken start Token
      * @param braceLine content of line with Brace
      */
-    private void validateNewLinePosion(DetailAST brace, DetailAST startToken,
-                                       String braceLine) {
+    private void validateNewLinePosition(DetailAST brace, DetailAST startToken, String braceLine) {
         // not on the same line
         if (startToken.getLineNo() + 1 == brace.getLineNo()) {
             if (CommonUtils.whitespaceBefore(brace.getColumnNo(), braceLine)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -337,8 +337,8 @@ public class NeedBracesCheck extends Check {
      * Checks if current case statement is single-line statement, e.g.:
      * <p>
      * {@code
-     * case 1: dosomeStuff(); break;
-     * case 2: dosomeStuff(); break;
+     * case 1: doSomeStuff(); break;
+     * case 2: doSomeStuff(); break;
      * }
      * </p>
      * @param literalCase {@link TokenTypes#LITERAL_CASE case statement}.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -189,7 +189,7 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
      * @param shouldStartLine do we need to check if right curly starts line.
      * @param targetSourceLine line that we need to check if shouldStartLine is true.
      * @return violation message or empty string
-     * if there was not violation durning validation.
+     * if there was not violation during validation.
      */
     private static String validate(Details details, RightCurlyOption bracePolicy,
                                    boolean shouldStartLine, String targetSourceLine) {
@@ -263,7 +263,7 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
     }
 
     /**
-     * Checks wthether lcurly is in anonymous inner class initialization.
+     * Checks whether lcurly is in anonymous inner class initialization.
      * @param lcurly left curly token.
      * @return true if lcurly begins anonymous inner class initialization.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java
@@ -36,7 +36,7 @@ public enum RightCurlyOption {
      * try {
      * ...
      * }
-     * inally {
+     * finally {
      *
      * // Single-line format of block
      * private int foo() { return 1; }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -214,14 +214,14 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck {
             }
             readerLines.add(line);
         }
-        postprocessHeaderLines();
+        postProcessHeaderLines();
     }
 
     /**
      * Hook method for post processing header lines.
      * This implementation does nothing.
      */
-    protected void postprocessHeaderLines() {
+    protected void postProcessHeaderLines() {
         // No code by default
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -138,7 +138,7 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck {
     }
 
     @Override
-    protected void postprocessHeaderLines() {
+    protected void postProcessHeaderLines() {
         final List<String> headerLines = getHeaderLines();
         headerRegexps.clear();
         for (String line : headerLines) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -337,11 +337,11 @@ public class SuppressionCommentFilter
             try {
                 if (on) {
                     format =
-                        expandFromCoont(text, filter.checkFormat, filter.onRegexp);
+                        expandFromComment(text, filter.checkFormat, filter.onRegexp);
                     tagCheckRegexp = Pattern.compile(format);
                     if (filter.messageFormat != null) {
                         format =
-                            expandFromCoont(text, filter.messageFormat, filter.onRegexp);
+                            expandFromComment(text, filter.messageFormat, filter.onRegexp);
                         tagMessageRegexp = Pattern.compile(format);
                     }
                     else {
@@ -350,14 +350,14 @@ public class SuppressionCommentFilter
                 }
                 else {
                     format =
-                        expandFromCoont(text, filter.checkFormat, filter.offRegexp);
+                        expandFromComment(text, filter.checkFormat, filter.offRegexp);
                     tagCheckRegexp = Pattern.compile(format);
                     if (filter.messageFormat != null) {
                         format =
-                            expandFromCoont(
-                                text,
-                                filter.messageFormat,
-                                filter.offRegexp);
+                            expandFromComment(
+                                    text,
+                                    filter.messageFormat,
+                                    filter.offRegexp);
                         tagMessageRegexp = Pattern.compile(format);
                     }
                     else {
@@ -461,10 +461,10 @@ public class SuppressionCommentFilter
          * @param regexp the parsed expander.
          * @return the expanded string
          */
-        private static String expandFromCoont(
-            String comment,
-            String stringToExpand,
-            Pattern regexp) {
+        private static String expandFromComment(
+                String comment,
+                String stringToExpand,
+                Pattern regexp) {
             final Matcher matcher = regexp.matcher(comment);
             // Match primarily for effect.
             if (!matcher.find()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -81,18 +81,18 @@ public final class SuppressionsLoader
     public void startElement(String namespaceURI,
                              String localName,
                              String qName,
-                             Attributes atts)
+                             Attributes attributes)
         throws SAXException {
         if ("suppress".equals(qName)) {
             //add SuppressElement filter to the filter chain
-            final String checks = atts.getValue("checks");
-            final String modId = atts.getValue("id");
+            final String checks = attributes.getValue("checks");
+            final String modId = attributes.getValue("id");
             if (checks == null && modId == null) {
                 throw new SAXException("missing checks and id attribute");
             }
             final SuppressElement suppress;
             try {
-                final String files = atts.getValue("files");
+                final String files = attributes.getValue("files");
                 suppress = new SuppressElement(files);
                 if (modId != null) {
                     suppress.setModuleId(modId);
@@ -104,11 +104,11 @@ public final class SuppressionsLoader
             catch (final PatternSyntaxException ignored) {
                 throw new SAXException("invalid files or checks format");
             }
-            final String lines = atts.getValue("lines");
+            final String lines = attributes.getValue("lines");
             if (lines != null) {
                 suppress.setLines(lines);
             }
-            final String columns = atts.getValue("columns");
+            final String columns = attributes.getValue("columns");
             if (columns != null) {
                 suppress.setColumns(columns);
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheckTest.java
@@ -57,7 +57,7 @@ public class NeedBracesCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testSigleLineStatements() throws Exception {
+    public void testSingleLineStatements() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(NeedBracesCheck.class);
         checkConfig.addAttribute("allowSingleLineStatement", "true");
@@ -75,7 +75,7 @@ public class NeedBracesCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testSigleLineLambda() throws Exception {
+    public void testSingleLineLambda() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(NeedBracesCheck.class);
         checkConfig.addAttribute("tokens", "LAMBDA");
@@ -89,7 +89,7 @@ public class NeedBracesCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testSigleLineCaseDefault() throws Exception {
+    public void testSingleLineCaseDefault() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(NeedBracesCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_CASE, LITERAL_DEFAULT");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -63,7 +63,7 @@ public class HeaderCheckTest extends BaseFileSetCheckTestSupport {
     public void testNonExistingHeaderFile() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(HeaderCheck.class);
-        checkConfig.addAttribute("headerFile", getPath("nonexisting.file"));
+        checkConfig.addAttribute("headerFile", getPath("nonExisting.file"));
         try {
             createChecker(checkConfig);
             fail();


### PR DESCRIPTION
Fixes some `SpellCheckingInspection` inspection violations.

Description:
>Spellchecker inspection helps locate typos and misspelling in your code, comments and literals.