### PR TITLE
Indentation fixes for pom.xml. Issue #46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1583,19 +1583,63 @@
                 <totalBranchRate>89</totalBranchRate>
                 <totalLineRate>95</totalLineRate>
                 <regexes>
-                  <regex><pattern>.*.checks.AbstractOptionCheck</pattern><branchRate>100</branchRate><lineRate>80</lineRate></regex>
-                  <regex><pattern>.*.checks.AbstractTypeAwareCheck</pattern><branchRate>87</branchRate><lineRate>84</lineRate></regex>
-                  <regex><pattern>.*.checks.AbstractTypeAwareCheck\$.*</pattern><branchRate>50</branchRate><lineRate>80</lineRate></regex>
-                  <regex><pattern>.*.checks.ClassResolver</pattern><branchRate>85</branchRate><lineRate>93</lineRate></regex>
-                  <regex><pattern>.*.checks.AbstractDeclarationCollector</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
-                  <regex><pattern>.*.checks.NewlineAtEndOfFileCheck</pattern><branchRate>83</branchRate><lineRate>88</lineRate></regex>
-                  <regex><pattern>.*.checks.SuppressWarningsHolder</pattern><branchRate>75</branchRate><lineRate>93</lineRate></regex>
-                  <regex><pattern>.*.checks.TranslationCheck</pattern><branchRate>81</branchRate><lineRate>83</lineRate></regex>
-                  <regex><pattern>.*.checks.UniquePropertiesCheck\$.*</pattern><branchRate>75</branchRate><lineRate>90</lineRate></regex>
+                  <regex>
+                    <pattern>.*.checks.AbstractOptionCheck</pattern>
+                    <branchRate>100</branchRate>
+                    <lineRate>80</lineRate>
+                  </regex>
+                  <regex>
+                    <pattern>.*.checks.AbstractTypeAwareCheck</pattern>
+                    <branchRate>87</branchRate>
+                    <lineRate>84</lineRate>
+                  </regex>
+                  <regex>
+                    <pattern>.*.checks.AbstractTypeAwareCheck\$.*</pattern>
+                    <branchRate>50</branchRate>
+                    <lineRate>80</lineRate>
+                  </regex>
+                  <regex>
+                    <pattern>.*.checks.ClassResolver</pattern>
+                    <branchRate>85</branchRate>
+                    <lineRate>93</lineRate>
+                  </regex>
+                  <regex>
+                    <pattern>.*.checks.AbstractDeclarationCollector</pattern>
+                    <branchRate>94</branchRate>
+                    <lineRate>100</lineRate>
+                  </regex>
+                  <regex>
+                    <pattern>.*.checks.NewlineAtEndOfFileCheck</pattern>
+                    <branchRate>83</branchRate>
+                    <lineRate>88</lineRate>
+                  </regex>
+                  <regex>
+                    <pattern>.*.checks.SuppressWarningsHolder</pattern>
+                    <branchRate>75</branchRate>
+                    <lineRate>93</lineRate>
+                  </regex>
+                  <regex>
+                    <pattern>.*.checks.TranslationCheck</pattern>
+                    <branchRate>81</branchRate>
+                    <lineRate>83</lineRate>
+                  </regex>
+                  <regex>
+                    <pattern>.*.checks.UniquePropertiesCheck\$.*</pattern>
+                    <branchRate>75</branchRate>
+                    <lineRate>90</lineRate>
+                  </regex>
 
-                  <regex><pattern>.*.checks.coding.DeclarationOrderCheck</pattern><branchRate>82</branchRate><lineRate>93</lineRate></regex>
+                  <regex>
+                    <pattern>.*.checks.coding.DeclarationOrderCheck</pattern>
+                    <branchRate>82</branchRate>
+                    <lineRate>93</lineRate>
+                  </regex>
 
-                  <regex><pattern>.*.checks.header.AbstractHeaderCheck</pattern><branchRate>90</branchRate><lineRate>87</lineRate></regex>
+                  <regex>
+                    <pattern>.*.checks.header.AbstractHeaderCheck</pattern>
+                    <branchRate>90</branchRate>
+                    <lineRate>87</lineRate>
+                  </regex>
                 </regexes>
               </check>
               <instrumentation>


### PR DESCRIPTION
Proper indentation is a simple and effective way to improve the code's readability. Consistent indentation among the developers on a team also reduces the differences that are committed to source control systems, making code reviews easier.

By default this rule checks that each block of code is indented but not the size of this indent. The parameter "indentSize" allows the expected indent size to be defined. Only the first line of a badly indented section is reported.

Should fix all violations in pom