### PR TITLE
Pull #2247: Update plexus-compiler-javac-errorprone to 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -479,7 +479,7 @@
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.5</version>
+            <version>2.6</version>
           </dependency>
           <dependency>
             <groupId>com.google.errorprone</groupId>


### PR DESCRIPTION
Changelog: https://github.com/codehaus-plexus/plexus-compiler/compare/plexus-compiler-2.5...codehaus-plexus:plexus-compiler-2.6