### PR TITLE
Issue 1537: Fix RedundantModifier check to recognise inner classes

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
@@ -314,14 +314,28 @@ public class RedundantModifierCheck
     }
 
     /**
-     * Checks if given class ast has public modifier.
-     * @param classDef class ast
-     * @return true if class is public, false otherwise
+     * Checks if given class is accessible from "public" scope.
+     * @param ast class def to check
+     * @return true if class is accessible from public scope,false otherwise
      */
-    private static boolean isClassPublic(DetailAST classDef) {
-        final DetailAST classModifiers =
-                classDef.findFirstToken(TokenTypes.MODIFIERS);
-        return classModifiers.branchContains(TokenTypes.LITERAL_PUBLIC);
+    private static boolean isClassPublic(DetailAST ast) {
+        boolean isAccessibleFromPublic = false;
+        final boolean isMostOuterScope = ast.getParent() == null;
+        final DetailAST modifiersAst = ast.findFirstToken(TokenTypes.MODIFIERS);
+        final boolean hasPublicModifier = modifiersAst.branchContains(TokenTypes.LITERAL_PUBLIC);
+
+        if (isMostOuterScope) {
+            isAccessibleFromPublic = hasPublicModifier;
+        }
+        else {
+            final DetailAST parentClassAst = ast.getParent().getParent();
+
+            if (parentClassAst.getType() == TokenTypes.INTERFACE_DEF || hasPublicModifier) {
+                isAccessibleFromPublic = isClassPublic(parentClassAst);
+            }
+        }
+
+        return isAccessibleFromPublic;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierTest.java
@@ -123,9 +123,26 @@ public class RedundantModifierTest
                 createCheckConfig(RedundantModifierCheck.class);
 
         final String[] expected = {
-            "15:5: " + getCheckMessage(MSG_KEY, "public"),
+            "18:5: "  + getCheckMessage(MSG_KEY, "public"),
         };
         verify(checkConfig, getPath("InputRedundantPublicModifierInNotPublicClass.java"), expected);
+    }
+
+    @Test
+    public void testNestedClassConsInPublicInterfaceHasValidPublicModifier() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(RedundantModifierCheck.class);
+
+        final String[] expected = {
+            "18:33: " + getCheckMessage(MSG_KEY, "public"),
+            "22:41: " + getCheckMessage(MSG_KEY, "public"),
+            "33:33: " + getCheckMessage(MSG_KEY, "public"),
+            "41:33: " + getCheckMessage(MSG_KEY, "public"),
+        };
+
+        verify(checkConfig,
+                getPath("InputNestedClassInPublicInterfaceRedundantModifiers.java"),
+                expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputNestedClassInPublicInterfaceRedundantModifiers.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputNestedClassInPublicInterfaceRedundantModifiers.java
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for checkstyle.
+// Created: 2015
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle;
+
+public interface InputNestedClassInPublicInterfaceRedundantModifiers {
+        interface PublicInnerInterface {
+                interface PublicInnerInnerInterface {
+                        class PublicInnerClassInNestedPublicInterfaces {
+                                public PublicInnerClassInNestedPublicInterfaces() { } // OK in public class
+                        }
+                }
+        }
+        class PublicClassInsideInterface {
+                private interface PrivateNestedInterface {
+                        class ClassInPrivateNestedInterface {
+                                public ClassInPrivateNestedInterface() { } // Redundant in not public class
+                        }
+                        public interface PrivateNestedInterfaceWithPublicModifier {
+                                class ClassInPrivateNestedInterface {
+                                        public ClassInPrivateNestedInterface() { } // Redundant in non public scope
+                                }
+                        }
+                }
+                public interface PublicInnerInnerPublicInterface {
+                        class PublicInnerClassInNestedPublicInterfaces {
+                                public PublicInnerClassInNestedPublicInterfaces() { } // OK in public class
+                        }
+                }
+                protected interface PublicInnerInnerProtectedInterface {
+                        class PublicInnerClassInNestedProtectedInterfaces {
+                                public PublicInnerClassInNestedProtectedInterfaces() { } // Redundant in non public scope
+                        }
+                }
+        }
+        class PublicNestedClassInInterfaceWithPublicConstructor {
+                public PublicNestedClassInInterfaceWithPublicConstructor() { } // OK in public class
+                private class PrivateClassInPublicNestedClass {
+                        public class PublicInPrivateClass {
+                                public PublicInPrivateClass() { } // Redundant in non public class
+                        }
+                }
+        }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputRedundantPublicModifierInNotPublicClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputRedundantPublicModifierInNotPublicClass.java
@@ -9,6 +9,9 @@ public class InputRedundantPublicModifierInNotPublicClass {
     protected class ProtectedClass {
         public ProtectedClass() {}
     }
+    public class PublicInnerClass {
+        public PublicInnerClass() { } // OK for class accessible from public scope
+    }
 }
 
 class PackagePrivateClass {
@@ -17,4 +20,5 @@ class PackagePrivateClass {
 
 class PackagePrivateClassWithNotRedundantConstructor {
     PackagePrivateClassWithNotRedundantConstructor() {}
+
 }


### PR DESCRIPTION
accessible from global scope

https://github.com/checkstyle/checkstyle/issues/1537#issuecomment-137801779

Problem was that in previous PR i assumed that class without explicit public modifier is non public so constructor "public" modifier is redundant because it cant be accessed in global scope. It is simply false because it can be nested in interfaces,public classes making it globally accessible  - for example

```java
public interface InputNestedClassInPublicInterfaceRedundantModifiers {
        interface PublicInnerInterface {
                interface PublicInnerInnerInterface {
                        class PublicInnerClassInNestedPublicInterfaces {
                                public PublicInnerClassInNestedPublicInterfaces() { } // OK in public class
                        }
                }
        }
```

Class PublicInnerClassInNestedPublicInterfaces can be accessed globally so "public" in constructor is not redundant.

Second bad assumption was that class with explicit "public" modifier must be public, but that is false as well. It can be nested pretty deep and if it is public or not depends on modifiers of their parents classes/interfaces. For example:

```java
class PublicNestedClassInInterfaceWithPublicConstructor {
                public PublicNestedClassInInterfaceWithPublicConstructor() { } // OK in public class
                private class PrivateClassInPublicNestedClass {
                        public class PublicInPrivateClass {
                                public PublicInPrivateClass() { } // Redundant in non public class
                        }
                }
}
```

Class PublicInPrivateClass has "public" modifier but it is not globally accessible - it can be accessed only within PublicNestedClassInInterfaceWithPublicConstructor.

Solution suggested by this commit is to check if given class is really accessible from global context going through parents of nested classes/interfaces and checking their accessibility.