### PR TITLE
Issue #1555: Flip negated if-else

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -68,11 +68,11 @@ public class MethodCallHandler extends AbstractExpressionHandler {
             findSubtreeLines(lines, getMainAst().getFirstChild(), true);
             final int firstCol = lines.firstLineCol();
             final int lineStart = getLineStart(getFirstAst(getMainAst()));
-            if (lineStart != firstCol) {
-                indentLevel = new IndentLevel(lineStart);
+            if (lineStart == firstCol) {
+                indentLevel = super.getLevelImpl();
             }
             else {
-                indentLevel = super.getLevelImpl();
+                indentLevel = new IndentLevel(lineStart);
             }
         }
         return indentLevel;


### PR DESCRIPTION
Fixes `NegatedIfElse` inspection violations introduced in recent commit.

Description:
>Reports if statements which contain else branches and whose conditions are negated. Flipping the order of the if and else branches will usually increase the clarity of such statements.