### PR TITLE
Issue #1555: Rename methods returning boolean to use question word

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -248,7 +248,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
 
         // Process each file
         for (final File file : files) {
-            if (!CommonUtils.fileExtensionMatches(file, fileExtensions)) {
+            if (!CommonUtils.matchesFileExtension(file, fileExtensions)) {
                 continue;
             }
             final String fileName = file.getAbsolutePath();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -187,7 +187,7 @@ public final class TreeWalker
         final long timestamp = file.lastModified();
         if (cache != null
                 && (cache.isInCache(fileName, timestamp)
-                    || !CommonUtils.fileExtensionMatches(file, getFileExtensions()))) {
+                    || !CommonUtils.matchesFileExtension(file, getFileExtensions()))) {
             return;
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -73,7 +73,7 @@ public abstract class AbstractFileSetCheck
                                                    List<String> lines) {
         messageCollector.reset();
         // Process only what interested in
-        if (CommonUtils.fileExtensionMatches(file, fileExtensions)) {
+        if (CommonUtils.matchesFileExtension(file, fileExtensions)) {
             processFiltered(file, lines);
         }
         return messageCollector.getMessages();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
@@ -190,7 +190,7 @@ public final class MissingDeprecatedCheck extends Check {
                 found = true;
             }
             else if (noargMultilineStart.find()) {
-                found = validateTagAtTheRestOfComment(lines, found, currentLine, i);
+                found = checkTagAtTheRestOfComment(lines, found, currentLine, i);
 
             }
         }
@@ -208,8 +208,8 @@ public final class MissingDeprecatedCheck extends Check {
      * @param i som index
      * @return true if Tag is found
      */
-    private boolean validateTagAtTheRestOfComment(String[] lines, boolean foundBefore,
-                                                  int currentLine, int i) {
+    private boolean checkTagAtTheRestOfComment(String[] lines, boolean foundBefore,
+            int currentLine, int i) {
 
         boolean found = false;
         for (int reindex = i + 1;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -296,7 +296,7 @@ public class LeftCurlyCheck
         if (braceLine.length() <= brace.getColumnNo() + 1
                 || braceLine.charAt(brace.getColumnNo() + 1) != '}') {
             if (getAbstractOption() == LeftCurlyOption.NL) {
-                if (!CommonUtils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
+                if (!CommonUtils.hasWhitespaceBefore(brace.getColumnNo(), braceLine)) {
                     log(brace, MSG_KEY_LINE_NEW, OPEN_CURLY_BRACE, brace.getColumnNo() + 1);
                 }
             }
@@ -318,7 +318,7 @@ public class LeftCurlyCheck
      * @param braceLine line content
      */
     private void validateEol(DetailAST brace, String braceLine) {
-        if (CommonUtils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
+        if (CommonUtils.hasWhitespaceBefore(brace.getColumnNo(), braceLine)) {
             log(brace, MSG_KEY_LINE_PREVIOUS, OPEN_CURLY_BRACE, brace.getColumnNo() + 1);
         }
         if (!hasLineBreakAfter(brace)) {
@@ -335,14 +335,14 @@ public class LeftCurlyCheck
     private void validateNewLinePosition(DetailAST brace, DetailAST startToken, String braceLine) {
         // not on the same line
         if (startToken.getLineNo() + 1 == brace.getLineNo()) {
-            if (CommonUtils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
+            if (CommonUtils.hasWhitespaceBefore(brace.getColumnNo(), braceLine)) {
                 log(brace, MSG_KEY_LINE_PREVIOUS, OPEN_CURLY_BRACE, brace.getColumnNo() + 1);
             }
             else {
                 log(brace, MSG_KEY_LINE_NEW, OPEN_CURLY_BRACE, brace.getColumnNo() + 1);
             }
         }
-        else if (!CommonUtils.whitespaceBefore(brace.getColumnNo(), braceLine)) {
+        else if (!CommonUtils.hasWhitespaceBefore(brace.getColumnNo(), braceLine)) {
             log(brace, MSG_KEY_LINE_NEW, OPEN_CURLY_BRACE, brace.getColumnNo() + 1);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -227,7 +227,7 @@ public class RightCurlyCheck extends AbstractOptionCheck<RightCurlyOption> {
         }
         else if (shouldStartLine) {
             final boolean startsLine =
-                    CommonUtils.whitespaceBefore(rcurly.getColumnNo(), targetSourceLine);
+                    CommonUtils.hasWhitespaceBefore(rcurly.getColumnNo(), targetSourceLine);
 
             if (!startsLine && lcurly.getLineNo() != rcurly.getLineNo()) {
                 violation = MSG_KEY_LINE_NEW;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -278,7 +278,7 @@ public class EqualsAvoidNullCheck extends Check {
         if (isObjectValid(objCalledOn)
                 && containsOneArgument(methodCall)
                 && containsAllSafeTokens(expr)
-                && calledOnStringField(objCalledOn)) {
+                && isCalledOnStringField(objCalledOn)) {
             final String methodName = methodCall.getFirstChild().getLastChild().getText();
             if (EQUALS.equals(methodName)) {
                 log(methodCall.getLineNo(), methodCall.getColumnNo(),
@@ -377,7 +377,7 @@ public class EqualsAvoidNullCheck extends Check {
      * @param objCalledOn object ast.
      * @return true if the object is of String type.
      */
-    private boolean calledOnStringField(DetailAST objCalledOn) {
+    private boolean isCalledOnStringField(DetailAST objCalledOn) {
         boolean result = false;
         final DetailAST previousSiblingAst = objCalledOn.getPreviousSibling();
         final String name = objCalledOn.getText();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -340,7 +340,7 @@ public class FallThroughCheck extends Check {
          *    /+ FALLTHRU +/}
          */
         final String linePart = lines[endLineNo - 1].substring(0, endColNo);
-        if (commentMatch(regExp, linePart, endLineNo)) {
+        if (matchesComment(regExp, linePart, endLineNo)) {
             allThroughComment = true;
         }
         else {
@@ -360,7 +360,7 @@ public class FallThroughCheck extends Check {
             final int startLineNo = currentCase.getLineNo();
             for (int i = endLineNo - 2; i > startLineNo - 1; i--) {
                 if (!lines[i].trim().isEmpty()) {
-                    allThroughComment = commentMatch(regExp, lines[i], i + 1);
+                    allThroughComment = matchesComment(regExp, lines[i], i + 1);
                     break;
                 }
             }
@@ -376,7 +376,7 @@ public class FallThroughCheck extends Check {
      * @param lineNo The line number in the file.
      * @return True if a match was found inside a comment.
      */
-    private boolean commentMatch(Pattern pattern, String line, int lineNo
+    private boolean matchesComment(Pattern pattern, String line, int lineNo
     ) {
         final Matcher matcher = pattern.matcher(line);
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
@@ -83,8 +83,8 @@ public class SimplifyBooleanReturnCheck
         final AST condition = ast.getFirstChild().getNextSibling();
         final AST thenStatement = condition.getNextSibling().getNextSibling();
 
-        if (returnsOnlyBooleanLiteral(thenStatement)
-            && returnsOnlyBooleanLiteral(elseStatement)) {
+        if (canReturnOnlyBooleanLiteral(thenStatement)
+            && canReturnOnlyBooleanLiteral(elseStatement)) {
             log(ast.getLineNo(), ast.getColumnNo(), MSG_KEY);
         }
     }
@@ -109,7 +109,7 @@ public class SimplifyBooleanReturnCheck
      * @param ast the sytax tree to check
      * @return if ast is a return statment with a boolean literal.
      */
-    private static boolean returnsOnlyBooleanLiteral(AST ast) {
+    private static boolean canReturnOnlyBooleanLiteral(AST ast) {
         if (isBooleanLiteralReturnStatement(ast)) {
             return true;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -260,7 +260,7 @@ public class CommentsIndentationCheck extends Check {
     private boolean isTrailingSingleLineComment(DetailAST singleLineComment) {
         final String targetSourceLine = getLine(singleLineComment.getLineNo() - 1);
         final int commentColumnNo = singleLineComment.getColumnNo();
-        return !CommonUtils.whitespaceBefore(commentColumnNo, targetSourceLine);
+        return !CommonUtils.hasWhitespaceBefore(commentColumnNo, targetSourceLine);
     }
 
     /**
@@ -303,7 +303,7 @@ public class CommentsIndentationCheck extends Check {
     private boolean isTrailingBlockComment(DetailAST blockComment) {
         final String commentLine = getLine(blockComment.getLineNo() - 1);
         final int commentColumnNo = blockComment.getColumnNo();
-        return !CommonUtils.whitespaceBefore(commentColumnNo, commentLine)
+        return !CommonUtils.hasWhitespaceBefore(commentColumnNo, commentLine)
             || blockComment.getNextSibling().getLineNo() == blockComment.getLineNo();
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/AbstractParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/AbstractParenPadCheck.java
@@ -100,7 +100,7 @@ abstract class AbstractParenPadCheck
         if (before >= 0) {
             if (getAbstractOption() == PadOption.NOSPACE
                 && Character.isWhitespace(line.charAt(before))
-                && !CommonUtils.whitespaceBefore(before, line)) {
+                && !CommonUtils.hasWhitespaceBefore(before, line)) {
                 log(ast.getLineNo(), before, WS_PRECEDED, CLOSE_PARENTHESIS);
             }
             else if (getAbstractOption() == PadOption.SPACE

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
@@ -92,7 +92,7 @@ public class EmptyForInitializerPadCheck
             final String line = getLines()[semiLineIdx];
             final int before = semi.getColumnNo() - 1;
             //don't check if semi at beginning of line
-            if (!CommonUtils.whitespaceBefore(before, line)) {
+            if (!CommonUtils.hasWhitespaceBefore(before, line)) {
                 final PadOption option = getAbstractOption();
                 if (option == PadOption.NOSPACE
                     && Character.isWhitespace(line.charAt(before))) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -150,7 +150,7 @@ public class GenericWhitespaceCheck extends Check {
         final int after = ast.getColumnNo() + 1;
 
         if (before >= 0 && Character.isWhitespace(line.charAt(before))
-                && !CommonUtils.whitespaceBefore(before, line)) {
+                && !CommonUtils.hasWhitespaceBefore(before, line)) {
             log(ast.getLineNo(), before, WS_PRECEDED, CLOSE_ANGLE_BRACKET);
         }
 
@@ -274,7 +274,7 @@ public class GenericWhitespaceCheck extends Check {
             }
             // Whitespace not required
             else if (Character.isWhitespace(line.charAt(before))
-                && !CommonUtils.whitespaceBefore(before, line)) {
+                && !CommonUtils.hasWhitespaceBefore(before, line)) {
                 log(ast.getLineNo(), before, WS_PRECEDED, OPEN_ANGLE_BRACKET);
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
@@ -132,7 +132,7 @@ public class MethodParamPadCheck
         }
 
         final String line = getLines()[parenAST.getLineNo() - 1];
-        if (CommonUtils.whitespaceBefore(parenAST.getColumnNo(), line)) {
+        if (CommonUtils.hasWhitespaceBefore(parenAST.getColumnNo(), line)) {
             if (!allowLineBreaks) {
                 log(parenAST, LINE_PREVIOUS, parenAST.getText());
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
@@ -213,7 +213,7 @@ public class OperatorWrapCheck
             log(lineNo, colNo, LINE_NEW, text);
         }
         else if (wOp == WrapOption.EOL
-                && CommonUtils.whitespaceBefore(colNo - 1, currentLine)) {
+                && CommonUtils.hasWhitespaceBefore(colNo - 1, currentLine)) {
             log(lineNo, colNo, LINE_PREVIOUS, text);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
@@ -52,7 +52,7 @@ public final class CommonUtils {
      *            files extensions, empty property in config makes it matches to all.
      * @return whether there is a match.
      */
-    public static boolean fileExtensionMatches(File file, String... fileExtensions) {
+    public static boolean matchesFileExtension(File file, String... fileExtensions) {
         boolean result = false;
         if (fileExtensions == null || fileExtensions.length == 0) {
             result = true;
@@ -90,7 +90,7 @@ public final class CommonUtils {
      *            the line to check
      * @return whether there is only whitespace
      */
-    public static boolean whitespaceBefore(int index, String line) {
+    public static boolean hasWhitespaceBefore(int index, String line) {
         for (int i = 0; i < index; i++) {
             if (!Character.isWhitespace(line.charAt(i))) {
                 return false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
@@ -295,7 +295,7 @@ public final class JavadocUtils {
      * @param type token type
      * @return true if node contains any node of type type among children on any deep level.
      */
-    public static boolean branchContains(DetailNode node, int type) {
+    public static boolean containsInBranch(DetailNode node, int type) {
         DetailNode curNode = node;
         while (true) {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
@@ -78,12 +78,12 @@ public class CommonUtilsTest {
     public void testFileExtensions() {
         final String[] fileExtensions = {"java"};
         File file = new File("file.pdf");
-        assertFalse(CommonUtils.fileExtensionMatches(file, fileExtensions));
-        assertTrue(CommonUtils.fileExtensionMatches(file, (String[]) null));
+        assertFalse(CommonUtils.matchesFileExtension(file, fileExtensions));
+        assertTrue(CommonUtils.matchesFileExtension(file, (String[]) null));
         file = new File("file.java");
-        assertTrue(CommonUtils.fileExtensionMatches(file, fileExtensions));
+        assertTrue(CommonUtils.matchesFileExtension(file, fileExtensions));
         file = new File("file.");
-        assertTrue(CommonUtils.fileExtensionMatches(file, ""));
+        assertTrue(CommonUtils.matchesFileExtension(file, ""));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java
@@ -200,14 +200,14 @@ public class JavadocUtilsTest {
         secondChild.setType(JavadocTokenTypes.CODE_LITERAL);
 
         node.setChildren(firstChild, secondChild);
-        assertFalse(JavadocUtils.branchContains(node, JavadocTokenTypes.AUTHOR_LITERAL));
+        assertFalse(JavadocUtils.containsInBranch(node, JavadocTokenTypes.AUTHOR_LITERAL));
 
         firstChild.setParent(node);
         secondChild.setParent(node);
-        assertFalse(JavadocUtils.branchContains(node, JavadocTokenTypes.AUTHOR_LITERAL));
+        assertFalse(JavadocUtils.containsInBranch(node, JavadocTokenTypes.AUTHOR_LITERAL));
 
         secondChild.setType(JavadocTokenTypes.AUTHOR_LITERAL);
-        assertTrue(JavadocUtils.branchContains(node, JavadocTokenTypes.AUTHOR_LITERAL));
+        assertTrue(JavadocUtils.containsInBranch(node, JavadocTokenTypes.AUTHOR_LITERAL));
     }
 
     @Test


### PR DESCRIPTION
Fixes some `BooleanMethodNameMustStartWithQuestion` inspection violations.

Description:
>Reports boolean methods whose names do not start with a question word. Boolean methods that override library methods are ignored by this inspection.