### PR TITLE
Issue #1555: Rename parameters to match names in overridden methods

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -181,7 +181,7 @@ public class PackageNamesLoaderTest {
     private static URL getMockUrl(final URLConnection connection) throws IOException {
         final URLStreamHandler handler = new URLStreamHandler() {
             @Override
-            protected URLConnection openConnection(final URL url) {
+            protected URLConnection openConnection(final URL u) {
                 return connection;
             }
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -260,8 +260,8 @@ public class XMLLoggerTest {
         private static final long serialVersionUID = 1L;
 
         @Override
-        public void printStackTrace(PrintWriter printWriter) {
-            printWriter.print("stackTrace");
+        public void printStackTrace(PrintWriter s) {
+            s.print("stackTrace");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheckTest.java
@@ -35,9 +35,9 @@ public class FileTabCharacterCheckTest
     extends BaseCheckTestSupport {
     @Override
     protected DefaultConfiguration createCheckerConfig(
-        Configuration checkConfig) {
+        Configuration config) {
         final DefaultConfiguration dc = new DefaultConfiguration("root");
-        dc.addChild(checkConfig);
+        dc.addChild(config);
         return dc;
     }
 


### PR DESCRIPTION
Fixes `ParameterNameDiffersFromOverriddenParameter` inspection violation.

Description:
>Reports parameters that have different names from the corresponding parameters in the methods they override. While legal in Java, such inconsistent names may be confusing, and lessen the documentation benefits of good naming practices.