### PR TITLE
Issue #46. Loops should not contain more than a single 'break' or 'continue' statement

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -120,16 +120,16 @@ public abstract class AbstractSuperCheck
         boolean inOverridingMethod = false;
         DetailAST dotAst = ast;
 
-        while (dotAst != null) {
+        while (dotAst != null
+                && dotAst.getType() != TokenTypes.CTOR_DEF
+                && dotAst.getType() != TokenTypes.INSTANCE_INIT) {
+
             if (dotAst.getType() == TokenTypes.METHOD_DEF) {
                 inOverridingMethod = isOverridingMethod(dotAst);
                 break;
             }
-            if (dotAst.getType() == TokenTypes.CTOR_DEF
-                || dotAst.getType() == TokenTypes.INSTANCE_INIT) {
-                break;
-            }
             dotAst = dotAst.getParent();
+
         }
         return inOverridingMethod;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -320,10 +320,9 @@ public class HiddenFieldCheck
         DetailAST parent = ast.getParent();
         boolean inStatic = false;
 
-        while (parent != null) {
+        while (parent != null && !inStatic) {
             if (parent.getType() == TokenTypes.STATIC_INIT) {
                 inStatic = true;
-                break;
             }
             else if (parent.getType() == TokenTypes.METHOD_DEF) {
                 final DetailAST mods =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
@@ -121,29 +121,40 @@ public class AvoidStaticImportCheck
         boolean exempt = false;
 
         for (String exclude : excludes) {
-            if (classOrStaticMember.equals(exclude)) {
+            if (classOrStaticMember.equals(exclude)
+                    || isStarImportOfPackage(classOrStaticMember, exclude)) {
                 exempt = true;
                 break;
             }
-            else if (exclude.endsWith(".*")) {
-                //this section allows explicit imports
-                //to be exempt when configured using
-                //a starred import
-                final String excludeMinusDotStar =
-                    exclude.substring(0, exclude.length() - 2);
-                if (classOrStaticMember.startsWith(excludeMinusDotStar)
-                        && !classOrStaticMember.equals(excludeMinusDotStar)) {
-                    final String member =
-                        classOrStaticMember.substring(
-                            excludeMinusDotStar.length() + 1);
-                    //if it contains a dot then it is not a member but a package
-                    if (member.indexOf('.') == -1) {
-                        exempt = true;
-                        break;
-                    }
+        }
+        return exempt;
+    }
+
+    /**
+     * Returns true if classOrStaticMember is a starred name of package,
+     *  not just member name.
+     * @param classOrStaticMember - full name of member
+     * @param exclude - current exclusion
+     * @return true if member in exclusion list
+     */
+    private static boolean isStarImportOfPackage(String classOrStaticMember, String exclude) {
+        boolean result = false;
+        if (exclude.endsWith(".*")) {
+            //this section allows explicit imports
+            //to be exempt when configured using
+            //a starred import
+            final String excludeMinusDotStar =
+                exclude.substring(0, exclude.length() - 2);
+            if (classOrStaticMember.startsWith(excludeMinusDotStar)
+                    && !classOrStaticMember.equals(excludeMinusDotStar)) {
+                final String member = classOrStaticMember.substring(
+                        excludeMinusDotStar.length() + 1);
+                //if it contains a dot then it is not a member but a package
+                if (member.indexOf('.') == -1) {
+                    result = true;
                 }
             }
         }
-        return exempt;
+        return result;
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputFinalize.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputFinalize.java
@@ -55,3 +55,14 @@ class MyClassWithGenericSuperMethod1
 class TestNative {
     public native void finalize();
 }
+
+class OneMore {
+    
+    public void doSmt() throws Throwable {
+        {
+            {
+                super.finalize();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Restricting the number of break and continue statements in a loop is done in the interest of good structured programming.

One break and continue statement is acceptable in a loop, since it facilitates optimal coding. If there is more than one, the code should be refactored to increase readability.