### PR TITLE
Issue #1555: Remove redundant initializer

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -338,7 +338,7 @@ public class CheckstyleAntTask extends Task {
                 + " files", Project.MSG_INFO);
         log("Using configuration " + configLocation, Project.MSG_VERBOSE);
 
-        int numErrs = 0;
+        int numErrs;
 
         try {
             final long processingStartTime = System.currentTimeMillis();


### PR DESCRIPTION
Fixes `UnusedAssignment` inspection violation.

Description:
>This inspection points out the cases where a variable value