### PR TITLE
Issue #2266: Fixed blank line indentification for EmptyLineSeparator check

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3sourcefile/EmptyLineSeparatorTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3sourcefile/EmptyLineSeparatorTest.java
@@ -21,7 +21,7 @@ public class EmptyLineSeparatorTest extends BaseCheckTestSupport{
 
     @Test
     public void emptyLineSeparatorTest() throws Exception {
-        
+
         Class<EmptyLineSeparatorCheck> clazz = EmptyLineSeparatorCheck.class;
         String messageKey = "empty.line.separator";
 
@@ -30,6 +30,7 @@ public class EmptyLineSeparatorTest extends BaseCheckTestSupport{
             "20: " + getCheckMessage(clazz, messageKey, "import"),
             "33: " + getCheckMessage(clazz, messageKey, "CLASS_DEF"),
             "37: " + getCheckMessage(clazz, messageKey, "STATIC_INIT"),
+            "66: " + getCheckMessage(clazz, messageKey, "METHOD_DEF"),
             "75: " + getCheckMessage(clazz, messageKey, "INTERFACE_DEF"),
             "82: " + getCheckMessage(clazz, messageKey, "INSTANCE_INIT"),
             "113: " + getCheckMessage(clazz, messageKey, "CLASS_DEF"),

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java
@@ -30,6 +30,7 @@ public class EmptyLineSeparatorTest extends BaseCheckTestSupport{
             "20: " + getCheckMessage(clazz, messageKey, "import"),
             "33: " + getCheckMessage(clazz, messageKey, "CLASS_DEF"),
             "37: " + getCheckMessage(clazz, messageKey, "STATIC_INIT"),
+            "66: " + getCheckMessage(clazz, messageKey, "METHOD_DEF"),
             "75: " + getCheckMessage(clazz, messageKey, "INTERFACE_DEF"),
             "82: " + getCheckMessage(clazz, messageKey, "INSTANCE_INIT"),
             "113: " + getCheckMessage(clazz, messageKey, "CLASS_DEF"),

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3sourcefilestructure/EmptyLineSeparatorInput.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3sourcefilestructure/EmptyLineSeparatorInput.java
@@ -37,11 +37,11 @@ class InputEmptyLineSeparatorCheck //warn
 	static {  //warn
         //empty static initializer
 	}
-	//separator blank line
+
 	{
 		//empty instance initializer
 	}
-	//separator blank line
+
 	/**
 	 * 
 	 * 
@@ -51,7 +51,7 @@ class InputEmptyLineSeparatorCheck //warn
 	{
 		//empty
 	}
-	//separator blank line
+
     public int compareTo(InputEmptyLineSeparatorCheck aObject)
     {
     	int number = 0;
@@ -63,18 +63,18 @@ class InputEmptyLineSeparatorCheck //warn
      * @param result
      * @return
      */
-    public static <T> Callable<T> callable(Runnable task, T result)
+    public static <T> Callable<T> callable(Runnable task, T result) // warn
     {
         return null;
     }
-    //separator blank line
+
     public int getBeastNumber()
     {
         return 666;
     }
     interface IntEnum { //warn
     }
-    //separator blank line
+
     class InnerClass {
     	
     	public static final double FOO_PI_INNER = 3.1415;
@@ -82,7 +82,7 @@ class InputEmptyLineSeparatorCheck //warn
     	{ //warn
     		//empty instance initializer
     	}
-    	//separator blank line
+
     	private InnerClass()
     	{
     		//empty

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorInput.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorInput.java
@@ -37,11 +37,11 @@ class InputEmptyLineSeparatorCheck //warn
 	static {  //warn
         //empty static initializer
 	}
-	//separator blank line
+
 	{
 		//empty instance initializer
 	}
-	//separator blank line
+
 	/**
 	 * 
 	 * 
@@ -51,7 +51,7 @@ class InputEmptyLineSeparatorCheck //warn
 	{
 		//empty
 	}
-	//separator blank line
+
     public int compareTo(InputEmptyLineSeparatorCheck aObject)
     {
     	int number = 0;
@@ -63,18 +63,18 @@ class InputEmptyLineSeparatorCheck //warn
      * @param result
      * @return
      */
-    public static <T> Callable<T> callable(Runnable task, T result)
+    public static <T> Callable<T> callable(Runnable task, T result) // warn
     {
         return null;
     }
-    //separator blank line
+
     public int getBeastNumber()
     {
         return 666;
     }
     interface IntEnum { //warn
     }
-    //separator blank line
+
     class InnerClass {
     	
     	public static final double FOO_PI_INNER = 3.1415;
@@ -82,7 +82,7 @@ class InputEmptyLineSeparatorCheck //warn
     	{ //warn
     		//empty instance initializer
     	}
-    	//separator blank line
+
     	private InnerClass()
     	{
     		//empty

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -252,6 +252,7 @@ public final class ModifiedControlVariableCheck extends Check {
     private void enterBlock() {
         variableStack.push(new ArrayDeque<String>());
     }
+
     /**
      * Leave an inner class, so restore variable set.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -197,6 +197,7 @@ public class MultipleStringLiteralsCheck extends Check {
          * Column of finding.
          */
         private final int col;
+
         /**
          * Creates information about a string position.
          * @param line int

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -77,6 +77,7 @@ final class ImportControlLoader extends AbstractLoader {
         DTD_RESOURCE_BY_ID.put(DTD_PUBLIC_ID_1_0, DTD_RESOURCE_NAME_1_0);
         DTD_RESOURCE_BY_ID.put(DTD_PUBLIC_ID_1_1, DTD_RESOURCE_NAME_1_1);
     }
+
     /**
      * Constructs an instance.
      * @throws ParserConfigurationException if an error occurs.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressElement.java
@@ -95,6 +95,7 @@ public class SuppressElement
     public void setModuleId(final String moduleId) {
         this.moduleId = moduleId;
     }
+
     /**
      * Sets the CSV values and ranges for line number filtering.
      * E.g. "1,7-15,18".

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -56,7 +56,11 @@ public class EmptyLineSeparatorCheckTest
             "35: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "CLASS_DEF"),
             "38: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "VARIABLE_DEF"),
             "39: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "STATIC_INIT"),
-            "77: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "INTERFACE_DEF"),
+            "43: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "INSTANCE_INIT"),
+            "57: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "CTOR_DEF"),
+            "62: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "79: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "110: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "INTERFACE_DEF"),
         };
         verify(checkConfig, getPath("InputEmptyLineSeparatorCheck.java"), expected);
     }
@@ -71,7 +75,11 @@ public class EmptyLineSeparatorCheckTest
             "21: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "import"),
             "35: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "CLASS_DEF"),
             "39: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "STATIC_INIT"),
-            "77: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "INTERFACE_DEF"),
+            "43: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "INSTANCE_INIT"),
+            "57: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "CTOR_DEF"),
+            "62: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "79: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "110: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "INTERFACE_DEF"),
         };
         verify(checkConfig, getPath("InputEmptyLineSeparatorCheck.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputEmptyLineSeparatorCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputEmptyLineSeparatorCheck.java
@@ -39,11 +39,16 @@ class InputEmptyLineSeparatorCheck
     static {
         //empty static initializer
     }
-    //separator blank line
+    // no blank line - fail
     {
         //empty instance initializer
     }
-    //separator blank line
+
+    // one blank line - ok
+    {
+        //empty instance initializer
+    }
+    // no blank line - fail
     /**
      * 
      * 
@@ -59,8 +64,14 @@ class InputEmptyLineSeparatorCheck
         int number = 0;
         return 0;
     }
+
+    public int compareTo2(Object aObject) // empty line - ok
+    {
+        int number = 0;
+        return 0;
+    }
     /**
-     * 
+     * No blank line between methods - fail
      * @param task
      * @param result
      * @return
@@ -69,24 +80,46 @@ class InputEmptyLineSeparatorCheck
     {
         return null;
     }
-    //separator blank line
+
+    /**
+     * Blank line before Javadoc - ok
+     * @param task
+     * @param result
+     * @return
+     */
+    public static <T> Callable<T> callable2(Runnable task, T result)
+    {
+        return null;
+    }
+    /**
+     * Blank line after Javadoc - ok
+     * @param task
+     * @param result
+     * @return
+     */
+    
+    public static <T> Callable<T> callable3(Runnable task, T result)
+    {
+        return null;
+    }
+
     public int getBeastNumber()
     {
         return 666;
     }
     interface IntEnum {
     }
-    //separator blank line
+
     class InnerClass {
         
         public static final double FOO_PI_INNER = 3.1415;
-        //separator blank line
+
         private boolean flagInner = true; 
-        //separator blank line
+
         {
             //empty instance initializer
         }
-        //separator blank line
+
         private InnerClass()
         {
             //empty


### PR DESCRIPTION
Current implementation count everything outside AntLR tree as blank lines. Javadoc and comments among them.

This patch checks, that lines between tokens are actually empty (trim().isEmpty()).

Checkstyle reports are uploaded to [my site] (http://pbaranchikov.github.io/checkstyle/empty-line-separator/checkstyle.html)
For guava project, found 1591 violations against 1576 for Checkstyle 6.11.2.

Validations are also fixed in Checkstyle code itself