### PR TITLE
Issue #1555: Remove usage of obsolete junit.framework.Assert class

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CommitValidationTest.java
@@ -19,7 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Collections;


### PR DESCRIPTION
Fixes `UseOfObsoleteAssert` inspection violations introduced in #1518.

Description:
>Reports any calls to methods from the junit.framework.Assert class. This class is obsolete and the calls can be replaced by calls to methods from the org.junit.Assert class.