### PR TITLE
Issue #2080: Fix typos in code

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameInput_OneCharVarName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameInput_OneCharVarName.java
@@ -4,7 +4,7 @@ import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
 
-class InputOneCharInintVarName
+class InputOneCharInitVarName
 {
     public void fooMethod()
     {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -192,7 +192,7 @@ public class ImportOrderCheck
     /** The special wildcard that catches all remaining groups. */
     private static final String WILDCARD_GROUP_NAME = "*";
 
-    /** Empty array of pattern type needed to initlialize check. */
+    /** Empty array of pattern type needed to initialize check. */
     private static final Pattern[] EMPTY_PATTERN_ARRAY = new Pattern[0];
 
     /** List of import groups specified by the user. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ForHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ForHandler.java
@@ -56,9 +56,9 @@ public class ForHandler extends BlockParentHandler {
                 getMainAst().findFirstToken(TokenTypes.FOR_CONDITION);
             checkExpressionSubtree(cond, expected, false, false);
 
-            final DetailAST iter =
+            final DetailAST forIterator =
                 getMainAst().findFirstToken(TokenTypes.FOR_ITERATOR);
-            checkExpressionSubtree(iter, expected, false, false);
+            checkExpressionSubtree(forIterator, expected, false, false);
         }
         // for each
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
  *
  * <p>
  * The basic idea behind this is that while
- * pretty printers are sometimes convenient for.  reformats of
+ * pretty printers are sometimes convenient for reformats of
  * legacy code, they often either aren't configurable enough or
  * just can't anticipate how format should be done.  Sometimes this is
  * personal preference, other times it is practical experience.  In any

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -85,7 +85,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * A key is pointing to the warning message text in "messages.properties"
      * file.
      */
-    public static final String MSG_EXCPECTED_TAG = "javadoc.expectedTag";
+    public static final String MSG_EXPECTED_TAG = "javadoc.expectedTag";
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -766,12 +766,12 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
         // the user has chosen to suppress these problems
         if (!allowMissingParamTags && reportExpectedTags) {
             for (DetailAST param : params) {
-                log(param, MSG_EXCPECTED_TAG,
+                log(param, MSG_EXPECTED_TAG,
                     JavadocTagInfo.PARAM.getText(), param.getText());
             }
 
             for (DetailAST typeParam : typeParams) {
-                log(typeParam, MSG_EXCPECTED_TAG,
+                log(typeParam, MSG_EXPECTED_TAG,
                     JavadocTagInfo.PARAM.getText(),
                     "<" + typeParam.findFirstToken(TokenTypes.IDENT).getText()
                     + ">");
@@ -912,7 +912,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
                 if (!ei.isFound()) {
                     final Token fi = ei.getName();
                     log(fi.getLineNo(), fi.getColumnNo(),
-                        MSG_EXCPECTED_TAG,
+                            MSG_EXPECTED_TAG,
                         JavadocTagInfo.THROWS.getText(), fi.getText());
                 }
             }
@@ -976,7 +976,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
         /**
          * Creates new instance for {@code FullIdent}.
          *
-         * @param classInfo clas info
+         * @param classInfo class info
          */
         ExceptionInfo(AbstractClassInfo classInfo) {
             this.classInfo = classInfo;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/doclets/package-info.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/doclets/package-info.java
@@ -18,7 +18,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
- * Contains the doclets used during the build of Checktyle. REally
+ * Contains the doclets used during the build of Checkstyle.
  * <p>
  * You should <strong>not be</strong> referring to this package.
  * </p>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckTest.java
@@ -111,7 +111,7 @@ public class MissingOverrideCheckTest extends BaseCheckTestSupport {
      * for only including the inheritDoc tag.
      */
     @Test
-    public void testBadAnnonOverride() throws Exception {
+    public void testBadAnnotationOverride() throws Exception {
         DefaultConfiguration checkConfig = createCheckConfig(MissingOverrideCheck.class);
         final String[] expected = {
             "10: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
@@ -120,7 +120,7 @@ public class MissingOverrideCheckTest extends BaseCheckTestSupport {
             "35: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
         };
 
-        verify(checkConfig, getPath("annotation" + File.separator + "BadAnnonOverride.java"), expected);
+        verify(checkConfig, getPath("annotation" + File.separator + "BadAnnotationOverride.java"), expected);
     }
 
     /**
@@ -128,12 +128,12 @@ public class MissingOverrideCheckTest extends BaseCheckTestSupport {
      * Java 5 compatibility mode.
      */
     @Test
-    public void testBadAnnonOverrideJ5Compat() throws Exception {
+    public void testBadAnnotationOverrideJ5Compat() throws Exception {
         DefaultConfiguration checkConfig = createCheckConfig(MissingOverrideCheck.class);
         checkConfig.addAttribute("javaFiveCompatibility", "true");
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("annotation" + File.separator + "BadAnnonOverride.java"), expected);
+        verify(checkConfig, getPath("annotation" + File.separator + "BadAnnotationOverride.java"), expected);
     }
 
     /**
@@ -209,11 +209,11 @@ public class MissingOverrideCheckTest extends BaseCheckTestSupport {
      * for only including the inheritDoc tag.
      */
     @Test
-    public void testGoodAnnonOverride() throws Exception {
+    public void testGoodAnnotationOverride() throws Exception {
         DefaultConfiguration checkConfig = createCheckConfig(MissingOverrideCheck.class);
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("annotation" + File.separator + "GoodAnnonOverride.java"), expected);
+        verify(checkConfig, getPath("annotation" + File.separator + "GoodAnnotationOverride.java"), expected);
     }
 
     /**
@@ -221,12 +221,12 @@ public class MissingOverrideCheckTest extends BaseCheckTestSupport {
      * Java 5 compatibility mode.
      */
     @Test
-    public void testGoodAnnonOverrideJ5Compat() throws Exception {
+    public void testGoodAnnotationOverrideJ5Compat() throws Exception {
         DefaultConfiguration checkConfig = createCheckConfig(MissingOverrideCheck.class);
         checkConfig.addAttribute("javaFiveCompatibility", "true");
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("annotation" + File.separator + "GoodAnnonOverride.java"), expected);
+        verify(checkConfig, getPath("annotation" + File.separator + "GoodAnnotationOverride.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -112,7 +112,7 @@ public class ImportControlCheckTest extends BaseCheckTestSupport {
             fail("should fail");
         }
         catch (CheckstyleException ex) {
-            //do nothng
+            //do nothing
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -44,7 +44,7 @@ public class AbstractJavadocCheckTest extends BaseCheckTestSupport {
                 + "alternative at input '<ul><li>a' {@link EntityEntry} (by way of {@link #;' "
                 + "while parsing HTML_TAG"),
         };
-        verify(checkConfig, getPath("javadoc/InputTestNumberFomatException.java"), expected);
+        verify(checkConfig, getPath("javadoc/InputTestNumberFormatException.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractTypeAwareCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractTypeAwareCheckTest.java
@@ -48,10 +48,10 @@ public class AbstractTypeAwareCheckTest extends BaseCheckTestSupport {
     @Test
     public void testIsSubclassWithNulls() throws Exception {
         JavadocMethodCheck check = new JavadocMethodCheck();
-        Method isSublclass = check.getClass().getSuperclass()
+        Method isSubclass = check.getClass().getSuperclass()
                 .getDeclaredMethod("isSubclass", Class.class, Class.class);
-        isSublclass.setAccessible(true);
-        assertFalse((boolean) isSublclass.invoke(check, null, null));
+        isSubclass.setAccessible(true);
+        assertFalse((boolean) isSubclass.invoke(check, null, null));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_CLASS_INFO;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_DUPLICATE_TAG;
-import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_EXCPECTED_TAG;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_EXPECTED_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_INVALID_INHERIT_DOC;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_JAVADOC_MISSING;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_RETURN_EXPECTED;
@@ -117,27 +117,27 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "18:9: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "unused"),
             "24: " + getCheckMessage(MSG_RETURN_EXPECTED),
             "33: " + getCheckMessage(MSG_RETURN_EXPECTED),
-            "40:16: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "Exception"),
-            "49:16: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "Exception"),
+            "40:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "Exception"),
+            "49:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "Exception"),
             "53:9: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "WrongException"),
-            "55:16: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "Exception"),
-            "55:27: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "NullPointerException"),
-            "60:22: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aOne"),
-            "68:22: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aOne"),
+            "55:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "Exception"),
+            "55:27: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "NullPointerException"),
+            "60:22: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
+            "68:22: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
             "72:9: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "WrongParam"),
-            "73:23: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aOne"),
-            "73:33: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aTwo"),
+            "73:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
+            "73:33: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aTwo"),
             "78:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "Unneeded"),
             "79: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL),
             "87:8: " + getCheckMessage(MSG_DUPLICATE_TAG, "@return"),
-            "109:23: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aOne"),
-            "109:55: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aFour"),
-            "109:66: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aFive"),
+            "109:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
+            "109:55: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aFour"),
+            "109:66: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aFive"),
             "178:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "ThreadDeath"),
             "179:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "ArrayStoreException"),
             "236:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "java.io.FileNotFoundException"),
             "254:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "java.io.FileNotFoundException"),
-            "256:28: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "IOException"),
+            "256:28: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IOException"),
             "262:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "aParam"),
             "320:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "329:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
@@ -156,24 +156,24 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "18:9: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "unused"),
             "24: " + getCheckMessage(MSG_RETURN_EXPECTED),
             "33: " + getCheckMessage(MSG_RETURN_EXPECTED),
-            "40:16: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "Exception"),
-            "49:16: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "Exception"),
-            "55:16: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "Exception"),
-            "55:27: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "NullPointerException"),
-            "60:22: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aOne"),
-            "68:22: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aOne"),
+            "40:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "Exception"),
+            "49:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "Exception"),
+            "55:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "Exception"),
+            "55:27: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "NullPointerException"),
+            "60:22: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
+            "68:22: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
             "72:9: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "WrongParam"),
-            "73:23: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aOne"),
-            "73:33: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aTwo"),
+            "73:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
+            "73:33: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aTwo"),
             "78:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "Unneeded"),
             "79: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL),
             "87:8: " + getCheckMessage(MSG_DUPLICATE_TAG, "@return"),
-            "109:23: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aOne"),
-            "109:55: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aFour"),
-            "109:66: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aFive"),
+            "109:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
+            "109:55: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aFour"),
+            "109:66: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aFive"),
             "236:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "java.io.FileNotFoundException"),
             "254:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "java.io.FileNotFoundException"),
-            "256:28: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "IOException"),
+            "256:28: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IOException"),
             "262:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "aParam"),
             "320:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "329:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
@@ -196,7 +196,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "74:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "79:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "84:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "94:32: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aA"),
+            "94:32: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aA"),
         };
         verify(checkConfig, getPath("InputPublicOnly.java"), expected);
     }
@@ -264,24 +264,24 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "18:9: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "unused"),
             "24: " + getCheckMessage(MSG_RETURN_EXPECTED),
             "33: " + getCheckMessage(MSG_RETURN_EXPECTED),
-            "40:16: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "Exception"),
-            "49:16: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "Exception"),
-            "55:16: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "Exception"),
-            "55:27: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "NullPointerException"),
-            "60:22: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aOne"),
-            "68:22: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aOne"),
+            "40:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "Exception"),
+            "49:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "Exception"),
+            "55:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "Exception"),
+            "55:27: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "NullPointerException"),
+            "60:22: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
+            "68:22: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
             "72:9: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "WrongParam"),
-            "73:23: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aOne"),
-            "73:33: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aTwo"),
+            "73:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
+            "73:33: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aTwo"),
             "78:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "Unneeded"),
             "79: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL),
             "87:8: " + getCheckMessage(MSG_DUPLICATE_TAG, "@return"),
-            "109:23: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aOne"),
-            "109:55: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aFour"),
-            "109:66: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "aFive"),
+            "109:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
+            "109:55: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aFour"),
+            "109:66: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aFive"),
             "178:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "ThreadDeath"),
             "179:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "ArrayStoreException"),
-            "256:28: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "IOException"),
+            "256:28: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IOException"),
             "262:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "aParam"),
             "320:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "329:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
@@ -407,8 +407,8 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
     public void testDoAllowMissingJavadocTagsByDefault() throws Exception {
         final String[] expected = {
             "10: " + getCheckMessage(MSG_RETURN_EXPECTED),
-            "20:26: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "number"),
-            "30:42: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "ThreadDeath"),
+            "20:26: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "number"),
+            "30:42: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "ThreadDeath"),
             "51: " + getCheckMessage(MSG_RETURN_EXPECTED),
             "61: " + getCheckMessage(MSG_RETURN_EXPECTED),
         };
@@ -468,9 +468,9 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
     public void testTypeParamsTags() throws Exception {
         final String[] expected = {
             "26:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<BB>"),
-            "28:13: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "<Z>"),
+            "28:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "<Z>"),
             "53:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<Z"),
-            "55:13: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "<Z>"),
+            "55:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "<Z>"),
         };
         verify(checkConfig, getPath("InputTypeParamsTags.java"), expected);
     }
@@ -501,11 +501,11 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("allowUndeclaredRTE", "true");
         checkConfig.addAttribute("validateThrows", "true");
         final String[] expected = {
-            "17:34: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "RE"),
-            "33:13: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "<NPE>"),
+            "17:34: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "RE"),
+            "33:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "<NPE>"),
             "40:12: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "E"),
-            "43:38: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "RuntimeException"),
-            "44:13: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "java.lang.RuntimeException"),
+            "43:38: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "RuntimeException"),
+            "44:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "java.lang.RuntimeException"),
         };
         verify(checkConfig, getPath("javadoc/TestGenerics.java"), expected);
     }
@@ -515,11 +515,11 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("allowThrowsTagsForSubclasses", "true");
         checkConfig.addAttribute("validateThrows", "true");
         final String[] expected = {
-            "17:34: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "RE"),
-            "33:13: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "<NPE>"),
+            "17:34: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "RE"),
+            "33:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "<NPE>"),
             "40:12: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "E"),
-            "43:38: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "RuntimeException"),
-            "44:13: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "java.lang.RuntimeException"),
+            "43:38: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "RuntimeException"),
+            "44:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "java.lang.RuntimeException"),
         };
         verify(checkConfig, getPath("javadoc/TestGenerics.java"), expected);
     }
@@ -529,11 +529,11 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("validateThrows", "true");
         final String[] expected = {
             "8:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "RE"),
-            "17:34: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "RE"),
-            "33:13: " + getCheckMessage(MSG_EXCPECTED_TAG, "@param", "<NPE>"),
+            "17:34: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "RE"),
+            "33:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "<NPE>"),
             "40:12: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "E"),
-            "43:38: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "RuntimeException"),
-            "44:13: " + getCheckMessage(MSG_EXCPECTED_TAG, "@throws", "java.lang.RuntimeException"),
+            "43:38: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "RuntimeException"),
+            "44:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "java.lang.RuntimeException"),
         };
         verify(checkConfig, getPath("javadoc/TestGenerics.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
@@ -225,7 +225,7 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testTypeNamesForThreePermitedCapitalLettersWithOverriddenMethod() throws Exception {
+    public void testTypeNamesForThreePermittedCapitalLettersWithOverriddenMethod() throws Exception {
 
         final DefaultConfiguration checkConfig = createCheckConfig(AbbreviationAsWordInNameCheck.class);
         final int expectedCapitalCount = 3;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheckTest.java
@@ -85,6 +85,6 @@ public class LocalVariableNameCheckTest
             "19:21: " + getCheckMessage(MSG_INVALID_PATTERN, "i", pattern),
             "25:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Index", pattern),
         };
-        verify(checkConfig, getPath("InputOneCharInintVarName.java"), expected);
+        verify(checkConfig, getPath("InputOneCharInitVarName.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputOneCharInitVarName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputOneCharInitVarName.java
@@ -8,7 +8,7 @@ import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
 
-class InputOneCharInintVarName
+class InputOneCharInitVarName
 {
 	public void fooMethod()
 	{

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/annotation/BadAnnotationOverride.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/annotation/BadAnnotationOverride.java
@@ -1,16 +1,18 @@
 package com.puppycrawl.tools.checkstyle.annotation;
 
-public class GoodAnnonOverride
+public class BadAnnotationOverride
 {
     Runnable r = new Runnable() {
 
+        /**
+         * {@inheritDoc}
+         */
         public void run() {
             Throwable t = new Throwable() {
 
                 /**
                  * {@inheritDoc}
                  */
-                @Override
                 public String toString() {
                     return "junk";
                 }
@@ -21,31 +23,15 @@ public class GoodAnnonOverride
     void doFoo(Runnable r) {
         doFoo(new Runnable() {
 
+            /**
+             * {@inheritDoc}
+             */
             public void run() {
                 Throwable t = new Throwable() {
 
                     /**
                      * {@inheritDoc}
                      */
-                    @Override
-                    public String toString() {
-                        return "junk";
-                    }
-                };
-            }
-        });
-    }
-    
-    void doFoo2(Runnable r) {
-        doFoo(new Runnable() {
-
-            public void run() {
-                Throwable t = new Throwable() {
-
-                    /**
-                     * {@inheritDoc}
-                     */
-                    @java.lang.Override
                     public String toString() {
                         return "junk";
                     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/annotation/GoodAnnotationOverride.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/annotation/GoodAnnotationOverride.java
@@ -1,18 +1,16 @@
 package com.puppycrawl.tools.checkstyle.annotation;
 
-public class BadAnnonOverride
+public class GoodAnnotationOverride
 {
     Runnable r = new Runnable() {
 
-        /**
-         * {@inheritDoc}
-         */
         public void run() {
             Throwable t = new Throwable() {
 
                 /**
                  * {@inheritDoc}
                  */
+                @Override
                 public String toString() {
                     return "junk";
                 }
@@ -23,15 +21,31 @@ public class BadAnnonOverride
     void doFoo(Runnable r) {
         doFoo(new Runnable() {
 
-            /**
-             * {@inheritDoc}
-             */
             public void run() {
                 Throwable t = new Throwable() {
 
                     /**
                      * {@inheritDoc}
                      */
+                    @Override
+                    public String toString() {
+                        return "junk";
+                    }
+                };
+            }
+        });
+    }
+    
+    void doFoo2(Runnable r) {
+        doFoo(new Runnable() {
+
+            public void run() {
+                Throwable t = new Throwable() {
+
+                    /**
+                     * {@inheritDoc}
+                     */
+                    @java.lang.Override
                     public String toString() {
                         return "junk";
                     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputTestNumberFormatException.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javadoc/InputTestNumberFormatException.java
@@ -1,4 +1,4 @@
 package com.puppycrawl.tools.checkstyle.javadoc;
 
 /** <ul><li>a' {@link EntityEntry} (by way of {@link #;}</li></ul> */
-class InputTestNumberFomatException{}
+class InputTestNumberFormatException{}


### PR DESCRIPTION
Fixes some `SpellCheckingInspection` inspection violations.

Description:
>Spellchecker inspection helps locate typos and misspelling in your code, comments and literals.