### PR TITLE
Issue #1555: Rename boolean methods to start with question word

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -184,7 +184,7 @@ public class GenericWhitespaceCheck extends Check {
         //
         final int indexOfAmp = line.indexOf('&', after);
         if (indexOfAmp >= 0
-            && whitespaceBetween(after, indexOfAmp, line)) {
+            && containsWhitespaceBetween(after, indexOfAmp, line)) {
             if (indexOfAmp - after == 0) {
                 log(ast.getLineNo(), after, WS_NOT_PRECEDED, "&");
             }
@@ -294,8 +294,8 @@ public class GenericWhitespaceCheck extends Check {
      * @param line the line to check
      * @return whether there are only whitespaces (or nothing)
      */
-    private static boolean whitespaceBetween(
-        int fromIndex, int toIndex, String line) {
+    private static boolean containsWhitespaceBetween(
+            int fromIndex, int toIndex, String line) {
         for (int i = fromIndex; i < toIndex; i++) {
             if (!Character.isWhitespace(line.charAt(i))) {
                 return false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
@@ -110,8 +110,7 @@ public final class TokenTypesDoclet {
      * @param reporter the reporter to report errors.
      * @return true if only valid options was specified
      */
-    public static boolean validOptions(String[][] options,
-                                       DocErrorReporter reporter) {
+    public static boolean checkOptions(String[][] options, DocErrorReporter reporter) {
         boolean foundDestFileOption = false;
         for (final String[] opt : options) {
             if (DEST_FILE_OPT.equals(opt[0])) {


### PR DESCRIPTION
Fixes `BooleanMethodNameMustStartWithQuestion` inspection violations.

Description:
>Reports boolean methods whose names do not start with a question word. Boolean methods that override library methods are ignored by this inspection.