### PR TITLE
Issue #2065: Add suppression for IntelliJ IDEA inspection as comment

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -1972,7 +1972,6 @@
                 <option value="deprecation" />
                 <option value="unchecked" />
                 <option value="rawtypes" />
-                <option value="idea: CollectionDeclaredAsConcreteClass" />
             </list>
         </option>
     </inspection_tool>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
@@ -37,8 +37,8 @@ public final class PropertiesExpander
      * @param properties the underlying properties to use for
      *     property resolution.
      * @throws IllegalArgumentException indicates null was passed
+     * @noinspection IDEA CollectionDeclaredAsConcreteClass
      */
-    @SuppressWarnings("idea: CollectionDeclaredAsConcreteClass")
     public PropertiesExpander(Properties properties) {
         if (properties == null) {
             throw new IllegalArgumentException("cannot pass null");


### PR DESCRIPTION
I found one more way of suppressing inspections thanks to the answer for my question: http://stackoverflow.com/questions/32363262/intellij-idea-suppresswarnings-for-inspection-with-name-of-tool/

Is it better?

Javadoc remains clear:
![image](https://cloud.githubusercontent.com/assets/5467276/9668829/18f22788-5284-11e5-8232-3daaf993e616.png)