### PR TITLE
Issue #1566: 'missing javadoc comment' violations fixed in ParseTreeModel, TreeTableModelAdapter

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeModel.java
@@ -34,21 +34,33 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
  * @author Lars Kühne
  */
 public class ParseTreeModel extends AbstractTreeTableModel {
+    /** Column names. */
     private static final String[] COLUMN_NAMES = {
         "Tree", "Type", "Line", "Column", "Text",
     };
 
+    /**
+     * @param parseTree DetailAST parse tree.
+     */
     public ParseTreeModel(DetailAST parseTree) {
         super(createArtificialTreeRoot());
         setParseTree(parseTree);
     }
 
+    /**
+     * Creates artificial tree root.
+     * @return Artificial tree root.
+     */
     private static DetailAST createArtificialTreeRoot() {
         final ASTFactory factory = new ASTFactory();
         factory.setASTNodeClass(DetailAST.class.getName());
         return (DetailAST) factory.create(TokenTypes.EOF, "ROOT");
     }
 
+    /**
+     * Sets parse tree.
+     * @param parseTree DetailAST parse tree.
+     */
     final void setParseTree(DetailAST parseTree) {
         final DetailAST root = (DetailAST) getRoot();
         root.setFirstChild(parseTree);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModelAdapter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModelAdapter.java
@@ -45,9 +45,15 @@ public class TreeTableModelAdapter extends AbstractTableModel {
     /** For Serialisation that will never happen. */
     private static final long serialVersionUID = 8269213416115369275L;
 
+    /** JTree component. */
     private final JTree tree;
+    /** Tree table model. */
     private final transient TreeTableModel treeTableModel;
 
+    /**
+     * @param treeTableModel Tree table model.
+     * @param tree JTree component.
+     */
     public TreeTableModelAdapter(TreeTableModel treeTableModel, JTree tree) {
         this.tree = tree;
         this.treeTableModel = treeTableModel;
@@ -83,11 +89,6 @@ public class TreeTableModelAdapter extends AbstractTableModel {
         return tree.getRowCount();
     }
 
-    private Object nodeForRow(int row) {
-        final TreePath treePath = tree.getPathForRow(row);
-        return treePath.getLastPathComponent();
-    }
-
     @Override
     public Object getValueAt(int row, int column) {
         return treeTableModel.getValueAt(nodeForRow(row), column);
@@ -96,6 +97,16 @@ public class TreeTableModelAdapter extends AbstractTableModel {
     @Override
     public boolean isCellEditable(int row, int column) {
         return treeTableModel.isCellEditable(column);
+    }
+
+    /**
+     * Finds node for a given row.
+     * @param row Row for which to find a related node.
+     * @return Node for a given row.
+     */
+    private Object nodeForRow(int row) {
+        final TreePath treePath = tree.getPathForRow(row);
+        return treePath.getLastPathComponent();
     }
 
     /**


### PR DESCRIPTION
Fix for:
- JavadocMethod ```Missing a Javadoc comment.```
- JavadocVariable ```Missing a Javadoc comment.```