### PR TITLE
Issue #2451: removed excess hierarchy from AbstractClassNameCheck

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -42,7 +42,7 @@
               files="AbstractClassNameCheckTest.java|AbstractTypeAwareCheckTest.java|AbstractJavadocCheckTest.java|AbstractViolationReporterTest.java"/>
 
     <!-- Tone down the checking for test code -->
-    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="329"/>
+    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="328"/>
     <suppress checks="EmptyBlock" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="ImportControl" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="Javadoc" files=".*[\\/]src[\\/](test|it)[\\/]"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
@@ -19,9 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
+import java.util.regex.Pattern;
+
+import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.checks.AbstractFormatCheck;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * <p>
@@ -39,7 +42,7 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractFormatCheck;
  * @author <a href="mailto:simon@redhillconsulting.com.au">Simon Harris</a>
  * @author <a href="mailto:solid.danil@gmail.com">Danil Lopatin</a>
  */
-public final class AbstractClassNameCheck extends AbstractFormatCheck {
+public final class AbstractClassNameCheck extends Check {
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -53,19 +56,17 @@ public final class AbstractClassNameCheck extends AbstractFormatCheck {
      */
     public static final String NO_ABSTRACT_CLASS_MODIFIER = "no.abstract.class.modifier";
 
-    /** Default format for abstract class names. */
-    private static final String DEFAULT_FORMAT = "^Abstract.+$";
-
     /** Whether to ignore checking the modifier. */
     private boolean ignoreModifier;
 
     /** Whether to ignore checking the name. */
     private boolean ignoreName;
 
-    /** Creates new instance of the check. */
-    public AbstractClassNameCheck() {
-        super(DEFAULT_FORMAT);
-    }
+    /** The format string of the regexp. */
+    private String format = "^Abstract.+$";
+
+    /** The regexp to match against. */
+    private Pattern regexp = Pattern.compile(format);
 
     /**
      * Whether to ignore checking for the {@code abstract} modifier.
@@ -81,6 +82,16 @@ public final class AbstractClassNameCheck extends AbstractFormatCheck {
      */
     public void setIgnoreName(boolean value) {
         ignoreName = value;
+    }
+
+    /**
+     * Set the format to the specified regular expression.
+     * @param format a {@code String} value
+     * @throws org.apache.commons.beanutils.ConversionException unable to parse format
+     */
+    public void setFormat(String format) {
+        this.format = format;
+        regexp = CommonUtils.createPattern(format);
     }
 
     @Override
@@ -114,7 +125,7 @@ public final class AbstractClassNameCheck extends AbstractFormatCheck {
             // if class has abstract modifier
             if (!ignoreName && !isMatchingClassName(className)) {
                 log(ast.getLineNo(), ast.getColumnNo(),
-                    ILLEGAL_ABSTRACT_CLASS_NAME, className, getFormat());
+                    ILLEGAL_ABSTRACT_CLASS_NAME, className, format);
             }
         }
         else if (!ignoreModifier && isMatchingClassName(className)) {
@@ -139,6 +150,6 @@ public final class AbstractClassNameCheck extends AbstractFormatCheck {
      * @return true if class name matches format of abstract class names.
      */
     private boolean isMatchingClassName(String className) {
-        return getRegexp().matcher(className).find();
+        return regexp.matcher(className).find();
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
@@ -110,7 +110,6 @@ public class XDocsPagesTest {
 
     private static final List<String> UNDOCUMENTED_PROPERTIES = Arrays.asList(
             "SuppressWithNearbyCommentFilter.fileContents",
-            "AbstractClassNameCheck.compileFlags",
             "ClassTypeParameterNameCheck.compileFlags",
             "ConstantNameCheck.compileFlags",
             "InterfaceTypeParameterNameCheck.compileFlags",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckTest.java
@@ -60,6 +60,26 @@ public class AbstractClassNameCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
+    public void testCustomFormat() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(AbstractClassNameCheck.class);
+        checkConfig.addAttribute("ignoreName", "false");
+        checkConfig.addAttribute("ignoreModifier", "true");
+        final String pattern = "^NonAbstract.+$";
+        checkConfig.addAttribute("format", pattern);
+
+        final String[] expected = {
+            "3:1: " + getCheckMessage(ILLEGAL_ABSTRACT_CLASS_NAME, "InputAbstractClassName",
+                pattern),
+            "9:1: " + getCheckMessage(ILLEGAL_ABSTRACT_CLASS_NAME, "AbstractClassOther", pattern),
+            "21:1: " + getCheckMessage(ILLEGAL_ABSTRACT_CLASS_NAME, "AbstractClassName2",
+                pattern),
+        };
+
+        verify(checkConfig, getPath("InputAbstractClassName.java"), expected);
+    }
+
+    @Test
     public void testIllegalClassType() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(AbstractClassNameCheck.class);
         checkConfig.addAttribute("ignoreName", "true");


### PR DESCRIPTION
AbstractClassNameCheck now extends Check.
Removed DEFAULT_FORMAT as it was only used once.
Added test for missing coverage of 'setFormat'.