### PR TITLE
Issue #2161: unify test input locations for sizes package

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
@@ -23,6 +23,9 @@ import static com.puppycrawl.tools.checkstyle.checks.sizes.FileLengthCheck.MSG_K
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
@@ -33,6 +36,12 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class FileLengthCheckTest
     extends BaseCheckTestSupport {
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("checks" + File.separator
+                + "sizes" + File.separator + filename);
+    }
+
     @Override
     protected DefaultConfiguration createCheckerConfig(
         Configuration config) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
@@ -22,6 +22,9 @@ package com.puppycrawl.tools.checkstyle.checks.sizes;
 import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
 import static org.junit.Assert.assertArrayEquals;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
@@ -29,6 +32,11 @@ import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
 public class LineLengthCheckTest extends BaseCheckTestSupport {
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("checks" + File.separator
+                + "sizes" + File.separator + filename);
+    }
 
     @Test
     public void testGetRequiredTokens() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
@@ -22,6 +22,9 @@ package com.puppycrawl.tools.checkstyle.checks.sizes;
 import static com.puppycrawl.tools.checkstyle.checks.sizes.MethodLengthCheck.MSG_KEY;
 import static org.junit.Assert.assertArrayEquals;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
@@ -30,6 +33,11 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class MethodLengthCheckTest extends BaseCheckTestSupport {
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("checks" + File.separator
+                + "sizes" + File.separator + filename);
+    }
 
     @Test
     public void testGetRequiredTokens() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckTest.java
@@ -22,6 +22,9 @@ package com.puppycrawl.tools.checkstyle.checks.sizes;
 import static com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck.MSG_KEY;
 import static org.junit.Assert.assertArrayEquals;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
@@ -30,6 +33,11 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class OuterTypeNumberCheckTest extends BaseCheckTestSupport {
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("checks" + File.separator
+                + "sizes" + File.separator + filename);
+    }
 
     @Test
     public void testGetRequiredTokens() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
@@ -22,6 +22,9 @@ package com.puppycrawl.tools.checkstyle.checks.sizes;
 import static com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck.MSG_KEY;
 import static org.junit.Assert.assertArrayEquals;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
@@ -31,6 +34,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class ParameterNumberCheckTest
     extends BaseCheckTestSupport {
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("checks" + File.separator
+                + "sizes" + File.separator + filename);
+    }
 
     @Test
     public void testGetRequiredTokens() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/InputModifier.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/InputModifier.java
@@ -3,14 +3,8 @@
 // Created: 2001
 ////////////////////////////////////////////////////////////////////////////////
 
-package com.puppycrawl.tools.checkstyle;
+package com.puppycrawl.tools.checkstyle.checks.sizes;
 
-/**
- * Test case for Modifier checks:
- * - order of modifiers
- * - use of 'public' in interface definition
- * @author lkuehne
- */
 strictfp final class InputModifier // illegal order of modifiers for class
 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/InputParameterNumberCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/InputParameterNumberCheck.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle;
+package com.puppycrawl.tools.checkstyle.checks.sizes;
 
 class InputParameterNumberCheckBase
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/InputSimple.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/InputSimple.java
@@ -1,0 +1,225 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for checkstyle.
+// Created: Feb-2001
+// Ignore error
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.sizes;
+import java.io.*;
+/**
+ * Contains simple mistakes:
+ * - Long lines
+ * - Tabs
+ * - Format of variables and parameters
+ * - Order of modifiers
+ * @author Oliver Burn
+ **/
+final class InputSimple
+{
+    // Long line ----------------------------------------------------------------
+    // Contains a tab ->	<-
+    // Contains trailing whitespace ->
+
+    // Name format tests
+    //
+    /** Invalid format **/
+    public static final int badConstant = 2;
+    /** Valid format **/
+    public static final int MAX_ROWS = 2;
+
+    /** Invalid format **/
+    private static int badStatic = 2;
+    /** Valid format **/
+    private static int sNumCreated = 0;
+
+    /** Invalid format **/
+    private int badMember = 2;
+    /** Valid format **/
+    private int mNumCreated1 = 0;
+    /** Valid format **/
+    protected int mNumCreated2 = 0;
+
+    /** commas are wrong **/
+    private int[] mInts = new int[] {1,2, 3,
+                                     4};
+
+    //
+    // Accessor tests
+    //
+    /** should be private **/
+    public static int sTest1;
+    /** should be private **/
+    protected static int sTest3;
+    /** should be private **/
+    static int sTest2;
+
+    /** should be private **/
+    int mTest1;
+    /** should be private **/
+    public int mTest2;
+
+    //
+    // Parameter name format tests
+    //
+
+    /**
+     * @return hack
+     * @param badFormat1 bad format
+     * @param badFormat2 bad format
+     * @param badFormat3 bad format
+     * @throws java.lang.Exception abc
+     **/
+    int test1(int badFormat1,int badFormat2,
+              final int badFormat3)
+        throws java.lang.Exception
+    {
+        return 0;
+    }
+
+    /** method that is 20 lines long **/
+    private void longMethod()
+    {
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+    }
+
+    /** constructor that is 10 lines long **/
+    private InputSimple()
+    {
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+    }
+
+    /** test local variables */
+    private void localVariables()
+    {
+        // normal decl
+        int abc = 0;
+        int ABC = 0;
+
+        // final decls
+        final int cde = 0;
+        final int CDE = 0;
+
+        // decl in for loop init statement
+        for (int k = 0; k < 1; k++)
+        {
+            String innerBlockVariable = "";
+        }
+        for (int I = 0; I < 1; I++)
+        {
+            String InnerBlockVariable = "";
+        }
+    }
+
+    /** test method pattern */
+    void ALL_UPPERCASE_METHOD()
+    {
+    }
+
+    /** test illegal constant **/
+    private static final int BAD__NAME = 3;
+
+    // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
+    // long line that has a tab ->	<- and would be OK if tab counted as 1 char
+    // tabs that count as one char because of their position ->	<-   ->	<-, OK
+ 
+    /** some lines to test the error column after tabs */
+    void errorColumnAfterTabs()
+    {
+        // with tab-width 8 all statements below start at the same column,
+        // with different combinations of ' ' and '\t' before the statement
+                int tab0 =1;
+        	int tab1 =1;
+         	int tab2 =1;
+		int tab3 =1;
+  	  	int tab4 =1;
+  	        int tab5 =1;
+    }
+
+    // FIXME:
+    /* FIXME: a
+     * FIXME:
+     * TODO
+     */
+    /* NOTHING */
+    /* YES */ /* FIXME: x */ /* YES!! */
+
+    /** test long comments **/
+    void veryLong()
+    {
+        /*
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          enough talk */
+    }
+
+    /**
+     * @see to lazy to document all args. Testing excessive # args
+     **/
+    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
+                    int aArg6, int aArg7, int aArg8, int aArg9)
+    {
+    }
+}
+
+/** Test class for variable naming in for each clauses. */
+class InputSimple2
+{
+    /** Some more Javadoc. */
+    public void doSomething()
+    {
+        //"O" should be named "o"
+        for (Object O : new java.util.ArrayList())
+        {
+
+        }
+    }
+}
+
+/** Test enum for member naming check */
+enum MyEnum1
+{
+    /** ABC constant */
+    ABC,
+
+    /** XYZ constant */
+    XYZ;
+
+    /** Should be mSomeMemeber */
+    private int someMember;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckInput.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckInput.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle;
+package com.puppycrawl.tools.checkstyle.checks.sizes;
 
 /**Contains empty inner class for OuterTypeNumberCheckTest*/
 public class OuterTypeNumberCheckInput {


### PR DESCRIPTION
1 input copied. InputModifier lost the javadoc tag since this is the only place the file is for, which is not a modifier package.