### PR TITLE
Issue #2126: Make coverage 100% for TokenTypesDoclet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1629,24 +1629,6 @@
                         </limit>
                       </limits>
                     </rule>
-                    <rule>
-                      <element>CLASS</element>
-                      <includes>
-                        <include>com.puppycrawl.tools.checkstyle.doclets.TokenTypesDoclet</include>
-                      </includes>
-                      <limits>
-                        <limit>
-                          <counter>LINE</counter>
-                          <value>COVEREDRATIO</value>
-                          <minimum>0.86</minimum>
-                        </limit>
-                        <limit>
-                          <counter>BRANCH</counter>
-                          <value>COVEREDRATIO</value>
-                          <minimum>0.85</minimum>
-                        </limit>
-                      </limits>
-                    </rule>
                   </rules>
                 </configuration>
               </execution>
@@ -1688,11 +1670,6 @@
                     <pattern>.*.checks.SuppressWarningsHolder</pattern>
                     <branchRate>75</branchRate>
                     <lineRate>93</lineRate>
-                  </regex>
-                  <regex>
-                    <pattern>.*.doclets.TokenTypesDoclet</pattern>
-                    <branchRate>85</branchRate>
-                    <lineRate>92</lineRate>
                   </regex>
                 </regexes>
               </check>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDocletTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDocletTest.java
@@ -89,14 +89,15 @@ public class TokenTypesDocletTest {
         // a lot of different places, must not be changed and an int value is used to encrypt
         // a token type.
         ListBuffer<String[]> options = new ListBuffer<>();
-        options.add(new String[]{"-doclet", "file.java"});
-        options.add(new String[]{"-destfile", "target/file.java"});
+        options.add(new String[]{"-doclet", "TokenTypesDoclet"});
+        options.add(new String[]{"-destfile", "target/tokentypes.properties"});
 
         ListBuffer<String> names = new ListBuffer<>();
-        names.add("com.puppycrawl.tools.checkstyle.doclets.InputTokenTypesDocletNotConstants");
+        names.add("src/test/resources/com/puppycrawl/tools/"
+                + "checkstyle/doclets/InputTokenTypesDocletNotConstants.java");
 
         Context context = new Context();
-        Messager.preRegister(context, "");
+        new TestMessager(context);
         JavadocTool javadocTool = JavadocTool.make0(context);
         RootDoc rootDoc = getRootDoc(javadocTool, options, names);
 
@@ -106,14 +107,14 @@ public class TokenTypesDocletTest {
     @Test
     public void testEmptyJavadoc() throws Exception {
         ListBuffer<String[]> options = new ListBuffer<>();
-        options.add(new String[]{"-doclet", "file.java"});
-        options.add(new String[]{"-destfile", "target/file.java"});
+        options.add(new String[]{"-destfile", "target/tokentypes.properties"});
 
         ListBuffer<String> names = new ListBuffer<>();
-        names.add("com.puppycrawl.tools.checkstyle.doclets.InputTokenTypesDocletEmptyJavadoc");
+        names.add("src/test/resources/com/puppycrawl/tools/"
+                + "checkstyle/doclets/InputTokenTypesDocletEmptyJavadoc.java");
 
         Context context = new Context();
-        Messager.preRegister(context, "");
+        new TestMessager(context);
         JavadocTool javadocTool = JavadocTool.make0(context);
         RootDoc rootDoc = getRootDoc(javadocTool, options, names);
 
@@ -128,6 +129,23 @@ public class TokenTypesDocletTest {
         }
     }
 
+    @Test
+    public void testCorrect() throws Exception {
+        ListBuffer<String[]> options = new ListBuffer<>();
+        options.add(new String[]{"-destfile", "target/tokentypes.properties"});
+
+        ListBuffer<String> names = new ListBuffer<>();
+        names.add("src/test/resources/com/puppycrawl/tools/"
+                + "checkstyle/doclets/InputTokenTypesDocletCorrect.java");
+
+        Context context = new Context();
+        new TestMessager(context);
+        JavadocTool javadocTool = JavadocTool.make0(context);
+        RootDoc rootDoc = getRootDoc(javadocTool, options, names);
+
+        assertTrue(TokenTypesDoclet.start(rootDoc));
+    }
+
     private static RootDoc getRootDoc(JavadocTool javadocTool, ListBuffer<String[]> options,
             ListBuffer<String> names) throws Exception {
         Method getRootDocImpl = getMethodGetRootDocImplByReflection();
@@ -140,7 +158,7 @@ public class TokenTypesDocletTest {
                     false,
                     new ListBuffer<String>().toList(),
                     new ListBuffer<String>().toList(),
-                    true, false, false);
+                    false, false, false);
         }
         else {
             rootDoc = (RootDoc) getRootDocImpl.invoke(javadocTool, "", "UTF-8",
@@ -151,7 +169,7 @@ public class TokenTypesDocletTest {
                     false,
                     new ListBuffer<String>().toList(),
                     new ListBuffer<String>().toList(),
-                    true, false, false);
+                    false, false, false);
         }
         return rootDoc;
     }
@@ -180,5 +198,8 @@ public class TokenTypesDocletTest {
         public void printError(String message) {
             messages.add(message);
         }
+
+        @Override
+        public void printNotice(String message) { }
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/doclets/InputTokenTypesDocletCorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/doclets/InputTokenTypesDocletCorrect.java
@@ -1,0 +1,14 @@
+package com.puppycrawl.tools.checkstyle.doclets;
+
+import com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaTokenTypes;
+
+public class InputTokenTypesDocletCorrect {
+
+        /**
+         * The end of file token.  This is the root node for the source
+         * file.  It's children are an optional package definition, zero
+         * or more import statements, and one or more class or interface
+         * definitions.
+         **/
+        public static final int EOF = GeneratedJavaTokenTypes.EOF;
+}


### PR DESCRIPTION
This PR needs to be rebased on #2196 and modified a bit to avoid [extra output](https://travis-ci.org/checkstyle/checkstyle/jobs/80798099#L614-L617).