### PR TITLE
Issue #1555: Remove unnecessary this keyword

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -543,7 +543,7 @@ public class EqualsAvoidNullCheck extends Check {
          * @param value value to set.
          */
         public void setClassOrEnumOrEnumConstDef(boolean value) {
-            this.classOrEnumOrEnumConstDef = value;
+            classOrEnumOrEnumConstDef = value;
         }
 
         /**


### PR DESCRIPTION
Fixes `UnnecessaryThis` inspection violations introduced in recent commit.

Description:
>Reports on any unnecessary uses of this in the code. Using this to disambiguate a code reference may easily become unnecessary via automatic refactorings, and is discouraged by many coding styles.