### PR TITLE
IgnoreMethods option has been removed from DeclarationOrderCheck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1625,12 +1625,6 @@
                   </regex>
 
                   <regex>
-                    <pattern>.*.checks.coding.DeclarationOrderCheck</pattern>
-                    <branchRate>82</branchRate>
-                    <lineRate>93</lineRate>
-                  </regex>
-
-                  <regex>
                     <pattern>.*.checks.header.AbstractHeaderCheck</pattern>
                     <branchRate>90</branchRate>
                     <lineRate>87</lineRate>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -177,6 +177,12 @@ public class DeclarationOrderCheck extends Check {
             case TokenTypes.OBJBLOCK:
                 scopeStates.push(new ScopeState());
                 break;
+            case TokenTypes.MODIFIERS:
+                if (parentType == TokenTypes.VARIABLE_DEF
+                    && ast.getParent().getParent().getType() == TokenTypes.OBJBLOCK) {
+                    processModifiers(ast);
+                }
+                break;
             case TokenTypes.CTOR_DEF:
                 if (parentType == TokenTypes.OBJBLOCK) {
                     processConstructor(ast);
@@ -187,12 +193,6 @@ public class DeclarationOrderCheck extends Check {
                     final ScopeState state = scopeStates.peek();
                     // nothing can be bigger than method's state
                     state.currentScopeState = STATE_METHOD_DEF;
-                }
-                break;
-            case TokenTypes.MODIFIERS:
-                if (parentType == TokenTypes.VARIABLE_DEF
-                        && ast.getParent().getParent().getType() == TokenTypes.OBJBLOCK) {
-                    processModifiers(ast);
                 }
                 break;
             default:

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -53,7 +53,6 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtils;
  * <ul>
  * <li>ignoreModifiers</li>
  * <li>ignoreConstructors</li>
- * <li>ignoreMethods</li>
  * </ul>
  *
  * <p>
@@ -113,12 +112,6 @@ public class DeclarationOrderCheck extends Check {
      * A key is pointing to the warning message text in "messages.properties"
      * file.
      */
-    public static final String MSG_METHOD = "declaration.order.method";
-
-    /**
-     * A key is pointing to the warning message text in "messages.properties"
-     * file.
-     */
     public static final String MSG_STATIC = "declaration.order.static";
 
     /**
@@ -153,8 +146,6 @@ public class DeclarationOrderCheck extends Check {
 
     /** If true, ignores the check to constructors. */
     private boolean ignoreConstructors;
-    /** If true, ignore the check to methods. */
-    private boolean ignoreMethods;
     /** If true, ignore the check to modifiers (fields, ...). */
     private boolean ignoreModifiers;
 
@@ -193,7 +184,9 @@ public class DeclarationOrderCheck extends Check {
                 break;
             case TokenTypes.METHOD_DEF:
                 if (parentType == TokenTypes.OBJBLOCK) {
-                    processMethod(ast);
+                    final ScopeState state = scopeStates.peek();
+                    // nothing can be bigger than method's state
+                    state.currentScopeState = STATE_METHOD_DEF;
                 }
                 break;
             case TokenTypes.MODIFIERS:
@@ -221,23 +214,6 @@ public class DeclarationOrderCheck extends Check {
         }
         else {
             state.currentScopeState = STATE_CTOR_DEF;
-        }
-    }
-
-    /**
-     * Process Method Token
-     * @param ast method token AST
-     */
-    private void processMethod(DetailAST ast) {
-
-        final ScopeState state = scopeStates.peek();
-        if (state.currentScopeState > STATE_METHOD_DEF) {
-            if (!ignoreMethods) {
-                log(ast, MSG_METHOD);
-            }
-        }
-        else {
-            state.currentScopeState = STATE_METHOD_DEF;
         }
     }
 
@@ -293,14 +269,6 @@ public class DeclarationOrderCheck extends Check {
      */
     public void setIgnoreConstructors(boolean ignoreConstructors) {
         this.ignoreConstructors = ignoreConstructors;
-    }
-
-    /**
-     * Sets whether to ignore methods.
-     * @param ignoreMethods whether to ignore methods.
-     */
-    public void setIgnoreMethods(boolean ignoreMethods) {
-        this.ignoreMethods = ignoreMethods;
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages.properties
@@ -4,7 +4,6 @@ avoid.finalizer.method=Avoid using finalizer method.
 avoid.clone.method=Avoid using clone method.
 covariant.equals=covariant equals without overriding equals(java.lang.Object).
 declaration.order.constructor=Constructor definition in wrong order.
-declaration.order.method=Method definition in wrong order.
 declaration.order.static=Static variable definition in wrong order.
 declaration.order.instance=Instance variable definition in wrong order.
 declaration.order.access=Variable access definition in wrong order.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_de.properties
@@ -4,7 +4,6 @@ avoid.finalizer.method=Die Verwendung von finalizer Methoden sollte vermieden we
 avoid.clone.method=Die Methode clone() sollte vermieden werden.
 covariant.equals=Kovariante Definition von equals() ohne equals(java.lang.Object) zu überschreiben.
 declaration.order.constructor=Konstruktordefinition in falscher Reihenfolge.
-declaration.order.method=Methodendefinition in falscher Reihenfolge.
 declaration.order.static=Statische Variablendefinition in falscher Reihenfolge.
 declaration.order.instance=Instanzvariablendefinition in falscher Reihenfolge.
 declaration.order.access=Fehlerhafte Deklarationsreihenfolge für diesen Scope.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_es.properties
@@ -48,7 +48,6 @@ return.count=El número de sentencias return es {0,number,integer} (máximo perm
 illegal.type=La declaración de variables, valores de retorno o parámetros de tipo ''{0}'' no está permitida.
 
 declaration.order.constructor=Definición de constructor en orden incorrecto.
-declaration.order.method=Definición de método en orden incorrecto.
 declaration.order.static=Definición de variable static en orden incorrecto.
 declaration.order.instance=Definición de variable de instancia en orden incorrecto.
 declaration.order.access=Definición de acceso a variable en orden incorrecto.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_fr.properties
@@ -48,7 +48,6 @@ return.count=Le nombre de return est de {0,number,integer} alors que le maximum 
 illegal.type=Déclarer des variables, des valeurs de retour ou des paramètres de type ''{0}'' est interdit.
 
 declaration.order.constructor=La définition des constructeurs n''apparait pas dans le bon ordre.
-declaration.order.method=La définition des méthodes n''apparait pas dans le bon ordre.
 declaration.order.static=La définition des variables statiques n''apparait pas dans le bon ordre.
 declaration.order.instance=La définition des variables d''instance n''apparait pas dans le bon ordre.
 declaration.order.access=La définition des variables n''est pas triée suivant leur portée.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_ja.properties
@@ -44,7 +44,6 @@ return.count=return が {0,number,integer} 個所あります（最大 {1,number
 illegal.type=''{0}'' 型の変数、戻り値、パラメータを宣言することは許可されていません。
 
 declaration.order.constructor=コンストラクタの定義順序が間違っています。
-declaration.order.method=メソッドの定義順序が間違っています。
 declaration.order.static=static 変数の定義順序が間違っています。
 declaration.order.instance=インスタンス変数の定義順序が間違っています。
 declaration.order.access=変数アクセスの定義順序が間違っています。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_pt.properties
@@ -4,7 +4,6 @@ covariant.equals=\"equals\" covariante sem implementar equals(java.lang.Object).
 declaration.order.access=Definição de acesso a variável em ordem errada.
 declaration.order.constructor=Definição de construtor em ordem errada.
 declaration.order.instance=Definição de variável de instância em ordem errada.
-declaration.order.method=Definição de método em ordem errada.
 declaration.order.static=Definição de variável estática em ordem errada.
 empty.statement=Declaração vazia.
 equals.noHashCode=Definição de ''equals()'' sem a definição de ''hashCode()''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_tr.properties
@@ -12,7 +12,6 @@ covariant.equals = java.lang.Object sınıfının ''equals'' metodundan başka b
 declaration.order.access      = Değişken, erişim seviyesine göre yanlış sırada tanımlanmış.
 declaration.order.constructor = ''constructor'' tanımı yanlış sırada yapılmış.
 declaration.order.instance    = Değişken tanımı yanlış sırada yapılmış.
-declaration.order.method      = Metot tanımı yanlış sırada yapılmış.
 declaration.order.static      = ''static'' değişken tanımı yanlış sırada yapılmış.
 
 default.comes.last = ''switch'' içerisindeki ''default'' ifadesi son durum olarak yer almalıdır.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class DeclarationOrderCheckTest
     extends BaseCheckTestSupport {
@@ -64,6 +66,7 @@ public class DeclarationOrderCheckTest
             "143:9: " + getCheckMessage(MSG_ACCESS),
             "152:5: " + getCheckMessage(MSG_CONSTRUCTOR),
             "178:5: " + getCheckMessage(MSG_INSTANCE),
+            "182:9: " + getCheckMessage(MSG_ACCESS),
         };
         verify(checkConfig, getPath("coding/InputDeclarationOrder.java"), expected);
     }
@@ -119,6 +122,7 @@ public class DeclarationOrderCheckTest
             "143:9: " + getCheckMessage(MSG_STATIC),
             "143:9: " + getCheckMessage(MSG_ACCESS),
             "178:5: " + getCheckMessage(MSG_INSTANCE),
+            "182:9: " + getCheckMessage(MSG_ACCESS),
         };
         verify(checkConfig, getPath("coding/InputDeclarationOrder.java"), expected);
     }
@@ -130,4 +134,33 @@ public class DeclarationOrderCheckTest
         Assert.assertNotNull(check.getDefaultTokens());
         Assert.assertNotNull(check.getRequiredTokens());
     }
+
+    @Test
+    public void testParents() {
+        DeclarationOrderCheck check = new DeclarationOrderCheck();
+        DetailAST parent = new DetailAST();
+        parent.setType(TokenTypes.STATIC_INIT);
+        DetailAST method = new DetailAST();
+        method.setType(TokenTypes.METHOD_DEF);
+        parent.setFirstChild(method);
+        DetailAST ctor = new DetailAST();
+        ctor.setType(TokenTypes.CTOR_DEF);
+        method.setNextSibling(ctor);
+
+        check.visitToken(method);
+        check.visitToken(ctor);
+    }
+
+    @Test
+    public void testImproperToken() {
+        DeclarationOrderCheck check = new DeclarationOrderCheck();
+        DetailAST parent = new DetailAST();
+        parent.setType(TokenTypes.STATIC_INIT);
+        DetailAST array = new DetailAST();
+        array.setType(TokenTypes.ARRAY_INIT);
+        parent.setFirstChild(array);
+
+        check.visitToken(array);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckTest.java
@@ -73,7 +73,6 @@ public class DeclarationOrderCheckTest
         final DefaultConfiguration checkConfig =
             createCheckConfig(DeclarationOrderCheck.class);
         checkConfig.addAttribute("ignoreConstructors", "false");
-        checkConfig.addAttribute("ignoreMethods", "true");
         checkConfig.addAttribute("ignoreModifiers", "true");
 
         final String[] expected = {
@@ -93,7 +92,6 @@ public class DeclarationOrderCheckTest
         final DefaultConfiguration checkConfig =
             createCheckConfig(DeclarationOrderCheck.class);
         checkConfig.addAttribute("ignoreConstructors", "true");
-        checkConfig.addAttribute("ignoreMethods", "true");
         checkConfig.addAttribute("ignoreModifiers", "false");
 
         final String[] expected = {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputDeclarationOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/coding/InputDeclarationOrder.java
@@ -176,4 +176,9 @@ enum InputDeclarationOrderEnum
 
     // error member variables should be before methods or ctors
     private int mFoo = 0;
+
+    class AsyncProcess {
+        private final int startLogErrorsCnt = 0;
+        protected final int maxTotalConcurrentTasks = 0;
+    }
 }

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -2083,12 +2083,6 @@ if (&quot;something&quot;.equals(x))
             <td><code>false</code></td>
           </tr>
           <tr>
-            <td>ignoreMethods</td>
-            <td>whether to ignore methods</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-          </tr>
-          <tr>
             <td>ignoreModifiers</td>
             <td>whether to ignore modifiers</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>


### PR DESCRIPTION
Also, UT coverage has been improved to 100%.
Checkstyle reports are identical: http://baratali.github.io/decl/
Following projects' sources were used:
 * checkstyle
 * sevntu-checkstyle
 * guava
 * spring-framework
 * hibernate-orm
 * Hbase
 * apache-ant