### PR TITLE
Issue #1566: OverloadMethodsDeclarationOrder violations fixed

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -335,6 +335,7 @@
     <module name="OneTopLevelClass"/>
     <module name="IllegalToken"/>
     <module name="PackageDeclaration"/>
+    <module name="OverloadMethodsDeclarationOrder"/>
 
     <!--
         All Checks bellow are our futute plan to enforce over our code.
@@ -342,9 +343,6 @@
         All of them have ignore severity to avoid build failure for now.
         As all violations are resolved Check need to got default severity as all other.
     -->
-    <module name="OverloadMethodsDeclarationOrder">
-      <property name="severity" value="ignore"/>
-    </module>
     <module name="VariableDeclarationUsageDistance">
       <property name="severity" value="ignore"/>
     </module>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -264,26 +264,6 @@ public final class TreeWalker
     }
 
     /**
-     * Validates that check's required tokens are subset of default tokens.
-     * @param check to validate
-     * @throws CheckstyleException when validation of default tokens fails
-     */
-    private static void validateDefaultTokens(Check check) throws CheckstyleException {
-        final int[] defaultTokens = check.getDefaultTokens();
-        if (check.getRequiredTokens().length != 0) {
-            Arrays.sort(defaultTokens);
-            for (final int token : check.getRequiredTokens()) {
-                if (Arrays.binarySearch(defaultTokens, token) < 0) {
-                    final String message = String.format("Token \"%s\" from required tokens was"
-                            + " not found in default tokens list in check %s",
-                            token, check.getClass().getName());
-                    throw new CheckstyleException(message);
-                }
-            }
-        }
-    }
-
-    /**
      * Register a check for a specified token id.
      * @param tokenID the id of the token
      * @param check the check to register
@@ -309,6 +289,26 @@ public final class TreeWalker
         }
         else {
             tokenToOrdinaryChecks.put(token, check);
+        }
+    }
+
+    /**
+     * Validates that check's required tokens are subset of default tokens.
+     * @param check to validate
+     * @throws CheckstyleException when validation of default tokens fails
+     */
+    private static void validateDefaultTokens(Check check) throws CheckstyleException {
+        final int[] defaultTokens = check.getDefaultTokens();
+        if (check.getRequiredTokens().length != 0) {
+            Arrays.sort(defaultTokens);
+            for (final int token : check.getRequiredTokens()) {
+                if (Arrays.binarySearch(defaultTokens, token) < 0) {
+                    final String message = String.format("Token \"%s\" from required tokens was"
+                            + " not found in default tokens list in check %s",
+                            token, check.getClass().getName());
+                    throw new CheckstyleException(message);
+                }
+            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
@@ -83,18 +83,6 @@ public abstract class AbstractViolationReporter
     }
 
     /**
-     * Helper method to log a LocalizedMessage.
-     *
-     * @param ast a node to get line id column numbers associated
-     *             with the message
-     * @param key key to locale message format
-     * @param args arguments to format
-     */
-    protected final void log(DetailAST ast, String key, Object... args) {
-        log(ast.getLineNo(), ast.getColumnNo(), key, args);
-    }
-
-    /**
      * Returns the message bundle name resourcebundle that contains the messages
      * used by this module.
      * <p>
@@ -116,15 +104,6 @@ public abstract class AbstractViolationReporter
     }
 
     /**
-     * Returns an unmodifiable map instance containing the custom messages
-     * for this configuration.
-     * @return unmodifiable map containing custom messages
-     */
-    protected Map<String, String> getCustomMessages() {
-        return getConfiguration().getMessages();
-    }
-
-    /**
      * For unit tests, especially with a class with no package name.
      * @param className class name of the module.
      * @return name of a resource bundle that contains the messages
@@ -138,6 +117,27 @@ public abstract class AbstractViolationReporter
         }
         final String packageName = className.substring(0, endIndex);
         return packageName + "." + messages;
+    }
+
+    /**
+     * Returns an unmodifiable map instance containing the custom messages
+     * for this configuration.
+     * @return unmodifiable map containing custom messages
+     */
+    protected Map<String, String> getCustomMessages() {
+        return getConfiguration().getMessages();
+    }
+
+    /**
+     * Helper method to log a LocalizedMessage.
+     *
+     * @param ast a node to get line id column numbers associated
+     *             with the message
+     * @param key key to locale message format
+     * @param args arguments to format
+     */
+    protected final void log(DetailAST ast, String key, Object... args) {
+        log(ast.getLineNo(), ast.getColumnNo(), key, args);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -175,6 +175,21 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
     }
 
     /**
+     * Returns the number of direct child tokens that have the specified type.
+     * @param type the token type to match
+     * @return the number of matching token
+     */
+    public int getChildCount(int type) {
+        int count = 0;
+        for (AST ast = getFirstChild(); ast != null; ast = ast.getNextSibling()) {
+            if (ast.getType() == type) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
      * Set the parent token.
      * @param parent the parent token
      */
@@ -335,21 +350,6 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
      */
     public boolean branchContains(int type) {
         return getBranchTokenTypes().get(type);
-    }
-
-    /**
-     * Returns the number of direct child tokens that have the specified type.
-     * @param type the token type to match
-     * @return the number of matching token
-     */
-    public int getChildCount(int type) {
-        int count = 0;
-        for (AST ast = getFirstChild(); ast != null; ast = ast.getNextSibling()) {
-            if (ast.getType() == type) {
-                count++;
-            }
-        }
-        return count;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -309,6 +309,29 @@ public class IllegalInstantiationCheck
     }
 
     /**
+     * Is class of the same package
+     * @param className class name
+     * @return true if same package class
+     */
+    private boolean isSamePackage(String className) {
+        boolean isSamePackage = false;
+        try {
+            final ClassLoader classLoader = getClassLoader();
+            if (classLoader != null) {
+                final String fqName = pkgName + "." + className;
+                classLoader.loadClass(fqName);
+                // no ClassNotFoundException, fqName is a known class
+                isSamePackage = true;
+            }
+        }
+        catch (final ClassNotFoundException ignored) {
+            // not a class from the same package
+            isSamePackage = false;
+        }
+        return isSamePackage;
+    }
+
+    /**
      * Is Standard Class
      * @param className class name
      * @param illegal illegal value
@@ -333,29 +356,6 @@ public class IllegalInstantiationCheck
             }
         }
         return false;
-    }
-
-    /**
-     * Is class of the same package
-     * @param className class name
-     * @return true if same package class
-     */
-    private boolean isSamePackage(String className) {
-        boolean isSamePackage = false;
-        try {
-            final ClassLoader classLoader = getClassLoader();
-            if (classLoader != null) {
-                final String fqName = pkgName + "." + className;
-                classLoader.loadClass(fqName);
-                // no ClassNotFoundException, fqName is a known class
-                isSamePackage = true;
-            }
-        }
-        catch (final ClassNotFoundException ignored) {
-            // not a class from the same package
-            isSamePackage = false;
-        }
-        return isSamePackage;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -240,6 +240,31 @@ public abstract class AbstractExpressionHandler {
     }
 
     /**
+     * Get the start of the specified line.
+     *
+     * @param line   the specified line number
+     *
+     * @return the start of the specified line
+     */
+    protected final int getLineStart(String line) {
+        int index = 0;
+        while (Character.isWhitespace(line.charAt(index))) {
+            index++;
+        }
+        return CommonUtils.lengthExpandedTabs(
+            line, index, indentCheck.getIndentationTabWidth());
+    }
+
+    /**
+     * @return true if indentation should be increased after
+     *              fisrt line in checkLinesIndent()
+     *         false otherwise
+     */
+    protected boolean shouldIncreaseIndent() {
+        return true;
+    }
+
+    /**
      * Check the indentation of consecutive lines for the expression we are
      * handling.
      *
@@ -258,15 +283,6 @@ public abstract class AbstractExpressionHandler {
         for (int i = startLine + 1; i <= endLine; i++) {
             checkSingleLine(i, offsetLevel);
         }
-    }
-
-    /**
-     * @return true if indentation should be increased after
-     *              fisrt line in checkLinesIndent()
-     *         false otherwise
-     */
-    protected boolean shouldIncreaseIndent() {
-        return true;
     }
 
     /**
@@ -358,22 +374,6 @@ public abstract class AbstractExpressionHandler {
                 || !mustMatch && colNum == start && indentLevel.isGreaterThan(start)) {
             logChildError(lineNum, start, indentLevel);
         }
-    }
-
-    /**
-     * Get the start of the specified line.
-     *
-     * @param line   the specified line number
-     *
-     * @return the start of the specified line
-     */
-    protected final int getLineStart(String line) {
-        int index = 0;
-        while (Character.isWhitespace(line.charAt(index))) {
-            index++;
-        }
-        return CommonUtils.lengthExpandedTabs(
-            line, index, indentCheck.getIndentationTabWidth());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -426,6 +426,34 @@ public class WhitespaceAroundCheck extends Check {
     }
 
     /**
+     * Tests if a given {@code DetailAST} is part of an empty block.
+     * An example empty block might look like the following
+     * <p>
+     * <pre>   public void myMethod(int val) {}</pre>
+     * </p>
+     * In the above, the method body is an empty block ("{}").
+     *
+     * @param ast the {@code DetailAST} to test.
+     * @param parentType the token type of {@code ast}'s parent.
+     * @param match the parent token type we're looking to match.
+     * @return {@code true} if {@code ast} makes up part of an
+     *         empty block contained under a {@code match} token type
+     *         node.
+     */
+    private static boolean isEmptyBlock(DetailAST ast, int parentType, int match) {
+        final int type = ast.getType();
+        if (type == TokenTypes.RCURLY) {
+            final DetailAST grandParent = ast.getParent().getParent();
+            return parentType == TokenTypes.SLIST
+                && grandParent.getType() == match;
+        }
+
+        return type == TokenTypes.SLIST
+            && parentType == match
+            && ast.getFirstChild().getType() == TokenTypes.RCURLY;
+    }
+
+    /**
      * Whether colon belongs to cases or defaults.
      * @param currentType current
      * @param parentType parent
@@ -521,33 +549,5 @@ public class WhitespaceAroundCheck extends Check {
         final int type = ast.getType();
         return (type == TokenTypes.RCURLY || type == TokenTypes.LCURLY)
                 && parentType == TokenTypes.OBJBLOCK;
-    }
-
-    /**
-     * Tests if a given {@code DetailAST} is part of an empty block.
-     * An example empty block might look like the following
-     * <p>
-     * <pre>   public void myMethod(int val) {}</pre>
-     * </p>
-     * In the above, the method body is an empty block ("{}").
-     *
-     * @param ast the {@code DetailAST} to test.
-     * @param parentType the token type of {@code ast}'s parent.
-     * @param match the parent token type we're looking to match.
-     * @return {@code true} if {@code ast} makes up part of an
-     *         empty block contained under a {@code match} token type
-     *         node.
-     */
-    private static boolean isEmptyBlock(DetailAST ast, int parentType, int match) {
-        final int type = ast.getType();
-        if (type == TokenTypes.RCURLY) {
-            final DetailAST grandParent = ast.getParent().getParent();
-            return parentType == TokenTypes.SLIST
-                && grandParent.getType() == match;
-        }
-
-        return type == TokenTypes.SLIST
-            && parentType == match
-            && ast.getFirstChild().getType() == TokenTypes.RCURLY;
     }
 }


### PR DESCRIPTION
Fix for:
OverloadMethodsDeclarationOrder ```Overload methods should not be split. Previous overloaded method located at line 'X'.```