### PR TITLE
Fix typos in properties. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
@@ -18,7 +18,7 @@ public class CustomImportOrderTest extends BaseCheckTestSupport{
     private static final String MSG_ORDER = "custom.import.order";
     private static ConfigurationBuilder builder;
     private final Class<CustomImportOrderCheck> clazz = CustomImportOrderCheck.class;
-    String msgNongroup = "custom.import.order.nongroup.import";
+    String msgNongroup = "custom.import.order.nonGroup.import";
 
     /** Shortcuts to make code more compact */
     private static final String STD = CustomImportOrderCheck.STANDARD_JAVA_PACKAGE_RULE_GROUP;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -44,7 +44,7 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
     /**
      * Localization key for check violation.
      */
-    public static final String MSG_KEY = "properties.duplicateproperty";
+    public static final String MSG_KEY = "properties.duplicate.property";
     /**
      * Localization key for IO exception occurred on file open.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -281,13 +281,13 @@ public class CustomImportOrderCheck extends Check {
      * A key is pointing to the warning message text in "messages.properties"
      * file.
      */
-    public static final String MSG_NONGROUP_IMPORT = "custom.import.order.nongroup.import";
+    public static final String MSG_NONGROUP_IMPORT = "custom.import.order.nonGroup.import";
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
      * file.
      */
-    public static final String MSG_NONGROUP_EXPECTED = "custom.import.order.nongroup.expected";
+    public static final String MSG_NONGROUP_EXPECTED = "custom.import.order.nonGroup.expected";
 
     /**
      * A key is pointing to the warning message text in "messages.properties"

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages.properties
@@ -13,5 +13,5 @@ import.control.unknown.pkg=Import control file does not handle this package.
 custom.import.order=Import statement for ''{2}'' is in the wrong order. Should be in the ''{0}'' group, expecting group ''{1}'' on this line.
 custom.import.order.line.separator=''{0}'' should be separated from previous import group.
 custom.import.order.lex=Wrong lexicographical order for ''{0}'' import. Should be before ''{1}''.
-custom.import.order.nongroup.import=Imports without groups should be placed at the end of the import list: ''{0}''.
-custom.import.order.nongroup.expected=Import statement for ''{1}'' is in the wrong order. Should be in the ''{0}'' group, expecting not assigned imports on this line.
+custom.import.order.nonGroup.import=Imports without groups should be placed at the end of the import list: ''{0}''.
+custom.import.order.nonGroup.expected=Import statement for ''{1}'' is in the wrong order. Should be in the ''{0}'' group, expecting not assigned imports on this line.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/messages.properties
@@ -24,7 +24,7 @@ array.type.style=Array brackets at illegal position.
 
 type.file.mismatch=The name of the outer type and the file do not match.
 
-properties.duplicateproperty=Duplicated property ''{0}'' ({1} occurrence(s)).
+properties.duplicate.property=Duplicated property ''{0}'' ({1} occurrence(s)).
 unable.open.cause=Unable to open ''{0}'': {1}.
 
 forbid.escaped.unicode.char=Unicode escape(s) usage should be avoided.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/messages_de.properties
@@ -24,7 +24,7 @@ array.type.style=Array-Klammern an ungültiger Position.
 
 type.file.mismatch=Der Name der äußeren Klasse stimmt nicht mit dem Dateinamen überein.
 
-properties.duplicateproperty=Duplizierte Property ''{0}'' (Anzahl {1}).
+properties.duplicate.property=Duplizierte Property ''{0}'' (Anzahl {1}).
 unable.open.cause=Kann ''{0}'' nicht öffnen: {1}.
 
 forbid.escaped.unicode.char=Unicode-Escapes sollten vermieden werden.


### PR DESCRIPTION
Fixes some `SpellCheckingInspection` inspection violations.

Description:
>Spellchecker inspection helps locate typos and misspelling in your code, comments and literals.