### PR TITLE
Issue #1555: Remove unused assignments

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AllChecksTest.java
@@ -76,7 +76,6 @@ public class AllChecksTest extends BaseCheckTestSupport {
     @Test
     public void testDefaultTokensAreSubsetOfAcceptableTokens() throws Exception {
         Set<Class<?>> checkstyleChecks = getCheckstyleChecks();
-        Set<Class<?>> checksWithIncorrectTokenSets = new HashSet<>();
 
         for (Class<?> check : checkstyleChecks) {
             if (Check.class.isAssignableFrom(check)) {
@@ -96,7 +95,6 @@ public class AllChecksTest extends BaseCheckTestSupport {
     @Test
     public void testRequiredTokensAreSubsetOfAcceptableTokens() throws Exception {
         Set<Class<?>> checkstyleChecks = getCheckstyleChecks();
-        Set<Class<?>> checksWithIncorrectTokenSets = new HashSet<>();
 
         for (Class<?> check : checkstyleChecks) {
             if (Check.class.isAssignableFrom(check)) {
@@ -116,7 +114,6 @@ public class AllChecksTest extends BaseCheckTestSupport {
     @Test
     public void testRequiredTokensAreSubsetOfDefaultTokens() throws Exception {
         Set<Class<?>> checkstyleChecks = getCheckstyleChecks();
-        Set<Class<?>> checksWithIncorrectTokenSets = new HashSet<>();
 
         for (Class<?> check : checkstyleChecks) {
             if (Check.class.isAssignableFrom(check)) {


### PR DESCRIPTION
Fixes `UnusedAssignment` inspection violations.

Description:
>This inspection points out the cases where a variable value is never used after its assignment