### PR TITLE
Use StandardCharsets and get rid of UnsupportedEncodingException

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -102,7 +102,7 @@
 
     <!-- Suppressions from PMD configuration-->
     <!-- validateCli is not reasonable to split as encapsulation of logic will be damaged -->
-    <suppress checks="CyclomaticComplexity" files="Main\.java"  lines="171"/>
+    <suppress checks="CyclomaticComplexity" files="Main\.java"  lines="168"/>
     <!-- JavadocMethodCheck, JavadocStyleCheck, JavadocUtils.getJavadocTags() - deprecated -->
     <suppress checks="CyclomaticComplexity" files="JavadocMethodCheck\.java"/>
     <suppress checks="CyclomaticComplexity" files="JavadocStyleCheck\.java"/>

--- a/src/it/java/com/google/checkstyle/test/base/BriefLogger.java
+++ b/src/it/java/com/google/checkstyle/test/base/BriefLogger.java
@@ -1,7 +1,6 @@
 package com.google.checkstyle.test.base;
 
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 
 import com.puppycrawl.tools.checkstyle.DefaultLogger;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
@@ -9,7 +8,7 @@ import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 /** A brief logger that only display info about errors. */
 class BriefLogger extends DefaultLogger
 {
-    BriefLogger(OutputStream out) throws UnsupportedEncodingException
+    BriefLogger(OutputStream out)
     {
         super(out, true, out, false, false);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
@@ -22,8 +22,8 @@ package com.puppycrawl.tools.checkstyle;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
@@ -46,9 +46,6 @@ public class DefaultLogger
     /** Cushion for avoiding StringBuffer.expandCapacity */
     private static final int BUFFER_CUSHION = 12;
 
-    /** Encoding name. */
-    private static final String UTF8_CHARSET_NAME = "UTF-8";
-
     /** Where to write info messages. **/
     private final PrintWriter infoWriter;
     /** Close info stream after use. */
@@ -66,10 +63,8 @@ public class DefaultLogger
      * Creates a new {@code DefaultLogger} instance.
      * @param os where to log infos and errors
      * @param closeStreamsAfterUse if oS should be closed in auditFinished()
-     * @exception UnsupportedEncodingException if there is a problem to use UTF-8 encoding
      */
-    public DefaultLogger(OutputStream os, boolean closeStreamsAfterUse)
-            throws UnsupportedEncodingException {
+    public DefaultLogger(OutputStream os, boolean closeStreamsAfterUse) {
         // no need to close oS twice
         this(os, closeStreamsAfterUse, os, false);
     }
@@ -81,13 +76,12 @@ public class DefaultLogger
      * @param errorStream the {@code OutputStream} for error messages.
      * @param closeErrorAfterUse auditFinished should close errorStream
      * @param printSeverity if severity level should be printed.
-     * @exception UnsupportedEncodingException if there is a problem to use UTF-8 encoding.
      */
     public DefaultLogger(OutputStream infoStream,
                          boolean closeInfoAfterUse,
                          OutputStream errorStream,
                          boolean closeErrorAfterUse,
-                         boolean printSeverity) throws UnsupportedEncodingException {
+                         boolean printSeverity) {
         this(infoStream, closeInfoAfterUse, errorStream, closeErrorAfterUse);
         this.printSeverity = printSeverity;
     }
@@ -99,16 +93,16 @@ public class DefaultLogger
      * @param closeInfoAfterUse auditFinished should close infoStream
      * @param errorStream the {@code OutputStream} for error messages
      * @param closeErrorAfterUse auditFinished should close errorStream
-     * @exception UnsupportedEncodingException if there is a problem to use UTF-8 encoding
      */
     public DefaultLogger(OutputStream infoStream,
                          boolean closeInfoAfterUse,
                          OutputStream errorStream,
-                         boolean closeErrorAfterUse) throws UnsupportedEncodingException {
+                         boolean closeErrorAfterUse) {
         closeInfo = closeInfoAfterUse;
         closeError = closeErrorAfterUse;
-        final Writer infoStreamWriter = new OutputStreamWriter(infoStream, UTF8_CHARSET_NAME);
-        final Writer errorStreamWriter = new OutputStreamWriter(errorStream, UTF8_CHARSET_NAME);
+        final Writer infoStreamWriter = new OutputStreamWriter(infoStream, StandardCharsets.UTF_8);
+        final Writer errorStreamWriter = new OutputStreamWriter(errorStream,
+            StandardCharsets.UTF_8);
         infoWriter = new PrintWriter(infoStreamWriter);
 
         if (infoStream == errorStream) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -25,7 +25,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -82,11 +81,9 @@ public final class Main {
      * Loops over the files specified checking them for errors. The exit code
      * is the number of errors found in all the files.
      * @param args the command line arguments.
-     * @throws UnsupportedEncodingException if there is a problem to use UTF-8
      * @throws FileNotFoundException if there is a problem with files access
      **/
-    public static void main(String... args) throws UnsupportedEncodingException,
-            FileNotFoundException {
+    public static void main(String... args) throws FileNotFoundException {
         int errorCounter = 0;
         boolean cliViolations = false;
         // provide proper exit code based on results.
@@ -234,11 +231,9 @@ public final class Main {
      *         when output file could not be found
      * @throws CheckstyleException
      *         when properties file could not be loaded
-     * @throws UnsupportedEncodingException
-     *         if there is problem to use UTf-8
      */
     private static int runCheckstyle(CliOptions cliOptions)
-            throws CheckstyleException, UnsupportedEncodingException, FileNotFoundException {
+            throws CheckstyleException, FileNotFoundException {
         // setup the properties
         final Properties props;
 
@@ -312,12 +307,11 @@ public final class Main {
      * @param format format of the audit listener
      * @param outputLocation the location of output
      * @return a fresh new {@code AuditListener}
-     * @exception UnsupportedEncodingException if there is problem to use UTf-8
      * @exception FileNotFoundException when provided output location is not found
      */
     private static AuditListener createListener(String format,
                                                 String outputLocation)
-            throws UnsupportedEncodingException, FileNotFoundException {
+            throws FileNotFoundException {
 
         // setup the output stream
         OutputStream out;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -23,7 +23,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ResourceBundle;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
@@ -64,9 +64,8 @@ public class XMLLogger
      * Sets the output to a defined stream.
      * @param os the stream to write logs to.
      * @param closeStream close oS in auditFinished
-     * @throws UnsupportedEncodingException is UTF-8 is not supported
      */
-    public XMLLogger(OutputStream os, boolean closeStream) throws UnsupportedEncodingException {
+    public XMLLogger(OutputStream os, boolean closeStream) {
         setOutputStream(os);
         this.closeStream = closeStream;
     }
@@ -74,10 +73,9 @@ public class XMLLogger
     /**
      * Sets the OutputStream.
      * @param oS the OutputStream to use
-     * @throws UnsupportedEncodingException is UTF-8 is not supported
      **/
-    private void setOutputStream(OutputStream oS) throws UnsupportedEncodingException {
-        final OutputStreamWriter osw = new OutputStreamWriter(oS, "UTF-8");
+    private void setOutputStream(OutputStream oS) {
+        final OutputStreamWriter osw = new OutputStreamWriter(oS, StandardCharsets.UTF_8);
         writer = new PrintWriter(osw);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
@@ -21,8 +21,10 @@ package com.puppycrawl.tools.checkstyle.doclets;
 
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import com.sun.javadoc.ClassDoc;
 import com.sun.javadoc.DocErrorReporter;
@@ -52,16 +54,15 @@ public final class TokenTypesDoclet {
      * @return true if the given {@code RootDoc} is processed.
      * @exception FileNotFoundException will be thrown if the doclet
      *            will be unable to write to the specified file.
-     * @exception UnsupportedEncodingException will be thrown if the doclet
-     *            will be unable to use UTF-8 encoding.
      */
     public static boolean start(RootDoc root)
-            throws FileNotFoundException, UnsupportedEncodingException {
+            throws FileNotFoundException {
         final String fileName = getDestFileName(root.options());
         final FileOutputStream fos = new FileOutputStream(fileName);
-        PrintStream ps = null;
+        final Writer osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
+        final PrintWriter pw = new PrintWriter(osw, false);
+
         try {
-            ps = new PrintStream(fos, false, "UTF-8");
             final ClassDoc[] classes = root.classes();
             final FieldDoc[] fields = classes[0].fields();
             for (final FieldDoc field : fields) {
@@ -71,15 +72,13 @@ public final class TokenTypesDoclet {
                         final String message = "Should be only one tag.";
                         throw new IllegalArgumentException(message);
                     }
-                    ps.println(field.name() + "="
+                    pw.println(field.name() + "="
                         + field.firstSentenceTags()[0].text());
                 }
             }
         }
         finally {
-            if (ps != null) {
-                ps.close();
-            }
+            pw.close();
         }
 
         return true;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
@@ -27,11 +26,11 @@ public abstract class BaseCheckTestSupport {
      */
     protected static class BriefLogger
             extends DefaultLogger {
-        public BriefLogger(OutputStream out) throws UnsupportedEncodingException {
+        public BriefLogger(OutputStream out) {
             super(out, true, out, false, false);
         }
 
-        public BriefLogger(OutputStream out, boolean printSeverity) throws UnsupportedEncodingException {
+        public BriefLogger(OutputStream out, boolean printSeverity) {
             super(out, true, out, false, printSeverity);
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 
 import org.junit.Test;
 
@@ -30,7 +29,7 @@ import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 public class DefaultLoggerTest {
 
     @Test
-    public void testCtor() throws UnsupportedEncodingException {
+    public void testCtor() {
         OutputStream infoStream = new ByteArrayOutputStream();
         OutputStream errorStream = new ByteArrayOutputStream();
         DefaultLogger dl = new DefaultLogger(infoStream, true, errorStream, true);
@@ -39,7 +38,7 @@ public class DefaultLoggerTest {
     }
 
     @Test
-    public void testCtorWithTwoParameters() throws UnsupportedEncodingException {
+    public void testCtorWithTwoParameters() {
         OutputStream infoStream = new ByteArrayOutputStream();
         DefaultLogger dl = new DefaultLogger(infoStream, true);
         dl.addException(new AuditEvent(5000, "myfile"), new IllegalStateException("upsss"));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
@@ -205,7 +204,7 @@ public class SuppressWithNearbyCommentFilterTest
 
     @Override
     protected Checker createChecker(Configuration checkConfig)
-            throws CheckstyleException, UnsupportedEncodingException {
+            throws CheckstyleException {
         final DefaultConfiguration checkerConfig =
             new DefaultConfiguration("configuration");
         final DefaultConfiguration checksConfig = createCheckConfig(TreeWalker.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
@@ -205,7 +204,7 @@ public class SuppressionCommentFilterTest
 
     @Override
     protected Checker createChecker(Configuration checkConfig)
-            throws CheckstyleException, UnsupportedEncodingException {
+            throws CheckstyleException {
         final DefaultConfiguration checkerConfig =
             new DefaultConfiguration("configuration");
         final DefaultConfiguration checksConfig = createCheckConfig(TreeWalker.class);


### PR DESCRIPTION
`DefaultLogger` and `XMLLogger` shall use `java.nio.charset.StandardCharsets#UTF_8` in the writer constructors. UTF-8 must be supported by default by any JVM implementation. This will allow to remove the `throws UnsupportedEncodingException` on the constructors.