### PR TITLE
New option for CyclomaticComplexityCheck: Treat SWITCH as single decision point, issue #2029

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheck.java
@@ -32,8 +32,15 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * the source and therefore the number of required tests. Generally 1-4 is
  * considered good, 5-7 ok, 8-10 consider re-factoring, and 11+ re-factor now!
  *
+ * <p>Check has following properties:
+ *
+ * <p><b>switchBlockAsSingleDecisionPoint</b> - controls whether to treat the whole switch
+ * block as a single decision point. Default value is <b>false</b>
+ *
+ *
  * @author <a href="mailto:simon@redhillconsulting.com.au">Simon Harris</a>
  * @author Oliver Burn
+ * @author <a href="mailto:andreyselkin@gmail.com">Andrei Selkin</a>
  */
 public class CyclomaticComplexityCheck
     extends AbstractComplexityCheck {
@@ -47,9 +54,21 @@ public class CyclomaticComplexityCheck
     /** Default allowed complexity. */
     private static final int DEFAULT_VALUE = 10;
 
+    /** Whether to treat the whole switch block as a single decision point.*/
+    private boolean switchBlockAsSingleDecisionPoint;
+
     /** Create an instance. */
     public CyclomaticComplexityCheck() {
         super(DEFAULT_VALUE);
+    }
+
+    /**
+     * Sets whether to treat the whole switch block as a single decision point.
+     * @param switchBlockAsSingleDecisionPoint whether to treat the whole switch
+     *                                          block as a single decision point.
+     */
+    public void setSwitchBlockAsSingleDecisionPoint(boolean switchBlockAsSingleDecisionPoint) {
+        this.switchBlockAsSingleDecisionPoint = switchBlockAsSingleDecisionPoint;
     }
 
     @Override
@@ -63,6 +82,7 @@ public class CyclomaticComplexityCheck
             TokenTypes.LITERAL_DO,
             TokenTypes.LITERAL_FOR,
             TokenTypes.LITERAL_IF,
+            TokenTypes.LITERAL_SWITCH,
             TokenTypes.LITERAL_CASE,
             TokenTypes.LITERAL_CATCH,
             TokenTypes.QUESTION,
@@ -82,6 +102,7 @@ public class CyclomaticComplexityCheck
             TokenTypes.LITERAL_DO,
             TokenTypes.LITERAL_FOR,
             TokenTypes.LITERAL_IF,
+            TokenTypes.LITERAL_SWITCH,
             TokenTypes.LITERAL_CASE,
             TokenTypes.LITERAL_CATCH,
             TokenTypes.QUESTION,
@@ -92,7 +113,14 @@ public class CyclomaticComplexityCheck
 
     @Override
     protected final void visitTokenHook(DetailAST ast) {
-        incrementCurrentValue(BigInteger.ONE);
+        if (switchBlockAsSingleDecisionPoint) {
+            if (ast.getType() != TokenTypes.LITERAL_CASE) {
+                incrementCurrentValue(BigInteger.ONE);
+            }
+        }
+        else if (ast.getType() != TokenTypes.LITERAL_SWITCH) {
+            incrementCurrentValue(BigInteger.ONE);
+        }
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheckTest.java
@@ -31,6 +31,34 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 public class CyclomaticComplexityCheckTest
     extends BaseCheckTestSupport {
     @Test
+    public void testSwitchBlockAsSingleDecisionPointSetToTrue() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(CyclomaticComplexityCheck.class);
+        checkConfig.addAttribute("max", "0");
+        checkConfig.addAttribute("switchBlockAsSingleDecisionPoint", "true");
+
+        final String[] expected = {
+            "4:5: " + getCheckMessage(MSG_KEY, 2, 0),
+        };
+
+        verify(checkConfig, getPath("metrics/ComplexityCheckSwitchBlocksTestInput.java"), expected);
+    }
+
+    @Test
+    public void testSwitchBlockAsSingleDecisionPointSetToFalse() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(CyclomaticComplexityCheck.class);
+        checkConfig.addAttribute("max", "0");
+        checkConfig.addAttribute("switchBlockAsSingleDecisionPoint", "false");
+
+        final String[] expected = {
+            "4:5: " + getCheckMessage(MSG_KEY, 5, 0),
+        };
+
+        verify(checkConfig, getPath("metrics/ComplexityCheckSwitchBlocksTestInput.java"), expected);
+    }
+
+    @Test
     public void test() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(CyclomaticComplexityCheck.class);
@@ -66,6 +94,7 @@ public class CyclomaticComplexityCheckTest
             TokenTypes.LITERAL_DO,
             TokenTypes.LITERAL_FOR,
             TokenTypes.LITERAL_IF,
+            TokenTypes.LITERAL_SWITCH,
             TokenTypes.LITERAL_CASE,
             TokenTypes.LITERAL_CATCH,
             TokenTypes.QUESTION,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/metrics/ComplexityCheckSwitchBlocksTestInput.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/metrics/ComplexityCheckSwitchBlocksTestInput.java
@@ -1,0 +1,20 @@
+package com.puppycrawl.tools.checkstyle.metrics;
+
+public class ComplexityCheckSwitchBlocksTestInput {
+    public void foo2() {
+        String programmingLanguage = "Java";
+        switch (programmingLanguage) {
+            case "Java":
+            case "C#":
+            case "C++":
+                System.out.printf(programmingLanguage + " is an object oriented programming language.");
+                break;
+            case "C":
+                System.out.printf(programmingLanguage + " is not an object oriented programming language.");
+                break;
+            default:
+                System.out.printf(programmingLanguage + " is unknown language.");
+                break;
+        }
+    }
+}

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -333,6 +333,12 @@
             <td><a href="property_types.html#integer">integer</a></td>
             <td><code>10</code></td>
           </tr>
+          <tr>
+            <td>switchBlockAsSingleDecisionPoint</td>
+            <td>whether to treat the whole switch block as a single decision point</td>
+            <td><a href="property_types.html#integer">boolean</a></td>
+            <td><code>false</code></td>
+          </tr>
         </table>
       </subsection>
 
@@ -353,11 +359,11 @@
 &lt;/module&gt;
         </source>
         <p>
-          Explanation on how complexity is calculated:
+          Explanation on how complexity is calculated (switchBlockAsSingleDecisionPoint is set to false):
         </p>
         <source>
 class CC {
-   // Cyclomatic Complexity = 13
+   // Cyclomatic Complexity = 12
    public void doSmth()  {               // 1
        if (a == b)  {                    // 2
             if (a1 == b1                 // 3
@@ -391,12 +397,33 @@ class CC {
               case 2:                    // 12
                     fiddle();
                     break;
-              default:                   // 13
+              default:
                     fiddle();
                     break;
             }
         }
     }
+}        </source>
+        <p>
+          Explanation on how complexity is calculated (switchBlockAsSingleDecisionPoint is set to true):
+        </p>
+        <source>
+class SwitchExample {
+   // Cyclomatic Complexity = 2
+   public void doSmth()  {            // 1
+       int z = 1;
+       switch (z) {                   // 2
+           case 1:
+               foo1();
+               break;
+           case 2:
+               foo2();
+               break;
+           default:
+               fooDefault();
+               break;
+       }
+   }
 }        </source>
       </subsection>
 


### PR DESCRIPTION
@romani 
1) Fixed bug in the Check. The Check did not take into account ```default``` label of ```switch```. For example:

````java
public class Test {
    public void foo() {          // CC = 1
        int i = 1;
        switch(i) {
            case 1:              // CC = 2
                 break;
           default:              // CC should be 3, but before fix was 2
                 break;
        }
    }
}
````

2) Implemented new option for the Check and provided UTs.
3) Resolved check's violation on SuppressWarningsCheck due to the fact that after fix ```default``` label is also calculated as decision point.