### PR TITLE
Issue #1555: Avoid reusing variables

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
@@ -109,9 +109,9 @@ public class IndentationConfigurationBuilder extends ConfigurationBuilder
         final int indentInComment = getIndentFromComment(comment);
         final boolean isWarnComment = isWarnComment(comment);
 
-        Matcher match = MULTILEVEL_COMMENT_REGEX.matcher(comment);
-        if (match.matches()) {
-            final String[] levels = match.group(1).split(",");
+        Matcher multilevelMatch = MULTILEVEL_COMMENT_REGEX.matcher(comment);
+        if (multilevelMatch.matches()) {
+            final String[] levels = multilevelMatch.group(1).split(",");
             final String indentInCommentStr = String.valueOf(indentInComment);
             final boolean containsActualLevel =
                             Arrays.asList(levels).contains(indentInCommentStr);
@@ -120,17 +120,17 @@ public class IndentationConfigurationBuilder extends ConfigurationBuilder
                     || !containsActualLevel && isWarnComment;
         }
 
-        match = SINGLE_LEVEL_COMMENT_REGEX.matcher(comment);
-        if (match.matches()) {
-            final int expectedLevel = Integer.parseInt(match.group(1));
+        Matcher singleLevelMatch = SINGLE_LEVEL_COMMENT_REGEX.matcher(comment);
+        if (singleLevelMatch.matches()) {
+            final int expectedLevel = Integer.parseInt(singleLevelMatch.group(1));
 
             return expectedLevel == indentInComment && !isWarnComment
                     || expectedLevel != indentInComment && isWarnComment;
         }
 
-        match = NON_STRICT_LEVEL_COMMENT_REGEX.matcher(comment);
-        if (match.matches()) {
-            final int expectedMinimalIndent = Integer.parseInt(match.group(1));
+        Matcher nonStrictLevelMatch = NON_STRICT_LEVEL_COMMENT_REGEX.matcher(comment);
+        if (nonStrictLevelMatch.matches()) {
+            final int expectedMinimalIndent = Integer.parseInt(nonStrictLevelMatch.group(1));
 
             return indentInComment >= expectedMinimalIndent && !isWarnComment
                     || indentInComment < expectedMinimalIndent && isWarnComment;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -174,8 +174,8 @@ public class CheckerTest {
         final List<File> files = new ArrayList<>();
         File file = new File("file.pdf");
         files.add(file);
-        file = new File("file.java");
-        files.add(file);
+        File otherFile = new File("file.java");
+        files.add(otherFile);
         final String[] fileExtensions = {"java", "xml", "properties"};
         checker.setFileExtensions(fileExtensions);
         final int counter = checker.process(files);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -207,17 +207,17 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         //checker.destroy();
         //checker.configure(checkerConfig);
 
-        checker = new Checker();
-        checker.setLocaleCountry(locale.getCountry());
-        checker.setLocaleLanguage(locale.getLanguage());
-        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
-        checker.configure(checkerConfig);
-        checker.addListener(new BriefLogger(stream));
+        Checker otherChecker = new Checker();
+        otherChecker.setLocaleCountry(locale.getCountry());
+        otherChecker.setLocaleLanguage(locale.getLanguage());
+        otherChecker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        otherChecker.configure(checkerConfig);
+        otherChecker.addListener(new BriefLogger(stream));
         // here is diff with previous checker
         checkerConfig.addAttribute("fileExtensions", "java,javax");
 
         // one more time on updated config
-        verify(checker, pathToEmptyFile, pathToEmptyFile, expected);
+        verify(otherChecker, pathToEmptyFile, pathToEmptyFile, expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
@@ -147,14 +147,14 @@ public class DetailASTTest {
         Object[] params = {
             node, parent, prev, filename, root,
         };
-        String msg = MessageFormat.format(
+        String badParentMsg = MessageFormat.format(
             "Bad parent node={0} parent={1} filename={3} root={4}",
             params);
-        assertEquals(msg, parent, node.getParent());
-        msg = MessageFormat.format(
+        assertEquals(badParentMsg, parent, node.getParent());
+        String badPrevMsg = MessageFormat.format(
             "Bad prev node={0} prev={2} parent={1} filename={3} root={4}",
             params);
-        assertEquals(msg, prev, node.getPreviousSibling());
+        assertEquals(badPrevMsg, prev, node.getPreviousSibling());
 
         if (node.getFirstChild() != null) {
             checkTree(node.getFirstChild(), node, null,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -127,9 +127,9 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
         final int indentInComment = getIndentFromComment(comment);
         final boolean isWarnComment = isWarnComment(comment);
 
-        Matcher match = MULTILEVEL_COMMENT_REGEX.matcher(comment);
-        if (match.matches()) {
-            final String[] levels = match.group(1).split(",");
+        Matcher multilevelMatch = MULTILEVEL_COMMENT_REGEX.matcher(comment);
+        if (multilevelMatch.matches()) {
+            final String[] levels = multilevelMatch.group(1).split(",");
             final String indentInCommentStr = String.valueOf(indentInComment);
             final boolean containsActualLevel =
                             Arrays.asList(levels).contains(indentInCommentStr);
@@ -138,17 +138,17 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
                     || !containsActualLevel && isWarnComment;
         }
 
-        match = SINGLELEVEL_COMMENT_REGEX.matcher(comment);
-        if (match.matches()) {
-            final int expectedLevel = Integer.parseInt(match.group(1));
+        Matcher singleLevelMatch = SINGLELEVEL_COMMENT_REGEX.matcher(comment);
+        if (singleLevelMatch.matches()) {
+            final int expectedLevel = Integer.parseInt(singleLevelMatch.group(1));
 
             return expectedLevel == indentInComment && !isWarnComment
                     || expectedLevel != indentInComment && isWarnComment;
         }
 
-        match = NONSTRICT_LEVEL_COMMENT_REGEX.matcher(comment);
-        if (match.matches()) {
-            final int expectedMinimalIndent = Integer.parseInt(match.group(1));
+        Matcher nonStrictLevelMatch = NONSTRICT_LEVEL_COMMENT_REGEX.matcher(comment);
+        if (nonStrictLevelMatch.matches()) {
+            final int expectedMinimalIndent = Integer.parseInt(nonStrictLevelMatch.group(1));
 
             return indentInComment >= expectedMinimalIndent && !isWarnComment
                     || indentInComment < expectedMinimalIndent && isWarnComment;


### PR DESCRIPTION
Fixes some `ReuseOfLocalVariable` inspection violations.

Description:
>Reports local variables that are "reused", overwriting their values with new values unrelated to their original use. Such local variable reuse may be confusing, as the intended semantics of the local variable may vary with each use. It may also be prone to bugs, if code changes result in values that were thought to be overwritten actually being live. It is good practices to keep variable lifetimes as short as possible, and not reuse local variables for the sake of brevity.