### PR TITLE
Issue #2137: Make test for FileTabCharacter locale and OS independent

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.api;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -192,6 +193,9 @@ public final class FileText extends AbstractList<String> {
      */
     private static String readFile(final File inputFile, final CharsetDecoder decoder)
             throws IOException {
+        if (!inputFile.exists()) {
+            throw new FileNotFoundException(inputFile.getPath() + " (No such file or directory)");
+        }
         final StringBuilder buf = new StringBuilder();
         final FileInputStream stream = new FileInputStream(inputFile);
         final Reader reader = new InputStreamReader(stream, decoder);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheckTest.java
@@ -23,7 +23,6 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacter
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck.FILE_CONTAINS_TAB;
 
 import java.io.File;
-import java.util.Locale;
 
 import org.junit.Test;
 
@@ -78,11 +77,7 @@ public class FileTabCharacterCheckTest
     public void testBadFile() throws Exception {
         final DefaultConfiguration checkConfig = createConfig(false);
         final String path = getPath("Claira");
-        String exceptionMessage = " (No such file or directory)";
-        if (System.getProperty("os.name")
-                .toLowerCase(Locale.ENGLISH).startsWith("windows")) {
-            exceptionMessage = " (The system cannot find the file specified)";
-        }
+        final String exceptionMessage = " (No such file or directory)";
 
         final String[] expected = {
             "0: Got an exception - " + path + exceptionMessage,


### PR DESCRIPTION
Constructor of `FileInputStream` throws `FileNotFoundException`, but validation happens in native method:
```java
    /**
     * Opens the specified file for reading.
     * @param name the name of the file
     */
    private native void open0(String name) throws FileNotFoundException;
```
Error message is locale and system dependent, so it cannot be reliably checked in test. It's better to use manual file existence validation instead.