### PR TITLE
Issue #1555: Use function after definition

### DIFF
--- a/src/site/resources/js/anchors.js
+++ b/src/site/resources/js/anchors.js
@@ -1,7 +1,5 @@
 'use strict';
 
-window.addEventListener('load', main);
-
 function main() {
     var url = window.location.href;
     var anchors = document.getElementsByTagName('h2');
@@ -21,3 +19,5 @@ function main() {
     }
 
 }
+
+window.addEventListener('load', main);


### PR DESCRIPTION
Fixes some `JSLint` inspection violations.

Description:
>JSLint: 'main' was used before it was defined.