### PR TITLE
Issue #1903: Fixed NPE in MutableExceptionCheck.isExtendedClassNamedAsException .

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
@@ -155,7 +155,7 @@ public final class MutableExceptionCheck extends AbstractFormatCheck {
         final DetailAST extendsClause = ast.findFirstToken(TokenTypes.EXTENDS_CLAUSE);
         if (extendsClause != null) {
             DetailAST currentNode = extendsClause;
-            while (currentNode.getType() != TokenTypes.IDENT) {
+            while (currentNode.getLastChild() != null) {
                 currentNode = currentNode.getLastChild();
             }
             final String extendedClassName = currentNode.getText();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
@@ -35,6 +35,18 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class MutableExceptionCheckTest extends BaseCheckTestSupport {
+
+    @Test
+    public void testClassExtendsGenericClass() throws Exception {
+        DefaultConfiguration checkConfig = createCheckConfig(MutableExceptionCheck.class);
+
+        String[] expected = {
+        };
+
+        verify(checkConfig, getPath("design" + File.separator
+            + "InputMutableExceptionClassExtendsGenericClass.java"), expected);
+    }
+
     @Test
     public void testDefault() throws Exception {
         DefaultConfiguration checkConfig = createCheckConfig(MutableExceptionCheck.class);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/design/InputMutableExceptionClassExtendsGenericClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/design/InputMutableExceptionClassExtendsGenericClass.java
@@ -1,0 +1,12 @@
+package com.puppycrawl.tools.checkstyle.design;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Convenience class for holding an {@link Exception} in a thread-safe way
+ */
+public class InputMutableExceptionClassExtendsGenericClass extends AtomicReference<Exception> { // NPE is not expected
+
+    private static final long serialVersionUID = 1L;
+
+}


### PR DESCRIPTION
Reports: http://mezk.github.io

Reports before and after are equal.