### PR TITLE
Issue #1555: Convert method with array parameter to vararg

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AllChecksTest.java
@@ -165,7 +165,7 @@ public class AllChecksTest extends BaseCheckTestSupport {
      * @param array to check whether it is a subset.
      * @param arrayToCheckIn array to check in.
      */
-    private static boolean isSubset(int[] array, int[] arrayToCheckIn) {
+    private static boolean isSubset(int[] array, int... arrayToCheckIn) {
         Arrays.sort(arrayToCheckIn);
         for (final int element : array) {
             if (Arrays.binarySearch(arrayToCheckIn, element) < 0) {


### PR DESCRIPTION
Fixes `MethodCanBeVariableArityMethod` inspection violations.

Description:
>Reports methods with which can be converted to be a variable arity/varargs method, available in Java 5 and newer.
This inspection only reports if the project or module is configured to use a language level of 5.0 or higher.