### PR TITLE
minor: refactoring xdoc xml validation

### DIFF
--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -457,6 +457,8 @@
     &lt;module name=&quot;TreeWalker&quot;&gt;
         &lt;property name=&quot;fileExtensions&quot; value=&quot;java,ejb,jpf&quot;/&gt;
         ...
+    &lt;/module&gt;
+&lt;/module&gt;
       </source>
 
       <p>


### PR DESCRIPTION
When starting to work on more xml parsing, I found it would be better to use some util to find elements on the xml structure instead of constantly trying to do it manually.
So I started to switch to this way, and found one new validation error that was missed from the old code because of the timing when I removed the "..."s and did the trimming.