### PR TITLE
Remove unused assignment. #1555

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -746,7 +746,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
 
             tagIt.remove();
 
-            boolean found = false;
+            boolean found;
             final String arg1 = tag.getFirstArg();
             found = removeMatchingParam(params, arg1);
 


### PR DESCRIPTION
Fixes `UnusedAssignment` inspection violations.

Description:
>This inspection points out the cases where a variable value is never used after its assignment.