### PR TITLE
Issue #2283: fixed NPE in NeedBraces.isSingleLineFor

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -283,7 +283,12 @@ public class NeedBracesCheck extends Check {
         else if (literalFor.getParent().getType() == TokenTypes.SLIST
                 && literalFor.getLastChild().getType() != TokenTypes.SLIST) {
             final DetailAST block = findExpressionBlockInForLoop(literalFor);
-            result = literalFor.getLineNo() == block.getLineNo();
+            if (block == null) {
+                result = literalFor.getLineNo() == literalFor.getLastChild().getLineNo();
+            }
+            else {
+                result = literalFor.getLineNo() == block.getLineNo();
+            }
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheckTest.java
@@ -67,10 +67,11 @@ public class NeedBracesCheckTest extends BaseCheckTestSupport {
             "38: " + getCheckMessage(MSG_KEY_NEED_BRACES, "if"),
             "46: " + getCheckMessage(MSG_KEY_NEED_BRACES, "while"),
             "53: " + getCheckMessage(MSG_KEY_NEED_BRACES, "do"),
-            "59: " + getCheckMessage(MSG_KEY_NEED_BRACES, "for"),
-            "88: " + getCheckMessage(MSG_KEY_NEED_BRACES, "if"),
-            "92: " + getCheckMessage(MSG_KEY_NEED_BRACES, "else"),
-            "104: " + getCheckMessage(MSG_KEY_NEED_BRACES, "if"),
+            "56: " + getCheckMessage(MSG_KEY_NEED_BRACES, "for"),
+            "62: " + getCheckMessage(MSG_KEY_NEED_BRACES, "for"),
+            "91: " + getCheckMessage(MSG_KEY_NEED_BRACES, "if"),
+            "95: " + getCheckMessage(MSG_KEY_NEED_BRACES, "else"),
+            "107: " + getCheckMessage(MSG_KEY_NEED_BRACES, "if"),
         };
         verify(checkConfig, getPath("InputBracesSingleLineStatements.java"), expected);
     }
@@ -96,8 +97,8 @@ public class NeedBracesCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("tokens", "LITERAL_CASE, LITERAL_DEFAULT");
         checkConfig.addAttribute("allowSingleLineStatement", "true");
         final String[] expected = {
-            "69: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
             "72: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
+            "75: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
         };
         verify(checkConfig, getPath("InputBracesSingleLineStatements.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputBracesSingleLineStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputBracesSingleLineStatements.java
@@ -53,6 +53,9 @@ public class InputBracesSingleLineStatements
         do
             this.notify();
         while (o != null);
+        for (;;)
+            break;
+        for (;;) break;
         for (int i = 0; i < 10; i++) {
              this.notify();
         }


### PR DESCRIPTION
'findExpressionBlockInForLoop' returns null because there is no expression in the test case, it is a plain "break".
To avoid the NPE, the code is changed to just get the last child of the for loop.