### PR TITLE
minor: removed unnecessary manual class lookups

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -353,14 +353,13 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
     public void testGetFullImportIdent() {
         Object actual;
         try {
-            Class<?> clazz = Class.forName(
-                    "com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck");
+            Class<?> clazz = CustomImportOrderCheck.class;
             Object t = clazz.getConstructor().newInstance();
             Method method = clazz.getDeclaredMethod("getFullImportIdent", DetailAST.class);
             method.setAccessible(true);
             actual = method.invoke(t, (DetailAST) null);
         }
-        catch (ClassNotFoundException | NoSuchMethodException | InstantiationException
+        catch (NoSuchMethodException | InstantiationException
                   | IllegalAccessException | InvocationTargetException ignored) {
             actual = null;
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
@@ -69,14 +69,13 @@ public class ImportControlLoaderTest {
                 }
             };
         try {
-            Class<?> clazz = Class.forName(
-                    "com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader");
+            Class<?> clazz = ImportControlLoader.class;
             Method privateMethod = clazz.getDeclaredMethod("safeGet", Attributes.class, String.class);
             privateMethod.setAccessible(true);
             privateMethod.invoke(null, attr, "you_cannot_find_me");
         }
         catch (IllegalAccessException | IllegalArgumentException
-                | ClassNotFoundException | NoSuchMethodException | SecurityException e) {
+                | NoSuchMethodException | SecurityException e) {
             throw new IllegalStateException(e);
         }
     }
@@ -88,14 +87,13 @@ public class ImportControlLoaderTest {
     public void testLoadThrowsException() throws InvocationTargetException {
         InputSource source = new InputSource();
         try {
-            Class<?> clazz = Class.forName(
-                    "com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader");
+            Class<?> clazz = ImportControlLoader.class;
             Method privateMethod = clazz.getDeclaredMethod("load", InputSource.class, URI.class);
             privateMethod.setAccessible(true);
             privateMethod.invoke(null, source, new File(getPath("import-control_complete.xml")).toURI());
         }
         catch (IllegalAccessException | IllegalArgumentException
-                | ClassNotFoundException | NoSuchMethodException | SecurityException e) {
+                | NoSuchMethodException | SecurityException e) {
             throw new IllegalStateException(e);
         }
     }


### PR DESCRIPTION
We do not need to use reflection to get a class that is public and know exactly where it resides. Let Java do the lookup for us, and keep the code a little bit simpler.