### PR TITLE
Issue #2451: removed excess hierarchy from IllegalTokenTextCheck

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -42,7 +42,7 @@
               files="AbstractClassNameCheckTest.java|AbstractTypeAwareCheckTest.java|AbstractJavadocCheckTest.java|AbstractViolationReporterTest.java"/>
 
     <!-- Tone down the checking for test code -->
-    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="330"/>
+    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="329"/>
     <suppress checks="EmptyBlock" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="ImportControl" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="Javadoc" files=".*[\\/]src[\\/](test|it)[\\/]"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1730,6 +1730,7 @@
                   <exclude>com/puppycrawl/tools/checkstyle/grammars/javadoc/*.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/gui/*.class</exclude>
                   <!-- deprecated classes -->
+                  <exclude>com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalCheck.class</exclude>
                 </excludes>
               </instrumentation>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
@@ -110,7 +110,6 @@ public class XDocsPagesTest {
 
     private static final List<String> UNDOCUMENTED_PROPERTIES = Arrays.asList(
             "SuppressWithNearbyCommentFilter.fileContents",
-            "IllegalTokenTextCheck.compileFlags",
             "AbstractClassNameCheck.compileFlags",
             "ClassTypeParameterNameCheck.compileFlags",
             "ConstantNameCheck.compileFlags",


### PR DESCRIPTION
'updateRegexp' is a new method to centralize creating the pattern.
Had to remove 'setCompileFlags' from AbstractFormatCheck to get code coverage to pass.

Everything else is a copy.