### PR TITLE
Issue #1551: Fix FinalLocalVariableCheck false-negative

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -132,7 +132,7 @@ public final class PackageNamesLoader
     public static Set<String> getPackageNames(ClassLoader classLoader)
             throws CheckstyleException {
 
-        Set<String> result;
+        final Set<String> result;
         try {
             //create the loader outside the loop to prevent PackageObjectFactory
             //being created anew for each file

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -345,7 +345,7 @@ public class CheckstyleAntTask extends Task {
                 + " files", Project.MSG_INFO);
         log("Using configuration " + configLocation, Project.MSG_VERBOSE);
 
-        int numErrs;
+        final int numErrs;
 
         try {
             final long processingStartTime = System.currentTimeMillis();
@@ -380,7 +380,7 @@ public class CheckstyleAntTask extends Task {
      * @return new instance of {@code Checker}
      */
     private Checker createChecker() {
-        Checker checker;
+        final Checker checker;
         try {
             final Properties props = createOverridingProperties();
             final Configuration config =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -306,7 +306,7 @@ public class SuppressWarningsHolder
      * @return get target of annotation
      */
     private static DetailAST getAnnotationTarget(DetailAST ast) {
-        DetailAST targetAST;
+        final DetailAST targetAST;
         final DetailAST parentAST = ast.getParent();
         switch (parentAST.getType()) {
             case TokenTypes.MODIFIERS:

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -143,7 +143,7 @@ final class ImportControlLoader extends AbstractLoader {
      * @throws CheckstyleException if an error occurs.
      */
     static PkgControl load(final URI uri) throws CheckstyleException {
-        InputStream inputStream;
+        final InputStream inputStream;
         try {
             inputStream = uri.toURL().openStream();
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -333,7 +333,7 @@ public class SuppressWithNearbyCommentFilter
                 }
                 format = CommonUtils.fillTemplateWithStringsByRegexp(
                         filter.influenceFormat, text, filter.commentRegexp);
-                int influence;
+                final int influence;
                 try {
                     if (CommonUtils.startsWithChar(format, '+')) {
                         format = format.substring(1);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -71,6 +71,15 @@ public class FinalLocalVariableCheckTest
             "96:17: " + getCheckMessage(MSG_KEY, "weird"),
             "97:17: " + getCheckMessage(MSG_KEY, "j"),
             "98:17: " + getCheckMessage(MSG_KEY, "k"),
+            "185:13: " + getCheckMessage(MSG_KEY, "x"),
+            "190:17: " + getCheckMessage(MSG_KEY, "x"),
+            "210:17: " + getCheckMessage(MSG_KEY, "n"),
+            "216:13: " + getCheckMessage(MSG_KEY, "q"),
+            "217:13: " + getCheckMessage(MSG_KEY, "w"),
+            "226:21: " + getCheckMessage(MSG_KEY, "w"),
+            "227:21: " + getCheckMessage(MSG_KEY, "e"),
+            "247:17: " + getCheckMessage(MSG_KEY, "n"),
+            "259:17: " + getCheckMessage(MSG_KEY, "t"),
         };
         verify(checkConfig, getPath("InputFinalLocalVariable.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputFinalLocalVariable.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputFinalLocalVariable.java
@@ -179,3 +179,85 @@ enum Enum1 {
         var = 1;
     }
 }
+
+class class2 {
+    public void method1(){
+        int x;
+        x = 3;
+    }
+    public void method2() {
+        for(int i=0;i<5;i++){
+            int x;
+            x = 3;
+        }
+        int y;
+        for(int i=0;i<5;i++) {
+            y = 3;
+        }
+        for(int i=0;i<5;i++) {
+            int z;
+            for(int j=0;j<5;j++) {
+                z = 3;
+            }
+        }
+    }
+    public void method3() {
+        int m;
+        do {
+           m = 0;
+        } while (false);
+        do {
+            int n;
+           n = 0;
+        } while (true);        
+    }
+
+    private void foo() {
+        int q;
+        int w;
+        int e;
+        q = 1;
+        w = 1;
+        e = 1;
+        e = 2;
+        class Local {
+            void bar() {
+                int q;
+                int w;
+                int e;
+                q = 1;
+                q = 2;
+                w = 1;
+                e = 1;
+            }
+        }
+
+        int i;
+        for (;; i = 1) { }
+    }
+
+    public void method4() {
+        int m;
+        int i = 5;
+        while (i > 1) {
+            m = 0;
+            i++;
+        }
+        while (true) {
+            int n;
+            n = 0;
+        }
+    }
+
+    int[] array = new int[10];
+    public void method5() {
+        int r;
+        for (int a: array) {
+            r = 0;
+        }
+        for (int a: array) {
+            int t;
+            t = 0;
+        }
+    }
+}


### PR DESCRIPTION
#1722 
> 1) please make it as "An example of how to configure the check to validate variable definition is:"

Done.

>  2)  mismatch of documentation and getRequiredTokens(). please update all examples (javadoc, xdoc).

Corrected examples, is it OK now?

> 3) please create new class that will store all information about scope (Map + Deque).

Done.

> 4) Please create UT that show that variables in different but nested scopes are named the same and one of them final another is not final and issue is reported to required variable.

Done.
https://github.com/Vladlis/checkstyle/commit/85bf34603f574445610d535a1bc55e5d69fe6d5c#diff-0b3755657c714c3c6e8b488b4d29606aR215

> 5) please generate reports against project to see that new violations are correct , please do check all of them yourself.

I've corrected all the new violations on CS sources, changes are in a in a separate commit.

> 6)  getDefaultToekns() , get AcceptableTokes()
pelase move TokenTypes.VARIABLE_DEF to the end of list to let future developer easily see a difference between collections,

Done.

> 7) private boolean defAndInitInDifferentLoop(DetailAST ast1, DetailAST ast2)
Why only Loops are checked there, that should be processing for any block structure that create extra scope (scope is "{ }").

There is already processing for all scopes, but here we look for loops, because there one statement can be executed more than once.