### PR TITLE
Issue #1555: Remove usage of obsolete junit.framework.Assert

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AllChecksTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
@@ -33,7 +34,6 @@ import com.google.common.reflect.ClassPath;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck;
-import junit.framework.Assert;
 
 public class AllChecksTest extends BaseCheckTestSupport {
 


### PR DESCRIPTION
Fixes `UseOfObsoleteAssert` inspection violations.

Description:
>Reports any calls to methods from the junit.framework.Assert class. This class is obsolete and the calls can be replaced by calls to methods from the org.junit.Assert class.