### PR TITLE
Issue #1555: Use constant for empty array of zero length

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -23,6 +23,7 @@ import static com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck.MSG
 
 import java.io.File;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,8 +56,7 @@ public class IllegalTypeCheckTest extends BaseCheckTestSupport {
     @Test
     public void testValidateAbstractClassNamesSetToFalse() throws Exception {
         checkConfig.addAttribute("validateAbstractClassNames", "false");
-        String[] expected = {
-        };
+        String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
         verify(checkConfig, getPath("coding" + File.separator + "InputIllegalTypeAbstractClassNames.java"), expected);
     }


### PR DESCRIPTION
Fixes `ZeroLengthArrayInitialization` inspection violations.

Description:
>Reports on allocations of arrays with known lengths of zero. Since array lengths in Java are non-modifiable, it is almost always possible to share zero-length arrays, rather than repeatedly allocating new zero-length arrays. Such sharing may provide useful optimizations in program runtime or footprint. Note that this inspection does not report zero-length arrays allocated as static final fields, as it is assumed that those arrays are being used to implement array sharing.