### PR TITLE
Issue #1555: Use curly braces in variables in bash script

### DIFF
--- a/fast-forward-merge.sh
+++ b/fast-forward-merge.sh
@@ -7,31 +7,31 @@ example:
 
     ./$(basename "$0") checkstyle konstantinos issue73
 "
-	exit 0;
+    exit 0;
 fi
 
 GIT_REPO=$1
 FORK_USER_NAME=$2
 USER_BRANCH=$3
-REPO=$FORK_USER_NAME-fork
-LOCAL_USER_BRANCH=$FORK_USER_NAME-$USER_BRANCH
+REPO=${FORK_USER_NAME}-fork
+LOCAL_USER_BRANCH=${FORK_USER_NAME}-${USER_BRANCH}
 
 echo "adding remote ..."
-git remote add $REPO https://github.com/$FORK_USER_NAME/$GIT_REPO.git
-git fetch $REPO
+git remote add ${REPO} https://github.com/${FORK_USER_NAME}/${GIT_REPO}.git
+git fetch ${REPO}
 
 echo "creating local branch ..."
-git checkout -b $LOCAL_USER_BRANCH $REPO/$USER_BRANCH
+git checkout -b ${LOCAL_USER_BRANCH} ${REPO}/${USER_BRANCH}
 
 echo "rebasing over master ..."
 git rebase master
 
 echo "merge to master ..."
 git checkout master
-git merge $LOCAL_USER_BRANCH
+git merge ${LOCAL_USER_BRANCH}
 
 echo "removing local branch ..."
-git branch -D $LOCAL_USER_BRANCH
+git branch -D ${LOCAL_USER_BRANCH}
 
 echo "removing remote ..."
-git remote rm $REPO
+git remote rm ${REPO}


### PR DESCRIPTION
Fixes `BashSimpleVarUsage` inspection violations.