### PR TITLE
Issue #2161: unify test input locations for comments package

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -65,9 +65,9 @@
     <suppress checks="MagicNumber" files=".*[\\/]checkstyle[\\/]gui[\\/]"/>
 
     <!-- Methods that build fake AST are very long-->
-    <suppress checks="MethodLength" files="src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]comments[\\/]CommentsTest\.java"/>
-    <suppress checks="ExecutableStatementCount" files="src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]comments[\\/]CommentsTest\.java"/>
-    <suppress checks="JavaNCSS" files="src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]comments[\\/]CommentsTest\.java"/>
+    <suppress checks="MethodLength" files="src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]grammars[\\/]comments[\\/]CommentsTest\.java"/>
+    <suppress checks="ExecutableStatementCount" files="src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]grammars[\\/]comments[\\/]CommentsTest\.java"/>
+    <suppress checks="JavaNCSS" files="src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]grammars[\\/]comments[\\/]CommentsTest\.java"/>
 
     <suppress checks="." files=".*JavadocTokenTypes\.java"/>
     <suppress checks="." files=".*ParseTreeBuilder\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/AllBlockCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/AllBlockCommentsTest.java
@@ -17,9 +17,11 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ////////////////////////////////////////////////////////////////////////////////
 
-package com.puppycrawl.tools.checkstyle.comments;
+package com.puppycrawl.tools.checkstyle.grammars.comments;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.Set;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -33,21 +35,26 @@ import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
-public class AllSinglelineCommentsTest extends BaseCheckTestSupport {
+public class AllBlockCommentsTest extends BaseCheckTestSupport {
     private static final Set<String> ALL_COMMENTS = Sets.newLinkedHashSet();
 
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("grammars" + File.separator
+                + "comments" + File.separator + filename);
+    }
+
     @Test
     public void testAllBlockComments() throws Exception {
-        DefaultConfiguration checkConfig = createCheckConfig(SinglelineCommentListenerCheck.class);
+        DefaultConfiguration checkConfig = createCheckConfig(BlockCommentListenerCheck.class);
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("comments" + File.separator
-                + "InputFullOfSinglelineComments.java"), expected);
+        verify(checkConfig, getPath("InputFullOfBlockComments.java"), expected);
         Assert.assertTrue(ALL_COMMENTS.isEmpty());
     }
 
-    private static class SinglelineCommentListenerCheck extends Check {
+    private static class BlockCommentListenerCheck extends Check {
         @Override
         public boolean isCommentNodesRequired() {
             return true;
@@ -60,7 +67,7 @@ public class AllSinglelineCommentsTest extends BaseCheckTestSupport {
 
         @Override
         public int[] getAcceptableTokens() {
-            return new int[] {TokenTypes.SINGLE_LINE_COMMENT};
+            return new int[] {TokenTypes.BLOCK_COMMENT_BEGIN};
         }
 
         @Override
@@ -70,11 +77,15 @@ public class AllSinglelineCommentsTest extends BaseCheckTestSupport {
 
         @Override
         public void init() {
-            int lines = 63;
-            for (int i = 0; i < lines; i++) {
-                ALL_COMMENTS.add(i + LINE_SEPARATOR);
-            }
-            ALL_COMMENTS.add(String.valueOf(lines));
+            ALL_COMMENTS.addAll(Arrays.asList("0", "1", "2", "3", "4", "5",
+                    "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
+                    "16", "17", "18", "19", "20",
+                    LINE_SEPARATOR + "21" + LINE_SEPARATOR,
+                    "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32",
+                    "33", "34", "35", "36", "37", "38", "  39  ", "40", "41",
+                    "42", "43", "44", "45", "46", "47", "48", "49", "50",
+                    "51", "52", "53", "54", "55", "56", "57", "58", "59",
+                    "60", "61"));
         }
 
         @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/AllSinglelineCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/AllSinglelineCommentsTest.java
@@ -17,10 +17,10 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ////////////////////////////////////////////////////////////////////////////////
 
-package com.puppycrawl.tools.checkstyle.comments;
+package com.puppycrawl.tools.checkstyle.grammars.comments;
 
 import java.io.File;
-import java.util.Arrays;
+import java.io.IOException;
 import java.util.Set;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -34,21 +34,26 @@ import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
-public class AllBlockCommentsTest extends BaseCheckTestSupport {
+public class AllSinglelineCommentsTest extends BaseCheckTestSupport {
     private static final Set<String> ALL_COMMENTS = Sets.newLinkedHashSet();
 
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("grammars" + File.separator
+                + "comments" + File.separator + filename);
+    }
+
     @Test
     public void testAllBlockComments() throws Exception {
-        DefaultConfiguration checkConfig = createCheckConfig(BlockCommentListenerCheck.class);
+        DefaultConfiguration checkConfig = createCheckConfig(SinglelineCommentListenerCheck.class);
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("comments" + File.separator
-                + "InputFullOfBlockComments.java"), expected);
+        verify(checkConfig, getPath("InputFullOfSinglelineComments.java"), expected);
         Assert.assertTrue(ALL_COMMENTS.isEmpty());
     }
 
-    private static class BlockCommentListenerCheck extends Check {
+    private static class SinglelineCommentListenerCheck extends Check {
         @Override
         public boolean isCommentNodesRequired() {
             return true;
@@ -61,7 +66,7 @@ public class AllBlockCommentsTest extends BaseCheckTestSupport {
 
         @Override
         public int[] getAcceptableTokens() {
-            return new int[] {TokenTypes.BLOCK_COMMENT_BEGIN};
+            return new int[] {TokenTypes.SINGLE_LINE_COMMENT};
         }
 
         @Override
@@ -71,15 +76,11 @@ public class AllBlockCommentsTest extends BaseCheckTestSupport {
 
         @Override
         public void init() {
-            ALL_COMMENTS.addAll(Arrays.asList("0", "1", "2", "3", "4", "5",
-                    "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
-                    "16", "17", "18", "19", "20",
-                    LINE_SEPARATOR + "21" + LINE_SEPARATOR,
-                    "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32",
-                    "33", "34", "35", "36", "37", "38", "  39  ", "40", "41",
-                    "42", "43", "44", "45", "46", "47", "48", "49", "50",
-                    "51", "52", "53", "54", "55", "56", "57", "58", "59",
-                    "60", "61"));
+            int lines = 63;
+            for (int i = 0; i < lines; i++) {
+                ALL_COMMENTS.add(i + LINE_SEPARATOR);
+            }
+            ALL_COMMENTS.add(String.valueOf(lines));
         }
 
         @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
@@ -17,7 +17,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ////////////////////////////////////////////////////////////////////////////////
 
-package com.puppycrawl.tools.checkstyle.comments;
+package com.puppycrawl.tools.checkstyle.grammars.comments;
 
 import static com.puppycrawl.tools.checkstyle.api.TokenTypes.ANNOTATIONS;
 import static com.puppycrawl.tools.checkstyle.api.TokenTypes.BLOCK_COMMENT_BEGIN;
@@ -47,6 +47,7 @@ import static com.puppycrawl.tools.checkstyle.api.TokenTypes.SLIST;
 import static com.puppycrawl.tools.checkstyle.api.TokenTypes.TYPE;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Assert;
@@ -92,31 +93,37 @@ public class CommentsTest extends BaseCheckTestSupport {
         annotationsDef.setType(ANNOTATIONS);
         annotationsDef.setText("ANNOTATIONS");
         annotationsDef.setLineNo(1);
-        annotationsDef.setColumnNo(39);
+        annotationsDef.setColumnNo(48);
 
         DetailAST dotDef = new DetailAST();
         dotDef.setType(DOT);
         dotDef.setText(".");
         dotDef.setLineNo(1);
-        dotDef.setColumnNo(39);
+        dotDef.setColumnNo(48);
 
         DetailAST subDotDef = new DetailAST();
         subDotDef.setType(DOT);
         subDotDef.setText(".");
         subDotDef.setLineNo(1);
-        subDotDef.setColumnNo(28);
+        subDotDef.setColumnNo(39);
 
         DetailAST subDotDef1 = new DetailAST();
         subDotDef1.setType(DOT);
         subDotDef1.setText(".");
         subDotDef1.setLineNo(1);
-        subDotDef1.setColumnNo(22);
+        subDotDef1.setColumnNo(28);
 
         DetailAST subDotDef2 = new DetailAST();
         subDotDef2.setType(DOT);
         subDotDef2.setText(".");
         subDotDef2.setLineNo(1);
-        subDotDef2.setColumnNo(11);
+        subDotDef2.setColumnNo(22);
+
+        DetailAST subDotDef3 = new DetailAST();
+        subDotDef3.setType(DOT);
+        subDotDef3.setText(".");
+        subDotDef3.setLineNo(1);
+        subDotDef3.setColumnNo(11);
 
         DetailAST identDef = new DetailAST();
         identDef.setType(IDENT);
@@ -140,7 +147,7 @@ public class CommentsTest extends BaseCheckTestSupport {
         semiDef.setType(SEMI);
         semiDef.setText(";");
         semiDef.setLineNo(1);
-        semiDef.setColumnNo(48);
+        semiDef.setColumnNo(57);
 
         DetailAST identDef4 = new DetailAST();
         identDef4.setType(IDENT);
@@ -150,9 +157,15 @@ public class CommentsTest extends BaseCheckTestSupport {
 
         DetailAST identDef5 = new DetailAST();
         identDef5.setType(IDENT);
-        identDef5.setText("comments");
+        identDef5.setText("grammars");
         identDef5.setLineNo(1);
         identDef5.setColumnNo(40);
+
+        DetailAST identDef6 = new DetailAST();
+        identDef6.setType(IDENT);
+        identDef6.setText("comments");
+        identDef6.setLineNo(1);
+        identDef6.setColumnNo(49);
 
         DetailAST classDef = new DetailAST();
         classDef.setType(CLASS_DEF);
@@ -237,11 +250,13 @@ public class CommentsTest extends BaseCheckTestSupport {
         dotDef.setFirstChild(subDotDef);
         subDotDef.setFirstChild(subDotDef1);
         subDotDef1.setFirstChild(subDotDef2);
-        subDotDef2.setFirstChild(identDef);
+        subDotDef2.setFirstChild(subDotDef3);
+        subDotDef3.setFirstChild(identDef);
         identDef.setNextSibling(identDef2);
-        subDotDef2.setNextSibling(identDef3);
-        subDotDef1.setNextSibling(identDef4);
-        subDotDef.setNextSibling(identDef5);
+        subDotDef2.setNextSibling(identDef4);
+        subDotDef3.setNextSibling(identDef3);
+        subDotDef1.setNextSibling(identDef5);
+        subDotDef.setNextSibling(identDef6);
         dotDef.setNextSibling(semiDef);
         packageDef.setNextSibling(classDef);
         classDef.setFirstChild(modifiers);
@@ -308,31 +323,37 @@ public class CommentsTest extends BaseCheckTestSupport {
         annotationsDef.setType(ANNOTATIONS);
         annotationsDef.setText("ANNOTATIONS");
         annotationsDef.setLineNo(1);
-        annotationsDef.setColumnNo(39);
+        annotationsDef.setColumnNo(48);
 
         DetailAST dotDef = new DetailAST();
         dotDef.setType(DOT);
         dotDef.setText(".");
         dotDef.setLineNo(1);
-        dotDef.setColumnNo(39);
+        dotDef.setColumnNo(48);
 
         DetailAST subDotDef = new DetailAST();
         subDotDef.setType(DOT);
         subDotDef.setText(".");
         subDotDef.setLineNo(1);
-        subDotDef.setColumnNo(28);
+        subDotDef.setColumnNo(39);
 
         DetailAST subDotDef1 = new DetailAST();
         subDotDef1.setType(DOT);
         subDotDef1.setText(".");
         subDotDef1.setLineNo(1);
-        subDotDef1.setColumnNo(22);
+        subDotDef1.setColumnNo(28);
 
         DetailAST subDotDef2 = new DetailAST();
         subDotDef2.setType(DOT);
         subDotDef2.setText(".");
         subDotDef2.setLineNo(1);
-        subDotDef2.setColumnNo(11);
+        subDotDef2.setColumnNo(22);
+
+        DetailAST subDotDef3 = new DetailAST();
+        subDotDef3.setType(DOT);
+        subDotDef3.setText(".");
+        subDotDef3.setLineNo(1);
+        subDotDef3.setColumnNo(11);
 
         DetailAST identDef = new DetailAST();
         identDef.setType(IDENT);
@@ -356,7 +377,7 @@ public class CommentsTest extends BaseCheckTestSupport {
         semiDef.setType(SEMI);
         semiDef.setText(";");
         semiDef.setLineNo(1);
-        semiDef.setColumnNo(48);
+        semiDef.setColumnNo(57);
 
         DetailAST identDef4 = new DetailAST();
         identDef4.setType(IDENT);
@@ -366,9 +387,15 @@ public class CommentsTest extends BaseCheckTestSupport {
 
         DetailAST identDef5 = new DetailAST();
         identDef5.setType(IDENT);
-        identDef5.setText("comments");
+        identDef5.setText("grammars");
         identDef5.setLineNo(1);
         identDef5.setColumnNo(40);
+
+        DetailAST identDef6 = new DetailAST();
+        identDef6.setType(IDENT);
+        identDef6.setText("comments");
+        identDef6.setLineNo(1);
+        identDef6.setColumnNo(49);
 
         DetailAST classDef = new DetailAST();
         classDef.setType(CLASS_DEF);
@@ -584,11 +611,13 @@ public class CommentsTest extends BaseCheckTestSupport {
         dotDef.setFirstChild(subDotDef);
         subDotDef.setFirstChild(subDotDef1);
         subDotDef1.setFirstChild(subDotDef2);
-        subDotDef2.setFirstChild(identDef);
+        subDotDef2.setFirstChild(subDotDef3);
+        subDotDef3.setFirstChild(identDef);
         identDef.setNextSibling(identDef2);
-        subDotDef2.setNextSibling(identDef3);
-        subDotDef1.setNextSibling(identDef4);
-        subDotDef.setNextSibling(identDef5);
+        subDotDef2.setNextSibling(identDef4);
+        subDotDef3.setNextSibling(identDef3);
+        subDotDef1.setNextSibling(identDef5);
+        subDotDef.setNextSibling(identDef6);
         dotDef.setNextSibling(semiDef);
         packageDef.setNextSibling(classDef);
         blockCommentStart.setNextSibling(literalProtected);
@@ -596,13 +625,18 @@ public class CommentsTest extends BaseCheckTestSupport {
         return packageDef;
     }
 
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("grammars" + File.separator
+                + "comments" + File.separator + filename);
+    }
+
     @Test
     public void testCompareExpectedTreeWithInput1() throws Exception {
         DefaultConfiguration checkConfig = createCheckConfig(CompareTreesWithComments.class);
         CompareTreesWithComments.expectedTree = buildInput1();
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("comments" + File.separator
-                + "InputCommentsTest_1.java"), expected);
+        verify(checkConfig, getPath("InputCommentsTest_1.java"), expected);
     }
 
     @Test
@@ -610,8 +644,7 @@ public class CommentsTest extends BaseCheckTestSupport {
         DefaultConfiguration checkConfig = createCheckConfig(CompareTreesWithComments.class);
         CompareTreesWithComments.expectedTree = buildInput2();
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("comments" + File.separator
-                + "InputCommentsTest_2.java"), expected);
+        verify(checkConfig, getPath("InputCommentsTest_2.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CompareTreesWithComments.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CompareTreesWithComments.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.comments;
+package com.puppycrawl.tools.checkstyle.grammars.comments;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Assert;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/comments/InputCommentsTest_1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/comments/InputCommentsTest_1.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.comments;
+package com.puppycrawl.tools.checkstyle.grammars.comments;
 public class /*
     i'mcomment567
     */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/comments/InputCommentsTest_2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/comments/InputCommentsTest_2.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.comments;
+package com.puppycrawl.tools.checkstyle.grammars.comments;
 // my class
 class InputCommentsTest_2
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/comments/InputFullOfBlockComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/comments/InputFullOfBlockComments.java
@@ -1,4 +1,4 @@
-/*0*//*1*/package/*2*/ com/*3*/./*4*/puppycrawl/*5*/./*6*/tools/*7*/./*8*/checkstyle/*9*/./*10*/comments/*11*/;/*12*/
+/*0*//*1*/package/*2*/ com/*3*/./*4*/puppycrawl/*5*/./*6*/tools/*7*/./*8*/checkstyle.grammars/*9*/./*10*/comments/*11*/;/*12*/
 /*13*/
 /*14*/public/*15*/ class /*16*/InputFullOfBlockComments /*49*/{/*17*/
 	/*18*/

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/comments/InputFullOfSinglelineComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/comments/InputFullOfSinglelineComments.java
@@ -6,7 +6,7 @@ puppycrawl//4
 .//5
 tools//6
 .//7
-checkstyle//8
+checkstyle.grammars//8
 .//9
 comments//10
 //11


### PR DESCRIPTION
Package was moved from "com.puppycrawl.tools.checkstyle.comments" to "com.puppycrawl.tools.checkstyle.grammars.comments".

checks pass, but please verify my new AST creation for any mistakes. I did not add new comments in the inputs, as I felt they weren't needed.