### PR TITLE
Issue #1555: Use try-with-resources to close streams in test code

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -128,23 +128,24 @@ public abstract class BaseCheckTestSupport
         // process each of the lines
         final ByteArrayInputStream localStream =
             new ByteArrayInputStream(stream.toByteArray());
-        final LineNumberReader lnr =
-            new LineNumberReader(new InputStreamReader(localStream, StandardCharsets.UTF_8));
+        try (final LineNumberReader lnr = new LineNumberReader(
+                new InputStreamReader(localStream, StandardCharsets.UTF_8))) {
 
-        for (int i = 0; i < aExpected.length; i++) {
-            final String expected = aMessageFileName + ":" + aExpected[i];
-            String actual = lnr.readLine();
-            assertEquals("error message " + i, expected, actual);
-            String parseInt = removeDeviceFromPathOnWindows(actual);
-            parseInt = parseInt.substring(parseInt.indexOf(':') + 1);
-            parseInt = parseInt.substring(0, parseInt.indexOf(':'));
-            int lineNumber = Integer.parseInt(parseInt);
-			Integer integer = Arrays.asList(aWarnsExpected).contains(lineNumber) ? lineNumber : 0;
-            assertEquals("error message " + i, (long) integer, lineNumber);
+            for (int i = 0; i < aExpected.length; i++) {
+                final String expected = aMessageFileName + ":" + aExpected[i];
+                String actual = lnr.readLine();
+                assertEquals("error message " + i, expected, actual);
+                String parseInt = removeDeviceFromPathOnWindows(actual);
+                parseInt = parseInt.substring(parseInt.indexOf(':') + 1);
+                parseInt = parseInt.substring(0, parseInt.indexOf(':'));
+                int lineNumber = Integer.parseInt(parseInt);
+                Integer integer = Arrays.asList(aWarnsExpected).contains(lineNumber) ? lineNumber : 0;
+                assertEquals("error message " + i, (long) integer, lineNumber);
+            }
+
+            assertEquals("unexpected output: " + lnr.readLine(),
+                    aExpected.length, errs);
         }
-
-        assertEquals("unexpected output: " + lnr.readLine(),
-                     aExpected.length, errs);
         aC.destroy();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -71,10 +71,10 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
                 createCheckConfig(ConstantNameCheck.class);
         final File file = temporaryFolder.newFile("file.pdf");
         final String content = "public class Main { public static final int k = 5 + 4; }";
-        final BufferedWriter writer = new BufferedWriter(
-                new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8));
-        writer.write(content);
-        writer.close();
+        try (final BufferedWriter writer = new BufferedWriter(
+                new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8))) {
+            writer.write(content);
+        }
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, file.getPath(), expected);
     }


### PR DESCRIPTION
The issue was stream not being closed at all or closed, but not in finally block.

Fixes some `IOResource` inspection violations.

Description:
>Reports any I/O resource which is not safely closed in a finally block. Such resources may be inadvertently leaked if an exception is thrown before the resource is closed. I/O resources checked by this inspection include java.io.InputStream, java.io.OutputStream, java.io.Reader, java.io.Writer and java.io.RandomAccessFile. I/O resources which are wrapped by other I/O resources are not reported, as the wrapped resource will be closed by the wrapping resource.