### PR TITLE
Mark method as static. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -797,7 +797,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * @param paramName name of parameter
      * @return true if parameter found and removed
      */
-    private boolean removeMatchingParam(List<DetailAST> params, String paramName) {
+    private static boolean removeMatchingParam(List<DetailAST> params, String paramName) {
         boolean found = false;
         final Iterator<DetailAST> paramIt = params.iterator();
         while (paramIt.hasNext()) {


### PR DESCRIPTION
Fixes `MethodMayBeStatic` inspection violation introduced in recent commit.

Description:
>Reports any methods which may safely be made static. A method may be static if it is not synchronized, it does not reference any of its class' non static methods and non static fields and is not overridden in a sub class.