### PR TITLE
Issue #2065: Add suppression for IntelliJ IDEA inspection

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -1972,6 +1972,7 @@
                 <option value="deprecation" />
                 <option value="unchecked" />
                 <option value="rawtypes" />
+                <option value="idea: CollectionDeclaredAsConcreteClass" />
             </list>
         </option>
     </inspection_tool>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
@@ -38,6 +38,7 @@ public final class PropertiesExpander
      *     property resolution.
      * @throws IllegalArgumentException indicates null was passed
      */
+    @SuppressWarnings("idea: CollectionDeclaredAsConcreteClass")
     public PropertiesExpander(Properties properties) {
         if (properties == null) {
             throw new IllegalArgumentException("cannot pass null");


### PR DESCRIPTION
Inspection in this case is right. Parameter `Properties` can be replaced with `Map<Object, Object>`. It works fine with Checkstyle, but it breaks binary compatiblity with Maven Checkstyle Plugin, which is not acceptable.