### PR TITLE
Issue #1566: ReturnCount violation fixed for AbstractJavadocCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -376,24 +376,25 @@ public abstract class AbstractJavadocCheck extends Check {
      * @return next sibling of ParseTree node.
      */
     private static ParseTree getNextSibling(ParseTree node) {
-        if (node.getParent() == null) {
-            return null;
-        }
+        ParseTree nextSibling = null;
 
-        final ParseTree parent = node.getParent();
-        final int childCount = parent.getChildCount();
+        if (node.getParent() != null) {
+            final ParseTree parent = node.getParent();
+            final int childCount = parent.getChildCount();
 
-        int i = 0;
-        while (true) {
-            final ParseTree currentNode = parent.getChild(i);
-            if (currentNode.equals(node)) {
-                if (i == childCount - 1) {
-                    return null;
+            int i = 0;
+            while (true) {
+                final ParseTree currentNode = parent.getChild(i);
+                if (currentNode.equals(node)) {
+                    if (i != childCount - 1) {
+                        nextSibling = parent.getChild(i + 1);
+                    }
+                    break;
                 }
-                return parent.getChild(i + 1);
+                i++;
             }
-            i++;
         }
+        return nextSibling;
     }
 
     /**


### PR DESCRIPTION
Fix for:
- ReturnCount ```Return count is X (max allowed is 2).```