### PR TITLE
Issue #46: loops should not have more then one break or continue statement

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.StringTokenizer;
 
 import antlr.collections.AST;
+
 import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -263,24 +264,15 @@ public class IllegalInstantiationCheck
         String illegalType = null;
         // import statements
         for (FullIdent importLineText : imports) {
-            final String importArg = importLineText.getText();
+            String importArg = importLineText.getText();
             if (importArg.endsWith(".*")) {
-                final String fqClass =
-                    importArg.substring(0, importArg.length() - 1)
-                    + className;
-                // assume that illegalInstances only contain existing classes
-                // or else we might create a false alarm here
-                if (illegalClasses.contains(fqClass)) {
-                    illegalType = fqClass;
-                    break;
-                }
+                importArg = importArg.substring(0, importArg.length() - 1)
+                        + className;
             }
-            else {
-                if (CommonUtils.baseClassName(importArg).equals(className)
+            if (CommonUtils.baseClassName(importArg).equals(className)
                     && illegalClasses.contains(importArg)) {
-                    illegalType = importArg;
-                    break;
-                }
+                illegalType = importArg;
+                break;
             }
         }
         return illegalType;


### PR DESCRIPTION
Restricting the number of break and continue statements in a loop is done in the interest of good structured programming.

One break and continue statement is acceptable in a loop, since it facilitates optimal coding. If there is more than one, the code should be refactored to increase readability.
