### PR TITLE
Issue #2080: Add missing assertions to utils tests

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilsTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.puppycrawl.tools.checkstyle.TestUtils.assertUtilsClassHasPrivateConstructor;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,8 +36,9 @@ public class CheckUtilsTest {
     }
 
     @Test
-    public void testParseDouble() throws Exception {
-        CheckUtils.parseDouble("1_02", TokenTypes.ASSIGN);
+    public void testParseDoubleWithIncorrectToken() throws Exception {
+        double parsedDouble = CheckUtils.parseDouble("1_02", TokenTypes.ASSIGN);
+        assertEquals(0.0, parsedDouble, 0.0);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
@@ -170,14 +170,12 @@ public class CommonUtilsTest {
 
     @Test
     public void testClose() {
+        TestCloseable closeable = new TestCloseable();
+
         CommonUtils.close(null);
+        CommonUtils.close(closeable);
 
-        CommonUtils.close(new Closeable() {
-
-            @Override
-            public void close() {
-            }
-        });
+        assertTrue(closeable.closed);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -189,5 +187,14 @@ public class CommonUtilsTest {
                 throw new IOException("Test IOException");
             }
         });
+    }
+
+    private static class TestCloseable implements Closeable {
+        private boolean closed;
+
+        @Override
+        public void close() {
+            closed = true;
+        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilsTest.java
@@ -51,6 +51,7 @@ public class TokenUtilsTest {
 
         try {
             TokenUtils.getIntFromField(field, 0);
+            fail();
         }
         catch (IllegalStateException expected) {
             // expected


### PR DESCRIPTION
Fixes some `TestMethodWithoutAssertion` inspection violations.

Description:
>Reports test methods of JUnit test case classes that do not contain any assertions. Such methods indicate either incomplete or weak test cases.