### PR TITLE
Issue #1555: Rename method returning boolean to use question word

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -206,7 +206,7 @@ public class SuppressWithNearbyCommentFilter
                     setFileContents(currentContents);
                     tagSuppressions();
                 }
-                if (matchTag(event)) {
+                if (matchesTag(event)) {
                     accepted = false;
                 }
             }
@@ -219,7 +219,7 @@ public class SuppressWithNearbyCommentFilter
      * @param event AuditEvent to test match on {@link #tags}.
      * @return true if event matches any tag from {@link #tags}, false otherwise.
      */
-    private boolean matchTag(AuditEvent event) {
+    private boolean matchesTag(AuditEvent event) {
         for (final Tag tag : tags) {
             if (tag.isMatch(event)) {
                 return true;


### PR DESCRIPTION
Fixes `BooleanMethodNameMustStartWithQuestion` inspection violations.

Description:
>Reports boolean methods whose names do not start with a question word. Boolean methods that override library methods are ignored by this inspection.