### PR TITLE
Issue #2161: unify test input locations for javadoc package

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -44,6 +44,7 @@
     <suppress checks="AvoidStaticImport" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="MethodCount" files="[\\/]ImportOrderCheckTest.java$"/>
     <suppress checks="MethodCount" files="[\\/]IndentationCheckTest.java$"/>
+    <suppress checks="MethodCount" files="[\\/]JavadocMethodCheckTest.java$"/>
     <suppress checks="MethodCount" files="[\\/]MainTest.java$"/>
     <suppress checks="EqualsAvoidNull" files="[\\/]Int.*FilterTest.java$"/>
     <suppress checks="WriteTag" files=".*[\\/]src[\\/]test[\\/]"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/FileSetCheckLifecycleTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/FileSetCheckLifecycleTest.java
@@ -58,7 +58,7 @@ public class FileSetCheckLifecycleTest
         final Configuration checkConfig =
             createCheckConfig(TestFileSetCheck.class);
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("InputScopeAnonInner.java"), expected);
+        verify(checkConfig, getPath("checks/InputIllegalTokens.java"), expected);
 
         assertTrue("destroy() not called by Checker", TestFileSetCheck.isDestroyed());
     }
@@ -85,7 +85,7 @@ public class FileSetCheckLifecycleTest
 
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
-        verify(checker, getPath("InputScopeAnonInner.java"), expected);
+        verify(checker, getPath("checks/InputIllegalTokens.java"), expected);
 
         assertTrue("FileContent should be available during finishProcessing() call",
                 TestFileSetCheck.isFileContentAvailable());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -30,6 +30,7 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.
 import static org.junit.Assert.assertArrayEquals;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Before;
@@ -46,6 +47,12 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
     @Before
     public void setUp() {
         checkConfig = createCheckConfig(JavadocMethodCheck.class);
+    }
+
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("checks" + File.separator
+                + "javadoc" + File.separator + filename);
     }
 
     @Test
@@ -75,7 +82,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
         final String[] expected = {
             "7:8: " + getCheckMessage(MSG_CLASS_INFO, "@throws", "InvalidExceptionName"),
         };
-        verify(config, getPath("checks/javadoc/InputLoadErrors.java"), expected);
+        verify(config, getPath("InputLoadErrors.java"), expected);
     }
 
     @Test
@@ -86,7 +93,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
         final String[] expected = {
             "46:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
-        verify(config, getPath("javadoc/ExtendAnnotation.java"), expected);
+        verify(config, getPath("ExtendAnnotation.java"), expected);
     }
 
     @Test
@@ -97,7 +104,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
         final String[] expected = {
             "57:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
-        verify(config, getPath("javadoc/InputJavadocMethodCheck_SmallMethods.java"), expected);
+        verify(config, getPath("InputJavadocMethodCheck_SmallMethods.java"), expected);
     }
 
     @Test
@@ -106,7 +113,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
         DefaultConfiguration config = createCheckConfig(JavadocMethodCheck.class);
         config.addAttribute("allowedAnnotations", "Override,ThisIsOk, \t\n\t ThisIsOkToo");
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-        verify(config, getPath("javadoc/AllowedAnnotations.java"), expected);
+        verify(config, getPath("AllowedAnnotations.java"), expected);
     }
 
     @Test
@@ -143,7 +150,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "329:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
-        verify(checkConfig, getPath("checks/javadoc/InputTags.java"), expected);
+        verify(checkConfig, getPath("InputTags.java"), expected);
     }
 
     @Test
@@ -177,7 +184,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "320:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "329:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
-        verify(checkConfig, getPath("checks/javadoc/InputTags.java"), expected);
+        verify(checkConfig, getPath("InputTags.java"), expected);
     }
 
     @Test
@@ -285,7 +292,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "320:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "329:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
-        verify(checkConfig, getPath("checks/javadoc/InputTags.java"), expected);
+        verify(checkConfig, getPath("InputTags.java"), expected);
     }
 
     @Test
@@ -327,9 +334,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "106:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "107:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "108:9: " + getCheckMessage(MSG_JAVADOC_MISSING), };
-        verify(checkConfig, getPath("checks" + File.separator
-                                    + "javadoc" + File.separator
-                                    + "InputNoJavadoc.java"), expected);
+        verify(checkConfig, getPath("InputNoJavadoc.java"), expected);
     }
 
     @Test
@@ -340,9 +345,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "11:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "21:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "22:9: " + getCheckMessage(MSG_JAVADOC_MISSING), };
-        verify(checkConfig, getPath("checks" + File.separator
-                                    + "javadoc" + File.separator
-                                    + "InputNoJavadoc.java"), expected);
+        verify(checkConfig, getPath("InputNoJavadoc.java"), expected);
     }
 
     @Test
@@ -374,18 +377,14 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "105:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "107:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "108:9: " + getCheckMessage(MSG_JAVADOC_MISSING), };
-        verify(checkConfig, getPath("checks" + File.separator
-                                    + "javadoc" + File.separator
-                                    + "InputNoJavadoc.java"), expected);
+        verify(checkConfig, getPath("InputNoJavadoc.java"), expected);
     }
 
     @Test
     public void testAllowMissingJavadoc() throws Exception {
         checkConfig.addAttribute("allowMissingJavadoc", "true");
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("checks" + File.separator
-                                    + "javadoc" + File.separator
-                                    + "InputNoJavadoc.java"), expected);
+        verify(checkConfig, getPath("InputNoJavadoc.java"), expected);
     }
 
     @Test
@@ -394,8 +393,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("allowMissingThrowsTags", "true");
         checkConfig.addAttribute("allowMissingReturnTag", "true");
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("javadoc" + File.separator
-                                    + "InputMissingJavadocTags.java"), expected);
+        verify(checkConfig, getPath("InputMissingJavadocTags.java"), expected);
     }
 
     @Test
@@ -407,8 +405,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "51: " + getCheckMessage(MSG_RETURN_EXPECTED),
             "61: " + getCheckMessage(MSG_RETURN_EXPECTED),
         };
-        verify(checkConfig, getPath("javadoc" + File.separator
-                + "InputMissingJavadocTags.java"), expected);
+        verify(checkConfig, getPath("InputMissingJavadocTags.java"), expected);
     }
 
     @Test
@@ -432,8 +429,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "74:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "76:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
-        verify(checkConfig, getPath("javadoc" + File.separator
-                                    + "InputSetterGetter.java"), expected);
+        verify(checkConfig, getPath("InputSetterGetter.java"), expected);
     }
 
     @Test
@@ -455,8 +451,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "74:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "76:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
-        verify(checkConfig, getPath("javadoc" + File.separator
-                                    + "InputSetterGetter.java"), expected);
+        verify(checkConfig, getPath("InputSetterGetter.java"), expected);
     }
 
     @Test
@@ -473,13 +468,13 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
     @Test
     public void test11684081() throws Exception {
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("checks/javadoc/Input_01.java"), expected);
+        verify(checkConfig, getPath("Input_01.java"), expected);
     }
 
     @Test
     public void test11684082() throws Exception {
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("checks/javadoc/Input_02.java"), expected);
+        verify(checkConfig, getPath("Input_02.java"), expected);
     }
 
     @Test
@@ -487,7 +482,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("allowThrowsTagsForSubclasses", "true");
         checkConfig.addAttribute("allowUndeclaredRTE", "true");
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("checks/javadoc/Input_03.java"), expected);
+        verify(checkConfig, getPath("Input_03.java"), expected);
     }
 
     @Test
@@ -502,7 +497,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "43:38: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "RuntimeException"),
             "44:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "java.lang.RuntimeException"),
         };
-        verify(checkConfig, getPath("javadoc/TestGenerics.java"), expected);
+        verify(checkConfig, getPath("TestGenerics.java"), expected);
     }
 
     @Test
@@ -516,7 +511,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "43:38: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "RuntimeException"),
             "44:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "java.lang.RuntimeException"),
         };
-        verify(checkConfig, getPath("javadoc/TestGenerics.java"), expected);
+        verify(checkConfig, getPath("TestGenerics.java"), expected);
     }
 
     @Test
@@ -530,7 +525,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "43:38: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "RuntimeException"),
             "44:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "java.lang.RuntimeException"),
         };
-        verify(checkConfig, getPath("javadoc/TestGenerics.java"), expected);
+        verify(checkConfig, getPath("TestGenerics.java"), expected);
     }
 
     @Test
@@ -538,7 +533,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("allowThrowsTagsForSubclasses", "true");
         checkConfig.addAttribute("allowUndeclaredRTE", "true");
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("checks/javadoc/Input_1379666.java"), expected);
+        verify(checkConfig, getPath("Input_1379666.java"), expected);
     }
 
     @Test
@@ -551,14 +546,14 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "41:5: " + getCheckMessage(MSG_INVALID_INHERIT_DOC),
             "46:5: " + getCheckMessage(MSG_INVALID_INHERIT_DOC),
         };
-        verify(checkConfig, getPath("javadoc/InputInheritDoc.java"), expected);
+        verify(checkConfig, getPath("InputInheritDoc.java"), expected);
     }
 
     @Test
     public void testSkipCertainMethods() throws Exception {
         checkConfig.addAttribute("ignoreMethodNamesRegex", "^foo.*$");
         String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("javadoc/InputJavadocMethodIgnoreNameRegex.java"), expected);
+        verify(checkConfig, getPath("InputJavadocMethodIgnoreNameRegex.java"), expected);
     }
 
     @Test
@@ -569,7 +564,6 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "9:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "13:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
-        verify(checkConfig, getPath("javadoc/InputJavadocMethodIgnoreNameRegex.java"), expected);
+        verify(checkConfig, getPath("InputJavadocMethodIgnoreNameRegex.java"), expected);
     }
-
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -27,6 +27,7 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.UN
 import static org.junit.Assert.assertArrayEquals;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
@@ -40,6 +41,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * @author Oliver.Burn
  */
 public class JavadocTypeCheckTest extends BaseCheckTestSupport {
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("checks" + File.separator
+                + "javadoc" + File.separator + filename);
+    }
 
     @Test
     public void testGetRequiredTokens() {
@@ -77,7 +83,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
             "302: " + getCheckMessage(JAVADOC_MISSING),
             "327: " + getCheckMessage(JAVADOC_MISSING),
         };
-        verify(checkConfig, getPath("checks/javadoc/InputTags.java"), expected);
+        verify(checkConfig, getPath("InputTags.java"), expected);
     }
 
     @Test
@@ -281,8 +287,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
             "111: " + getCheckMessage(JAVADOC_MISSING),
         };
         verify(checkConfig,
-               getPath("checks" + File.separator
-                       + "javadoc" + File.separator + "InputNoJavadoc.java"),
+               getPath("InputNoJavadoc.java"),
                expected);
     }
 
@@ -296,8 +301,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
             "15: " + getCheckMessage(JAVADOC_MISSING),
         };
         verify(checkConfig,
-               getPath("checks" + File.separator
-                       + "javadoc" + File.separator + "InputNoJavadoc.java"),
+               getPath("InputNoJavadoc.java"),
                expected);
     }
 
@@ -318,8 +322,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
             "111: " + getCheckMessage(JAVADOC_MISSING),
         };
         verify(checkConfig,
-               getPath("checks" + File.separator
-                       + "javadoc" + File.separator + "InputNoJavadoc.java"),
+               getPath("InputNoJavadoc.java"),
                expected);
     }
 
@@ -356,8 +359,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
             "5:4: " + getCheckMessage(UNKNOWN_TAG, "mytag"),
         };
         verify(checkConfig,
-               getPath("checks" + File.separator
-                       + "javadoc" + File.separator + "InputBadTag.java"),
+               getPath("InputBadTag.java"),
                expected);
     }
 
@@ -368,8 +370,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("allowUnknownTags", "true");
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig,
-                getPath("checks" + File.separator
-                        + "javadoc" + File.separator + "InputBadTag.java"),
+                getPath("InputBadTag.java"),
                 expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
@@ -23,6 +23,7 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableChec
 import static org.junit.Assert.assertArrayEquals;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
@@ -34,6 +35,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class JavadocVariableCheckTest
     extends BaseCheckTestSupport {
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("checks" + File.separator
+                + "javadoc" + File.separator + filename);
+    }
 
     @Test
     public void testGetRequiredTokens() {
@@ -69,7 +75,7 @@ public class JavadocVariableCheckTest
             "311:5: " + getCheckMessage(JAVADOC_MISSING),
             "330:5: " + getCheckMessage(JAVADOC_MISSING),
         };
-        verify(checkConfig, getPath("checks/javadoc/InputTags.java"), expected);
+        verify(checkConfig, getPath("InputTags.java"), expected);
     }
 
     @Test
@@ -168,8 +174,7 @@ public class JavadocVariableCheckTest
             "113:9: " + getCheckMessage(JAVADOC_MISSING),
         };
         verify(checkConfig,
-               getPath("checks" + File.separator
-                       + "javadoc" + File.separator + "InputNoJavadoc.java"),
+               getPath("InputNoJavadoc.java"),
                expected);
     }
 
@@ -185,8 +190,7 @@ public class JavadocVariableCheckTest
             "17:9: " + getCheckMessage(JAVADOC_MISSING),
         };
         verify(checkConfig,
-               getPath("checks" + File.separator
-                       + "javadoc" + File.separator + "InputNoJavadoc.java"),
+               getPath("InputNoJavadoc.java"),
                expected);
     }
 
@@ -232,8 +236,7 @@ public class JavadocVariableCheckTest
             "113:9: " + getCheckMessage(JAVADOC_MISSING),
         };
         verify(checkConfig,
-               getPath("checks" + File.separator
-                       + "javadoc" + File.separator + "InputNoJavadoc.java"),
+               getPath("InputNoJavadoc.java"),
                expected);
     }
 
@@ -282,8 +285,7 @@ public class JavadocVariableCheckTest
             "103:9: " + getCheckMessage(JAVADOC_MISSING),
         };
         verify(checkConfig,
-                getPath("checks" + File.separator
-                        + "javadoc" + File.separator + "InputNoJavadoc.java"),
+                getPath("InputNoJavadoc.java"),
                 expected);
     }
 
@@ -333,9 +335,7 @@ public class JavadocVariableCheckTest
             "113:9: " + getCheckMessage(JAVADOC_MISSING),
         };
         verify(checkConfig,
-                getPath("checks" + File.separator
-                        + "javadoc" + File.separator + "InputNoJavadoc.java"),
+                getPath("InputNoJavadoc.java"),
                 expected);
     }
-
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/AllowedAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/AllowedAnnotations.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.javadoc;
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 /**
  * Some javadoc.
@@ -11,7 +11,7 @@ public class AllowedAnnotations implements SomeInterface {
     @ThisIsOkToo
     public void allowed2() {}
 
-    @com.puppycrawl.tools.checkstyle.javadoc.ThisIsOk
+    @com.puppycrawl.tools.checkstyle.checks.javadoc.ThisIsOk
     public void allowed3() {}
 
     @Override

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/ExtendAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/ExtendAnnotation.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.puppycrawl.tools.checkstyle.javadoc;
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputInheritDoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputInheritDoc.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.javadoc;
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 public class InputInheritDoc
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputInner.java
@@ -1,0 +1,79 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for checkstyle.
+// Created: 2001
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+/**
+ * Tests having inner types
+ * @author Oliver Burn
+ **/
+class InputInner
+{
+    // Ignore - two errors
+    class InnerInner2
+    {
+        // Ignore
+        public int fData;
+    }
+
+    // Ignore - 2 errors
+    interface InnerInterface2
+    {
+        // Ignore - should be all upper case
+        String data = "zxzc";
+
+        // Ignore
+        class InnerInterfaceInnerClass
+        {
+            // Ignore - need Javadoc and made private
+            public int rData;
+
+            /** needs to be made private unless allowProtected. */
+            protected int protectedVariable;
+
+            /** needs to be made private unless allowPackage. */
+            int packageVariable;
+        }
+    }
+
+    /** demonstrate bug in handling static final **/
+    protected static Object sWeird = new Object();
+    /** demonstrate bug in handling static final **/
+    static Object sWeird2 = new Object();
+    
+    /** demonstrate bug in local final variable */
+    public interface Inter
+    {
+    }
+    
+     public static void main()
+     {
+        Inter m = new Inter()
+        {
+            private static final int CDS = 1;
+            
+            private int ABC;
+        };
+     }
+
+    /** annotation field incorrectly named. */
+    @interface InnerAnnotation
+    {
+        /** Ignore - should be all upper case. */
+        String data = "zxzc";
+    }
+
+    /** enum with public member variable */
+    enum InnerEnum
+    {
+        /** First constant */
+        A,
+
+        /** Second constant */
+        B;
+
+        /** Should be private */
+        public int someValue;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputJavadoc.java
@@ -3,7 +3,7 @@
 // Created: 2001
 ////////////////////////////////////////////////////////////////////////////////
 
-package com.puppycrawl.tools.checkstyle;
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 /**
  * Testing author and version tag patterns

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputJavadocMethodCheck_SmallMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputJavadocMethodCheck_SmallMethods.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.javadoc;
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 /**
  * The following is a bad tag.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputJavadocMethodIgnoreNameRegex.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputJavadocMethodIgnoreNameRegex.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.javadoc;
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 public class InputJavadocMethodIgnoreNameRegex
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputMissingJavadocTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputMissingJavadocTags.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.javadoc;
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 public class InputMissingJavadocTags {
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputPublicOnly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputPublicOnly.java
@@ -2,7 +2,7 @@
 // Test case file for checkstyle.
 // Created: 2001
 ////////////////////////////////////////////////////////////////////////////////
-package com.puppycrawl.tools.checkstyle;
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 public class InputPublicOnly // ignore - need javadoc
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputScopeAnonInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputScopeAnonInner.java
@@ -2,7 +2,7 @@
 // Test case file for checkstyle.
 // Created: 2001
 ////////////////////////////////////////////////////////////////////////////////
-package com.puppycrawl.tools.checkstyle;
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseAdapter;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputScopeInnerClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputScopeInnerClasses.java
@@ -2,7 +2,7 @@
 // Test case file for checkstyle.
 // Created: 2001
 ////////////////////////////////////////////////////////////////////////////////
-package com.puppycrawl.tools.checkstyle;
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 /**
    Checks javadoc scoping for inner classes.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputScopeInnerInterfaces.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputScopeInnerInterfaces.java
@@ -2,7 +2,7 @@
 // Test case file for checkstyle.
 // Created: 2001
 ////////////////////////////////////////////////////////////////////////////////
-package com.puppycrawl.tools.checkstyle;
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 public class InputScopeInnerInterfaces
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputSetterGetter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputSetterGetter.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.javadoc;
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 public class InputSetterGetter
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputTypeParamsTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputTypeParamsTags.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle;
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 /**
  * Some explanation.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputWhitespace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputWhitespace.java
@@ -1,0 +1,61 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for checkstyle.
+// Created: 2001
+////////////////////////////////////////////////////////////////////////////////
+package com . puppycrawl
+    .tools.
+    checkstyle.checks.javadoc;
+
+/**
+ * Class for testing javadoc issues.
+ * error missing author tag
+ **/
+class InputWhitespace
+{
+    /** another check */
+    void donBradman(Runnable aRun)
+    {
+        donBradman(new Runnable() {
+            public void run() {
+            }
+        });
+
+        final Runnable r = new Runnable() {
+            public void run() {
+            }
+        };
+    }
+
+    /** bug 806243 (NoWhitespaceBeforeCheck error for anonymous inner class) */
+    void bug806243()
+    {
+        Object o = new InputWhitespace() {
+            private int j ;
+        };
+    }
+}
+
+/**
+ * Bug 806242 (NoWhitespaceBeforeCheck error with an interface).
+ * @author o_sukhodolsky
+ * @version 1.0
+ */
+interface IFoo
+{
+    void foo() ;
+}
+
+/**
+ * Avoid Whitespace errors in for loop.
+ * @author lkuehne
+ * @version 1.0
+ */
+class SpecialCasesInForLoop
+{
+    public void myMethod() {
+        new Thread() {
+            public void run() {
+            }
+        }.start();
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/TestGenerics.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/TestGenerics.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.javadoc;
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 public class TestGenerics <E extends java.lang.Exception,
                            RE extends RuntimeException & java.io.Serializable>


### PR DESCRIPTION
new suppression needed
> JavadocMethodCheckTest.java:44: error: Total number of methods is 36 (max allowed is 35).

FileSetCheckLifecycleTest was using javadoc input files, but it doesn't look like it really needs a specific file, so I just picked one in its current directory.