### PR TITLE
Pull #2464: Update Maven Shade Plugin to 2.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1211,7 +1211,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>2.4.1</version>
+            <version>2.4.2</version>
             <executions>
               <execution>
                 <phase>package</phase>


### PR DESCRIPTION
Release Notes - Apache Maven Shade Plugin  Version 2.4.2

https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317921&version=12333008

Bugs:

 * [MSHADE-172] - "java.lang.ArithmeticException: / by zero" in MinijarFilter
 * [MSHADE-190] - Shade does not relocate the contents of META-INF/services files
 * [MSHADE-209] - [REGRESSION] "java.lang.ArithmeticException: / by zero" in MinijarFilter (reporter Jon McLean).

Improvements:

 * [MSHADE-205] - Better use of ClazzpathUnit for improved jar minimization (contribution of Benoit Perrot).
 * [MSHADE-207] - Replace wrong link to codehaus with correct location
 * [MSHADE-210] - Upgrade maven-plugins parent to version 28.
 * [MSHADE-211] - Keep Java 1.5
