### PR TITLE
Issue #1273: CustomImportOrderCheck rule priorities

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder2.java
@@ -1,20 +1,28 @@
 package com.puppycrawl.tools.checkstyle.imports;
 
 import static java.io.File.createTempFile;
-import static java.awt.Button.ABORT;
+import static java.awt.Button.ABORT; //warn, LEXIC, should be before java.io.File.createTempFile
 import static javax.swing.WindowConstants.*;
 
-import java.util.List;
-import java.util.StringTokenizer;
-import java.util.*;
-import java.util.concurrent.AbstractExecutorService;
-import java.util.concurrent.*;
+import java.util.List; //warn, LEXIC, should be before javax.swing.WindowConstants.*
+import java.util.StringTokenizer; //warn, LEXIC, should be before javax.swing.WindowConstants.*
+import java.util.*; //warn, LEXIC, should be before javax.swing.WindowConstants.*
+import java.util.concurrent.AbstractExecutorService; //warn, LEXIC, should be before javax.swing.WindowConstants.*
+import java.util.concurrent.*; //warn, LEXIC, should be before javax.swing.WindowConstants.*
 
 import com.puppycrawl.tools.*;
-import com.*;
+import com.*; //warn, LEXIC, should be before com.puppycrawl.tools.*
 
-import com.google.common.base.*;
+import com.google.common.base.*; //warn, LEXIC, should be before com.puppycrawl.tools.*
 import org.junit.*;
 
 public class InputCustomImportOrder2 {
 }
+/*
+test: testOrderRuleWithOneGroup()
+configuration:
+        checkConfig.addAttribute("thirdPartyPackageRegExp", "org.");
+        checkConfig.addAttribute("customImportOrderRules",
+                "STANDARD_JAVA_PACKAGE");
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
+*/

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder_MultiplePatternMatches.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder_MultiplePatternMatches.java
@@ -1,0 +1,6 @@
+package com.puppycrawl.tools.checkstyle.imports;
+
+import org.junit.Test;
+
+public class InputCustomImportOrder_MultiplePatternMatches {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder_OverlappingPatterns.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/imports/InputCustomImportOrder_OverlappingPatterns.java
@@ -1,0 +1,37 @@
+package com.puppycrawl.tools.checkstyle.checks.imports;
+
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderOption;
+
+// every import from javadoc package has comment in brackets indicating presence of keywords
+// Javadoc, Check, Tag. For example J_T = Javadoc, no Check, Tag
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl; //warn, should be on THIRD-PARTY (J__)
+
+// STANDARD - keyword Check
+
+import com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck; // (JC_)
+import com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck; // (_C_)
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagContinuationIndentationCheck; // (JCT)
+
+// SPECIAL_IMPORTS - keyword Tag
+
+import com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocTag; // (J_T)
+//import com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser; // (__T)
+import com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck; //warn, should be on STANDARD (_CT)
+
+import com.puppycrawl.tools.*;
+//import com.puppycrawl.tools.checkstyle.checks.javadoc.HtmlTag; //warn, should be on SPECIAL (__T)
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTag; //warn, should be on SPECIAL (J_T)
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck; //warn, should be on STANDARD  (JC_)
+import com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck; //warn, should be on STANDARD (_C_)
+
+public class InputCustomImportOrder_OverlappingPatterns {
+}
+/*
+test: testRulesOrder_ThirdBeforeSame()
+configuration:
+        checkConfig.addAttribute("customImportOrderRules",
+                "THIRD_PARTY_PACKAGE###SAME_PACKAGE(3)###SPECIAL_IMPORTS");
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
+*/

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -825,7 +825,49 @@ import java.util.regex.Matcher; //#8
         <p>
           Use the separator '###' between rules.
         </p>
-      </subsection>
+        <p>
+          To set RegExps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
+          thirdPartyPackageRegExp and standardPackageRegExp options.
+        </p>
+        <p>
+          Pretty often one import can match more than one group. For example, static import from standard
+          package or regular expressions are configured to allow one import match multiple groups.
+          In this case, group will be assigned according to priorities:
+        </p>
+        <ol>
+          <li>STATIC has top priority</li>
+          <li>SAME_PACKAGE has second priority</li>
+          <li>STANDARD_JAVA_PACKAGE and SPECIAL_IMPORTS will compete using "best match" rule: longer
+          matching substring wins; in case of the same length, lower position of matching substring
+          wins; if position is the same, order of rules in configuration solves the puzzle.</li>
+          <li>THIRD_PARTY has the least priority</li>
+        </ol>
+        <p>
+          Few examples to illustrate "best match":
+        </p>
+        <p>
+          1. patterns STANDARD_JAVA_PACKAGE = "Check", SPECIAL_IMPORTS="ImportOrderCheck" and input file:
+        </p>
+        <source>
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+        </source>
+        <p>
+          Result: imports will be assigned to SPECIAL_IMPORTS, because matching substring length is 16. Matching
+          substring for STANDARD_JAVA_PACKAGE is 5.
+        </p>
+        <p>
+          2. patterns STANDARD_JAVA_PACKAGE = "Check", SPECIAL_IMPORTS="Avoid" and file:
+        </p>
+        <source>
+import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
+        </source>
+        <p>
+          Result: import will be assigned to SPECIAL_IMPORTS. Matching substring length is 5 for both
+          patterns. However, "Avoid" position is lower then "Check" position.
+        </p>
+
+    </subsection>
 
       <subsection name="Properties">
         <table>


### PR DESCRIPTION
Fixed. 
Also made few minor changes on Javadoc, mainly by removing `{@code }` for XML examples because it caused `&lt;` not being resolved to `<`