### PR TITLE
Pull #2293: Update PowerMock to 1.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,13 +269,13 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Change log 1.6.3 (2015-10-02)
----------------------------
* Mock name in @Mock(name="abc") annotations are no longer ignored for the Mockito API extension
* Fixed NPE in withArguments() constructor (thanks to Tomoyuki Saito for pull request)
* Upgraded Javassist dependency to version 3.20.0-GA.
* Using soft reference in classloader cache
* MockClassloader now extends Javassist Loader classloader to implement findClass etc
* PowerMock now works better with ByteBuddy (issue 579)
* This allows creating mocks in the applyInterceptionPolicy method of MockPolicy, which in turn allows using MockPolicy together with PowerMockRule (issue 581).
* Upgraded the powermock-easymock extension to use EasyMock 3.4