### PR TITLE
Issue #2080: Replace ternary condition operator with if

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -366,7 +366,7 @@
     <inspection_tool class="ComparisonOfShortAndChar" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ComparisonToNaN" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ConditionSignal" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ConditionalExpression" enabled="false" level="ERROR" enabled_by_default="false">
+    <inspection_tool class="ConditionalExpression" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="ignoreSimpleAssignmentsAndReturns" value="false" />
     </inspection_tool>
     <inspection_tool class="ConditionalExpressionJS" enabled="true" level="ERROR" enabled_by_default="true" />

--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -123,7 +123,10 @@ public abstract class BaseCheckTestSupport
                 parseInt = parseInt.substring(parseInt.indexOf(':') + 1);
                 parseInt = parseInt.substring(0, parseInt.indexOf(':'));
                 int lineNumber = Integer.parseInt(parseInt);
-                Integer integer = Arrays.asList(aWarnsExpected).contains(lineNumber) ? lineNumber : 0;
+                Integer integer = 0;
+                if (Arrays.asList(aWarnsExpected).contains(lineNumber)) {
+                    integer = lineNumber;
+                }
                 assertEquals("error message " + i, (long) integer, lineNumber);
             }
 


### PR DESCRIPTION
Fixes `ConditionalExpression` inspection violations.

Description:
>Reports the ternary condition operator. Some coding standards prohibit the use of the condition operator, in favor of if-else statements.