### PR TITLE
Issue #157: fix java grammar for unicode escape

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
@@ -1796,7 +1796,7 @@ ESC
             (options { generateAmbigWarnings=false; }
             :    '0' '0' '5' ('c'|'C')
                 (options { generateAmbigWarnings=false; }
-                :    '\\' ('u')+ '0' '0' '5' ('c'|'C')
+                :    '\\' ('u')+ HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
                 |    STD_ESC
                 )
             |    HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/UnicodeEscape.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/UnicodeEscape.java
@@ -22,6 +22,8 @@ public class UnicodeEscape
     char o = '\u005B';
     char p = '\uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu005cr'; // Tests the lookahead
     char q = '\uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu005D';
+    char r = '\u005c\u0027';
+    char s = '\uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu005c\uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu0027';
     
     char wtf1 = '\u005c\u005c'; // This is a legal backslash
     String wtf2 = "\\u005c";    // = "\u005c", with a single backslash, and != a backslash!
@@ -29,4 +31,11 @@ public class UnicodeEscape
     //char wtf3 = '\\u005c';    // This is therefore, illegal
 
     //char z = '\u005cu005c'; /* This is illegal */
+    
+    String sa = "\u0078\u006b\u0020\u005c\u0022\u003f\u0020\u19e8\u19f2\u19ec";
+    String sb = "ihcp gyqnaznr \u2d21\u2d07\u2d0a\u2d02\u2d23\u2d27";
+    String sc = "\u3009\u3007\u3017\u3032 ]*+f?)).[. xhc";
+    String sd = "\u1f073\u1f08a\u1f09d\u1f09a nfllv \u03ac\udd762\u029c";
+    String se = "\u0721\ue723\ue76eM \u2ffc\u2ff1 \u123e1 tzouw \ufadaZ";
+    String sf = "abc\uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu005c\u0022def";
 }


### PR DESCRIPTION
Fixed grammar for '\u005C\uXXXX' and added 2 test cases for the issue.