### PR TITLE
Issue #1267: validate existence of config file sooner

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -170,6 +170,15 @@ public final class Main {
         final List<String> result = new ArrayList<>();
         // ensure a configuration file is specified
         if (cmdLine.hasOption(OPTION_C_NAME)) {
+            final String configLocation = cmdLine.getOptionValue(OPTION_C_NAME);
+            try {
+                // test location only
+                CommonUtils.getUriByFilename(configLocation);
+            }
+            catch (CheckstyleException ignored) {
+                result.add(String.format("Could not find config XML file '%s'.", configLocation));
+            }
+
             // validate optional parameters
             if (cmdLine.hasOption(OPTION_F_NAME)) {
                 final String format = cmdLine.getOptionValue(OPTION_F_NAME);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -143,15 +143,15 @@ public class MainTest {
     @Test
     public void testNonExistingConfigFile()
             throws Exception {
-        exit.expectSystemExitWithStatus(-2);
+        exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(new Assertion() {
             @Override
             public void checkAssertion() {
-                assertEquals(String.format(Locale.ROOT, "Checkstyle ends with 1 errors.%n"),
+                assertEquals(String.format(Locale.ROOT,
+                        "Could not find config XML file "
+                            + "'src/main/resources/non_existing_config.xml'.%n"),
                         systemOut.getLog());
-                final String cause = "com.puppycrawl.tools.checkstyle.api.CheckstyleException:"
-                        + " Unable to find: src/main/resources/non_existing_config.xml";
-                assertTrue(systemErr.getLog().startsWith(cause));
+                assertEquals("", systemErr.getLog());
             }
         });
         Main.main("-c", "src/main/resources/non_existing_config.xml",


### PR DESCRIPTION
Test config location the same way we read the file in "ConfigurationLoader.loadConfiguration", so unlikely we will have false missing file.

**Questions**:
Do we still need complicated Test of testing if config can be found in JAR? From written code, I assume the jar file name will have to be updated each release. Also won't running a maven command while in a maven test break something?
https://github.com/Bhavik3/checkstyle/commit/5369f353d5f7dd9086e4e5f109c731c48b0e5e4e#diff-9cb7b23a8bfd6d92a3a35bdba7bac261R360

I assume we still need IT. I couldn't find any "Main" examples in IT currently, so I will need some guidance on what folder it should be in.