### PR TITLE
Issue #2421: expanded checks on test directory

### DIFF
--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -27,8 +27,7 @@
                 failureProperty="checkstyle.failure.property"
                 >
       <fileset dir="src"
-               includes="main/**/*.java,main/**/*.properties,xdocs/**/*.xml,test/java/**/*Test.java"
-               excludes="**/Generated*.java"/>
+               includes="main/**/*.java,main/**/*.properties,xdocs/**/*.xml,test/java/**/*.java"/>
       <formatter type="plain"/>
       <formatter type="xml" toFile="${mvn.project.build.directory}/cs_errors.xml"/>
       <classpath path="${mvn.runtime_classpath}"/>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -47,6 +47,7 @@
     <suppress checks="MethodCount" files="[\\/]JavadocMethodCheckTest.java$"/>
     <suppress checks="MethodCount" files="[\\/]MainTest.java$"/>
     <suppress checks="EqualsAvoidNull" files="[\\/]Int.*FilterTest.java$"/>
+    <suppress checks="VisibilityModifier" files="[\\/]BaseCheckTestSupport.java$"/>
     <suppress checks="WriteTag" files=".*[\\/]src[\\/]test[\\/]"/>
 
     <!-- suppressions to remove over time -->
@@ -91,7 +92,7 @@
     <suppress checks="ClassDataAbstractionCoupling" files="AutomaticBean\.java"/>
     <!-- they are aggregators of logic, usage a several of classes are ok -->
     <suppress checks="ClassDataAbstractionCoupling" files="(Checker|TreeWalker|Main|CheckstyleAntTask|AbstractJavadocCheck)\.java"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="(CheckerTest|TreeWalkerTest)\.java"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="(CheckerTest|TreeWalkerTest|BaseCheckTestSupport)\.java"/>
     <!-- a lot of GUI elements is OK -->
     <suppress checks="ClassDataAbstractionCoupling" files="ParseTreeInfoPanel\.java"/>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseFileSetCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseFileSetCheckTestSupport.java
@@ -1,3 +1,22 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
 package com.puppycrawl.tools.checkstyle;
 
 import com.puppycrawl.tools.checkstyle.api.Configuration;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DebugAuditAdapter.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DebugAuditAdapter.java
@@ -1,7 +1,21 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
 
 package com.puppycrawl.tools.checkstyle;
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DebugChecker.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DebugChecker.java
@@ -1,7 +1,21 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
 
 package com.puppycrawl.tools.checkstyle;
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DebugFilter.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DebugFilter.java
@@ -1,7 +1,21 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
 
 package com.puppycrawl.tools.checkstyle;
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/GeneratedJava14LexerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/GeneratedJava14LexerTest.java
@@ -1,3 +1,22 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
 package com.puppycrawl.tools.checkstyle.grammars;
 
 import java.io.File;
@@ -30,15 +49,19 @@ public class GeneratedJava14LexerTest
 
     @Test
     public void testUnexpectedChar() throws Exception {
-        Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS); // Encoding problems can occur in Windows
+        // Encoding problems can occur in Windows
+        Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
+
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
+        // input is 'ÃЯ'
         final String[] expected = {
-            "7:9: Name 'ÃЯ' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "7:9: Name '" + (char) 0xC3 + (char) 0x042F
+                 + "' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         };
         verify(checkConfig, getPath("InputGrammar.java"), expected);
     }
-    
+
     @Test
     public void testSemicolonBetweenImports() throws Exception {
         final DefaultConfiguration checkConfig =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
@@ -634,7 +634,7 @@ public class CommentsTest extends BaseCheckTestSupport {
     @Test
     public void testCompareExpectedTreeWithInput1() throws Exception {
         DefaultConfiguration checkConfig = createCheckConfig(CompareTreesWithComments.class);
-        CompareTreesWithComments.expectedTree = buildInput1();
+        CompareTreesWithComments.setExpectedTree(buildInput1());
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputComments1.java"), expected);
     }
@@ -642,7 +642,7 @@ public class CommentsTest extends BaseCheckTestSupport {
     @Test
     public void testCompareExpectedTreeWithInput2() throws Exception {
         DefaultConfiguration checkConfig = createCheckConfig(CompareTreesWithComments.class);
-        CompareTreesWithComments.expectedTree = buildInput2();
+        CompareTreesWithComments.setExpectedTree(buildInput2());
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputComments2.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CompareTreesWithComments.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CompareTreesWithComments.java
@@ -1,3 +1,22 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
 package com.puppycrawl.tools.checkstyle.grammars.comments;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -7,7 +26,7 @@ import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 
 class CompareTreesWithComments extends Check {
-    static DetailAST expectedTree;
+    private static DetailAST expectedTree;
 
     @Override
     public boolean isCommentNodesRequired() {
@@ -35,38 +54,51 @@ class CompareTreesWithComments extends Check {
     }
 
     private static boolean isAstEquals(DetailAST expected, DetailAST actual) {
-        boolean result = false;
+        boolean result;
         if (expected == actual) {
             result = true;
         }
         else if (actual == null || expected == null) {
             result = false;
-        } else {
-            if (expected.getType() == actual.getType()
-                    && expected.getLineNo() == actual.getLineNo()
-                    && expected.getColumnNo() == actual.getColumnNo()) {
-                if (expected.getText() == null) {
-                    result = actual.getText() == null;
-                }
-                else if (expected.getText().equals(actual.getText())) {
-                    result = true;
-                }
-            }
-
-            if (result) {
-                DetailAST childExpected = expected.getFirstChild();
-                DetailAST childActual = actual.getFirstChild();
-                result = isAstEquals(childExpected, childActual);
-                if (result) {
-                    DetailAST nextSiblingExpected = expected.getNextSibling();
-                    DetailAST nextSiblingActual = actual.getNextSibling();
-                    result = isAstEquals(nextSiblingExpected, nextSiblingActual);
-                }
-            }
+        }
+        else {
+            result = isAstEqualsSafe(expected, actual);
         }
         if (!result) {
             System.out.println("Expected: " + expected + " | Actual: " + actual);
         }
         return result;
+    }
+
+    private static boolean isAstEqualsSafe(DetailAST expected, DetailAST actual) {
+        boolean result = false;
+
+        if (expected.getType() == actual.getType()
+                && expected.getLineNo() == actual.getLineNo()
+                && expected.getColumnNo() == actual.getColumnNo()) {
+            if (expected.getText() == null) {
+                result = actual.getText() == null;
+            }
+            else if (expected.getText().equals(actual.getText())) {
+                result = true;
+            }
+        }
+
+        if (result) {
+            DetailAST childExpected = expected.getFirstChild();
+            DetailAST childActual = actual.getFirstChild();
+            result = isAstEquals(childExpected, childActual);
+            if (result) {
+                DetailAST nextSiblingExpected = expected.getNextSibling();
+                DetailAST nextSiblingActual = actual.getNextSibling();
+                result = isAstEquals(nextSiblingExpected, nextSiblingActual);
+            }
+        }
+
+        return result;
+    }
+
+    public static void setExpectedTree(DetailAST expectedTree) {
+        CompareTreesWithComments.expectedTree = expectedTree;
     }
 }


### PR DESCRIPTION
Can't test "GeneratedJava14LexerTest.testUnexpectedChar" since I'm windows.
Removed exclude in "ant-phase-verify". It's only parsing the "src" directory, so it shouldn't be an issue.
Added suppressions for "BaseCheckTestSupport" since it covers alot of things.

Added missing headers.
Split long/complex methods into 2.
Made "CompareTreesWithComments.expectedTree" private with a setter. If this isn't acceptable, the only other option I see here is a suppression.