### PR TITLE
Fix for issue #2398: Exception thrown for incomplete @return tag if next line is empty

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -664,12 +664,13 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
         while (remIndex < lines.length) {
             final Matcher multilineCont = MATCH_JAVADOC_MULTILINE_CONT
                     .matcher(lines[remIndex]);
-            multilineCont.find();
-            remIndex = lines.length;
-            final String lFin = multilineCont.group(1);
-            if (!lFin.equals(NEXT_TAG)
-                && !lFin.equals(END_JAVADOC)) {
-                tags.add(new JavadocTag(tagLine, col, param1));
+            if (multilineCont.find()) {
+                remIndex = lines.length;
+                final String lFin = multilineCont.group(1);
+                if (!lFin.equals(NEXT_TAG)
+                    && !lFin.equals(END_JAVADOC)) {
+                    tags.add(new JavadocTag(tagLine, col, param1));
+                }
             }
             remIndex++;
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -404,6 +404,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
             "30:42: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "ThreadDeath"),
             "51: " + getCheckMessage(MSG_RETURN_EXPECTED),
             "61: " + getCheckMessage(MSG_RETURN_EXPECTED),
+            "72: " + getCheckMessage(MSG_RETURN_EXPECTED),
         };
         verify(checkConfig, getPath("InputMissingJavadocTags.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputMissingJavadocTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputMissingJavadocTags.java
@@ -61,4 +61,15 @@ public class InputMissingJavadocTags {
     private int missingReturnAtTheEnd(int number) {
         return number;
     }
+
+    /**
+     * Missing return at the end followed by empty line.
+     *
+     * @param number to return
+     * @return
+     * 
+     */
+    private int missingReturnAtTheEndFollowedByEmptyLine(int number) {
+        return number;
+    }
 }


### PR DESCRIPTION
Fix for issue #2398 
* Added test data to expose the error.
* Added a check that regexp matching second line of a multiline tag actually finds anything.