### PR TITLE
Issue #2080: Fix typos in code

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -347,14 +347,14 @@
 
     <module name="MissingCtor">
       <!--
-        we will not uset that fanatic validation, extra code is not good
+        we will not use that fanatic validation, extra code is not good
         But this Check will exists as it was created by community demand.
       -->
       <property name="severity" value="ignore"/>
     </module>
     <module name="RequireThis">
       <!--
-        we will not uset that fanatic validation, extra modifiers polute a code
+        we will not use that fanatic validation, extra modifiers pollute a code
         it is better to use different names for arguments, or expect IDE to highlight field.
         But this Check will exists as it was created by community demand.
       -->
@@ -362,7 +362,7 @@
     </module>
     <module name="FinalParameters">
       <!--
-        we will not uset that fanatic validation, extra modifiers polute a code
+        we will not use that fanatic validation, extra modifiers pollute a code
         it is better to use extra validation(Check) that argument is reassigned
         But this Check will exists as it was created by community demand.
       -->

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
@@ -18,7 +18,7 @@ public class CustomImportOrderTest extends BaseCheckTestSupport{
     private static final String MSG_ORDER = "custom.import.order";
     private static ConfigurationBuilder builder;
     private final Class<CustomImportOrderCheck> clazz = CustomImportOrderCheck.class;
-    String msgNongroup = "custom.import.order.nonGroup.import";
+    String msgNonGroup = "custom.import.order.nonGroup.import";
 
     /** Shortcuts to make code more compact. */
     private static final String STD = CustomImportOrderCheck.STANDARD_JAVA_PACKAGE_RULE_GROUP;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -208,7 +208,7 @@ public final class Main {
     }
 
     /**
-     * Util method to convert ComandLine type to POJO object.
+     * Util method to convert CommandLine type to POJO object.
      * @param cmdLine command line object
      * @return command line option as POJO object
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -290,7 +290,7 @@ public final class TreeWalker
         }
         else if (TokenUtils.isCommentType(token)) {
             final String message = String.format("Check '%s' waits for comment type "
-                    + "token ('%s') and should override 'isCommentNodesRequred()' "
+                    + "token ('%s') and should override 'isCommentNodesRequired()' "
                     + "method to return 'true'", check.getClass().getName(), token);
             LOG.warn(message);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -35,7 +35,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 /**
  * Simple XML logger.
  * It outputs everything in UTF-8 (default XML encoding is UTF-8) in case
- * we want to localize error messages or simply that filenames are
+ * we want to localize error messages or simply that file names are
  * localized and takes care about escaping as well.
 
  * @author <a href="mailto:stephane.bailliez@wanadoo.fr">Stephane Bailliez</a>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -34,8 +34,8 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtils;
  * implemented by subclasses.
  * </p>
  *
- * <p>The exact rule is that nonprivate, nonstatic methods in
- * nonfinal classes (or classes that do not
+ * <p>The exact rule is that non-private, non-static methods in
+ * non-final classes (or classes that do not
  * only have private constructors) must either be
  * <ul>
  * <li>abstract or</li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
@@ -135,7 +135,7 @@ public class NoWhitespaceBeforeCheck
     }
 
     /**
-     * Control whether whitespace is flagged at linebreaks.
+     * Control whether whitespace is flagged at line breaks.
      * @param allowLineBreaks whether whitespace should be
      *     flagged at line breaks.
      */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -125,10 +125,10 @@ public class CheckerTest {
         assertFalse("Checker.fireFileFinished() does call removed listener", auditAdapter.wasCalled());
 
         aa2.resetListener();
-        final SortedSet<LocalizedMessage> msgs = Sets.newTreeSet();
-        msgs.add(new LocalizedMessage(0, 0, "a Bundle", "message.key",
+        final SortedSet<LocalizedMessage> messages = Sets.newTreeSet();
+        messages.add(new LocalizedMessage(0, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
-        checker.fireErrors("Some File Name", msgs);
+        checker.fireErrors("Some File Name", messages);
         assertTrue("Checker.fireErrors() doesn't call listener", aa2.wasCalled());
         assertFalse("Checker.fireErrors() does call removed listener", auditAdapter.wasCalled());
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -77,10 +77,10 @@ public class ConfigurationLoaderTest {
             "src/test/resources/com/puppycrawl/tools/checkstyle/configs/checkstyle_checks.xml", new PropertiesExpander(props));
 
         //verify the root, and property substitution
-        final Properties atts = new Properties();
-        atts.setProperty("tabWidth", "4");
-        atts.setProperty("basedir", "basedir");
-        verifyConfigNode(config, "Checker", 3, atts);
+        final Properties attributes = new Properties();
+        attributes.setProperty("tabWidth", "4");
+        attributes.setProperty("basedir", "basedir");
+        verifyConfigNode(config, "Checker", 3, attributes);
     }
 
     @Test
@@ -323,7 +323,7 @@ public class ConfigurationLoaderTest {
     }
 
     @Test
-    public void testExternalEntitySubdir() throws Exception {
+    public void testExternalEntitySubdirectory() throws Exception {
         final Properties props = new Properties();
         props.setProperty("checkstyle.basedir", "basedir");
 
@@ -331,10 +331,10 @@ public class ConfigurationLoaderTest {
             (DefaultConfiguration) loadConfiguration(
                 "subdir/including.xml", props);
 
-        final Properties atts = new Properties();
-        atts.setProperty("tabWidth", "4");
-        atts.setProperty("basedir", "basedir");
-        verifyConfigNode(config, "Checker", 2, atts);
+        final Properties attributes = new Properties();
+        attributes.setProperty("tabWidth", "4");
+        attributes.setProperty("basedir", "basedir");
+        verifyConfigNode(config, "Checker", 2, attributes);
     }
 
     @Test
@@ -360,9 +360,9 @@ public class ConfigurationLoaderTest {
             Class<?> aClassParent = ConfigurationLoader.class;
             Constructor<?> ctorParent = null;
             Constructor<?>[] parentConstructors = aClassParent.getDeclaredConstructors();
-            for (Constructor<?> constr: parentConstructors) {
-                constr.setAccessible(true);
-                ctorParent = constr;
+            for (Constructor<?> parentConstructor: parentConstructors) {
+                parentConstructor.setAccessible(true);
+                ctorParent = parentConstructor;
             }
             Class<?> aClass = Class.forName("com.puppycrawl.tools.checkstyle."
                     + "ConfigurationLoader$InternalLoader");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -119,12 +119,12 @@ public class PackageNamesLoaderTest {
 
         URL url = getMockUrl(mockConnection);
 
-        Enumeration<URL> enumer = (Enumeration<URL>) mock(Enumeration.class);
-        when(enumer.hasMoreElements()).thenReturn(true);
-        when(enumer.nextElement()).thenReturn(url);
+        Enumeration<URL> enumeration = (Enumeration<URL>) mock(Enumeration.class);
+        when(enumeration.hasMoreElements()).thenReturn(true);
+        when(enumeration.nextElement()).thenReturn(url);
 
         ClassLoader classLoader = mock(ClassLoader.class);
-        when(classLoader.getResources("checkstyle_packages.xml")).thenReturn(enumer);
+        when(classLoader.getResources("checkstyle_packages.xml")).thenReturn(enumeration);
 
         try {
             PackageNamesLoader.getPackageNames(classLoader);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -52,7 +52,7 @@ public class PropertyCacheFileTest {
 
     @Test
     public void testNonAccessibleFile() throws IOException {
-        Configuration config = new DefaultConfiguration("myname");
+        Configuration config = new DefaultConfiguration("myName");
         final File file = temporaryFolder.newFile("file.output");
         file.setReadable(true, false);
         file.setWritable(false, false);
@@ -69,7 +69,7 @@ public class PropertyCacheFileTest {
             assertEquals("config can not be null", ex.getMessage());
         }
         try {
-            Configuration config = new DefaultConfiguration("myname");
+            Configuration config = new DefaultConfiguration("myName");
             new PropertyCacheFile(config, null);
         }
         catch (IllegalArgumentException ex) {
@@ -79,7 +79,7 @@ public class PropertyCacheFileTest {
 
     @Test
     public void testInCache() throws IOException {
-        Configuration config = new DefaultConfiguration("myname");
+        Configuration config = new DefaultConfiguration("myName");
         final String filePath = temporaryFolder.newFile().getPath();
         PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
         cache.put("myFile", 1);
@@ -92,7 +92,7 @@ public class PropertyCacheFileTest {
     @SuppressWarnings("unchecked")
     public void testException_NoSuchAlgorithmException() throws Exception {
 
-        Configuration config = new DefaultConfiguration("myname");
+        Configuration config = new DefaultConfiguration("myName");
         final String filePath = temporaryFolder.newFile().getPath();
         PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
         cache.put("myFile", 1);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -261,7 +261,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testProcessWithParserTrowable() throws Exception {
+    public void testProcessWithParserThrowable() throws Exception {
         final TreeWalker treeWalker = new TreeWalker();
         treeWalker.configure(createCheckConfig(TypeNameCheck.class));
         PackageObjectFactory factory = new PackageObjectFactory(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheckTest.java
@@ -59,7 +59,7 @@ public class InnerAssignmentCheckTest
     }
 
     @Test
-    public void testLambdExpression() throws Exception {
+    public void testLambdaExpression() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(InnerAssignmentCheck.class);
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;


### PR DESCRIPTION
Fixes some `SpellCheckingInspection` inspection violations.

Description:
>Spellchecker inspection helps locate typos and misspelling in your code, comments and literals.