### PR TITLE
Issue #2193: ROOT locale added in checker creation for UT; travis updated with a new check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
     - jdk: oraclejdk8
       env: DESC="tests" CMD="mvn clean integration-test failsafe:verify" COVERAGE_CMD=""
 
+    # unit tests in German locale (oraclejdk8)
+    - jdk: oraclejdk8
+      env: DESC="tests" CMD="mvn clean integration-test failsafe:verify -DargLine='-Duser.language=de -Duser.country=DE'" COVERAGE_CMD=""
+
     # checkstyle (oraclejdk8)
     - jdk: oraclejdk8
       env:

--- a/src/it/java/com/google/checkstyle/test/base/ConfigValidationTest.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigValidationTest.java
@@ -5,6 +5,7 @@ import static org.apache.commons.lang3.ArrayUtils.EMPTY_STRING_ARRAY;
 
 import java.io.File;
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.Test;
 
@@ -17,6 +18,9 @@ public class ConfigValidationTest extends BaseCheckTestSupport {
         ConfigurationBuilder builder = new ConfigurationBuilder(new File("src/it/"));
         final Configuration checkerConfig = builder.getConfiguration();
         final Checker checker = new Checker();
+        final Locale locale = Locale.ROOT;
+        checker.setLocaleCountry(locale.getCountry());
+        checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(checkerConfig);
         checker.addListener(new BriefLogger(stream));


### PR DESCRIPTION
- Missed ROOT locale was added during checker creation for UT
- Travis was updated with the check which runs tests in non-English locale