### PR TITLE
Issue #1555: Refer to collections by interface

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -38,7 +39,7 @@ public final class PropertiesExpander
      *     property resolution.
      * @throws IllegalArgumentException indicates null was passed
      */
-    public PropertiesExpander(Properties properties) {
+    public PropertiesExpander(Map<Object, Object> properties) {
         if (properties == null) {
             throw new IllegalArgumentException("cannot pass null");
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -31,6 +31,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -254,7 +255,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         treeWalker.setCacheFile(temporaryFolder.newFile().getPath());
         treeWalker.setupChild(createCheckConfig(TypeNameCheck.class));
         final File file = temporaryFolder.newFile("file.java");
-        ArrayList<String> lines = new ArrayList<>();
+        List<String> lines = new ArrayList<>();
         lines.add(" class a {} ");
         treeWalker.processFiltered(file, lines);
     }
@@ -269,7 +270,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         treeWalker.setCacheFile(temporaryFolder.newFile().getPath());
         treeWalker.setupChild(createCheckConfig(TypeNameCheck.class));
         final File file = temporaryFolder.newFile("file.java");
-        ArrayList<String> lines = new ArrayList<>();
+        List<String> lines = new ArrayList<>();
         lines.add(" classD a {} ");
 
         try {
@@ -291,7 +292,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         treeWalker.setCacheFile(temporaryFolder.newFile().getPath());
         treeWalker.setupChild(createCheckConfig(TypeNameCheck.class));
         final File file = temporaryFolder.newFile("file.java");
-        ArrayList<String> lines = new ArrayList<>();
+        List<String> lines = new ArrayList<>();
         lines.add(" class a%$# {} ");
 
         try {


### PR DESCRIPTION
Fixes `DeclareCollectionAsInterface` inspection violations.

Description:
>Reports on declarations of Collection variables made by using the collection class as the type, rather than an appropriate interface.