### PR TITLE
Issue #1238: Add codeclimate-checkstyle and Checkstyles for Bitbucket Server tools

### DIFF
--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -125,6 +125,18 @@
                   <th>Remarks</th>
               </tr>
               <tr>
+                  <td>
+                      <a href="https://bitbucket.org/product/server">Bitbucket Server</a>
+                  </td>
+                  <td>Stephan Bechter</td>
+                  <td>
+                      <a href="https://marketplace.atlassian.com/plugins/at.apogeum.bitbucket.checkstyle">
+                          Checkstyles for Bitbucket Server
+                      </a>
+                  </td>
+                  <td/>
+              </tr>
+              <tr>
                   <td><a href="http://www.eclipse.org">Eclipse/RAD/RDz</a></td>
                   <td>David Schneider</td>
                   <td>
@@ -178,6 +190,18 @@
                   <td>Atlassian (formerly by Ross Rowe and Stephan Paulicke)</td>
                   <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">Bamboo Checkstyle plug-in Home Page</a></td>
                   <td>An add-on that will parse and record CheckStyle reports and report your style violations over time.</td>
+              </tr>
+              <tr>
+                  <td>
+                      <a href="https://codeclimate.com/">Code Climate</a>
+                  </td>
+                  <td>Sivakumar Kailasam</td>
+                  <td>
+                      <a href="https://github.com/sivakumar-kailasam/codeclimate-checkstyle">
+                          codeclimate-checkstyle
+                      </a>
+                  </td>
+                  <td/>
               </tr>
               <tr>
                   <td><a href="https://wiki.jenkins-ci.org/display/JENKINS/Checkstyle+Plugin">Jenkins Checkstyle plug-in</a></td>


### PR DESCRIPTION
Added two new tools to *Related Tools* section:
* codeclimate-checkstyle - [build tool](https://codeclimate.com/), [available from](https://github.com/sivakumar-kailasam/codeclimate-checkstyle)
* Checkstyles for Bitbucket Server - [build tool](https://bitbucket.org/product/server), [available from](https://marketplace.atlassian.com/plugins/at.apogeum.bitbucket.checkstyle)

![image](https://cloud.githubusercontent.com/assets/2310862/10734517/f5eb0fda-7c03-11e5-936c-ba477368762a.png)

This PR should close Issue #1238