### PR TITLE
Issue #2268: require all filters appear in checkstyle_checks.xml

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -380,4 +380,31 @@
   <module name="Translation">
     <property name="requiredTranslations" value="de, fr, fi, es, pt, ja, tr"/>
   </module>
+  <module name="SuppressWarningsFilter"/>
+  <module name="SeverityMatchFilter">
+    <!--
+      report all violations except ignore
+    -->
+    <property name="severity" value="ignore"/>
+    <property name="acceptOnMatch" value="false"/>
+  </module>
+  <module name="SuppressWithNearbyCommentFilter">
+    <!--
+      Use suppressions.xml for suppressions, this is only example.
+      checkFormat will prevent suppression comments from being valid.
+    -->
+    <property name="checkFormat" value="IGNORETHIS"/>
+    <property name="commentFormat" value="SUPPRESS CHECKSTYLE, (\w+)"/>
+    <property name="messageFormat" value="$1"/>
+    <property name="influenceFormat" value="-1"/>
+  </module>
+  <module name="SuppressionCommentFilter">
+    <!--
+      Use suppressions.xml for suppressions, this is only example.
+      checkFormat will prevent suppression comments from being valid.
+    -->
+    <property name="checkFormat" value="IGNORETHIS"/>
+    <property name="offCommentFormat" value="CSOFF\: .*"/>
+    <property name="onCommentFormat" value="CSON\: .*"/>
+  </module>
 </module>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AllChecksTest.java
@@ -191,13 +191,6 @@ public class AllChecksTest extends BaseCheckTestSupport {
         final Set<String> configChecks = getCheckStyleChecksReferencedInConfig(CONFIG_PATH);
 
         for (String moduleName : getSimpleNames(getCheckstyleModules())) {
-            if ("SuppressionCommentFilter".equals(moduleName)
-                || "SeverityMatchFilter".equals(moduleName)
-                || "SuppressWithNearbyCommentFilter".equals(moduleName)
-                || "SuppressWarningsFilter".equals(moduleName)) {
-                continue;
-            }
-
             Assert.assertTrue("checkstyle_checks.xml is missing module: " + moduleName,
                     configChecks.contains(moduleName));
         }

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -73,6 +73,12 @@
           </source>
       </subsection>
       <subsection name="Example of Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle_checks.xml#L384-L390">
+            Checkstyle Style</a>
+          </li>
+        </ul>
       </subsection>
       <subsection name="Package">
         <p> com.puppycrawl.tools.checkstyle.filters </p>
@@ -528,6 +534,12 @@ HashSet hashSet; // Warning here: Declaring variables, return values or paramete
           </source>
       </subsection>
       <subsection name="Example of Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle_checks.xml#L401-L409">
+            Checkstyle Style</a>
+          </li>
+        </ul>
       </subsection>
       <subsection name="Package">
         <p> com.puppycrawl.tools.checkstyle.filters </p>
@@ -713,6 +725,12 @@ public static final int [] array; // @cs.suppress ConstantName | NoWhitespaceAft
             </source>
         </subsection>
         <subsection name="Example of Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle_checks.xml#L391-L400">
+            Checkstyle Style</a>
+          </li>
+        </ul>
         </subsection>
         <subsection name="Package">
             <p> com.puppycrawl.tools.checkstyle.filters </p>
@@ -774,6 +792,12 @@ private int [] ARRAY; // should NOT fail MemberNameCheck and NoWhitespaceAfterCh
           </source>
       </subsection>
       <subsection name="Example of Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle_checks.xml#L383">
+            Checkstyle Style</a>
+          </li>
+        </ul>
       </subsection>
       <subsection name="Package">
         <p> com.puppycrawl.tools.checkstyle.filters </p>


### PR DESCRIPTION
All filters are now in CS.
Added links, but line numbers may change depending on our conversations here.

My main goal for these new filters was to make CS' reporting act the same as it is before adding them.

**SuppressWarningsFilter**:
No properties to customize, so can't put this on a 'ignore' list.
Won't SuppressWarningsCheck conflict with this if someone used CS' SuppressWarnings? If so, then there is no issue allowing this filter to be as it is.

**SeverityMatchFilter**:
We wish to report all violations, so I told it to accept all != ignore. So this shouldn't change any of our reportings as ignore is ignored anyways.

**SuppressWithNearbyCommentFilter and SuppressionCommentFilter**:
I assumed we didn't want to really allow these comment suppressions since we don't use them now and use suppressions.xml, so 'checkFormat' is set to an invalid check name.
Other properties are similar to examples, but customized slightly on how I would like the check implemented.