### PR TITLE
Issue #1555: Rename parameters to match names

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule231filetab/FileTabCharacterTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule231filetab/FileTabCharacterTest.java
@@ -22,10 +22,10 @@ public class FileTabCharacterTest extends BaseCheckTestSupport{
     
     @Override
     protected DefaultConfiguration createCheckerConfig(
-        Configuration aCheckConfig)
+        Configuration aConfig)
     {
         final DefaultConfiguration dc = new DefaultConfiguration("root");
-        dc.addChild(aCheckConfig);
+        dc.addChild(aConfig);
         return dc;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
@@ -113,10 +113,10 @@ public class DetailASTTest {
     private static void checkDir(File dir) throws Exception {
         File[] files = dir.listFiles(new FileFilter() {
                 @Override
-                public boolean accept(File file) {
-                    return (file.getName().endsWith(".java")
-                            || file.isDirectory())
-                        && !file.getName().endsWith("InputGrammar.java");
+                public boolean accept(File pathname) {
+                    return (pathname.getName().endsWith(".java")
+                            || pathname.isDirectory())
+                        && !pathname.getName().endsWith("InputGrammar.java");
                 }
             });
         for (File file : files) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
@@ -106,7 +106,7 @@ public class LocalizedMessageTest {
     private static URL getMockUrl(final URLConnection connection) throws IOException {
         final URLStreamHandler handler = new URLStreamHandler() {
             @Override
-            protected URLConnection openConnection(final URL arg0) {
+            protected URLConnection openConnection(final URL u) {
                 return connection;
             }
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
@@ -35,9 +35,9 @@ public class JavadocPackageCheckTest
     extends BaseCheckTestSupport {
     @Override
     protected DefaultConfiguration createCheckerConfig(
-        Configuration aCheckConfig) {
+        Configuration config) {
         final DefaultConfiguration dc = new DefaultConfiguration("root");
-        dc.addChild(aCheckConfig);
+        dc.addChild(config);
         return dc;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParseTreeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParseTreeTest.java
@@ -274,10 +274,10 @@ public class JavadocParseTreeTest {
     private static class FailOnErrorListener extends BaseErrorListener {
         @Override
         public void syntaxError(
-                Recognizer<?, ?> aRecognizer, Object aOffendingSymbol,
-                int aLine, int aCharPositionInLine,
-                String aMsg, RecognitionException aEx) {
-            Assert.fail("[" + aLine + ", " + aCharPositionInLine + "] " + aMsg);
+                Recognizer<?, ?> recognizer, Object offendingSymbol,
+                int line, int charPositionInLine,
+                String msg, RecognitionException e) {
+            Assert.fail("[" + line + ", " + charPositionInLine + "] " + msg);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
@@ -35,9 +35,9 @@ public class FileLengthCheckTest
     extends BaseCheckTestSupport {
     @Override
     protected DefaultConfiguration createCheckerConfig(
-        Configuration aCheckConfig) {
+        Configuration config) {
         DefaultConfiguration dc = new DefaultConfiguration("root");
-        dc.addChild(aCheckConfig);
+        dc.addChild(config);
         return dc;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/comments/AllBlockCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/comments/AllBlockCommentsTest.java
@@ -83,8 +83,8 @@ public class AllBlockCommentsTest extends BaseCheckTestSupport {
         }
 
         @Override
-        public void visitToken(DetailAST aAST) {
-            String commentContent = aAST.getFirstChild().getText();
+        public void visitToken(DetailAST ast) {
+            String commentContent = ast.getFirstChild().getText();
             if (!ALL_COMMENTS.remove(commentContent)) {
                 Assert.fail("Unexpected comment: " + commentContent);
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/comments/AllSinglelineCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/comments/AllSinglelineCommentsTest.java
@@ -78,8 +78,8 @@ public class AllSinglelineCommentsTest extends BaseCheckTestSupport {
         }
 
         @Override
-        public void visitToken(DetailAST aAST) {
-            String commentContent = aAST.getFirstChild().getText();
+        public void visitToken(DetailAST ast) {
+            String commentContent = ast.getFirstChild().getText();
             if (!ALL_COMMENTS.remove(commentContent)) {
                 Assert.fail("Unexpected comment: " + commentContent);
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/comments/CompareTreesWithComments.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/comments/CompareTreesWithComments.java
@@ -30,8 +30,8 @@ class CompareTreesWithComments extends Check {
     }
 
     @Override
-    public void beginTree(DetailAST aRootAST) {
-        Assert.assertTrue(isAstEquals(expectedTree, aRootAST));
+    public void beginTree(DetailAST rootAST) {
+        Assert.assertTrue(isAstEquals(expectedTree, rootAST));
     }
 
     private static boolean isAstEquals(DetailAST expected, DetailAST actual) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -86,7 +86,7 @@ public class SuppressWarningsFilterTest
     }
 
     @Override
-    protected Checker createChecker(Configuration filterConfig)
+    protected Checker createChecker(Configuration checkConfig)
         throws Exception {
         final DefaultConfiguration checkerConfig =
             new DefaultConfiguration("configuration");
@@ -103,8 +103,8 @@ public class SuppressWarningsFilterTest
         checksConfig.addChild(createCheckConfig(ParameterNumberCheck.class));
         checksConfig.addChild(createCheckConfig(IllegalCatchCheck.class));
         checkerConfig.addChild(checksConfig);
-        if (filterConfig != null) {
-            checkerConfig.addChild(filterConfig);
+        if (checkConfig != null) {
+            checkerConfig.addChild(checkConfig);
         }
         final Checker checker = new Checker();
         final Locale locale = Locale.ROOT;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -204,7 +204,7 @@ public class SuppressWithNearbyCommentFilterTest
     }
 
     @Override
-    protected Checker createChecker(Configuration filterConfig)
+    protected Checker createChecker(Configuration checkConfig)
             throws CheckstyleException, UnsupportedEncodingException {
         final DefaultConfiguration checkerConfig =
             new DefaultConfiguration("configuration");
@@ -214,8 +214,8 @@ public class SuppressWithNearbyCommentFilterTest
         checksConfig.addChild(createCheckConfig(ConstantNameCheck.class));
         checksConfig.addChild(createCheckConfig(IllegalCatchCheck.class));
         checkerConfig.addChild(checksConfig);
-        if (filterConfig != null) {
-            checkerConfig.addChild(filterConfig);
+        if (checkConfig != null) {
+            checkerConfig.addChild(checkConfig);
         }
         final Checker checker = new Checker();
         final Locale locale = Locale.ROOT;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -204,7 +204,7 @@ public class SuppressionCommentFilterTest
     }
 
     @Override
-    protected Checker createChecker(Configuration aFilterConfig)
+    protected Checker createChecker(Configuration checkConfig)
             throws CheckstyleException, UnsupportedEncodingException {
         final DefaultConfiguration checkerConfig =
             new DefaultConfiguration("configuration");
@@ -214,8 +214,8 @@ public class SuppressionCommentFilterTest
         checksConfig.addChild(createCheckConfig(ConstantNameCheck.class));
         checksConfig.addChild(createCheckConfig(IllegalCatchCheck.class));
         checkerConfig.addChild(checksConfig);
-        if (aFilterConfig != null) {
-            checkerConfig.addChild(aFilterConfig);
+        if (checkConfig != null) {
+            checkerConfig.addChild(checkConfig);
         }
         final Checker checker = new Checker();
         final Locale locale = Locale.ROOT;


### PR DESCRIPTION
Fixes `ParameterNameDiffersFromOverriddenParameter` inspection violation.

Description:
>Reports parameters that have different names from the corresponding parameters in the methods they override. While legal in Java, such inconsistent names may be confusing, and lessen the documentation benefits of good naming practices.