### PR TITLE
Issue #2421: enabling checking on it folder

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -52,22 +52,16 @@
 
     <!-- Suppressions to remove over time for sure -->
     <suppress checks="FinalLocalVariable" files=".*[\\/]src[\\/]it[\\/]" />
-    <suppress checks="Regexp" files=".*[\\/]src[\\/]it[\\/]" />
     <suppress checks="LineLength" files=".*[\\/]src[\\/]it[\\/]" />
     <suppress checks="NoWhitespaceBefore" files=".*[\\/]src[\\/]it[\\/]" />
     <suppress checks="WhitespaceAfter" files=".*[\\/]src[\\/]it[\\/]" />
     <suppress checks="WhitespaceAround" files=".*[\\/]src[\\/]it[\\/]" />
-    <suppress checks="DeclarationOrder" files=".*[\\/]src[\\/]it[\\/]"/>
-    <suppress checks="RightCurly" files=".*[\\/]src[\\/]it[\\/]"/>
     <suppress checks="AbbreviationAsWordInName" files=".*[\\/]src[\\/]it[\\/]"/>
-    <suppress checks="AbstractClassName" files=".*[\\/]src[\\/]it[\\/]"/>
-    <suppress checks="EmptyLineSeparator" files=".*[\\/]src[\\/]it[\\/]"/>
     <suppress checks="ReturnCount" files=".*[\\/]src[\\/]it[\\/]"/>
     <suppress checks="SeparatorWrap" files=".*[\\/]src[\\/]it[\\/]"/>
 
     <!-- quesionable suppressions, should be permanent ? -->
     <suppress checks="CyclomaticComplexity" files=".*[\\/]src[\\/]it[\\/]"/>
-    <suppress checks="VisibilityModifier" files=".*[\\/]src[\\/]it[\\/]"/>
 
     <!--
       Turn off all checks for Generated and Test code. Fixes issues with using

--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -43,9 +43,9 @@ import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.AbstractViolationReporter;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 
-public abstract class BaseCheckTestSupport {
-    final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+public class BaseCheckTestSupport {
     protected final Properties props = new Properties();
+    final ByteArrayOutputStream stream = new ByteArrayOutputStream();
 
     protected static DefaultConfiguration createCheckConfig(Class<?> aClazz) {
         return new DefaultConfiguration(aClazz.getName());

--- a/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigurationBuilder.java
@@ -60,7 +60,8 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
         try {
             return ConfigurationLoader.loadConfiguration(aConfigName,
                     new PropertiesExpander(aProps));
-        } catch (final CheckstyleException e) {
+        }
+        catch (final CheckstyleException e) {
             System.out.println("Error loading configuration file");
             e.printStackTrace(System.out);
             System.exit(1);
@@ -80,7 +81,8 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
                         return checkConfig;
                     }
                 }
-            } else if (aCheckName.equals(currentConfig.getName())) {
+            }
+            else if (aCheckName.equals(currentConfig.getName())) {
                 return currentConfig;
             }
         }
@@ -106,7 +108,8 @@ public class ConfigurationBuilder extends BaseCheckTestSupport {
                 for (final File file : folder.listFiles()) {
                     listFiles(files, file, extension);
                 }
-            } else if (folder.toString().endsWith("." + extension)) {
+            }
+            else if (folder.toString().endsWith("." + extension)) {
                 files.add(folder);
             }
         }

--- a/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
+++ b/src/it/java/com/google/checkstyle/test/base/IndentationConfigurationBuilder.java
@@ -37,6 +37,24 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 public class IndentationConfigurationBuilder extends ConfigurationBuilder {
     private static final int TAB_WIDTH = 4;
 
+    private static final Pattern NONEMPTY_LINE_REGEX =
+            Pattern.compile(".*?\\S+.*?");
+
+    private static final Pattern LINE_WITH_COMMENT_REGEX =
+            Pattern.compile(".*?\\S+.*?(//indent:(\\d+) exp:((>=\\d+)|(\\d+(,\\d+)*?))( warn)?)");
+
+    private static final Pattern GET_INDENT_FROM_COMMENT_REGEX =
+            Pattern.compile("//indent:(\\d+).*?");
+
+    private static final Pattern MULTILEVEL_COMMENT_REGEX =
+            Pattern.compile("//indent:\\d+ exp:(\\d+(,\\d+)+?)( warn)?");
+
+    private static final Pattern SINGLE_LEVEL_COMMENT_REGEX =
+            Pattern.compile("//indent:\\d+ exp:(\\d+)( warn)?");
+
+    private static final Pattern NON_STRICT_LEVEL_COMMENT_REGEX =
+            Pattern.compile("//indent:\\d+ exp:>=(\\d+)( warn)?");
+
     public IndentationConfigurationBuilder(File aROOT) {
         super(aROOT);
     }
@@ -45,24 +63,6 @@ public class IndentationConfigurationBuilder extends ConfigurationBuilder {
     public Integer[] getLinesWithWarn(String aFileName) throws IOException {
         return getLinesWithWarnAndCheckComments(aFileName, TAB_WIDTH);
     }
-
-    private static final Pattern NONEMPTY_LINE_REGEX =
-                    Pattern.compile(".*?\\S+.*?");
-
-    private static final Pattern LINE_WITH_COMMENT_REGEX =
-                    Pattern.compile(".*?\\S+.*?(//indent:(\\d+) exp:((>=\\d+)|(\\d+(,\\d+)*?))( warn)?)");
-
-    private static final Pattern GET_INDENT_FROM_COMMENT_REGEX =
-                    Pattern.compile("//indent:(\\d+).*?");
-
-    private static final Pattern MULTILEVEL_COMMENT_REGEX =
-                    Pattern.compile("//indent:\\d+ exp:(\\d+(,\\d+)+?)( warn)?");
-
-    private static final Pattern SINGLE_LEVEL_COMMENT_REGEX =
-                    Pattern.compile("//indent:\\d+ exp:(\\d+)( warn)?");
-
-    private static final Pattern NON_STRICT_LEVEL_COMMENT_REGEX =
-                    Pattern.compile("//indent:\\d+ exp:>=(\\d+)( warn)?");
 
     private static Integer[] getLinesWithWarnAndCheckComments(String aFileName,
             final int tabWidth)

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
@@ -35,13 +35,13 @@ public class CustomImportOrderTest extends BaseCheckTestSupport {
     private static final String MSG_SEPARATOR = "custom.import.order.line.separator";
     private static final String MSG_LEX = "custom.import.order.lex";
     private static final String MSG_ORDER = "custom.import.order";
-    private static ConfigurationBuilder builder;
-    private final Class<CustomImportOrderCheck> clazz = CustomImportOrderCheck.class;
-    String msgNonGroup = "custom.import.order.nonGroup.import";
 
     /** Shortcuts to make code more compact. */
     private static final String STD = CustomImportOrderCheck.STANDARD_JAVA_PACKAGE_RULE_GROUP;
     private static final String SPECIAL = CustomImportOrderCheck.SPECIAL_IMPORTS_RULE_GROUP;
+
+    private static ConfigurationBuilder builder;
+    private final Class<CustomImportOrderCheck> clazz = CustomImportOrderCheck.class;
 
     @BeforeClass
     public static void setConfigurationBuilder() {
@@ -112,6 +112,7 @@ public class CustomImportOrderTest extends BaseCheckTestSupport {
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }
+
     @Test
     public void validTest() throws Exception {
 

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
@@ -105,6 +105,7 @@ public class WhitespaceAroundTest extends BaseCheckTestSupport {
         Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }
+
     @Test
     public void whitespaceAroundEmptyTypesCyclesTest() throws Exception {
 
@@ -124,7 +125,6 @@ public class WhitespaceAroundTest extends BaseCheckTestSupport {
         String msgNotPreceded = "ws.notPreceded";
         String msgIllegalFollow = "ws.illegalFollow";
         Configuration checkConfig = builder.getCheckConfig("GenericWhitespace");
-
 
         final String[] expected = {
             "16:13: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java
@@ -47,7 +47,6 @@ public class PackageNameTest extends BaseCheckTestSupport {
     @Test
     public void goodPackageNameTest() throws Exception {
 
-
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
         String filePath = builder.getFilePath("PackageNameInputGood");
@@ -76,7 +75,6 @@ public class PackageNameTest extends BaseCheckTestSupport {
     @Test
     public void badPackageName2Test() throws Exception {
 
-
         String packagePath = "com.google.checkstyle.test.chapter5naming.rule521_packagenames";
         String msg = getCheckMessage(checkConfig.getMessages(), MSG_KEY, packagePath, format);
 
@@ -92,7 +90,6 @@ public class PackageNameTest extends BaseCheckTestSupport {
 
     @Test
     public void badPackageName3Test() throws Exception {
-
 
         String packagePath = "com.google.checkstyle.test.chapter5naming.rule521$packagenames";
         String msg = getCheckMessage(checkConfig.getMessages(), MSG_KEY, packagePath, format);

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassMethodTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassMethodTypeParameterNameTest.java
@@ -72,7 +72,6 @@ public class ClassMethodTypeParameterNameTest extends BaseCheckTestSupport {
             "42:14: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "EE", format),
         };
 
-
         String filePath = builder.getFilePath("MethodTypeParameterNameInput");
 
         Integer[] warnList = builder.getLinesWithWarn(filePath);


### PR DESCRIPTION
Fixed AbstractClassName, DeclarationOrder, RightCurly, EmptyLineSeparator, Regexp, and VisibilityModifier.
MagicNumber was also already being suppressed.

Test has no abstract on BaseCheckTestSupport, so I made IT the same. This was related to AbstractClassName.
msgNonGroup in CustomImportOrderTest was not being used, so it was removed. This was related to VisibilityModifier.