### PR TITLE
Issue #1555: Avoid reusing variables

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -385,8 +385,7 @@ public final class IllegalTypeCheck extends AbstractFormatCheck {
                 currentNode = currentNode.getParent();
             }
         }
-        currentNode = toVisitAst;
-        return currentNode;
+        return toVisitAst;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -720,8 +720,7 @@ public class VisibilityModifierCheck
                 currentNode = currentNode.getParent();
             }
         }
-        currentNode = toVisitAst;
-        return currentNode;
+        return toVisitAst;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/ClassResolverTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/ClassResolverTest.java
@@ -59,14 +59,14 @@ public class ClassResolverTest {
         }
 
         imps.add("java.text.ChoiceFormat");
-        cr = new ClassResolver(Thread.currentThread().getContextClassLoader(), null, imps);
-        cr.resolve("ChoiceFormat", "");
+        ClassResolver newClassResolver = new ClassResolver(Thread.currentThread().getContextClassLoader(), null, imps);
+        newClassResolver.resolve("ChoiceFormat", "");
 
-        cr = new ClassResolver(Thread.currentThread().getContextClassLoader(),
-                               "java.util", imps);
-        cr.resolve("List", "");
+        ClassResolver javaUtilClassResolver = new ClassResolver(
+                Thread.currentThread().getContextClassLoader(), "java.util", imps);
+        javaUtilClassResolver.resolve("List", "");
         try {
-            cr.resolve("two.nil.england", "");
+            javaUtilClassResolver.resolve("two.nil.england", "");
             fail();
         }
         catch (ClassNotFoundException e) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterTest.java
@@ -36,16 +36,17 @@ public class SeverityMatchFilterTest {
     public void testDefault() {
         final AuditEvent ev = new AuditEvent(this, "Test.java");
         assertFalse("no message", filter.accept(ev));
-        SeverityLevel level = SeverityLevel.ERROR;
-        LocalizedMessage message =
+        SeverityLevel errorLevel = SeverityLevel.ERROR;
+        LocalizedMessage errorMessage =
             new LocalizedMessage(0, 0, "", "", null,
-                level, null, getClass(), null);
-        final AuditEvent ev2 = new AuditEvent(this, "ATest.java", message);
-        assertTrue("level:" + level, filter.accept(ev2));
-        level = SeverityLevel.INFO;
-        message = new LocalizedMessage(0, 0, "", "", null, level, null, getClass(), null);
-        final AuditEvent ev3 = new AuditEvent(this, "ATest.java", message);
-        assertFalse("level:" + level, filter.accept(ev3));
+                errorLevel, null, getClass(), null);
+        final AuditEvent ev2 = new AuditEvent(this, "ATest.java", errorMessage);
+        assertTrue("level:" + errorLevel, filter.accept(ev2));
+        SeverityLevel infoLevel = SeverityLevel.INFO;
+        LocalizedMessage infoMessage =
+                new LocalizedMessage(0, 0, "", "", null, infoLevel, null, getClass(), null);
+        final AuditEvent ev3 = new AuditEvent(this, "ATest.java", infoMessage);
+        assertFalse("level:" + infoLevel, filter.accept(ev3));
     }
 
     @Test
@@ -54,16 +55,17 @@ public class SeverityMatchFilterTest {
         final AuditEvent ev = new AuditEvent(this, "Test.java");
         // event with no message has severity level INFO
         assertTrue("no message", filter.accept(ev));
-        SeverityLevel level = SeverityLevel.ERROR;
-        LocalizedMessage message =
+        SeverityLevel errorLevel = SeverityLevel.ERROR;
+        LocalizedMessage errorMessage =
             new LocalizedMessage(0, 0, "", "", null,
-                level, null, getClass(), null);
-        final AuditEvent ev2 = new AuditEvent(this, "ATest.java", message);
-        assertFalse("level:" + level, filter.accept(ev2));
-        level = SeverityLevel.INFO;
-        message = new LocalizedMessage(0, 0, "", "", null, level, null, getClass(), null);
-        final AuditEvent ev3 = new AuditEvent(this, "ATest.java", message);
-        assertTrue("level:" + level, filter.accept(ev3));
+                errorLevel, null, getClass(), null);
+        final AuditEvent ev2 = new AuditEvent(this, "ATest.java", errorMessage);
+        assertFalse("level:" + errorLevel, filter.accept(ev2));
+        SeverityLevel infoLevel = SeverityLevel.INFO;
+        LocalizedMessage infoMessage =
+                new LocalizedMessage(0, 0, "", "", null, infoLevel, null, getClass(), null);
+        final AuditEvent ev3 = new AuditEvent(this, "ATest.java", infoMessage);
+        assertTrue("level:" + infoLevel, filter.accept(ev3));
     }
 
     @Test
@@ -73,15 +75,15 @@ public class SeverityMatchFilterTest {
         final AuditEvent ev = new AuditEvent(this, "Test.java");
         // event with no message has severity level INFO
         assertFalse("no message", filter.accept(ev));
-        SeverityLevel level = SeverityLevel.ERROR;
-        LocalizedMessage message =
+        SeverityLevel errorLevel = SeverityLevel.ERROR;
+        LocalizedMessage errorMessage =
             new LocalizedMessage(0, 0, "", "", null,
-                level, null, getClass(), null);
-        final AuditEvent ev2 = new AuditEvent(this, "ATest.java", message);
-        assertTrue("level:" + level, filter.accept(ev2));
-        level = SeverityLevel.INFO;
-        message = new LocalizedMessage(0, 0, "", "", null, level, null, getClass(), null);
-        final AuditEvent ev3 = new AuditEvent(this, "ATest.java", message);
-        assertFalse("level:" + level, filter.accept(ev3));
+                errorLevel, null, getClass(), null);
+        final AuditEvent ev2 = new AuditEvent(this, "ATest.java", errorMessage);
+        assertTrue("level:" + errorLevel, filter.accept(ev2));
+        SeverityLevel infoLevel = SeverityLevel.INFO;
+        LocalizedMessage infoMessage = new LocalizedMessage(0, 0, "", "", null, infoLevel, null, getClass(), null);
+        final AuditEvent ev3 = new AuditEvent(this, "ATest.java", infoMessage);
+        assertFalse("level:" + infoLevel, filter.accept(ev3));
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
@@ -77,13 +77,13 @@ public class CommonUtilsTest {
     @Test
     public void testFileExtensions() {
         final String[] fileExtensions = {"java"};
-        File file = new File("file.pdf");
-        assertFalse(CommonUtils.matchesFileExtension(file, fileExtensions));
-        assertTrue(CommonUtils.matchesFileExtension(file, (String[]) null));
-        file = new File("file.java");
-        assertTrue(CommonUtils.matchesFileExtension(file, fileExtensions));
-        file = new File("file.");
-        assertTrue(CommonUtils.matchesFileExtension(file, ""));
+        File pdfFile = new File("file.pdf");
+        assertFalse(CommonUtils.matchesFileExtension(pdfFile, fileExtensions));
+        assertTrue(CommonUtils.matchesFileExtension(pdfFile, (String[]) null));
+        File javaFile = new File("file.java");
+        assertTrue(CommonUtils.matchesFileExtension(javaFile, fileExtensions));
+        File emptyExtensionFile = new File("file.");
+        assertTrue(CommonUtils.matchesFileExtension(emptyExtensionFile, ""));
     }
 
     @Test


### PR DESCRIPTION
Fixes `ReuseOfLocalVariable` inspection violation.

Description:
>Reports local variables that are "reused", overwriting their values with new values unrelated to their original use. Such local variable reuse may be confusing, as the intended semantics of the local variable may vary with each use. It may also be prone to bugs, if code changes result in values that were thought to be overwritten actually being live. It is good practices to keep variable lifetimes as short as possible, and not reuse local variables for the sake of brevity.