### PR TITLE
minor: Exclude OBJBLOCK from acceptable tokens of VisibilityModifier

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -386,24 +386,20 @@ public class VisibilityModifierCheck
 
     @Override
     public int[] getDefaultTokens() {
-        return new int[] {
-            TokenTypes.VARIABLE_DEF,
-            TokenTypes.IMPORT,
-        };
+        return getAcceptableTokens();
     }
 
     @Override
     public int[] getAcceptableTokens() {
         return new int[] {
             TokenTypes.VARIABLE_DEF,
-            TokenTypes.OBJBLOCK,
             TokenTypes.IMPORT,
         };
     }
 
     @Override
     public int[] getRequiredTokens() {
-        return getDefaultTokens();
+        return getAcceptableTokens();
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -260,7 +260,6 @@ public class VisibilityModifierCheckTest
         VisibilityModifierCheck obj = new VisibilityModifierCheck();
         int[] expected = {
             TokenTypes.VARIABLE_DEF,
-            TokenTypes.OBJBLOCK,
             TokenTypes.IMPORT,
         };
         assertArrayEquals(expected, obj.getAcceptableTokens());


### PR DESCRIPTION
OBJBLOCK was excluded form acceptable tokens of VisibilityModifier since it was not used during parsing at all. See [visitToken](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java#L423). The only occurrence of OBJBLOCK was in [isAnonymousClassVariable](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java#L444).