### PR TITLE
Issue #2451: removed excess hierarchy from PackageNameCheck

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -37,7 +37,7 @@
               files="AbstractClassNameCheckTest.java|AbstractTypeAwareCheckTest.java|AbstractJavadocCheckTest.java|AbstractViolationReporterTest.java"/>
 
     <!-- Tone down the checking for test code -->
-    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="325"/>
+    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="324"/>
     <suppress checks="EmptyBlock" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="ImportControl" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="Javadoc" files=".*[\\/]src[\\/](test|it)[\\/]"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
@@ -125,7 +125,6 @@ public class XDocsPagesTest {
             "MemberNameCheck.compileFlags",
             "MethodNameCheck.compileFlags",
             "MethodTypeParameterNameCheck.compileFlags",
-            "PackageNameCheck.compileFlags",
             "ParameterNameCheck.compileFlags",
             "StaticVariableNameCheck.compileFlags",
             "TypeNameCheck.compileFlags",


### PR DESCRIPTION
PackageNameCheck now extends Check.
Fields and setters copied from AbstractFormatCheck.

**Minor changes**:
Error property moved to MSG_KEY constant.
Fixed minor errors in javadoc.