### PR TITLE
Issue #2065: Remove additional context from IDEA suppression

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
@@ -37,7 +37,7 @@ public final class PropertiesExpander
      * @param properties the underlying properties to use for
      *     property resolution.
      * @throws IllegalArgumentException indicates null was passed
-     * @noinspection IDEA CollectionDeclaredAsConcreteClass
+     * @noinspection CollectionDeclaredAsConcreteClass
      */
     public PropertiesExpander(Properties properties) {
         if (properties == null) {


### PR DESCRIPTION
While suppression works fine, it causes false positive in `RedundantSuppression` inspection reported as [IDEA-144818](https://youtrack.jetbrains.com/issue/IDEA-144818).

Tag `@noinspection` is self-descriptive enough on its own.