### PR TITLE
Issue #1555: Narrow scope of variable

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -746,9 +746,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
 
             tagIt.remove();
 
-            boolean found;
             final String arg1 = tag.getFirstArg();
-            found = removeMatchingParam(params, arg1);
+            boolean found = removeMatchingParam(params, arg1);
 
             if (CommonUtils.startsWithChar(arg1, '<') && CommonUtils.endsWithChar(arg1, '>')) {
                 // Loop looking for matching type param


### PR DESCRIPTION
Fixes `TooBroadScope` inspection violations introduced in recent commit.

Description:
>Reports any variable declarations of which the scope can be narrowed. Especially useful for "Pascal style" declarations at the start of a method, but variables with too broad a scope are also often left over after refactorings.