### PR TITLE
minor: added missing exception checks

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -80,7 +80,11 @@ public class HeaderCheckTest extends BaseFileSetCheckTestSupport {
             fail();
         }
         catch (CheckstyleException ex) {
-            // expected exception
+            assertTrue(ex.getMessage()
+                    .startsWith("cannot initialize module"
+                            + " com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck"
+                            + " - Unable to find: "));
+            assertTrue(ex.getMessage().endsWith("nonExisting.file"));
         }
     }
 
@@ -94,7 +98,11 @@ public class HeaderCheckTest extends BaseFileSetCheckTestSupport {
             fail();
         }
         catch (CheckstyleException ex) {
-            // expected exception
+            assertEquals("cannot initialize module"
+                    + " com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck"
+                    + " - Cannot set property 'charset' to 'XSO-8859-1' in module"
+                    + " com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck",
+                    ex.getMessage());
         }
     }
 
@@ -107,7 +115,11 @@ public class HeaderCheckTest extends BaseFileSetCheckTestSupport {
             fail("Checker creation should not succeed with invalid headerFile");
         }
         catch (CheckstyleException ex) {
-            // expected exception
+            assertEquals("cannot initialize module"
+                    + " com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck"
+                    + " - Cannot set property 'headerFile' to '' in module"
+                    + " com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck",
+                    ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.header;
 
 import static com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck.MSG_MISMATCH;
 import static com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck.MSG_MISSING;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -90,7 +91,9 @@ public class RegexpHeaderCheckTest extends BaseFileSetCheckTestSupport {
                     ConversionException.class));
         }
         catch (ConversionException ex) {
-            // expected
+            assertEquals("Unable to parse format: ^/**\\n *"
+                    + " Licensed to the Apache Software Foundation (ASF)",
+                    ex.getMessage());
         }
     }
 
@@ -111,7 +114,11 @@ public class RegexpHeaderCheckTest extends BaseFileSetCheckTestSupport {
             fail("Checker creation should not succeed with invalid headerFile");
         }
         catch (CheckstyleException ex) {
-            // expected exception
+            assertEquals("cannot initialize module"
+                    + " com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck"
+                    + " - Cannot set property 'headerFile' to '' in"
+                    + " module com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck",
+                    ex.getMessage());
         }
     }
 
@@ -159,7 +166,11 @@ public class RegexpHeaderCheckTest extends BaseFileSetCheckTestSupport {
             fail("Checker creation should not succeed when regexp spans multiple lines");
         }
         catch (CheckstyleException ex) {
-            // expected exception
+            assertEquals("cannot initialize module"
+                    + " com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck"
+                    + " - Cannot set property 'header' to '^(.*\\n.*)' in module"
+                    + " com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck",
+                    ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming;
 
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -55,7 +56,11 @@ public class ConstantNameCheckTest
             fail();
         }
         catch (CheckstyleException ex) {
-            // expected exception
+            assertEquals("cannot initialize module"
+                    + " com.puppycrawl.tools.checkstyle.TreeWalker - Cannot set property"
+                    + " 'format' to '\\' in module"
+                    + " com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck",
+                    ex.getMessage());
         }
     }
 


### PR DESCRIPTION
All expected exceptions should be verified to make sure future changes don't change the exception being thrown.
For example, we are moving a lot of files around during the unification process. A missing file throws the same CheckstyleException as a "cannot set property" exception. If I accidentally moved a file to a wrong location, I would be changing the exception message and not realize it without these asserts in place.