### PR TITLE
Pull #2394: Update Maven Surefire and Failsafe plugins to 2.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -681,7 +681,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.18.1</version>
+        <version>2.19</version>
         <configuration>
           <includes>
             <include>com/google/**/*.java</include>
@@ -707,7 +707,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.18.1</version>
+        <version>2.19</version>
         <configuration>
           <argLine>-Duser.language=en -Duser.country=US -XX:-UseSplitVerifier</argLine>
           <systemPropertyVariables>
@@ -958,7 +958,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>2.18.1</version>
+        <version>2.19</version>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
# Release Notes - Maven Surefire 2.19

<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-856'>SUREFIRE-856</a>]
-         Running single test in Failsafe using CLI does not override
&lt;includes&gt; configuration
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-919'>SUREFIRE-919</a>]
-         TestNG plugin fails to apply &#39;verbose&#39; setting from
TestNG.xml
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-945'>SUREFIRE-945</a>]
-         Top of web page is pretty opaque
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-964'>SUREFIRE-964</a>]
-         TEST-*.xml files generated by Surefire throw validation warnings
in Eclipse for no grammer constraints (DTD or XML schema) referenced in the document </li> <li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-983'>SUREFIRE-983</a>]
-         &#39;Running a Single Test&#39; feature does not work as expected
(for testng provider)
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-986'>SUREFIRE-986</a>]
-         Groovy power assert incorrect indentation
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1024'>SUREFIRE-1024</a>]
-         &quot;verify&quot; goal ignores &quot;dependenciesToScan&quot;
parameter when checking tests existence
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1037'>SUREFIRE-1037</a>]
-         Elapsed time is reported incorrectly for tests run in parallel
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1067'>SUREFIRE-1067</a>]
-         Nested causes conflated with wrapper exception
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1084'>SUREFIRE-1084</a>]
-         Surefire-report stack traces appear on a single line.
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1125'>SUREFIRE-1125</a>]
-         Running multiple methods via the `test` property does not work in
junit47 provider
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1126'>SUREFIRE-1126</a>]
-         Discrepancy between test exclusion docs and plugin behavior
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1127'>SUREFIRE-1127</a>]
-         Failsafe project does not fail in verify phase when a test case
object errors during initialization
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1128'>SUREFIRE-1128</a>]
-         Fix mvn 2.2.1 build process
https://builds.apache.org/view/All/job/maven-surefire-mvn-2.2.1
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1129'>SUREFIRE-1129</a>]
-         JDK 5 should be the min requirements in surefire project
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1131'>SUREFIRE-1131</a>]
-         Remove obsolete maven profiles
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1133'>SUREFIRE-1133</a>]
-         Surefire Windows Build fails on OOM
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1136'>SUREFIRE-1136</a>]
-         Current working directory propagation in forked mode
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1137'>SUREFIRE-1137</a>]
-         Problem with Umlauts in stdout
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1138'>SUREFIRE-1138</a>]
-         Enabling reuseForks runs all tests in series on just one fork
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1144'>SUREFIRE-1144</a>]
-         Time for testsuite on commandline does not suit with the time
value given in the report file
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1146'>SUREFIRE-1146</a>]
-         rerunFailingTestsCount not working with Parameterized test
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1148'>SUREFIRE-1148</a>]
-         JUnit Method Filter (**/Class#method) should use same syntax as
&quot;test&quot; parameter
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1150'>SUREFIRE-1150</a>]
-         The surefire and failsafe plugin should not be dependent on JCIP
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1151'>SUREFIRE-1151</a>]
-         surefire/failsafe home pages should link to apache.org for issues
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1152'>SUREFIRE-1152</a>]
-         Option rerunFailingTestsCount silently fails with test suites
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1154'>SUREFIRE-1154</a>]
-         TestNG and JUnit should be able to run its own tests
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1158'>SUREFIRE-1158</a>]
-         Remove startup logs of the plugin and TestNG configurator
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1159'>SUREFIRE-1159</a>]
-         JUnit47 runner failing in parallel mode
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1160'>SUREFIRE-1160</a>]
-         -DTest=... should be independent of execustion section
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1161'>SUREFIRE-1161</a>]
-         Executing selected (multiple) tests of same class gives Exception
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1167'>SUREFIRE-1167</a>]
-         Upgrade DOXIA to Version 1.6
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1173'>SUREFIRE-1173</a>]
-         Link to plugin&#39;s web site is reported as redirected by maven
linkcheck plugin.
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1177'>SUREFIRE-1177</a>]
-         TestNG &quot;suitethreadpoolsize&quot; parameter can not be set
by Maven Surefire
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1179'>SUREFIRE-1179</a>]
-         TestNG parallel options seem to not be honored
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1180'>SUREFIRE-1180</a>]
-         Does not overrides include/exclude using -Dtest property
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1181'>SUREFIRE-1181</a>]
-         &quot;forkedProcessTimeoutInSeconds&quot; does not kill forked
JVM although interrupted build
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1182'>SUREFIRE-1182</a>]
-         Surefire 2.19 rc hangs when building maven core
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1184'>SUREFIRE-1184</a>]
-         Documentation for TestNG parameter &quot;testnames&quot; - see
SUREFIRE-845
</li>
</ul>

<h2>        Improvement
</h2>
<ul>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-574'>SUREFIRE-574</a>]
-         additionalClasspathElements-feature improved
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-597'>SUREFIRE-597</a>]
-         Surefire report creation fails on processing absent optional
JUnit xml attributes
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-622'>SUREFIRE-622</a>]
-         The TestNG command line option &#39;-testrunfactory&#39; should
be supported.
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-745'>SUREFIRE-745</a>]
-         -Dtest supports multiple test classes but not multiple test
methods
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-826'>SUREFIRE-826</a>]
-         maven-surefire-plugin does not add its own plugin dependencies to
the classpath
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-850'>SUREFIRE-850</a>]
-         Document how to run TestNG &amp; JUnit 4 tests
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-855'>SUREFIRE-855</a>]
-         Allow failsafe to use actual jar file instead of target/classes
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1065'>SUREFIRE-1065</a>]
-         Allow includesFile and excludesFile parameters to be set from the
commandline
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1155'>SUREFIRE-1155</a>]
-         REFACTORING for Java 5
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1162'>SUREFIRE-1162</a>]
-         Upgrade maven-shared-utils to Version 0.8
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1163'>SUREFIRE-1163</a>]
-         Upgrade maven-verifier to Version 1.6
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1174'>SUREFIRE-1174</a>]
-         Concurrent RunListeners should be annotated @ThreadSafe
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1178'>SUREFIRE-1178</a>]
-         Upgrade maven-shared-utils to Version 0.9
</li>
</ul>

<h2>        New Feature
</h2>
<ul>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-131'>SUREFIRE-131</a>]
-         Excluding tests with command line pattern
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-524'>SUREFIRE-524</a>]
-         Forked Process not terminated if maven process aborted. Provide
means to clean up.
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-580'>SUREFIRE-580</a>]
-         Allow &quot;fail fast&quot; or stop running on first failure
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1134'>SUREFIRE-1134</a>]
-         Take list of tests from file (-Dtest has upper limits for
comma-separated list of tests)
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1140'>SUREFIRE-1140</a>]
-         Support anchoring all test case names
</li>
</ul>
