### PR TITLE
Issue #1555: Avoid reuse of local variables

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
@@ -94,21 +94,21 @@ public class ClassResolver {
 
         // See if in the package
         if (pkg != null && !pkg.isEmpty()) {
-            clazz = resolveQualifiedName(pkg + PERIOD + name);
-            if (clazz != null) {
-                return clazz;
+            final Class<?> classFromQualifiedName = resolveQualifiedName(pkg + PERIOD + name);
+            if (classFromQualifiedName != null) {
+                return classFromQualifiedName;
             }
         }
 
         // see if inner class of this class
-        clazz = resolveInnerClass(name, currentClass);
-        if (clazz != null) {
-            return clazz;
+        final Class<?> innerClass = resolveInnerClass(name, currentClass);
+        if (innerClass != null) {
+            return innerClass;
         }
 
-        clazz = resolveByStarImports(name);
-        if (clazz != null) {
-            return clazz;
+        final Class<?> classFromStarImport = resolveByStarImports(name);
+        if (classFromStarImport != null) {
+            return classFromStarImport;
         }
 
         // Giving up, the type is unknown, so load the class to generate an

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -481,7 +481,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
             return;
         }
 
-        Iterator<JavadocTag> it = tags.iterator();
+        final Iterator<JavadocTag> it = tags.iterator();
         if (ast.getType() != TokenTypes.ANNOTATION_FIELD_DEF) {
             // Check for inheritDoc
             boolean hasInheritDocTag = false;
@@ -497,9 +497,9 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
         }
 
         // Dump out all unused tags
-        it = tags.iterator();
-        while (it.hasNext()) {
-            final JavadocTag jt = it.next();
+        final Iterator<JavadocTag> unusedTagIt = tags.iterator();
+        while (unusedTagIt.hasNext()) {
+            final JavadocTag jt = unusedTagIt.next();
             if (!jt.isSeeOrInheritDocTag()) {
                 log(jt.getLineNo(), MSG_UNUSED_TAG_GENERAL);
             }
@@ -921,7 +921,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
         ExceptionInfo foundException = null;
 
         // First look for matches on the exception name
-        ListIterator<ExceptionInfo> throwIt = throwsList.listIterator();
+        final ListIterator<ExceptionInfo> throwIt = throwsList.listIterator();
         while (!found && throwIt.hasNext()) {
             final ExceptionInfo ei = throwIt.next();
 
@@ -933,9 +933,9 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
         }
 
         // Now match on the exception type
-        throwIt = throwsList.listIterator();
-        while (!found && throwIt.hasNext()) {
-            final ExceptionInfo ei = throwIt.next();
+        final ListIterator<ExceptionInfo> exceptionInfoIt = throwsList.listIterator();
+        while (!found && exceptionInfoIt.hasNext()) {
+            final ExceptionInfo ei = exceptionInfoIt.next();
 
             if (documentedCI.getClazz() == ei.getClazz()) {
                 found = true;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
@@ -171,17 +171,17 @@ class TagParser {
         }
 
         text = text.substring(column).trim();
-        column = 0;
+        int position = 0;
 
         //Character.isJavidentifier... may not be a valid HTML
         //identifier but is valid for generics
-        while (column < text.length()
-            && (Character.isJavaIdentifierStart(text.charAt(column))
-                || Character.isJavaIdentifierPart(text.charAt(column)))) {
-            column++;
+        while (position < text.length()
+            && (Character.isJavaIdentifierStart(text.charAt(position))
+                || Character.isJavaIdentifierPart(text.charAt(position)))) {
+            position++;
         }
 
-        return text.substring(0, column);
+        return text.substring(0, position);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
@@ -158,13 +158,13 @@ public class ParenPadCheck extends AbstractParenPadCheck {
      * @param ast the token to check.
      */
     private void visitLiteralFor(DetailAST ast) {
-        DetailAST parenAst = ast.findFirstToken(TokenTypes.LPAREN);
-        if (!isPrecedingEmptyForInit(parenAst)) {
-            processLeft(parenAst);
+        final DetailAST lparen = ast.findFirstToken(TokenTypes.LPAREN);
+        if (!isPrecedingEmptyForInit(lparen)) {
+            processLeft(lparen);
         }
-        parenAst = ast.findFirstToken(TokenTypes.RPAREN);
-        if (!isFollowsEmptyForIterator(parenAst)) {
-            processRight(parenAst);
+        final DetailAST rparen = ast.findFirstToken(TokenTypes.RPAREN);
+        if (!isFollowsEmptyForIterator(rparen)) {
+            processRight(rparen);
         }
     }
 


### PR DESCRIPTION
Fixes `ReuseOfLocalVariable` inspection violation.

Description:
>Reports local variables that are "reused", overwriting their values with new values unrelated to their original use. Such local variable reuse may be confusing, as the intended semantics of the local variable may vary with each use. It may also be prone to bugs, if code changes result in values that were thought to be overwritten actually being live. It is good practices to keep variable lifetimes as short as possible, and not reuse local variables for the sake of brevity.