### PR TITLE
Issue #1555: Use previously unused parameter

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -114,7 +114,7 @@ public class AutomaticBeanTest {
         }
 
         public void setExceptionalMethod(String value) {
-            throw new IllegalStateException(privateField);
+            throw new IllegalStateException(privateField + value);
         }
 
     }


### PR DESCRIPTION
Fixes `UnusedParameters` inspection violations.

Description:
>This inspection reports parameters that are not used by their methods and all method implementations/overriders.