### PR TITLE
Deploy snapshots versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   include:
     # unit tests (oraclejdk8)
     - jdk: oraclejdk8
-      env: DESC="tests" CMD="mvn clean integration-test failsafe:verify" COVERAGE_CMD=""
+      env: DESC="tests" CMD="mvn clean integration-test failsafe:verify" COVERAGE_CMD="" DEPLOY="true"
 
     # checkstyle (oraclejdk8)
     - jdk: oraclejdk8
@@ -211,6 +211,7 @@ script: eval $CMD
 
 after_success:
   - eval $COVERAGE_CMD
+  - if [[ $TRAVIS_REPO_SLUG == 'checkstyle/checkstyle' && $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' && $DEPLOY == 'true' ]]; then mvn -s config/deploy-settings.xml deploy ; fi
 
 cache:
   directories:

--- a/config/deploy-settings.xml
+++ b/config/deploy-settings.xml
@@ -1,0 +1,9 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>sonatype-nexus-snapshots</id>
+      <username>${env.CI_DEPLOY_USERNAME}</username>
+      <password>${env.CI_DEPLOY_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>


### PR DESCRIPTION
Implements #2167.

The credentials of a Sonatype JIRA account which has access to the OSSRH repo, should be added in the [Travis settings](https://travis-ci.org/checkstyle/checkstyle/settings). Two secure environment variables are needed, `CI_DEPLOY_USERNAME` and `CI_DEPLOY_PASSWORD`.

I added the deployment to the `# unit tests (oraclejdk8)` job of the build matrix. I am not sure this is appropriate, so i need opinion on that.

Also, i cannot test this PR, so hopefully this works. It can be tested locally with executing the following command:
```sh
# set the two environment variables first
mvn -s config/deploy-settings.xml deploy
```