### PR TITLE
Correct ITs for NonEmptyAtclauseDescription and JavadocTagContinuationIndentation

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/JavadocTagContinuationIndentationTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/JavadocTagContinuationIndentationTest.java
@@ -2,58 +2,38 @@ package com.google.checkstyle.test.chapter7javadoc.rule713atclauses;
 
 import java.io.File;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.BaseCheckTestSupport;
 import com.google.checkstyle.test.base.ConfigurationBuilder;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
-import com.puppycrawl.tools.checkstyle.checks.coding.NoFinalizerCheck;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagContinuationIndentationCheck;
 
 public class JavadocTagContinuationIndentationTest extends BaseCheckTestSupport{
 
-    private static ConfigurationBuilder builder;
-
-    @BeforeClass
-    public static void setConfigurationBuilder() {
-        builder = new ConfigurationBuilder(new File("src/it/"));
-    }
-
     @Test
-    public void noFinalizerBasicTest() throws Exception {
-        
-        String msg = getCheckMessage(NoFinalizerCheck.class, "avoid.finalizer.method");
+    public void testWithDefaultConfiguration() throws Exception {
+        ConfigurationBuilder builder = new ConfigurationBuilder(new File("src/it/"));
+        String msg = getCheckMessage(JavadocTagContinuationIndentationCheck.class,
+                "tag.continuation.indent", 4);
 
         final String[] expected = {
-            "5: " + msg,
+            "47: " + msg,
+            "109: " + msg,
+            "112: " + msg,
+            "203: " + msg,
+            "206: " + msg,
+            "221: " + msg,
+            "223: " + msg,
+            "285: " + msg,
+            "288: " + msg,
+            "290: " + msg,
+            "310: " + msg,
+            "322: " + msg,
         };
 
-        Configuration checkConfig = builder.getCheckConfig("NoFinalizer");
-        String filePath = builder.getFilePath("NoFinalizerInput");
-        
-        Integer[] warnList = builder.getLinesWithWarn(filePath);
-        verify(checkConfig, filePath, expected, warnList);
-    }
-    
-    @Test
-    public void noFinalizerExtendedTest() throws Exception {
-        
-        String msg = getCheckMessage(NoFinalizerCheck.class, "avoid.finalizer.method");
-
-        final String[] expected = {
-            "9: " + msg,
-            "21: " + msg,
-            "33: " + msg,
-            "45: " + msg,
-            "57: " + msg,
-            "69: " + msg,
-            "79: " + msg,
-            "119: " + msg,
-            "136: " + msg,
-        };
-
-        Configuration checkConfig = builder.getCheckConfig("NoFinalizer");
-        String filePath = builder.getFilePath("NoFinalizeExtendInput");
+        Configuration checkConfig = builder.getCheckConfig("JavadocTagContinuationIndentation");
+        String filePath = builder.getFilePath("InputJavaDocTagContinuationIndentation");
         
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/NonEmptyAtclauseDescriptionTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/NonEmptyAtclauseDescriptionTest.java
@@ -1,5 +1,6 @@
 package com.google.checkstyle.test.chapter7javadoc.rule713atclauses;
 
+
 import java.io.File;
 
 import org.junit.BeforeClass;
@@ -8,7 +9,7 @@ import org.junit.Test;
 import com.google.checkstyle.test.base.BaseCheckTestSupport;
 import com.google.checkstyle.test.base.ConfigurationBuilder;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
-import com.puppycrawl.tools.checkstyle.checks.coding.NoFinalizerCheck;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck;
 
 public class NonEmptyAtclauseDescriptionTest extends BaseCheckTestSupport{
 
@@ -20,42 +21,62 @@ public class NonEmptyAtclauseDescriptionTest extends BaseCheckTestSupport{
     }
 
     @Test
-    public void noFinalizerBasicTest() throws Exception {
-        
-        String msg = getCheckMessage(NoFinalizerCheck.class, "avoid.finalizer.method");
+    public void testDefaultConfiguration() throws Exception {
+        String msg = getCheckMessage(NonEmptyAtclauseDescriptionCheck.class, "non.empty.atclause");
 
         final String[] expected = {
-            "5: " + msg,
+            "34: " + msg,
+            "35: " + msg,
+            "36: " + msg,
+            "37: " + msg,
+            "38: " + msg,
+            "39: " + msg,
+            "48: " + msg,
+            "49: " + msg,
+            "50: " + msg,
+            "51: " + msg,
+            "52: " + msg,
         };
 
-        Configuration checkConfig = builder.getCheckConfig("NoFinalizer");
-        String filePath = builder.getFilePath("NoFinalizerInput");
+        Configuration checkConfig = builder.getCheckConfig("NonEmptyAtclauseDescription");
+        String filePath = builder.getFilePath("InputNonEmptyAtclauseDescriptionCheck");
         
-        Integer[] warnList = builder.getLinesWithWarn(filePath);
+        Integer[] warnList = getLineNumbersFromExpected(expected);
         verify(checkConfig, filePath, expected, warnList);
     }
-    
+
     @Test
-    public void noFinalizerExtendedTest() throws Exception {
-        
-        String msg = getCheckMessage(NoFinalizerCheck.class, "avoid.finalizer.method");
+    public void testSpaceSequence() throws Exception {
+        String msg = getCheckMessage(NonEmptyAtclauseDescriptionCheck.class, "non.empty.atclause");
 
         final String[] expected = {
-            "9: " + msg,
-            "21: " + msg,
-            "33: " + msg,
-            "45: " + msg,
-            "57: " + msg,
-            "69: " + msg,
-            "79: " + msg,
-            "119: " + msg,
-            "136: " + msg,
+            "27: " + msg,
+            "28: " + msg,
+            "29: " + msg,
+            "38: " + msg,
+            "39: " + msg,
+            "40: " + msg,
         };
 
-        Configuration checkConfig = builder.getCheckConfig("NoFinalizer");
-        String filePath = builder.getFilePath("NoFinalizeExtendInput");
+        Configuration checkConfig = builder.getCheckConfig("NonEmptyAtclauseDescription");
+        String filePath = builder.getFilePath("InputNonEmptyAtclauseDescriptionCheckSpaceSeq");
         
-        Integer[] warnList = builder.getLinesWithWarn(filePath);
+        Integer[] warnList = getLineNumbersFromExpected(expected);
         verify(checkConfig, filePath, expected, warnList);
+    }
+
+    /**
+     * Gets line numbers with violations from an array with expected messages.
+     * This is used as using "warn" comments in input files would affects the work
+     * of the Check.
+     * @param expected an array with expected messages.
+     * @return Integer array with numbers of lines with violations.
+     */
+    private static Integer[] getLineNumbersFromExpected(String[] expected) {
+        Integer[] result = new Integer[expected.length];
+        for (int i = 0; i < expected.length; i++) {
+            result[i] = Integer.valueOf(expected[i].substring(0, expected[i].indexOf(':')));
+        }
+        return result;
     }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputNonEmptyAtclauseDescriptionCheck.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputNonEmptyAtclauseDescriptionCheck.java
@@ -3,48 +3,6 @@ package com.google.checkstyle.test.chapter7javadoc.rule713atclauses;
 class InputNonEmptyAtclauseDescriptionCheck
 {
 	/**
-	 * Some javadoc.
-	 * @param a Some javadoc.
-	 * @param b Some javadoc.
-	 */
-	public InputNonEmptyAtclauseDescriptionCheck(String a, int b)
-	{
-		
-	}
-	
-	/**
-	 * Some javadoc.
-	 * @param a Some javadoc.
-	 * @deprecated Some javadoc.
-	 */
-	public InputNonEmptyAtclauseDescriptionCheck(String a)
-	{
-		
-	}
-	
-	/**
-	 * Some javadoc.
-	 * @param a                     
-	 * @param b           
-	 * @param c     
-	 */
-	public InputNonEmptyAtclauseDescriptionCheck(String a, int b, double c)
-	{
-		
-	}
-	
-	/**
-	 * 
-	 * @param a  
-	 * @param e     
-	 * @deprecated     
-	 */
-	public InputNonEmptyAtclauseDescriptionCheck(String a, boolean e)
-	{
-		
-	}
-	
-	/**
 	 * Some javadoc
 	 * @param a Some javadoc
 	 * @param b Some javadoc

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputNonEmptyAtclauseDescriptionCheckSpaceSeq.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputNonEmptyAtclauseDescriptionCheckSpaceSeq.java
@@ -1,0 +1,46 @@
+package com.google.checkstyle.test.chapter7javadoc.rule713atclauses;
+
+class InputNonEmptyAtclauseDescriptionCheckSpaceSeq
+{
+        /**
+         * Some javadoc.
+         * @param a Some javadoc.
+         * @param b Some javadoc.
+         */
+        public InputNonEmptyAtclauseDescriptionCheckSpaceSeq(String a, int b)
+        {
+                
+        }
+        
+        /**
+         * Some javadoc.
+         * @param a Some javadoc.
+         * @deprecated Some javadoc.
+         */
+        public InputNonEmptyAtclauseDescriptionCheckSpaceSeq(String a)
+        {
+                
+        }
+        
+        /**
+         * Some javadoc.
+         * @param a                     
+         * @param b           
+         * @param c     
+         */
+        public InputNonEmptyAtclauseDescriptionCheckSpaceSeq(String a, int b, double c)
+        {
+                
+        }
+        
+        /**
+         * 
+         * @param a  
+         * @param e     
+         * @deprecated     
+         */
+        public InputNonEmptyAtclauseDescriptionCheckSpaceSeq(String a, boolean e)
+        {
+                
+        }
+}


### PR DESCRIPTION
In NonEmptyAtclauseDescriptionTest the only way I found possible to write "//warn" comments in the input file is
```java
/**
 	 * Some javadoc.  
 	 * @param c     	 */ //warn
```
But this would make the test incomplete, I guess.