### PR TITLE
Issue #2442: adding xdoc check validation

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -37,6 +37,7 @@
               files="AbstractClassNameCheckTest.java|AbstractTypeAwareCheckTest.java|AbstractJavadocCheckTest.java|AbstractViolationReporterTest.java"/>
 
     <!-- Tone down the checking for test code -->
+    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="342"/>
     <suppress checks="EmptyBlock" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="ImportControl" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="Javadoc" files=".*[\\/]src[\\/](test|it)[\\/]"/>
@@ -81,7 +82,7 @@
     <suppress checks="ClassDataAbstractionCoupling" files="AutomaticBean\.java"/>
     <!-- they are aggregators of logic, usage a several of classes are ok -->
     <suppress checks="ClassDataAbstractionCoupling" files="(Checker|TreeWalker|Main|CheckstyleAntTask|AbstractJavadocCheck)\.java"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="(CheckerTest|TreeWalkerTest|BaseCheckTestSupport)\.java"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="(CheckerTest|TreeWalkerTest|BaseCheckTestSupport|XDocsPagesTest)\.java"/>
     <!-- a lot of GUI elements is OK -->
     <suppress checks="ClassDataAbstractionCoupling" files="ParseTreeInfoPanel\.java"/>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -50,7 +50,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck {
     /** Pattern to detect occurrences of '\n' in text. */
     private static final Pattern ESCAPED_LINE_FEED_PATTERN = Pattern.compile("\\\\n");
     /** The file that contains the header to check against. */
-    private String filename;
+    private String headerFile;
 
     /** Name of a charset to use for loading the header from a file. */
     private String charset = System.getProperty("file.encoding", "UTF-8");
@@ -97,7 +97,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck {
                     + getConfiguration().getName());
         }
 
-        filename = fileName;
+        headerFile = fileName;
     }
 
     /**
@@ -108,14 +108,14 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck {
         checkHeaderNotInitialized();
         Reader headerReader = null;
         try {
-            final URI uri = CommonUtils.getUriByFilename(filename);
+            final URI uri = CommonUtils.getUriByFilename(headerFile);
             headerReader = new InputStreamReader(new BufferedInputStream(
                     uri.toURL().openStream()), charset);
             loadHeader(headerReader);
         }
         catch (final IOException ex) {
             throw new CheckstyleException(
-                    "unable to load header file " + filename, ex);
+                    "unable to load header file " + headerFile, ex);
         }
         finally {
             Closeables.closeQuietly(headerReader);
@@ -182,7 +182,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck {
 
     @Override
     protected final void finishLocalSetup() throws CheckstyleException {
-        if (filename != null) {
+        if (headerFile != null) {
             loadHeaderFile();
         }
         if (readerLines.isEmpty()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
@@ -34,7 +34,7 @@ public class SeverityMatchFilter
     extends AutomaticBean
     implements Filter {
     /** The severity level to accept. */
-    private SeverityLevel severityLevel = SeverityLevel.ERROR;
+    private SeverityLevel severity = SeverityLevel.ERROR;
 
     /** Whether to accept or reject on severity matches. */
     private boolean acceptOnMatch = true;
@@ -47,7 +47,7 @@ public class SeverityMatchFilter
      * @see SeverityLevel
      */
     public final void setSeverity(String severity) {
-        severityLevel = SeverityLevel.getInstance(severity);
+        this.severity = SeverityLevel.getInstance(severity);
     }
 
     /**
@@ -61,7 +61,7 @@ public class SeverityMatchFilter
 
     @Override
     public boolean accept(AuditEvent event) {
-        final boolean result = severityLevel == event.getSeverityLevel();
+        final boolean result = severity == event.getSeverityLevel();
         if (acceptOnMatch) {
             return result;
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
@@ -21,28 +21,40 @@ package com.puppycrawl.tools.checkstyle;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.beans.PropertyDescriptor;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import com.google.common.io.Files;
+import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
+import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
 
 public class XDocsPagesTest {
     private static final File JAVA_SOURCES_DIRECTORY = new File("src/main/java");
@@ -85,6 +97,7 @@ public class XDocsPagesTest {
             "name=\"SuppressWithNearbyCommentFilter\"",
             "name=\"SuppressWarningsFilter\"",
             "name=\"RegexpHeader\"",
+            "name=\"RegexpSingleline\"",
             "name=\"RegexpMultiline\"",
             "name=\"JavadocPackage\"",
             "name=\"NewlineAtEndOfFile\"",
@@ -92,6 +105,53 @@ public class XDocsPagesTest {
             "name=\"FileLength\"",
             "name=\"FileTabCharacter\""
     );
+
+    private static final Set<String> CHECK_PROPERTIES = getProperties(Check.class);
+    private static final Set<String> FILESET_PROPERTIES = getProperties(AbstractFileSetCheck.class);
+
+    private static final List<String> UNDOCUMENTED_PROPERTIES = Arrays.asList(
+            "SuppressWarningsCheck.compileFlags",
+            "SuppressWithNearbyCommentFilter.fileContents",
+            "IllegalTokenTextCheck.compileFlags",
+            "ReturnCountCheck.compileFlags",
+            "IllegalTypeCheck.compileFlags",
+            "MutableExceptionCheck.compileFlags",
+            "TrailingCommentCheck.compileFlags",
+            "AbstractClassNameCheck.compileFlags",
+            "ClassTypeParameterNameCheck.compileFlags",
+            "ConstantNameCheck.compileFlags",
+            "InterfaceTypeParameterNameCheck.compileFlags",
+            "LocalFinalVariableNameCheck.compileFlags",
+            "LocalVariableNameCheck.compileFlags",
+            "MemberNameCheck.compileFlags",
+            "MethodNameCheck.compileFlags",
+            "MethodTypeParameterNameCheck.compileFlags",
+            "PackageNameCheck.compileFlags",
+            "ParameterNameCheck.compileFlags",
+            "StaticVariableNameCheck.compileFlags",
+            "TypeNameCheck.compileFlags",
+            "RegexpCheck.compileFlags",
+            "SuppressionCommentFilter.fileContents",
+            "MissingSwitchDefaultCheck.limitedTokens",
+            "MissingSwitchDefaultCheck.maximumDepth",
+            "MissingSwitchDefaultCheck.maximumMessage",
+            "MissingSwitchDefaultCheck.maximumNumber",
+            "MissingSwitchDefaultCheck.minimumDepth",
+            "MissingSwitchDefaultCheck.minimumMessage",
+            "MissingSwitchDefaultCheck.minimumNumber",
+            "MissingSwitchDefaultCheck.sumTokenCounts",
+            "MissingCtorCheck.limitedTokens",
+            "MissingCtorCheck.maximumDepth",
+            "MissingCtorCheck.maximumMessage",
+            "MissingCtorCheck.maximumNumber",
+            "MissingCtorCheck.minimumDepth",
+            "MissingCtorCheck.minimumMessage",
+            "MissingCtorCheck.minimumNumber",
+            "MissingCtorCheck.sumTokenCounts",
+            "MethodNameCheck.applyToPackage",
+            "MethodNameCheck.applyToPrivate",
+            "MethodNameCheck.applyToProtected",
+            "MethodNameCheck.applyToPublic");
 
     @Test
     public void testAllChecksPresentOnAvailableChecksPage() throws IOException {
@@ -242,6 +302,369 @@ public class XDocsPagesTest {
         catch (CheckstyleException e) {
             Assert.fail(fileName + " has invalid Checkstyle xml (" + e.getMessage() + "): "
                     + unserializedSource);
+        }
+    }
+
+    @Test
+    public void testAllCheckSections() throws Exception {
+        final ClassLoader cl = XDocsPagesTest.class.getClassLoader();
+        final Set<String> packageNames = PackageNamesLoader.getPackageNames(cl);
+        final ModuleFactory moduleFactory = new PackageObjectFactory(packageNames, cl);
+
+        for (File file : Files.fileTreeTraverser().preOrderTraversal(XDOCS_DIRECTORY)) {
+            final String fileName = file.getName();
+
+            if (!fileName.startsWith("config_") || "config_reporting.xml".equals(fileName)) {
+                continue;
+            }
+
+            final String input = Files.toString(file, UTF_8);
+            final Document document = getRawXml(fileName, input, input);
+            final NodeList sources = document.getElementsByTagName("section");
+
+            for (int position = 0; position < sources.getLength(); position++) {
+                final Node section = sources.item(position);
+                final String sectionName = section.getAttributes().getNamedItem("name")
+                        .getNodeValue();
+
+                if ("Content".equals(sectionName) || "Overview".equals(sectionName)) {
+                    continue;
+                }
+
+                Assert.assertTrue(fileName + " section '" + sectionName
+                        + "' shouldn't end with 'Check'", !sectionName.endsWith("Check"));
+
+                validateCheckSection(moduleFactory, fileName, sectionName, section);
+            }
+        }
+    }
+
+    private static void validateCheckSection(ModuleFactory moduleFactory, String fileName,
+            String sectionName, Node section) {
+        Object instance = null;
+
+        try {
+            instance = moduleFactory.createModule(sectionName);
+        }
+        catch (CheckstyleException e) {
+            Assert.fail(fileName + " couldn't find class: " + sectionName);
+        }
+
+        int subSectionPos = 0;
+        for (Node subSection : getChildrenElements(section)) {
+            final String subSectionName = subSection.getAttributes().getNamedItem("name")
+                    .getNodeValue();
+
+            // can be in different orders, and completely optional
+            if ("Notes".equals(subSectionName)
+                    || "Rule Description".equals(subSectionName)) {
+                continue;
+            }
+
+            if (subSectionPos == 1 && !"Properties".equals(subSectionName)) {
+                validatePropertySection(fileName, sectionName, null, instance);
+                subSectionPos++;
+            }
+
+            Assert.assertEquals(fileName + " section '" + sectionName
+                    + "' should be in order", getSubSectionName(subSectionPos),
+                    subSectionName);
+
+            switch (subSectionPos) {
+                case 0:
+                    break;
+                case 1:
+                    validatePropertySection(fileName, sectionName, subSection, instance);
+                    break;
+                case 2:
+                    break;
+                case 3:
+                    validateUsageExample(fileName, sectionName, subSection);
+                    break;
+                case 4:
+                    validatePackageSection(fileName, sectionName, subSection, instance);
+                    break;
+                case 5:
+                    validateParentSection(fileName, sectionName, subSection);
+                    break;
+                default:
+                    break;
+            }
+
+            subSectionPos++;
+        }
+    }
+
+    private static Object getSubSectionName(int subSectionPos) {
+        final String result;
+
+        switch (subSectionPos) {
+            case 0:
+                result = "Description";
+                break;
+            case 1:
+                result = "Properties";
+                break;
+            case 2:
+                result = "Examples";
+                break;
+            case 3:
+                result = "Example of Usage";
+                break;
+            case 4:
+                result = "Package";
+                break;
+            case 5:
+                result = "Parent Module";
+                break;
+            default:
+                result = null;
+                break;
+        }
+
+        return result;
+    }
+
+    private static void validatePropertySection(String fileName, String sectionName,
+            Node subSection, Object instance) {
+        final Set<String> properties = getProperties(instance.getClass());
+        final Class<?> clss = instance.getClass();
+
+        // remove global properties that don't need documentation
+        if (hasParentModule(sectionName)) {
+            properties.removeAll(CHECK_PROPERTIES);
+        }
+        else if (AbstractFileSetCheck.class.isAssignableFrom(clss)) {
+            properties.removeAll(FILESET_PROPERTIES);
+
+            // override
+            properties.add("fileExtensions");
+        }
+
+        // missing setter, should be fixed
+        if (CustomImportOrderCheck.class.isAssignableFrom(clss)) {
+            properties.add("samePackageMatchingDepth");
+        }
+
+        // remove undocumented properties
+        for (String p : new HashSet<>(properties)) {
+            if (UNDOCUMENTED_PROPERTIES.contains(clss.getSimpleName() + "." + p)) {
+                properties.remove(p);
+            }
+        }
+
+        final Check check;
+
+        if (Check.class.isAssignableFrom(clss)) {
+            check = (Check) instance;
+
+            if (!Arrays.equals(check.getAcceptableTokens(), check.getDefaultTokens())
+                    || !Arrays.equals(check.getAcceptableTokens(), check.getRequiredTokens())) {
+                properties.add("tokens");
+            }
+        }
+        else {
+            check = null;
+        }
+
+        if (subSection != null) {
+            Assert.assertTrue(fileName + " section '" + sectionName
+                    + "' should have no properties to show", !properties.isEmpty());
+
+            validatePropertySectionProperties(fileName, sectionName, subSection, check,
+                    properties);
+        }
+
+        Assert.assertTrue(fileName + " section '" + sectionName + "' should show properties: "
+                + properties, properties.isEmpty());
+    }
+
+    private static void validatePropertySectionProperties(String fileName, String sectionName,
+            Node subSection, Check check, Set<String> properties) {
+        boolean skip = true;
+        boolean didTokens = false;
+
+        for (Node row : getChildrenElements(getFirstChildElement(subSection))) {
+            if (skip) {
+                skip = false;
+                continue;
+            }
+            Assert.assertFalse(fileName + " section '" + sectionName
+                    + "' should have token properties last", didTokens);
+
+            final List<Node> columns = new ArrayList<>(getChildrenElements(row));
+
+            final String propertyName = columns.get(0).getTextContent();
+            Assert.assertTrue(fileName + " section '" + sectionName
+                    + "' should not contain the property: " + propertyName,
+                    properties.remove(propertyName));
+
+            if ("tokens".equals(propertyName)) {
+                Assert.assertEquals(fileName + " section '" + sectionName
+                        + "' should have the basic token description", "tokens to check",
+                        columns.get(1).getTextContent());
+                Assert.assertEquals(fileName + " section '" + sectionName
+                        + "' should have all the acceptable tokens", "subset of tokens "
+                        + getTokenText(check.getAcceptableTokens(), check.getRequiredTokens()),
+                        columns.get(2).getTextContent().replaceAll("\\s+", " ").trim());
+                Assert.assertEquals(fileName + " section '" + sectionName
+                        + "' should have all the default tokens",
+                        getTokenText(check.getDefaultTokens(), check.getRequiredTokens()),
+                        columns.get(3).getTextContent().replaceAll("\\s+", " ").trim());
+                didTokens = true;
+            }
+            else {
+                Assert.assertFalse(fileName + " section '" + sectionName
+                        + "' should have a description for " + propertyName, columns.get(1)
+                        .getTextContent().trim().isEmpty());
+                Assert.assertFalse(fileName + " section '" + sectionName
+                        + "' should have a type for " + propertyName, columns.get(2)
+                        .getTextContent().trim().isEmpty());
+                // default can be empty string
+            }
+        }
+    }
+
+    private static void validateUsageExample(String fileName, String sectionName, Node subSection) {
+        Assert.assertNull(fileName + " section '" + sectionName
+                + "' should have no xml examples, they belong in 'Examples'",
+                findChildElementByTag(subSection, "source"));
+    }
+
+    private static void validatePackageSection(String fileName, String sectionName,
+            Node subSection, Object instance) {
+        Assert.assertEquals(fileName + " section '" + sectionName
+                + "' should have matching package", instance.getClass().getPackage().getName(),
+                subSection.getTextContent().trim());
+    }
+
+    private static void validateParentSection(String fileName, String sectionName,
+            Node subSection) {
+        final String expected;
+
+        if (hasParentModule(sectionName)) {
+            expected = "TreeWalker";
+        }
+        else {
+            expected = "Checker";
+        }
+
+        Assert.assertEquals(
+                fileName + " section '" + sectionName + "' should have matching parent",
+                expected, subSection
+                        .getTextContent().trim());
+    }
+
+    private static Set<Node> getChildrenElements(Node node) {
+        final Set<Node> result = new LinkedHashSet<>();
+
+        for (Node child = node.getFirstChild(); child != null; child = child.getNextSibling()) {
+            if (child.getNodeType() != Node.TEXT_NODE) {
+                result.add(child);
+            }
+        }
+
+        return result;
+    }
+
+    private static Node getFirstChildElement(Node node) {
+        for (Node child = node.getFirstChild(); child != null; child = child.getNextSibling()) {
+            if (child.getNodeType() != Node.TEXT_NODE) {
+                return child;
+            }
+        }
+
+        return null;
+    }
+
+    private static Node findChildElementByTag(Node node, String tag) {
+        Node result = null;
+
+        for (Node child = node.getFirstChild(); child != null; child = child.getNextSibling()) {
+            if (tag.equals(child.getNodeName())) {
+                result = child;
+                break;
+            }
+
+            if (child.hasChildNodes()) {
+                result = findChildElementByTag(child, tag);
+
+                if (result != null) {
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static boolean hasParentModule(String sectionName) {
+        final String search = "\"" + sectionName + "\"";
+        boolean result = true;
+
+        for (String find : XML_FILESET_LIST) {
+            if (find.contains(search)) {
+                result = false;
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    private static Set<String> getProperties(Class<?> clss) {
+        final Set<String> result = new TreeSet<>();
+        final PropertyDescriptor[] map = PropertyUtils.getPropertyDescriptors(clss);
+
+        for (PropertyDescriptor p : map) {
+            if (p.getWriteMethod() != null) {
+                result.add(p.getName());
+            }
+        }
+
+        return result;
+    }
+
+    private static String getTokenText(int[] tokens, int... subtractions) {
+        if (Arrays.equals(tokens, TokenUtils.getAllTokenIds()) && subtractions.length == 0) {
+            return "TokenTypes.";
+        }
+        else {
+            final StringBuilder result = new StringBuilder();
+            boolean first = true;
+
+            for (int token : tokens) {
+                boolean found = false;
+
+                for (int subtraction : subtractions) {
+                    if (subtraction == token) {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (found) {
+                    continue;
+                }
+
+                if (first) {
+                    first = false;
+                }
+                else {
+                    result.append(", ");
+                }
+
+                result.append(TokenUtils.getTokenName(token));
+            }
+
+            if (result.length() == 0) {
+                result.append("empty");
+            }
+            else {
+                result.append(".");
+            }
+
+            return result.toString();
         }
     }
 }

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -522,7 +522,16 @@ public String getNameIfPresent() { ... }
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">PARAMETER_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">ANNOTATION_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">TYPECAST</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_THROWS">LITERAL_THROWS</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPLEMENTS_CLAUSE">IMPLEMENTS_CLAUSE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_ARGUMENT">TYPE_ARGUMENT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">LITERAL_NEW</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">DOT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">ANNOTATION_FIELD_DEF</a>.
             </td>
             <td>
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
@@ -601,7 +610,7 @@ public String getNameIfPresent() { ... }
       </subsection>
 
       <subsection name="Package">
-        <p> com.puppycrawl.tools.checkstyle.checks </p>
+        <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
       </subsection>
 
       <subsection name="Parent Module">

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -42,34 +42,34 @@
           </tr>
           <tr>
             <td>tokens</td>
-            <td>blocks to check</td>
+            <td>tokens to check</td>
 
             <td>
               subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">LITERAL_FINALLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">LITERAL_FINALLY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">INSTANCE_INIT</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">STATIC_INIT</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">LITERAL_SYNCHRONIZED</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">LITERAL_CASE</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DEFAULT">LITERAL_DEFAULT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">ARRAY_INIT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>.
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">ARRAY_INIT</a>.
             </td>
             <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">LITERAL_FINALLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">LITERAL_FINALLY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">INSTANCE_INIT</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">STATIC_INIT</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
@@ -294,49 +294,50 @@ try {
           </tr>
           <tr>
             <td>tokens</td>
-            <td>blocks to check</td>
+            <td>tokens to check</td>
 
             <td>subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">ANNOTATION_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">LITERAL_FINALLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">LITERAL_SYNCHRONIZED</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">ANNOTATION_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">LITERAL_FINALLY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">LITERAL_SYNCHRONIZED</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">STATIC_INIT</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#OBJBLOCK">OBJBLOCK</a>.
             </td>
 
             <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">ANNOTATION_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">LITERAL_FINALLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">LITERAL_SYNCHRONIZED</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">ANNOTATION_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">STATIC_INIT</a>.
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">LITERAL_FINALLY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">LITERAL_SYNCHRONIZED</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">STATIC_INIT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#OBJBLOCK">OBJBLOCK</a>.
             </td>
           </tr>
         </table>
@@ -407,31 +408,33 @@ try {
             <th>default value</th>
           </tr>
           <tr>
+            <td>allowSingleLineStatement</td>
+            <td>allows single-line statements without braces</td>
+            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td>false</td>
+          </tr>
+          <tr>
             <td>tokens</td>
-            <td>blocks to check</td>
+            <td>tokens to check</td>
 
             <td>subset of tokens
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">LITERAL_CASE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DEFAULT">LITERAL_DEFAULT</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">LAMBDA</a>.
             </td>
 
             <td>
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>.
             </td>
-          </tr>
-          <tr>
-            <td>allowSingleLineStatement</td>
-            <td>allows single-line statements without braces</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
-            <td>false</td>
           </tr>
         </table>
       </subsection>
@@ -547,8 +550,15 @@ switch (num) {
             <td><code>same</code></td>
           </tr>
           <tr>
+            <td>shouldStartLine</td>
+            <td>should we check if <code>'}'</code>
+            starts line.</td>
+            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><code>true</code></td>
+          </tr>
+          <tr>
             <td>tokens</td>
-            <td>blocks to check</td>
+            <td>tokens to check</td>
 
             <td>subset of tokens <a
              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
@@ -587,13 +597,6 @@ switch (num) {
              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
             <a
              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>.</td>
-          </tr>
-          <tr>
-            <td>shouldStartLine</td>
-            <td>should we check if <code>'}'</code>
-            starts line.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
-            <td><code>true</code></td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -140,7 +140,7 @@ String b = (a==null || a.length&lt;1) ? null : a.substring(1);
         </p>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -263,7 +263,7 @@ String nullString = null;
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -310,7 +310,7 @@ String nullString = null;
         </p>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -370,20 +370,6 @@ String nullString = null;
             <th>default value</th>
           </tr>
           <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">PARAMETER_DEF</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
-            </td>
-            <td>
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
-            </td>
-          </tr>
-          <tr>
             <td>validateEnhancedForLoopVariable</td>
             <td>Controls whether to check <a href = "http://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.14.2">enhanced for-loop</a> variable.</td>
             <td>
@@ -394,6 +380,20 @@ String nullString = null;
              <code>
               false
              </code>
+            </td>
+          </tr>
+          <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+            <td>
+              subset of tokens <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">PARAMETER_DEF</a>.
+            </td>
+            <td>
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
             </td>
           </tr>
         </table>
@@ -483,24 +483,6 @@ String nullString = null;
             <th>default value</th>
           </tr>
           <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">PARAMETER_DEF</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
-            </td>
-
-            <td>
-              <a
-               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">PARAMETER_DEF</a>,
-               <a
-               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
-            </td>
-          </tr>
-
-          <tr>
             <td>ignoreFormat</td>
             <td>pattern for names of variables and parameters to ignore</td>
             <td><a href="property_types.html#regexp">regular expression</a></td>
@@ -562,6 +544,25 @@ String nullString = null;
             <td><code>false</code></td>
           </tr>
 
+          <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+            <td>
+              subset of tokens <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">PARAMETER_DEF</a>,
+              LAMBDA.
+            </td>
+
+            <td>
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">PARAMETER_DEF</a>,
+              LAMBDA.
+            </td>
+          </tr>
         </table>
       </subsection>
 
@@ -718,10 +719,24 @@ class SomeClass
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td>{}</td>
           </tr>
+
+          <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+
+            <td>
+              subset of tokens
+              CLASS_DEF.
+            </td>
+
+            <td>
+              CLASS_DEF.
+            </td>
+          </tr>
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check to find instantiations of java.lang.Boolean:
         </p>
@@ -784,7 +799,7 @@ class SomeClass
             <td>tokens</td>
             <td>tokens to check</td>
             <td>
-              subset of
+              subset of tokens
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>.
             </td>
             <td>
@@ -794,7 +809,7 @@ class SomeClass
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check to find token LITERAL_NATIVE:
         </p>
@@ -843,14 +858,6 @@ class SomeClass
             <th>default value</th>
           </tr>
           <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>subset of <a
-            href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
-            </td>
-            <td>empty</td>
-          </tr>
-          <tr>
             <td>format</td>
             <td>illegal pattern</td>
             <td><a href="property_types.html#regexp">regular expression</a></td>
@@ -868,6 +875,14 @@ class SomeClass
             if empty then the default message is used.</td>
             <td><a href="property_types.html#string">String</a></td>
             <td><code>&quot;&quot;</code>(empty)</td>
+          </tr>
+          <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+            <td>subset of tokens <a
+            href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>.
+            </td>
+            <td>empty</td>
           </tr>
         </table>
       </subsection>
@@ -949,49 +964,6 @@ while ((line = bufferedReader.readLine()) != null) {
         </p>
       </subsection>
 
-      <subsection name="Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>assignments to check</td>
-            <td>subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">BAND_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">BOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">BSR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">BXOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">DIV_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">MINUS_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">MOD_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">PLUS_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">SL_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">SR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">STAR_ASSIGN</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">BAND_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">BOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">BSR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">BXOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">DIV_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">MINUS_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">MOD_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">PLUS_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">SL_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">SR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">STAR_ASSIGN</a>.
-            </td>
-          </tr>
-        </table>
-      </subsection>
-
       <subsection name="Examples">
         <p>
           To configure the check:
@@ -1066,22 +1038,6 @@ static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
             <th>default value</th>
           </tr>
           <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>subset of tokens
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">NUM_DOUBLE</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">NUM_FLOAT</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">NUM_INT</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">NUM_LONG</a>.
-            </td>
-            <td>
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">NUM_DOUBLE</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">NUM_FLOAT</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">NUM_INT</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">NUM_LONG</a>.
-            </td>
-          </tr>
-          <tr>
             <td>ignoreNumbers</td>
             <td>non-magic numbers</td>
             <td>list of numbers</td>
@@ -1138,6 +1094,22 @@ static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">PLUS</a>,
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">MINUS</a>.
               </td>
+          </tr>
+          <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+            <td>subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">NUM_DOUBLE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">NUM_FLOAT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">NUM_INT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">NUM_LONG</a>.
+            </td>
+            <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">NUM_DOUBLE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">NUM_FLOAT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">NUM_INT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">NUM_LONG</a>.
+            </td>
           </tr>
         </table>
       </subsection>
@@ -1351,7 +1323,7 @@ class MyClass {
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -1422,7 +1394,7 @@ class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -1483,7 +1455,7 @@ return !valid();
         </p>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -1538,7 +1510,7 @@ if (&quot;something&quot;.equals(x))
         </source>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -1594,7 +1566,7 @@ if (&quot;something&quot;.equals(x))
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -1658,7 +1630,7 @@ if (&quot;something&quot;.equals(x))
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -1722,7 +1694,7 @@ if (&quot;something&quot;.equals(x))
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -1784,7 +1756,7 @@ if (&quot;something&quot;.equals(x))
        This check is almost exactly the same as the {@link NoFinalizerCheck}
        </p>
       </subsection>
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -1823,7 +1795,7 @@ if (&quot;something&quot;.equals(x))
         </p>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -2177,21 +2149,6 @@ if (&quot;something&quot;.equals(x))
             <th>default value</th>
           </tr>
           <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">LAMBDA</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">LAMBDA</a>.
-            </td>
-          </tr>
-          <tr>
             <td>max</td>
             <td>maximum allowed number of return statements</td>
             <td><a href="property_types.html#integer">Integer</a></td>
@@ -2202,6 +2159,21 @@ if (&quot;something&quot;.equals(x))
             <td>method names to ignore</td>
             <td><a href="property_types.html#regexp">regular expression</a></td>
             <td><code>^equals$</code> (empty)</td>
+          </tr>
+          <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+            <td>
+              subset of tokens
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">LAMBDA</a>.
+            </td>
+            <td>
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">LAMBDA</a>.
+            </td>
           </tr>
         </table>
       </subsection>
@@ -2291,21 +2263,6 @@ if (&quot;something&quot;.equals(x))
             <th>description</th>
             <th>type</th>
             <th>default value</th>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">PARAMETER_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">PARAMETER_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>.
-            </td>
           </tr>
           <tr>
             <td>validateAbstractClassNames</td>
@@ -3351,7 +3308,7 @@ cal.set(Calendar.MINUTE, minutes);
 &lt;/module&gt;
          </source>
       </subsection>
-      <subsection name="Note">
+      <subsection name="Notes">
         <p>
           ATTENTION!! (Not supported cases)
         </p>

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -322,7 +322,7 @@ class SomeClass
         </p>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -604,10 +604,6 @@ public abstract class Plant {
     public abstract void grow();
 }
         </source>
-      </subsection>
-
-      <subsection name="Properties">
-        <p> None.</p>
       </subsection>
 
       <subsection name="Examples">

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -59,7 +59,7 @@
           </tr>
         </table>
       </subsection>
-      <subsection name="Example of Usage">
+      <subsection name="Examples">
           <p>
             For example, the following configuration fragment directs the
             Checker to not report audit events with severity
@@ -72,8 +72,14 @@
 &lt;/module&gt;
           </source>
       </subsection>
+      <subsection name="Example of Usage">
+      </subsection>
       <subsection name="Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.filters </p>
+        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      </subsection>
+
+      <subsection name="Parent Module">
+        <p> <a href="config.html#Checker">Checker</a> </p>
       </subsection>
     </section>
 
@@ -175,8 +181,6 @@
             suppressed if all specified attributes match against the audit
             event.
           </p>
-      </subsection>
-      <subsection name="Example of Usage">
           <p>
             You can download template of empty suppression filter
             <a href="files/suppressions_none.xml">here</a>.
@@ -277,8 +281,20 @@
 &lt;suppress checks=&quot;FileLength&quot; files=&quot;com[\\/]mycompany[\\/]app[\\/].*IT.java&quot;/&gt;
           </source>
       </subsection>
+      <subsection name="Example of Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle_checks.xml#L21">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
       <subsection name="Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.filters </p>
+        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      </subsection>
+
+      <subsection name="Parent Module">
+        <p> <a href="config.html#Checker">Checker</a> </p>
       </subsection>
     </section>
 
@@ -511,8 +527,14 @@ HashSet hashSet; // Warning here: Declaring variables, return values or paramete
 ...
           </source>
       </subsection>
+      <subsection name="Example of Usage">
+      </subsection>
       <subsection name="Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.filters </p>
+        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      </subsection>
+
+      <subsection name="Parent Module">
+        <p> <a href="config.html#Checker">Checker</a> </p>
       </subsection>
     </section>
 
@@ -584,7 +606,7 @@ HashSet hashSet; // Warning here: Declaring variables, return values or paramete
                 </tr>
             </table>
         </subsection>
-        <subsection name="Example of Usage">
+        <subsection name="Examples">
             <p>
                 To configure the check that makes comments available to the filter:
             </p>
@@ -690,8 +712,14 @@ private int D2;
 public static final int [] array; // @cs.suppress ConstantName | NoWhitespaceAfter
             </source>
         </subsection>
+        <subsection name="Example of Usage">
+        </subsection>
         <subsection name="Package">
-            <p> com.puppycrawl.tools.checkstyle.checks.filters </p>
+            <p> com.puppycrawl.tools.checkstyle.filters </p>
+        </subsection>
+
+        <subsection name="Parent Module">
+          <p> <a href="config.html#Checker">Checker</a> </p>
         </subsection>
       </section>
 
@@ -720,10 +748,7 @@ public static final int [] array; // @cs.suppress ConstantName | NoWhitespaceAft
               be written in lower case with any dotted prefix or "Check" suffix removed.
           </p>
       </subsection>
-      <subsection name="Properties">
-          <p>This filter does not expose any properties</p>
-      </subsection>
-      <subsection name="Example of Usage">
+      <subsection name="Examples">
           <p>
               To configure the check that makes tha annotations available to
               the filter.
@@ -748,8 +773,14 @@ private int J; // should NOT fail MemberNameCheck
 private int [] ARRAY; // should NOT fail MemberNameCheck and NoWhitespaceAfterCheck
           </source>
       </subsection>
+      <subsection name="Example of Usage">
+      </subsection>
       <subsection name="Package">
-        <p> com.puppycrawl.tools.checkstyle.checks.filters </p>
+        <p> com.puppycrawl.tools.checkstyle.filters </p>
+      </subsection>
+
+      <subsection name="Parent Module">
+        <p> <a href="config.html#Checker">Checker</a> </p>
       </subsection>
     </section>
   </body>

--- a/src/xdocs/config_header.xml
+++ b/src/xdocs/config_header.xml
@@ -98,7 +98,7 @@ line 5: ////////////////////////////////////////////////////////////////////
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
           <p>
               In default configuration the check does not rise any violations. Default values of properties are used.
           </p>
@@ -280,7 +280,7 @@ line 6: ^\W*$
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
           <p>
               In default configuration the check does not rise any violations. Default values of properties are used.
           </p>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -74,7 +74,7 @@
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           An example how to configure the check so that star imports from
           packages java.io and java.net as well as static members from class
@@ -161,7 +161,7 @@
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           An example of how to configure the check so that the <code>java.lang.System.out</code> member and all
           members from <code>java.lang.Math</code> are
@@ -289,7 +289,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -399,7 +399,7 @@ class FooBar {
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -513,10 +513,24 @@ class FooBar {
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
           </tr>
+
+          <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+
+            <td>
+              subset of tokens
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">STATIC_IMPORT</a>.
+            </td>
+
+            <td>
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">STATIC_IMPORT</a>.
+            </td>
+          </tr>
         </table>
       </subsection>
 
-      <subsection name="Example" id="ImportOrder_Example">
+      <subsection name="Examples" id="ImportOrder_Example">
         <p>To configure the check so that it matches default Eclipse formatter configuration
            (tested on Kepler and Luna releases):</p>
         <ul>
@@ -707,7 +721,7 @@ public class SomeClass { ... }
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check using a import control file called
           &quot;config/import-control.xml&quot;, then have the following:
@@ -776,7 +790,7 @@ public class SomeClass { ... }
         </p>
       </subsection>
 
-      <subsection name="RuleDescription">
+      <subsection name="Rule Description">
         <p>
           The rule consists of:
         </p>
@@ -816,7 +830,7 @@ import java.util.regex.Matcher; //#8
         </p>
       </subsection>
 
-      <subsection name="Note">
+      <subsection name="Notes">
         <p>
           Use the separator '###' between rules.
         </p>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -52,10 +52,16 @@
             <td><a href="property_types.html#boolean">boolean</a></td>
             <td><code>false</code></td>
           </tr>
+          <tr>
+            <td>fileExtensions</td>
+            <td>file type extension of files to process</td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
+            <td><code>{}</code></td>
+          </tr>
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check:
         </p>
@@ -159,23 +165,6 @@
             <td>whether to ignore errors when a Javadoc tag is not recognised.</td>
             <td><a href="property_types.html#boolean">boolean</a></td>
             <td><code>false</code></td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>definitions to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">ANNOTATION_DEF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">ANNOTATION_DEF</a>.
-            </td>
           </tr>
         </table>
       </subsection>
@@ -456,16 +445,18 @@ public boolean isSomething()
           </tr>
           <tr>
             <td>tokens</td>
-            <td>definitions to check</td>
+            <td>tokens to check</td>
 
             <td>
               subset of tokens
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>.
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">ANNOTATION_FIELD_DEF</a>.
             </td>
             <td>
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>.
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">ANNOTATION_FIELD_DEF</a>.
             </td>
           </tr>
         </table>
@@ -592,11 +583,9 @@ public boolean isSomething()
             <td>tokens</td>
             <td>tokens to check</td>
             <td>subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>.
             </td>
             <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>.
             </td>
           </tr>
@@ -834,7 +823,7 @@ public boolean isSomething()
 
       <subsection name="Package">
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
@@ -945,7 +934,7 @@ public boolean isSomething()
 
       <subsection name="Package">
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
@@ -988,7 +977,7 @@ public boolean isSomething()
 
       <subsection name="Package">
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
@@ -1049,7 +1038,7 @@ public boolean isSomething()
 
       <subsection name="Package">
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
@@ -1131,7 +1120,7 @@ public boolean isSomething()
 
       <subsection name="Package">
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
@@ -1218,7 +1207,7 @@ public boolean isSomething()
 
       <subsection name="Package">
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
@@ -1253,7 +1242,7 @@ public boolean isSomething()
             <th>default value</th>
           </tr>
           <tr>
-            <td>tagImmediatelyBeforeFirstWord</td>
+            <td>allowNewlineParagraph</td>
             <td>whether the &lt;p&gt; tag should be placed immediately before the first word</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
@@ -1313,7 +1302,7 @@ public boolean isSomething()
 
       <subsection name="Package">
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
@@ -1389,7 +1378,7 @@ public boolean isSomething()
 
       <subsection name="Package">
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -361,6 +361,38 @@
             <td><a href="property_types.html#integer">boolean</a></td>
             <td><code>false</code></td>
           </tr>
+
+          <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+
+            <td>
+              subset of tokens
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">LITERAL_CASE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>.
+            </td>
+
+            <td>
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">LITERAL_CASE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>.
+            </td>
+          </tr>
         </table>
       </subsection>
 
@@ -555,6 +587,38 @@ class SwitchExample {
             <td>the maximum threshold allowed</td>
             <td><a href="property_types.html#integer">integer</a></td>
             <td><code>200</code></td>
+          </tr>
+
+          <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+
+            <td>
+              subset of tokens
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">LITERAL_CASE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>.
+            </td>
+
+            <td>
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">LITERAL_CASE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>.
+            </td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -231,7 +231,7 @@
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the Check:
         </p>
@@ -364,7 +364,7 @@ messages.properties: Key 'ok' missing.
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check for files with '_' name separator:
         </p>
@@ -648,8 +648,14 @@ messages.properties: Key 'ok' missing.
             <th>default value</th>
           </tr>
           <tr>
+            <td>ignorePrimitiveTypes</td>
+            <td>ignore primitive types as parameters</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>false</code></td>
+          </tr>
+          <tr>
             <td>tokens</td>
-            <td>blocks to check</td>
+            <td>tokens to check</td>
             <td>
               subset of tokens
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
@@ -661,12 +667,6 @@ messages.properties: Key 'ok' missing.
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>.
             </td>
-          </tr>
-          <tr>
-            <td>ignorePrimitiveTypes</td>
-            <td>ignore primitive types as parameters</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
           </tr>
         </table>
       </subsection>
@@ -750,13 +750,6 @@ messages.properties: Key 'ok' missing.
             <th>description</th>
             <th>type</th>
             <th>default value</th>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>token types to check</td>
-            <td>subset of tokens declared in <a
-            href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a></td>
-            <td>empty set</td>
           </tr>
           <tr>
             <td>limitedTokens</td>
@@ -1274,7 +1267,7 @@ d = e / f;        // Another comment for this line
 
       <subsection name="Package">
         <p>
-          com.puppycrawl.tools.checkstyle.checks.indentation
+          com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
@@ -1292,10 +1285,6 @@ d = e / f;        // Another comment for this line
           the class <code>Foo</code> must be in a file named
           <code>Foo.java</code>.
         </p>
-      </subsection>
-
-      <subsection name="Properties">
-        <p>None.</p>
       </subsection>
 
       <subsection name="Examples">
@@ -1549,6 +1538,19 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
         </p>
       </subsection>
 
+      <subsection name="Examples">
+        <p>
+          This check should not be used by itself, as it does no reporting.
+          It is to be used in conjuction with other checks like
+          <a href="config_filters.html#SuppressionCommentFilter">SuppressionCommentFilter</a>
+          and
+          <a href="config_filters.html#SuppressWithNearbyCommentFilter">SuppressWithNearbyCommentFilter</a>.
+        </p>
+      </subsection>
+
+      <subsection name="Example of Usage">
+      </subsection>
+
       <subsection name="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
@@ -1557,7 +1559,7 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
 
       <subsection name="Parent Module">
         <p>
-          <a href="config.html#Checker">Checker</a>
+          <a href="config.html#TreeWalker">TreeWalker</a>
         </p>
       </subsection>
       </section>

--- a/src/xdocs/config_modifier.xml
+++ b/src/xdocs/config_modifier.xml
@@ -68,7 +68,7 @@
         </ol>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p> To configure the check: </p>
         <source>
 &lt;module name=&quot;ModifierOrder&quot;/&gt;
@@ -238,7 +238,7 @@
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p> To configure the check: </p>
         <source>
 &lt;module name=&quot;RedundantModifier&quot;/&gt;

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -77,7 +77,7 @@
             <td>true</td>
           </tr>
           <tr>
-            <td>ignoreOverriddenMethod</td>
+            <td>ignoreOverriddenMethods</td>
             <td>Allows to ignore methods tagged with @Override annotation
             (that usually mean inherited name).</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
@@ -149,11 +149,11 @@
       </subsection>
 
       <subsection name="Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
       <subsection name="Parent Module">
-        <p><a href="config.html#TreeWalker">TreeWalker</a></p>
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>
 
@@ -212,7 +212,7 @@
         </source>
       </subsection>
 
-      <subsection name="Examples of Usage">
+      <subsection name="Example of Usage">
         <ul>
           <li>
             <a href="https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle_checks.xml#L297">
@@ -222,11 +222,11 @@
       </subsection>
 
       <subsection name="Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
       <subsection name="Parent Module">
-        <p><a href="config.html#TreeWalker">TreeWalker</a></p>
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>
 
@@ -261,7 +261,7 @@
         </source>
       </subsection>
 
-      <subsection name="Examples of Usage">
+      <subsection name="Example of Usage">
         <ul>
           <li>
             <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml#L122-L126">
@@ -275,11 +275,11 @@
       </subsection>
 
       <subsection name="Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
       <subsection name="Parent Module">
-        <p><a href="config.html#TreeWalker">TreeWalker</a></p>
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>
 
@@ -350,7 +350,7 @@
         </source>
       </subsection>
 
-      <subsection name="Examples of Usage">
+      <subsection name="Example of Usage">
         <ul>
           <li>
             <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/sun_checks.xml#L91">
@@ -364,11 +364,11 @@
       </subsection>
 
       <subsection name="Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
       <subsection name="Parent Module">
-        <p><a href="config.html#TreeWalker">TreeWalker</a></p>
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>
 
@@ -405,7 +405,7 @@
         </source>
       </subsection>
 
-      <subsection name="Examples of Usage">
+      <subsection name="Example of Usage">
         <ul>
           <li>
             <a href="https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle_checks.xml#L261">
@@ -415,11 +415,11 @@
       </subsection>
 
       <subsection name="Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
       <subsection name="Parent Module">
-        <p><a href="config.html#TreeWalker">TreeWalker</a></p>
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>
 
@@ -470,7 +470,7 @@
         </source>
       </subsection>
 
-      <subsection name="Examples of Usage">
+      <subsection name="Example of Usage">
         <ul>
           <li>
             <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/sun_checks.xml#L92">
@@ -484,11 +484,11 @@
       </subsection>
 
       <subsection name="Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
       <subsection name="Parent Module">
-        <p><a href="config.html#TreeWalker">TreeWalker</a></p>
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>
 
@@ -568,7 +568,7 @@ for (int i = 1; i &lt; 10; i++) {}
         </source>
       </subsection>
 
-      <subsection name="Examples of Usage">
+      <subsection name="Example of Usage">
         <ul>
           <li>
             <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml#L115-L121">
@@ -586,11 +586,11 @@ for (int i = 1; i &lt; 10; i++) {}
       </subsection>
 
       <subsection name="Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
       <subsection name="Parent Module">
-        <p><a href="config.html#TreeWalker">TreeWalker</a></p>
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>
 
@@ -660,7 +660,7 @@ for (int i = 1; i &lt; 10; i++) {}
         </source>
       </subsection>
 
-      <subsection name="Examples of Usage">
+      <subsection name="Example of Usage">
         <ul>
           <li>
             <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml#L105-L109">
@@ -678,11 +678,11 @@ for (int i = 1; i &lt; 10; i++) {}
       </subsection>
 
       <subsection name="Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
       <subsection name="Parent Module">
-        <p><a href="config.html#TreeWalker">TreeWalker</a></p>
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>
 
@@ -737,7 +737,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Examples of Usage">
+      <subsection name="Example of Usage">
         <ul>
           <li>
             <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml#L193-L197">
@@ -755,11 +755,11 @@ class MyClass {
       </subsection>
 
       <subsection name="Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
       <subsection name="Parent Module">
-        <p><a href="config.html#TreeWalker">TreeWalker</a></p>
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>
 
@@ -796,7 +796,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Examples of Usage">
+      <subsection name="Example of Usage">
         <ul>
           <li>
             <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml#L127-L131">
@@ -810,11 +810,11 @@ class MyClass {
       </subsection>
 
       <subsection name="Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
       <subsection name="Parent Module">
-        <p><a href="config.html#TreeWalker">TreeWalker</a></p>
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>
 
@@ -860,7 +860,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Examples of Usage">
+      <subsection name="Example of Usage">
         <ul>
           <li>
             <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml#L96-L100">
@@ -878,11 +878,11 @@ class MyClass {
       </subsection>
 
       <subsection name="Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
       <subsection name="Parent Module">
-        <p><a href="config.html#TreeWalker">TreeWalker</a></p>
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>
 
@@ -919,7 +919,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Examples of Usage">
+      <subsection name="Example of Usage">
         <ul>
           <li>
             <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml#L110-L114">
@@ -937,11 +937,11 @@ class MyClass {
       </subsection>
 
       <subsection name="Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
       <subsection name="Parent Module">
-        <p><a href="config.html#TreeWalker">TreeWalker</a></p>
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>
 
@@ -1004,7 +1004,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Examples of Usage">
+      <subsection name="Example of Usage">
         <ul>
           <li>
             <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/sun_checks.xml#L98">
@@ -1018,11 +1018,11 @@ class MyClass {
       </subsection>
 
       <subsection name="Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
       <subsection name="Parent Module">
-        <p><a href="config.html#TreeWalker">TreeWalker</a></p>
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>
 
@@ -1075,7 +1075,7 @@ class MyClass {
           </tr>
           <tr>
             <td>tokens</td>
-            <td>Controls the kind of type that the check applies to.</td>
+            <td>tokens to check</td>
             <td>
               subset of tokens
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
@@ -1118,7 +1118,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Examples of Usage">
+      <subsection name="Example of Usage">
         <ul>
           <li>
             <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml#L101-L104">
@@ -1136,11 +1136,11 @@ class MyClass {
       </subsection>
 
       <subsection name="Package">
-        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+        <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
       <subsection name="Parent Module">
-        <p><a href="config.html#TreeWalker">TreeWalker</a></p>
+        <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>
 

--- a/src/xdocs/config_regexp.xml
+++ b/src/xdocs/config_regexp.xml
@@ -448,7 +448,7 @@
 
       <subsection name="Package">
         <p>
-          com.puppycrawl.tools.checkstyle.checks
+          com.puppycrawl.tools.checkstyle.checks.regexp
         </p>
       </subsection>
 

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -44,7 +44,7 @@
           </tr>
           <tr>
             <td>tokens</td>
-            <td>members to check</td>
+            <td>tokens to check</td>
             <td>
               subset of tokens
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
@@ -319,7 +319,7 @@
           </tr>
           <tr>
             <td>tokens</td>
-            <td>blocks to check</td>
+            <td>tokens to check</td>
 
             <td>
               subset of tokens <a
@@ -490,7 +490,7 @@
           </tr>
           <tr>
             <td>tokens</td>
-            <td>declarations to check</td>
+            <td>tokens to check</td>
 
             <td>
               subset of tokens <a
@@ -694,6 +694,26 @@ public void needsLotsOfParameters(int a, int b, int c, int d, int e, int f, int 
             <td>maximum allowable number of <code>public</code> methods</td>
             <td><a href="property_types.html#integer">integer</a></td>
             <td>100</td>
+          </tr>
+
+          <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+
+            <td>
+              subset of tokens
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>.
+            </td>
+
+            <td>
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>.
+            </td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -43,9 +43,7 @@
           <li> should not be preceded with whitespace in all cases.</li>
           <li> should be followed with whitespace in almost all cases, except diamond operators and when preceding method name.</li>
         </ul>
-      </subsection>
 
-      <subsection name="Examples">
         <p>
           Examples with correct spacing:
         </p>
@@ -58,13 +56,6 @@ Pair&lt;Integer, String> p1 = new Pair&lt;&gt;(1, "apple");     // Diamond opera
 List&lt;T&gt; list = ImmutableList.Builder&lt;T&gt;::new;          // Method reference
 sort(list, Comparable::&lt;String&gt;compareTo);             // Method reference
         </source>
-      </subsection>
-
-      <subsection name="Properties">
-
-        <p>
-          None.
-        </p>
       </subsection>
 
       <subsection name="Examples">
@@ -416,19 +407,19 @@ for (Iterator foo = very.long.line.iterator();
               subset of tokens <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">ARRAY_INIT</a>,
               <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BNOT">BNOT</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DEC">DEC</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">DOT</a>,
-              <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INC">INC</a>,
               <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LNOT">LNOT</a>,
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DEC">DEC</a>,
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">UNARY_MINUS</a>,
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">UNARY_PLUS</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BNOT">BNOT</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LNOT">LNOT</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">DOT</a>,
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">TYPECAST</a>,
               <a
@@ -443,19 +434,19 @@ for (Iterator foo = very.long.line.iterator();
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">ARRAY_INIT</a>,
               <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BNOT">BNOT</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DEC">DEC</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">DOT</a>,
-              <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INC">INC</a>,
               <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LNOT">LNOT</a>,
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DEC">DEC</a>,
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">UNARY_MINUS</a>,
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">UNARY_PLUS</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BNOT">BNOT</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LNOT">LNOT</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">DOT</a>,
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR">ARRAY_DECLARATOR</a>.
             </td>
@@ -541,19 +532,19 @@ for (Iterator foo = very.long.line.iterator();
 
             <td>
               subset of tokens
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">COMMA</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SEMI">SEMI</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">DOT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_DEC">POST_DEC</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_INC">POST_INC</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_DEC">POST_DEC</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">DOT</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_START">GENERIC_START</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_END">GENERIC_END</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">COMMA</a>.
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_END">GENERIC_END</a>.
             </td>
             <td>
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">COMMA</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SEMI">SEMI</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_DEC">POST_DEC</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_INC">POST_INC</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">COMMA</a>.
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_DEC">POST_DEC</a>.
             </td>
           </tr>
         </table>
@@ -632,122 +623,66 @@ for (Iterator foo = very.long.line.iterator();
             <td>tokens to check</td>
 
             <td>
-              subset of tokens <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">ASSIGN</a>,
-              <a
-               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">BAND</a>,
-               <a
-                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">BAND_ASSIGN</a>,
-                <a
-                 href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">BOR</a>,
-                 <a
-                  href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">BOR_ASSIGN</a>,
-                  <a
-                   href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">BSR</a>,
-                   <a
-                    href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">BSR_ASSIGN</a>,
-                    <a
-                     href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">BXOR</a>,
-                     <a
-                      href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">BXOR_ASSIGN</a>,
-                      <a
-                       href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">COLON</a>,
-                       <a
-                        href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">DIV</a>,
-                        <a
-                         href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">DIV_ASSIGN</a>,
-                         <a
-                          href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">EQUAL</a>,
-                          <a
-                           href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">GE</a>,
-                           <a
-                            href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">GT</a>,
-                            <a
-                             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
-                             <a
-                              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">LE</a>,
-                              <a
-                               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">LITERAL_INSTANCEOF</a>,
-                               <a
-                                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>,
-                                <a
-                                 href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">LT</a>,
-                                 <a
-                                  href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">MINUS</a>,
-                                  <a
-                                   href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">MINUS_ASSIGN</a>,
-                                   <a
-                                    href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">MOD</a>,
-                                    <a
-                                     href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">MOD_ASSIGN</a>,
-                                     <a
-                                      href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">NOT_EQUAL</a>,
-                                      <a
-                                       href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">PLUS</a>,
-                                       <a
-                                        href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">PLUS_ASSIGN</a>,
-                                        <a
-                                         href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>,
-                                         <a
-                                          href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">SL</a>,
-                                          <a
-                                           href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">SL_ASSIGN</a>,
-                                           <a
-                                            href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">SR</a>,
-                                            <a
-                                             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">SR_ASSIGN</a>,
-                                             <a
-                                              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">STAR</a>,
-                                              <a
-                                              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">STAR_ASSIGN</a>
+              subset of tokens
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">COLON</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">EQUAL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">NOT_EQUAL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV, PLUS">DIV, PLUS</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">MINUS</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">STAR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">MOD</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">SR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">BSR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">GE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">GT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">SL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">LE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">LT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">BXOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">BOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">BAND</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">LITERAL_INSTANCEOF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">TYPE_EXTENSION_AND</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">DIV_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">PLUS_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">MINUS_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">STAR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">MOD_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">SR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">BSR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">SL_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">BXOR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">BOR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">BAND_ASSIGN</a>.
             </td>
 
             <td>
-              <a
-               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">BAND</a>,
-               <a
-                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">BOR</a>,
-                <a
-                 href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">BSR</a>,
-                 <a
-                  href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">BXOR</a>,
-                  <a
-                   href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">COLON</a>,
-                   <a
-                    href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">DIV</a>,
-                    <a
-                     href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">EQUAL</a>,
-                     <a
-                      href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">GE</a>,
-                      <a
-                       href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">GT</a>,
-                       <a
-                        href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
-                        <a
-                         href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">LE</a>,
-                         <a
-                          href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">LITERAL_INSTANCEOF</a>,
-                          <a
-                           href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>,
-                           <a
-                            href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">LT</a>,
-                            <a
-                             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">MINUS</a>,
-                             <a
-                              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">MOD</a>,
-                              <a
-                               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">NOT_EQUAL</a>,
-                               <a
-                                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">PLUS</a>,
-                                <a
-                                 href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>,
-                                 <a
-                                  href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">SL</a>,
-                                  <a
-                                   href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">SR</a>,
-                                   <a
-                                   href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">STAR</a>
-            (all tokens except assignment operators)
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">COLON</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">EQUAL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">NOT_EQUAL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV, PLUS">DIV, PLUS</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">MINUS</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">STAR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">MOD</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">SR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">BSR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">GE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">GT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">SL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">LE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">LT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">BXOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">BOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">BAND</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">TYPE_EXTENSION_AND</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">LITERAL_INSTANCEOF</a>.
             </td>
           </tr>
         </table>
@@ -844,9 +779,9 @@ for (Iterator foo = very.long.line.iterator();
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">ANNOTATION_FIELD_DEF</a>,
               <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
-              <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_CALL">CTOR_CALL</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>,
               <a
@@ -872,11 +807,11 @@ for (Iterator foo = very.long.line.iterator();
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
               <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>,
+              <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE_SPECIFICATION">RESOURCE_SPECIFICATION</a>,
               <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SUPER_CTOR_CALL">SUPER_CTOR_CALL</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>.
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SUPER_CTOR_CALL">SUPER_CTOR_CALL</a>.
             </td>
 
             <td>
@@ -885,9 +820,9 @@ for (Iterator foo = very.long.line.iterator();
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">ANNOTATION_FIELD_DEF</a>,
               <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
-              <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_CALL">CTOR_CALL</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>,
               <a
@@ -913,11 +848,11 @@ for (Iterator foo = very.long.line.iterator();
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
               <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>,
+              <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE_SPECIFICATION">RESOURCE_SPECIFICATION</a>,
               <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SUPER_CTOR_CALL">SUPER_CTOR_CALL</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>.
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SUPER_CTOR_CALL">SUPER_CTOR_CALL</a>.
             </td>
           </tr>
         </table>
@@ -1087,7 +1022,7 @@ for (Iterator foo = very.long.line.iterator();
         </table>
       </subsection>
 
-      <subsection name="Example">
+      <subsection name="Examples">
         <p>
           To configure the check to report on the first instance in each
           file:
@@ -1255,119 +1190,6 @@ public @interface Beta {} // empty annotation type
             <th>default value</th>
           </tr>
           <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">BAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">BAND_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">BOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">BOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">BSR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">BSR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">BXOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">BXOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">COLON</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">DIV</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">DIV_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DO_WHILE">DO_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">EQUAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">GE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">GT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LCURLY">LCURLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">LE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ASSERT">LITERAL_ASSERT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">LITERAL_FINALLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_RETURN">LITERAL_RETURN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">LITERAL_SYNCHRONIZED</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">LT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">MINUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">MINUS_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">MOD</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">MOD_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">NOT_EQUAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">PLUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">PLUS_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RCURLY">RCURLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">SL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SLIST">SLIST</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">SL_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">SR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">SR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">STAR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">STAR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">TYPE_EXTENSION_AND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#WILDCARD_TYPE">WILDCARD_TYPE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_START">GENERIC_START</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_END">GENERIC_END</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">BAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">BAND_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">BOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">BOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">BSR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">BSR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">BXOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">BXOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">COLON</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">DIV</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">DIV_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DO_WHILE">DO_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">EQUAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">GE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">GT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LCURLY">LCURLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">LE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ASSERT">LITERAL_ASSERT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">LITERAL_FINALLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_RETURN">LITERAL_RETURN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">LITERAL_SYNCHRONIZED</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">LT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">MINUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">MINUS_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">MOD</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">MOD_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">NOT_EQUAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">PLUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">PLUS_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RCURLY">RCURLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">SL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SLIST">SLIST</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">SL_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">SR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">SR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">STAR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">STAR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">TYPE_EXTENSION_AND</a>.
-            </td>
-          </tr>
-          <tr>
             <td>allowEmptyConstructors</td>
             <td>allow empty constructor bodies</td>
             <td><a href="property_types.html#boolean">boolean</a></td>
@@ -1396,6 +1218,119 @@ public @interface Beta {} // empty annotation type
             <td>ignore whitespace around colon in for-each loops</td>
             <td><a href="property_types.html#boolean">boolean</a></td>
             <td><code>true</code></td>
+          </tr>
+          <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+
+            <td>
+              subset of tokens
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">BAND</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">BAND_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">BOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">BOR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">BSR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">BSR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">BXOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">BXOR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">COLON</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">DIV</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">DIV_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DO_WHILE">DO_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">EQUAL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">GE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">GT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LCURLY">LCURLY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">LE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">LITERAL_FINALLY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_RETURN">LITERAL_RETURN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">LITERAL_SYNCHRONIZED</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">LT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">MINUS</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">MINUS_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">MOD</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">MOD_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">NOT_EQUAL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">PLUS</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">PLUS_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RCURLY">RCURLY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">SL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SLIST">SLIST</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">SL_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">SR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">SR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">STAR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">STAR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ASSERT">LITERAL_ASSERT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">TYPE_EXTENSION_AND</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#WILDCARD_TYPE">WILDCARD_TYPE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_START">GENERIC_START</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_END">GENERIC_END</a>.
+            </td>
+            <td>
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">BAND</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">BAND_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">BOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">BOR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">BSR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">BSR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">BXOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">BXOR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">COLON</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">DIV</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">DIV_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DO_WHILE">DO_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">EQUAL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">GE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">GT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LCURLY">LCURLY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">LE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">LITERAL_DO</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">LITERAL_FINALLY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">LITERAL_FOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_RETURN">LITERAL_RETURN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">LITERAL_SYNCHRONIZED</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">LT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">MINUS</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">MINUS_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">MOD</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">MOD_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">NOT_EQUAL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">PLUS</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">PLUS_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RCURLY">RCURLY</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">SL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SLIST">SLIST</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">SL_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">SR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">SR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">STAR</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">STAR_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ASSERT">LITERAL_ASSERT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">TYPE_EXTENSION_AND</a>.
+            </td>
           </tr>
         </table>
       </subsection>
@@ -1468,22 +1403,23 @@ public @interface Beta {} // empty annotation type
           </tr>
           <tr>
             <td>tokens</td>
-            <td>assignments to check</td>
-            <td>subset of tokens <a
-            href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">PACKAGE_DEF</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">IMPORT</a>,
-             <a
+            <td>tokens to check</td>
+            <td>subset of tokens
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">IMPORT</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">PACKAGE_DEF</a>,
+              <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
               <a
-                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>
-               <a
-               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
               <a
-               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
-               <a
-               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>.
-               </td>
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>.
+            </td>
             <td><a
             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">PACKAGE_DEF</a>,
             <a
@@ -1570,34 +1506,6 @@ import com.puppycrawl.tools.checkstyle.api.Check;
             <th>default value</th>
           </tr>
           <tr>
-            <td>tokens</td>
-            <td>assignments to check</td>
-            <td>subset of tokens
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">PACKAGE_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">IMPORT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">STATIC_INIT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">INSTANCE_INIT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
-          </td>
-          <td>
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">PACKAGE_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">IMPORT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">STATIC_INIT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">INSTANCE_INIT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
-          </td>
-          </tr>
-          <tr>
             <td>allowNoEmptyLineBetweenFields</td>
             <td>Allow no empty line between fields</td>
             <td><a href="property_types.html#boolean">boolean</a></td>
@@ -1608,6 +1516,34 @@ import com.puppycrawl.tools.checkstyle.api.Check;
              <td>Allow multiple empty lines between class members</td>
              <td><a href="property_types.html#boolean">boolean</a></td>
              <td>true</td>
+          </tr>
+          <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+            <td>subset of tokens
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">PACKAGE_DEF</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">IMPORT</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">STATIC_INIT</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">INSTANCE_INIT</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
+          </td>
+          <td>
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">PACKAGE_DEF</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">IMPORT</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">STATIC_INIT</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">INSTANCE_INIT</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
+          </td>
           </tr>
         </table>
       </subsection>


### PR DESCRIPTION
preview of xdoc check validation. no fixes here, will be in separate commit. shouldn't be merged until then.
use reflection alot here.

**Added the following requirements:**
All sections shouldn't end with 'Check'.
All sections should be able to be instantiated.
All sub-sections should follow the order: Description, Properties (optional), Examples, Example of Usage, Package, Parent Module
Following sub-sections can be out of order and optional: Notes, Rule Description, Use Case

Package must be the check's package location.
Parent Module must be TreeWalker if it extends Check, otherwise must be Checker.
Properties is optional, but must exist if there is a bean to be documented, or its tokens should be documented. (default != acceptable != required)

**Still to implement:**
If tokens property is displayed, all tokens must be displayed for type (acceptable) and default value.

@romani 
**Questions:**
1) Should 'Description' sub-section forbid source tags? I feel descriptions should be text only for simplicity. We should have a different section for code examples.
2) Should 'Examples' sub-section show all properties in atleast one example? Exlude tokens?
3) When I build the list of properties, I am going through all sub-classes. Some sub-classes have a property, while the main class sets it to a specific value. Right now these aren't document but could be set for any random reason, so I am making a list of "undocumented" beans for this. This sound ok? You can see my current list in the code.
4) Any other requirements you want me to add?