### PR TITLE
Issue #46: switch case clauses should not have too many lines.

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -167,14 +167,7 @@ public class XMLLogger
                     sb.append("&quot;");
                     break;
                 case '&':
-                    final int nextSemi = value.indexOf(';', i);
-                    if (nextSemi < 0
-                        || !isReference(value.substring(i, nextSemi + 1))) {
-                        sb.append("&amp;");
-                    }
-                    else {
-                        sb.append('&');
-                    }
+                    sb.append(encodeAmpersend(value, i));
                     break;
                 default:
                     sb.append(chr);
@@ -222,5 +215,24 @@ public class XMLLogger
             }
         }
         return reference;
+    }
+
+    /**
+     * Encodes ampersand in value at required position.
+     * @param value string value, which contains ampersand
+     * @param ampPosition position of ampersand in value
+     * @return encoded ampersand which should be used in xml
+     */
+    private static String encodeAmpersend(String value, int ampPosition) {
+        final int nextSemi = value.indexOf(';', ampPosition);
+        String result;
+        if (nextSemi < 0
+            || !isReference(value.substring(ampPosition, nextSemi + 1))) {
+            result = "&amp;";
+        }
+        else {
+            result = "&";
+        }
+        return result;
     }
 }


### PR DESCRIPTION
The switch statement should be used only to clearly define some new branches in the control flow. As soon as a case clause contains too many statements this highly decreases the readability of the overall control flow statement. In such case, the content of case clause should be extracted in a dedicated method.
Default threshold of 5.