### PR TITLE
Issue #1555: Remove unsafe calls to Class.newInstance()

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AllChecksTest.java
@@ -80,7 +80,7 @@ public class AllChecksTest extends BaseCheckTestSupport {
 
         for (Class<?> check : checkstyleChecks) {
             if (Check.class.isAssignableFrom(check)) {
-                final Check testedCheck = (Check) check.newInstance();
+                final Check testedCheck = (Check) check.getDeclaredConstructor().newInstance();
                 final int[] defaultTokens = testedCheck.getDefaultTokens();
                 final int[] acceptableTokens = testedCheck.getAcceptableTokens();
 
@@ -100,7 +100,7 @@ public class AllChecksTest extends BaseCheckTestSupport {
 
         for (Class<?> check : checkstyleChecks) {
             if (Check.class.isAssignableFrom(check)) {
-                final Check testedCheck = (Check) check.newInstance();
+                final Check testedCheck = (Check) check.getDeclaredConstructor().newInstance();
                 final int[] requiredTokens = testedCheck.getRequiredTokens();
                 final int[] acceptableTokens = testedCheck.getAcceptableTokens();
 
@@ -120,7 +120,7 @@ public class AllChecksTest extends BaseCheckTestSupport {
 
         for (Class<?> check : checkstyleChecks) {
             if (Check.class.isAssignableFrom(check)) {
-                final Check testedCheck = (Check) check.newInstance();
+                final Check testedCheck = (Check) check.getDeclaredConstructor().newInstance();
                 final int[] defaultTokens = testedCheck.getDefaultTokens();
                 final int[] requiredTokens = testedCheck.getRequiredTokens();
 


### PR DESCRIPTION
Fixes `ClassNewInstance` inspection violations.

Description:
>Reports any calls to java.lang.Class.newInstance(). The newInstance method propagates any exception thrown by the no-arg constructor, including checked exceptions. Use of this method effectively bypasses the compile-time exception checking that would otherwise be performed by the compiler. Replacing such a method call with a call to the java.lang.reflect.Constructor.newInstance() method avoids this problem by wrapping any exception thrown by the constructor in a java.lang.reflect.InvocationTargetException.