### PR TITLE
Issue #2268: require all checks appear in checkstyle_checks.xml

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -375,6 +375,7 @@
       -->
       <property name="severity" value="ignore"/>
     </module>
+    <module name="FileContentsHolder"/>
   </module>
   <module name="Translation">
     <property name="requiredTranslations" value="de, fr, fi, es, pt, ja, tr"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AllChecksTest.java
@@ -53,6 +53,8 @@ import com.puppycrawl.tools.checkstyle.api.Filter;
 import com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck;
 
 public class AllChecksTest extends BaseCheckTestSupport {
+    private static final String CONFIG_PATH = "config" + File.separator
+            + "checkstyle_checks.xml";
 
     @Test
     public void testAllChecksWithDefaultConfiguration() throws Exception {
@@ -151,10 +153,9 @@ public class AllChecksTest extends BaseCheckTestSupport {
 
     @Test
     public void testAllChecksAreReferencedInConfigFile() throws Exception {
-        final String configFilePath = "config/checkstyle_checks.xml";
         final Set<Class<?>> checksFromClassPath = getCheckstyleChecks();
         final Set<String> checksReferencedInConfig =
-                getCheckStyleChecksReferencedInConfig(configFilePath);
+                getCheckStyleChecksReferencedInConfig(CONFIG_PATH);
         final Set<String> checksNames = getSimpleNames(checksFromClassPath);
 
         for (String check : checksNames) {
@@ -182,6 +183,23 @@ public class AllChecksTest extends BaseCheckTestSupport {
                     moduleName);
                 Assert.fail(missingModuleMessage);
             }
+        }
+    }
+
+    @Test
+    public void testAllCheckstyleModulesInCheckstyleConfig() throws Exception {
+        final Set<String> configChecks = getCheckStyleChecksReferencedInConfig(CONFIG_PATH);
+
+        for (String moduleName : getSimpleNames(getCheckstyleModules())) {
+            if ("SuppressionCommentFilter".equals(moduleName)
+                || "SeverityMatchFilter".equals(moduleName)
+                || "SuppressWithNearbyCommentFilter".equals(moduleName)
+                || "SuppressWarningsFilter".equals(moduleName)) {
+                continue;
+            }
+
+            Assert.assertTrue("checkstyle_checks.xml is missing module: " + moduleName,
+                    configChecks.contains(moduleName));
         }
     }
 
@@ -261,7 +279,8 @@ public class AllChecksTest extends BaseCheckTestSupport {
         final String className = loadedClass.getSimpleName();
         return isCheckstyleNonAbstractCheck(loadedClass, className)
             || isFilterModule(loadedClass, className)
-            || "SuppressWarningsHolder".equals(className);
+            || "SuppressWarningsHolder".equals(className)
+            || "FileContentsHolder".equals(className);
     }
 
     /**
@@ -332,8 +351,7 @@ public class AllChecksTest extends BaseCheckTestSupport {
                 final Element module = (Element) currentNode;
                 final String checkName = module.getAttribute("name");
                 if (!"Checker".equals(checkName)
-                    && !"TreeWalker".equals(checkName)
-                    && !"SuppressionFilter".equals(checkName)) {
+                    && !"TreeWalker".equals(checkName)) {
                     checksReferencedInCheckstyleChecksXML.add(checkName);
                 }
             }

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -398,7 +398,7 @@ messages.properties: Key 'ok' missing.
             Sun Style</a>
           </li>
           <li>
-            <a href="https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle_checks.xml#L379">
+            <a href="https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle_checks.xml#L380">
             Checkstyle Style</a>
           </li>
         </ul>
@@ -1549,6 +1549,12 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
       </subsection>
 
       <subsection name="Example of Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle_checks.xml#L378">
+            Checkstyle Style</a>
+          </li>
+        </ul>
       </subsection>
 
       <subsection name="Package">


### PR DESCRIPTION
Added override for "FileContentsHolder" to "isCheckstyleModule".
Only 1 change to XML file, added FileContentsHolder.

Currently skipping Filters. Issue said to "discuss with before".