### PR TITLE
Issue #1555: Replace for loop that misses component with while loop

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
@@ -235,13 +235,13 @@ public final class ParameterAssignmentCheck extends Check {
         DetailAST parameterDefAST =
             ast.findFirstToken(TokenTypes.PARAMETER_DEF);
 
-        for (; parameterDefAST != null;
-             parameterDefAST = parameterDefAST.getNextSibling()) {
+        while (parameterDefAST != null) {
             if (parameterDefAST.getType() == TokenTypes.PARAMETER_DEF) {
                 final DetailAST param =
                     parameterDefAST.findFirstToken(TokenTypes.IDENT);
                 parameterNames.add(param.getText());
             }
+            parameterDefAST = parameterDefAST.getNextSibling();
         }
     }
 }


### PR DESCRIPTION
Fixes `ForLoopWithMissingComponent` inspection violation.

Description:
>Reports for loops that lack initialization, condition, or update clauses. Some coding styles prohibit such loops.