### PR TITLE
Issue #1555: Fix false-positive in mismatched array read write rule

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
@@ -33,11 +33,6 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtils;
  */
 public class JavadocNodeImpl implements DetailNode {
     /**
-     * Empty array of {@link DetailNode} type.
-     */
-    private static final DetailNode[] EMPTY_DETAIL_NODE_ARRAY = new DetailNode[0];
-
-    /**
      * Node index among parent's children
      */
     private int index;
@@ -95,7 +90,7 @@ public class JavadocNodeImpl implements DetailNode {
     @Override
     public DetailNode[] getChildren() {
         if (children == null) {
-            return EMPTY_DETAIL_NODE_ARRAY.clone();
+            return JavadocUtils.EMPTY_DETAIL_NODE_ARRAY;
         }
         else {
             return Arrays.copyOf(children, children.length);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
@@ -43,6 +43,10 @@ import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTags;
  * @author Lyle Hanson
  */
 public final class JavadocUtils {
+    /**
+     * Empty array of {@link DetailNode} type.
+     */
+    public static final DetailNode[] EMPTY_DETAIL_NODE_ARRAY = new DetailNode[0];
     /** Maps from a token name to value */
     private static final ImmutableMap<String, Integer> TOKEN_NAME_TO_VALUE;
     /** Maps from a token value to name */


### PR DESCRIPTION
False-positive reported to JetBrains as [IDEA-144521](https://youtrack.jetbrains.com/issue/IDEA-144521).

Fixes `MismatchedArrayReadWrite` inspection violations.

Description:
>Reports any array fields or variables whose contents are read but not written, or written but not read. Such mismatched reads and writes are pointless, and probably indicate dead, incomplete or erroneous code.