### PR TITLE
Pull #2183: Update Maven Wagon to 2.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -514,7 +514,7 @@
           <dependency>
             <groupId>org.apache.maven.wagon</groupId>
             <artifactId>wagon-ssh</artifactId>
-            <version>2.9</version>
+            <version>2.10</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
Release Notes - Maven Wagon - Version 2.10

* [WAGON-413] Private Key authentication is no longer working with
wagon-ssh-2.6
* [WAGON-440]  wagon-ssh not able to handle JSch interactive mode