### PR TITLE
Issue #1238: Replaced outdated link for bamboo-checkstyle-plugin

### DIFF
--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -176,7 +176,7 @@
               <tr>
                   <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">Bamboo Checkstyle plug-in</a></td>
                   <td>Atlassian (formerly by Ross Rowe and Stephan Paulicke)</td>
-                  <td><a href="https://marketplace.atlassian.com/archive/com.atlassian.bamboo.plugins.bamboo-checkstyle-plugin">Bamboo Checkstyle plug-in Atlassian Marketplace page</a></td>
+                  <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">Bamboo Checkstyle plug-in Home Page</a></td>
                   <td>An add-on that will parse and record CheckStyle reports and report your style violations over time.</td>
               </tr>
               <tr>


### PR DESCRIPTION
Both links are forwarding to bitbucket project which is being updated.
 
![image](https://cloud.githubusercontent.com/assets/2310862/10496062/3ba0ada8-72bf-11e5-86ce-a8b7d47a1e7d.png)
