### PR TITLE
Issue #1555: Use try-with-resources in test code

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -112,17 +112,18 @@ public abstract class BaseCheckTestSupport {
         // process each of the lines
         final ByteArrayInputStream bais =
                 new ByteArrayInputStream(stream.toByteArray());
-        final LineNumberReader lnr =
-                new LineNumberReader(new InputStreamReader(bais, StandardCharsets.UTF_8));
+        try (final LineNumberReader lnr = new LineNumberReader(
+                new InputStreamReader(bais, StandardCharsets.UTF_8))) {
 
-        for (int i = 0; i < expected.length; i++) {
-            final String expectedResult = messageFileName + ":" + expected[i];
-            final String actual = lnr.readLine();
-            assertEquals("error message " + i, expectedResult, actual);
+            for (int i = 0; i < expected.length; i++) {
+                final String expectedResult = messageFileName + ":" + expected[i];
+                final String actual = lnr.readLine();
+                assertEquals("error message " + i, expectedResult, actual);
+            }
+
+            assertEquals("unexpected output: " + lnr.readLine(),
+                    expected.length, errs);
         }
-
-        assertEquals("unexpected output: " + lnr.readLine(),
-                expected.length, errs);
         checker.destroy();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -55,10 +55,10 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
                 createCheckConfig(ConstantNameCheck.class);
         final String content = "public class Main { public static final int k = 5 + 4; }";
         final File file = temporaryFolder.newFile("file.java");
-        final Writer writer = new BufferedWriter(
-                new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8));
-        writer.write(content);
-        writer.close();
+        try (final Writer writer = new BufferedWriter(
+                new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8))) {
+            writer.write(content);
+        }
         final String[] expected1 = {
             "1:45: Name 'k' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -221,17 +221,17 @@ public class XMLLoggerTest {
         final byte[] bytes = outStream.toByteArray();
         final ByteArrayInputStream inStream =
             new ByteArrayInputStream(bytes);
-        final BufferedReader reader =
-            new BufferedReader(new InputStreamReader(inStream, StandardCharsets.UTF_8));
         final List<String> lineList = Lists.newArrayList();
-        while (true) {
-            final String line = reader.readLine();
-            if (line == null) {
-                break;
+        try (final BufferedReader reader = new BufferedReader(
+                new InputStreamReader(inStream, StandardCharsets.UTF_8))) {
+            while (true) {
+                final String line = reader.readLine();
+                if (line == null) {
+                    break;
+                }
+                lineList.add(line);
             }
-            lineList.add(line);
         }
-        reader.close();
         return lineList.toArray(new String[lineList.size()]);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -204,18 +204,18 @@ public class WriteTagCheckTest extends BaseCheckTestSupport {
         // process each of the lines
         final ByteArrayInputStream bais =
             new ByteArrayInputStream(stream.toByteArray());
-        final LineNumberReader lnr =
-            new LineNumberReader(new InputStreamReader(bais, StandardCharsets.UTF_8));
+        try (final LineNumberReader lnr = new LineNumberReader(
+                new InputStreamReader(bais, StandardCharsets.UTF_8))) {
 
-        for (int i = 0; i < expected.length; i++) {
-            final String expectedResult = messageFileName + ":" + expected[i];
-            final String actual = lnr.readLine();
-            assertEquals("error message " + i, expectedResult, actual);
+            for (int i = 0; i < expected.length; i++) {
+                final String expectedResult = messageFileName + ":" + expected[i];
+                final String actual = lnr.readLine();
+                assertEquals("error message " + i, expectedResult, actual);
+            }
+
+            assertTrue("unexpected output: " + lnr.readLine(),
+                    expected.length >= errs);
         }
-
-        assertTrue("unexpected output: " + lnr.readLine(),
-                   expected.length >= errs);
-
         checker.destroy();
     }
 }


### PR DESCRIPTION
The issue was stream not being closed at all or closed, but not in finally block.

Fixes some `IOResource` inspection violations.

Description:
>Reports any I/O resource which is not safely closed in a finally block. Such resources may be inadvertently leaked if an exception is thrown before the resource is closed. I/O resources checked by this inspection include java.io.InputStream, java.io.OutputStream, java.io.Reader, java.io.Writer and java.io.RandomAccessFile. I/O resources which are wrapped by other I/O resources are not reported, as the wrapped resource will be closed by the wrapping resource.