### PR TITLE
Issue #1555: Mark methods as static

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
@@ -121,7 +121,7 @@ public class NoWhitespaceBeforeCheck
      * @param semicolonAst DetailAST of semicolon.
      * @return true if semicolon is in empty for initializer.
      */
-    private boolean isInEmptyForInitializer(DetailAST semicolonAst) {
+    private static boolean isInEmptyForInitializer(DetailAST semicolonAst) {
         boolean result = false;
         if (semicolonAst.getType() == TokenTypes.SEMI) {
             final DetailAST sibling = semicolonAst.getPreviousSibling();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -431,7 +431,7 @@ public class WhitespaceAroundCheck extends Check {
      * @param parentType parent
      * @return true if current token in colon of case or default tokens
      */
-    private boolean isColonOfCaseOrDefault(int currentType, int parentType) {
+    private static boolean isColonOfCaseOrDefault(int currentType, int parentType) {
         return currentType == TokenTypes.COLON
                 && (parentType == TokenTypes.LITERAL_DEFAULT
                     || parentType == TokenTypes.LITERAL_CASE);


### PR DESCRIPTION
Fixes `MethodMayBeStatic` inspection violations.

Description:
>Reports any methods which may safely be made static. A method may be static if it is not synchronized, it does not reference any of its class' non static methods and non static fields and is not overridden in a sub class.