### PR TITLE
Pull #2182: Update Maven Project Info Reports Plugin to 2.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -856,7 +856,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.8</version>
+        <version>2.8.1</version>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Release Notes - Apache Maven Project Info Reports Plugin - Version 2.8.1

Bug
* [MPIR-300] Reporting plugins are reported with wrong version if version
specified via pluginManagement

Improvement
* [MPIR-329] French translation in project-info-report_fr.properties

Task
* [MPIR-333] switch to Fluido
* [MPIR-332] don't warn when removing path from git scm url