### PR TITLE
Fix some typos in coding package. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
@@ -66,7 +66,7 @@ public class ArrayTrailingCommaCheck extends Check {
     public void visitToken(DetailAST arrayInit) {
         final DetailAST rcurly = arrayInit.findFirstToken(TokenTypes.RCURLY);
 
-        // if curlys are on the same line
+        // if curlies are on the same line
         // or array is empty then check nothing
         if (arrayInit.getLineNo() == rcurly.getLineNo()
             || arrayInit.getChildCount() == 1) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -226,7 +226,7 @@ public class DeclarationOrderCheck extends Check {
 
     /**
      * Process Method Token
-     * @param ast ,ethod token AST
+     * @param ast method token AST
      */
     private void processMethod(DetailAST ast) {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -161,7 +161,7 @@ public class EqualsAvoidNullCheck extends Check {
      * Checks for calling equals on String literal and
      * anon object which cannot be null
      * Also, checks if calling using strange inner class
-     * syntax outter.inner.equals(otherObj) by looking
+     * syntax outer.inner.equals(otherObj) by looking
      * for the dot operator which cannot be improved
      * @param objCalledOn object AST
      * @return if it is string literal

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -102,8 +102,8 @@ public class ExplicitInitializationCheck extends Check {
     }
 
     /**
-     * Examin Char literal for initializing to default value
-     * @param exprStart exprssion
+     * Examine char literal for initializing to default value
+     * @param exprStart expression
      * @return true is literal is initialized by zero symbol
      */
     private static boolean isZeroChar(DetailAST exprStart) {
@@ -113,7 +113,7 @@ public class ExplicitInitializationCheck extends Check {
     }
 
     /**
-     * Chekc for cases that should be skipped: no assignment, local variable, final variables
+     * Chekck for cases that should be skipped: no assignment, local variable, final variables
      * @param ast Variable def AST
      * @return true is that is a case that need to be skipped.
      */
@@ -136,7 +136,7 @@ public class ExplicitInitializationCheck extends Check {
     }
 
     /**
-     * Determines if a giiven type is an object type.
+     * Determines if a given type is an object type.
      * @param type type to check.
      * @return true if it is an object type.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -84,7 +84,7 @@ public class FallThroughCheck extends Check {
     /** Do we need to check last case group. */
     private boolean checkLastCaseGroup;
 
-    /** Relief pattern to allow fall throught to the next case branch. */
+    /** Relief pattern to allow fall through to the next case branch. */
     private String reliefPattern = "fallthru|falls? ?through";
 
     /** Relief regexp. */
@@ -256,7 +256,7 @@ public class FallThroughCheck extends Check {
      * @param ast loop to check
      * @param useBreak should we consider break as terminator.
      * @param useContinue should we consider continue as terminator.
-     * @return true if try/cath/finally block is terminated.
+     * @return true if try/catch/finally block is terminated.
      */
     private boolean checkTry(final DetailAST ast, boolean useBreak,
                              boolean useContinue) {
@@ -300,7 +300,7 @@ public class FallThroughCheck extends Check {
 
     /**
      * Determines if the fall through case between {@code currentCase} and
-     * {@code nextCase} is reliefed by a appropriate comment.
+     * {@code nextCase} is relieved by a appropriate comment.
      *
      * @param currentCase AST of the case that falls through to the next case.
      * @param nextCase AST of the next case.
@@ -329,8 +329,8 @@ public class FallThroughCheck extends Check {
          *    default:
          *    /+ FALLTHRU +/}
          */
-        final String linepart = lines[endLineNo - 1].substring(0, endColNo);
-        if (commentMatch(regExp, linepart, endLineNo)) {
+        final String linePart = lines[endLineNo - 1].substring(0, endColNo);
+        if (commentMatch(regExp, linePart, endLineNo)) {
             return true;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -265,9 +265,9 @@ public class FinalLocalVariableCheck extends Check {
     }
 
     /**
-     * Check if current param is lamda's param.
+     * Check if current param is lambda's param.
      * @param paramDef {@link TokenTypes#PARAMETER_DEF parameter def}.
-     * @return true if current param is lamda's param.
+     * @return true if current param is lambda's param.
      */
     private static boolean inLambda(DetailAST paramDef) {
         return paramDef.getParent().getParent().getType() == TokenTypes.LAMBDA;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -283,7 +283,7 @@ public class HiddenFieldCheck
             final DetailAST nameAST = ast.findFirstToken(TokenTypes.IDENT);
             final String name = nameAST.getText();
 
-            if (isStaticOrOnstanceField(ast, name)
+            if (isStaticOrInstanceField(ast, name)
                 && !isMatchingRegexp(name)
                 && !isIgnoredSetterParam(ast, name)
                 && !isIgnoredConstructorParam(ast)
@@ -299,7 +299,7 @@ public class HiddenFieldCheck
      * @param name identifier of token
      * @return true if static or instance field
      */
-    private boolean isStaticOrOnstanceField(DetailAST ast, String name) {
+    private boolean isStaticOrInstanceField(DetailAST ast, String name) {
         return frame.containsStaticField(name)
                 || !inStatic(ast) && frame.containsInstanceField(name);
     }
@@ -448,7 +448,7 @@ public class HiddenFieldCheck
      * abstract method.
      * @param ast the AST to check.
      * @return true if ast should be ignored because check property
-     * ignoreAbstactMethods is true and ast is a parameter of abstract
+     * ignoreAbstractMethods is true and ast is a parameter of abstract
      * methods.
      */
     private boolean isIgnoredParamOfAbstractMethod(DetailAST ast) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -63,10 +63,10 @@ public final class IllegalCatchCheck extends AbstractIllegalCheck {
 
     @Override
     public void visitToken(DetailAST detailAST) {
-        final DetailAST paradef =
+        final DetailAST parameterDef =
             detailAST.findFirstToken(TokenTypes.PARAMETER_DEF);
         final DetailAST excTypeParent =
-                paradef.findFirstToken(TokenTypes.TYPE);
+                parameterDef.findFirstToken(TokenTypes.TYPE);
         final List<DetailAST> excTypes = getAllExceptionTypes(excTypeParent);
 
         for (DetailAST excType : excTypes) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -75,7 +75,7 @@ public class IllegalInstantiationCheck
     /** {@link java.lang} package as string */
     private static final String JAVA_LANG = "java.lang.";
 
-    /** Set of fully qualified classnames. E.g. "java.lang.Boolean" */
+    /** Set of fully qualified class names. E.g. "java.lang.Boolean" */
     private final Set<String> illegalClasses = Sets.newHashSet();
 
     /** Name of the package */
@@ -147,7 +147,7 @@ public class IllegalInstantiationCheck
     @Override
     public void finishTree(DetailAST rootAST) {
         for (DetailAST literalNewAST : instantiations) {
-            postprocessLiteralNew(literalNewAST);
+            postProcessLiteralNew(literalNewAST);
         }
     }
 
@@ -155,7 +155,7 @@ public class IllegalInstantiationCheck
      * Collects classes defined in the source file. Required
      * to avoid false alarms for local vs. java.lang classes.
      *
-     * @param ast the classdef token.
+     * @param ast the class def token.
      */
     private void processClassDef(DetailAST ast) {
         final DetailAST identToken = ast.findFirstToken(TokenTypes.IDENT);
@@ -197,11 +197,11 @@ public class IllegalInstantiationCheck
     }
 
     /**
-     * Processes one of the collected "new" tokens when treewalking
+     * Processes one of the collected "new" tokens when walking tree
      * has finished.
      * @param newTokenAst the "new" token.
      */
-    private void postprocessLiteralNew(DetailAST newTokenAst) {
+    private void postProcessLiteralNew(DetailAST newTokenAst) {
         final DetailAST typeNameAst = newTokenAst.getFirstChild();
         final AST nameSibling = typeNameAst.getNextSibling();
         if (nameSibling.getType() == TokenTypes.ARRAY_DECLARATOR) {
@@ -257,7 +257,7 @@ public class IllegalInstantiationCheck
     /**
      * Check import statements
      * @param className name of the class
-     * @return value of illegal instatiated type
+     * @return value of illegal instantiated type
      */
     private String checkImportStatements(String className) {
         String illegalType = null;
@@ -268,7 +268,7 @@ public class IllegalInstantiationCheck
                 final String fqClass =
                     importArg.substring(0, importArg.length() - 1)
                     + className;
-                // assume that illegalInsts only contain existing classes
+                // assume that illegalInstances only contain existing classes
                 // or else we might create a false alarm here
                 if (illegalClasses.contains(fqClass)) {
                     illegalType = fqClass;
@@ -296,8 +296,8 @@ public class IllegalInstantiationCheck
     private boolean isSamePackage(String className, int pkgNameLen, String illegal) {
         // class from same package
 
-        // the toplevel package (pkgName == null) is covered by the
-        // "illegalInsts.contains(className)" check above
+        // the top level package (pkgName == null) is covered by the
+        // "illegalInstances.contains(className)" check above
 
         // the test is the "no garbage" version of
         // illegal.equals(pkgName + "." + className)
@@ -360,7 +360,7 @@ public class IllegalInstantiationCheck
 
     /**
      * Sets the classes that are illegal to instantiate.
-     * @param names a comma seperate list of class names
+     * @param names a comma separate list of class names
      */
     public void setClasses(String names) {
         illegalClasses.clear();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -227,14 +227,14 @@ public final class IllegalTypeCheck extends AbstractFormatCheck {
 
     /**
      * Checks type of parameters.
-     * @param paradef parameter list for check.
+     * @param parameterDef parameter list for check.
      */
-    private void visitParameterDef(DetailAST paradef) {
-        final DetailAST grandParentAST = paradef.getParent().getParent();
+    private void visitParameterDef(DetailAST parameterDef) {
+        final DetailAST grandParentAST = parameterDef.getParent().getParent();
 
         if (grandParentAST.getType() == TokenTypes.METHOD_DEF
             && isCheckedMethod(grandParentAST)) {
-            checkClassName(paradef);
+            checkClassName(parameterDef);
         }
     }
 


### PR DESCRIPTION
Fixes some `SpellCheckingInspection` inspection violations.

Description:
>Spellchecker inspection helps locate typos and misspelling in your code, comments and literals.