### PR TITLE
Adding "all" warning key in SuppressWarningsHolder

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -37,6 +37,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Maintains a set of check suppressions from {@link SuppressWarnings}
  * annotations.
  * @author Trevor Robinson
+ * @author St&eacute;phane Galland
  */
 public class SuppressWarningsHolder
     extends Check {
@@ -61,6 +62,9 @@ public class SuppressWarningsHolder
 
     /** Suffix to be removed from subclasses of Check. */
     private static final String CHECK_SUFFIX = "Check";
+
+    /** Special warning id for matching all the warnings. */
+    private static final String ALL_WARNING_MATCHING_ID = "all";
 
     /** A map from check source names to suppression aliases. */
     private static final Map<String, String> CHECK_ALIAS_MAP = new HashMap<>();
@@ -158,7 +162,8 @@ public class SuppressWarningsHolder
                     || entry.getLastLine() == line && entry
                         .getLastColumn() >= column;
             final boolean nameMatches =
-                entry.getCheckName().equals(checkAlias);
+                ALL_WARNING_MATCHING_ID.equals(entry.getCheckName())
+                    || entry.getCheckName().equals(checkAlias);
             if (afterStart && beforeEnd && nameMatches) {
                 return true;
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -135,6 +135,34 @@ public class SuppressWarningsHolderTest extends BaseCheckTestSupport {
     }
 
     @Test
+    public void testIsSuppressedWithAllArgument() throws Exception {
+        Class<?> entry = Class
+                .forName("com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder$Entry");
+        Constructor<?> entryConstr = entry.getDeclaredConstructor(String.class, int.class,
+                int.class, int.class, int.class);
+        entryConstr.setAccessible(true);
+
+        Object entryInstance = entryConstr.newInstance("all", 100, 100, 350, 350);
+
+        List<Object> entriesList = new ArrayList<>();
+        entriesList.add(entryInstance);
+
+        ThreadLocal<?> threadLocal = mock(ThreadLocal.class);
+        PowerMockito.doReturn(entriesList).when(threadLocal, "get");
+
+        SuppressWarningsHolder holder = new SuppressWarningsHolder();
+        Field entries = holder.getClass().getDeclaredField("ENTRIES");
+        entries.setAccessible(true);
+        entries.set(holder, threadLocal);
+
+        assertFalse(SuppressWarningsHolder.isSuppressed("SourceName", 100, 10));
+
+        assertTrue(SuppressWarningsHolder.isSuppressed("SourceName", 100, 150));
+
+        assertTrue(SuppressWarningsHolder.isSuppressed("SourceName", 200, 1));
+    }
+
+    @Test
     public void testAnnotationInTry() throws Exception {
         Configuration checkConfig = createCheckConfig(SuppressWarningsHolder.class);
 

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -440,6 +440,15 @@
           </source>
       </p>
 
+      <p>It is possible to suppress all the checkstyle warnings with the argument <code>"all"</code>:
+          <source>
+            @SuppressWarnings("all")
+            public void someFunctionWithInvalidStyle() {
+              //...
+            }
+          </source>
+      </p>
+
       </subsection>
 
       <subsection name="Example of Usage">


### PR DESCRIPTION
Related to the issue #2275, this pull request provides the code for supporting the `"all"` argument to `@SuppressWarnings` annotations.