### PR TITLE
Issue #2451: isolated check methods

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -84,7 +84,7 @@ public final class IllegalCatchCheck extends AbstractIllegalCheck {
      * @param parentToken - parent node for types (TYPE or BOR)
      * @return list, that contains all exception types in current catch
      */
-    public static List<DetailAST> getAllExceptionTypes(DetailAST parentToken) {
+    private static List<DetailAST> getAllExceptionTypes(DetailAST parentToken) {
         DetailAST currentNode = parentToken.getFirstChild();
         final List<DetailAST> exceptionTypes = new LinkedList<>();
         if (currentNode.getType() == TokenTypes.BOR) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -262,7 +262,8 @@ public class CommentsIndentationCheck extends Check {
      * @param comment single line comment.
      * @return the first token of the destributed previous statement of single line comment.
      */
-    public static DetailAST getDistributedPreviousStatementOfSingleLineComment(DetailAST comment) {
+    private static DetailAST getDistributedPreviousStatementOfSingleLineComment(
+            DetailAST comment) {
         DetailAST previousStatement = comment.getPreviousSibling();
         if (previousStatement.getType() == TokenTypes.LITERAL_RETURN
                 || previousStatement.getType() == TokenTypes.LITERAL_THROW) {


### PR DESCRIPTION
since we are splitting the heirachy of checks making them more standalone and not intertwined, there isn't much reason for methods of checks to be public when possible.