### PR TITLE
Remove redundant throws declarations. #1555

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java
@@ -17,7 +17,7 @@ public class IndentationTest extends BaseCheckTestSupport{
     private static ConfigurationBuilder builder;
 
     @BeforeClass
-    public static void setConfigurationBuilder() throws CheckstyleException {
+    public static void setConfigurationBuilder() {
         builder = new IndentationConfigurationBuilder(new File("src/it/"));
     }
 


### PR DESCRIPTION
Fixes `RedundantThrowsDeclaration` inspection violations.

Description:
>This inspection reports exceptions that are declared in a method's signature but never thrown by the method itself.