### PR TITLE
Issue #2451: removed excess hierarchy from RegexpCheck

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -37,7 +37,7 @@
               files="AbstractClassNameCheckTest.java|AbstractTypeAwareCheckTest.java|AbstractJavadocCheckTest.java|AbstractViolationReporterTest.java"/>
 
     <!-- Tone down the checking for test code -->
-    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="324"/>
+    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="323"/>
     <suppress checks="EmptyBlock" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="ImportControl" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="Javadoc" files=".*[\\/]src[\\/](test|it)[\\/]"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
@@ -184,8 +184,23 @@ public final class CommonUtils {
      *             if unable to create Pattern object.
      **/
     public static Pattern createPattern(String pattern) {
+        return createPattern(pattern, 0);
+    }
+
+    /**
+     * Helper method to create a regular expression with a specific flags.
+     *
+     * @param pattern
+     *            the pattern to match
+     * @param flags
+     *            the flags to set
+     * @return a created regexp object
+     * @throws ConversionException
+     *             if unable to create Pattern object.
+     **/
+    public static Pattern createPattern(String pattern, int flags) {
         try {
-            return Pattern.compile(pattern);
+            return Pattern.compile(pattern, flags);
         }
         catch (final PatternSyntaxException e) {
             throw new ConversionException(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
@@ -128,7 +128,6 @@ public class XDocsPagesTest {
             "ParameterNameCheck.compileFlags",
             "StaticVariableNameCheck.compileFlags",
             "TypeNameCheck.compileFlags",
-            "RegexpCheck.compileFlags",
             "SuppressionCommentFilter.fileContents",
             "MethodNameCheck.applyToPackage",
             "MethodNameCheck.applyToPrivate",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Constructor;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Dictionary;
+import java.util.regex.Pattern;
 
 import org.apache.commons.beanutils.ConversionException;
 import org.junit.Test;
@@ -84,6 +85,11 @@ public class CommonUtilsTest {
     @Test(expected = ConversionException.class)
     public void testBadRegex() {
         CommonUtils.createPattern("[");
+    }
+
+    @Test(expected = ConversionException.class)
+    public void testBadRegex2() {
+        CommonUtils.createPattern("[", Pattern.MULTILINE);
     }
 
     @Test


### PR DESCRIPTION
RegexpCheck now extends Check.
Fields and setters copied from AbstractFormatCheck, with minor modifications.

**Minor changes:**
Created new CommonUtils.createPattern for setting flags.
Fixed minor errors in javadoc.