### PR TITLE
Issue #1555: Specify encoding explicitly

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.io.OutputStream;
-import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -43,8 +42,7 @@ public abstract class BaseCheckTestSupport
         public void auditStarted(AuditEvent evt) {}
     }
 
-    private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final PrintStream stream = new PrintStream(baos);
+    final ByteArrayOutputStream stream = new ByteArrayOutputStream();
     protected final Properties props = new Properties();
 
     protected static DefaultConfiguration createCheckConfig(Class<?> aClazz)
@@ -129,7 +127,7 @@ public abstract class BaseCheckTestSupport
 
         // process each of the lines
         final ByteArrayInputStream bais =
-            new ByteArrayInputStream(baos.toByteArray());
+            new ByteArrayInputStream(stream.toByteArray());
         final LineNumberReader lnr =
             new LineNumberReader(new InputStreamReader(bais, StandardCharsets.UTF_8));
 

--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -2,9 +2,12 @@ package com.google.checkstyle.test.base;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -104,7 +107,8 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
 
 	public Integer[] getLinesWithWarn(String aFileName) throws IOException {
 		List<Integer> result = new ArrayList<>();
-	    try(BufferedReader br = new BufferedReader(new FileReader(aFileName))) {
+	    try(BufferedReader br = new BufferedReader(new InputStreamReader(
+				new FileInputStream(aFileName), StandardCharsets.UTF_8))) {
 			int lineNumber = 1;
 			while (true) {
 	            String line = br.readLine();

--- a/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
@@ -2,8 +2,11 @@ package com.google.checkstyle.test.base;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -48,7 +51,8 @@ public class IndentationConfigurationBuilder extends ConfigurationBuilder
                     throws IOException
     {
         List<Integer> result = new ArrayList<>();
-        try (BufferedReader br = new BufferedReader(new FileReader(aFileName))) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(
+                new FileInputStream(aFileName), StandardCharsets.UTF_8))) {
             int lineNumber = 1;
             for (String line = br.readLine(); line != null; line = br.readLine()) {
                 Matcher match = LINE_WITH_COMMENT_REGEX.matcher(line);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.io.OutputStream;
-import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -38,8 +37,7 @@ public abstract class BaseCheckTestSupport {
 
     }
 
-    protected final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    protected final PrintStream stream = new PrintStream(baos);
+    protected final ByteArrayOutputStream stream = new ByteArrayOutputStream();
 
     protected static DefaultConfiguration createCheckConfig(Class<?> clazz) {
         return new DefaultConfiguration(clazz.getName());
@@ -113,7 +111,7 @@ public abstract class BaseCheckTestSupport {
 
         // process each of the lines
         final ByteArrayInputStream bais =
-                new ByteArrayInputStream(baos.toByteArray());
+                new ByteArrayInputStream(stream.toByteArray());
         final LineNumberReader lnr =
                 new LineNumberReader(new InputStreamReader(bais, StandardCharsets.UTF_8));
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -24,9 +24,11 @@ import static org.junit.Assert.fail;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Locale;
@@ -53,7 +55,8 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
                 createCheckConfig(ConstantNameCheck.class);
         final String content = "public class Main { public static final int k = 5 + 4; }";
         final File file = temporaryFolder.newFile("file.java");
-        final Writer writer = new BufferedWriter(new FileWriter(file));
+        final Writer writer = new BufferedWriter(
+                new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8));
         writer.write(content);
         writer.close();
         final String[] expected1 = {
@@ -68,7 +71,8 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
                 createCheckConfig(ConstantNameCheck.class);
         final File file = temporaryFolder.newFile("file.pdf");
         final String content = "public class Main { public static final int k = 5 + 4; }";
-        final BufferedWriter writer = new BufferedWriter(new FileWriter(file));
+        final BufferedWriter writer = new BufferedWriter(
+                new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8));
         writer.write(content);
         writer.close();
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -27,8 +27,10 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -70,7 +72,8 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
                     final int tabWidth)
                     throws IOException {
         List<Integer> result = new ArrayList<>();
-        try (BufferedReader br = new BufferedReader(new FileReader(aFileName))) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(
+                new FileInputStream(aFileName), StandardCharsets.UTF_8))) {
             int lineNumber = 1;
             for (String line = br.readLine(); line != null; line = br.readLine()) {
                 Matcher match = LINE_WITH_COMMENT_REGEX.matcher(line);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -203,7 +203,7 @@ public class WriteTagCheckTest extends BaseCheckTestSupport {
 
         // process each of the lines
         final ByteArrayInputStream bais =
-            new ByteArrayInputStream(baos.toByteArray());
+            new ByteArrayInputStream(stream.toByteArray());
         final LineNumberReader lnr =
             new LineNumberReader(new InputStreamReader(bais, StandardCharsets.UTF_8));
 


### PR DESCRIPTION
Fixes `ImplicitDefaultCharsetUsage` inspection violations.

Description:
>Reports method and constructor calls which implicitly use the platform's default charset. These can produce different results on (e.g. foreign language) systems that use a different default charset, resulting in unexpected behaviour.