### PR TITLE
Issue #1555: Fix malformed JUnit Rule

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -56,7 +56,7 @@ import com.puppycrawl.tools.checkstyle.api.FilterSet;
 public class SuppressionsLoaderTest extends BaseCheckTestSupport {
 
     @Rule
-    private final ExpectedException thrown = ExpectedException.none();
+    public final ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testNoSuppressions()


### PR DESCRIPTION
Fixes `JUnitRule` inspection violations.

Description:
>Reports malformed @Rule/@ClassRule usages:
* Checks for any member that is annotated with @Rule but is not public.
* Checks for any member that is annotated with @ClassRule but is not public or not static.