### PR TITLE
Issue #1555: Remove unnecessary boxing

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -130,12 +130,12 @@ public class UniquePropertiesCheckTest extends BaseFileSetCheckTestSupport {
         constructor.setAccessible(true);
         Object uniqueProperties = constructor.newInstance();
         Method method = uniqueProperties.getClass().getDeclaredMethod("put", Object.class, Object.class);
-        Object result = method.invoke(uniqueProperties, new Integer(1), "value");
+        Object result = method.invoke(uniqueProperties, 1, "value");
         Map<Object, Object> table = new Hashtable<>();
-        Object expected = table.put(new Integer(1), "value");
+        Object expected = table.put(1, "value");
         assertEquals(expected, result);
-        Object result2 = method.invoke(uniqueProperties, new Integer(1), "value");
-        Object expected2 = table.put(new Integer(1), "value");
+        Object result2 = method.invoke(uniqueProperties, 1, "value");
+        Object expected2 = table.put(1, "value");
         assertEquals(expected2, result2);
     }
 


### PR DESCRIPTION
Fixes `CachedNumberConstructorCall` inspection violations.

Description:
>Reports any attempt to instantiate a new Long, Integer, Short or Byte object from a primitive long, integer, short or byte argument. It may be more efficient to use the static method valueOf() here (introduced in Java 5), which will cache objects for values between -128 and 127 inclusive.
This inspection only reports if the project or module is configured to use a language level of 5.0 or higher.