### PR TITLE
Corrected javadoc/xdoc for IllegalTypeCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -34,13 +34,10 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
 
 /**
  * Checks that particular class are never used as types in variable
- * declarations, return values or parameters. Includes
- * a pattern check that by default disallows abstract classes.
+ * declarations, return values or parameters.
  *
  * <p>Rationale:
- * Helps reduce coupling on concrete classes. In addition abstract
- * classes should be thought of a convenience base class
- * implementations of interfaces and as such are not types themselves.
+ * Helps reduce coupling on concrete classes.
  *
  * <p>Check has following properties:
  *
@@ -90,6 +87,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
  *
  * @author <a href="mailto:simon@redhillconsulting.com.au">Simon Harris</a>
  * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
+ * @author <a href="mailto:andreyselkin@gmail.com">Andrei Selkin</a>
  */
 public final class IllegalTypeCheck extends AbstractFormatCheck {
 

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -1924,14 +1924,11 @@ if (&quot;something&quot;.equals(x))
       <subsection name="Description">
         <p>
           Checks that particular classes are never used as types in variable
-          declarations, return values or parameters. Includes a pattern check
-          that by default disallows abstract classes.
+          declarations, return values or parameters.
         </p>
 
         <p>
-          Rationale: Helps reduce coupling on concrete classes. In addition
-          abstract classes should be thought of as convenient base class
-          implementations of interfaces, and as such, are not types themselves.
+          Rationale: Helps reduce coupling on concrete classes.
         </p>
       </subsection>
 


### PR DESCRIPTION
@romani 
Since we implemented new option ```validateAbstractClassNames``` for the Check, I've corrected documentation. 

Please also take a look at @mkordas suggestions:
https://github.com/checkstyle/checkstyle/pull/1941#issuecomment-135886623