### PR TITLE
Issue 2451 12

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -42,7 +42,7 @@
               files="AbstractClassNameCheckTest.java|AbstractTypeAwareCheckTest.java|AbstractJavadocCheckTest.java|AbstractViolationReporterTest.java"/>
 
     <!-- Tone down the checking for test code -->
-    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="328"/>
+    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="317"/>
     <suppress checks="EmptyBlock" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="ImportControl" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="Javadoc" files=".*[\\/]src[\\/](test|it)[\\/]"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.java
@@ -31,9 +31,11 @@ import com.puppycrawl.tools.checkstyle.api.Check;
  * {@link Pattern regular expression}.  It
  * provides support for setting the regular
  * expression using the property name {@code format}.  </p>
- *
+ * @deprecated Checkstyle will not support abstract checks anymore. Use {@link Check} instead.
  * @author Oliver Burn
+ * @noinspection AbstractClassNeverImplemented
  */
+@Deprecated
 public abstract class AbstractFormatCheck
     extends Check {
     /** The flags to create the regular expression with. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractNameCheck.java
@@ -19,9 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
+import java.util.regex.Pattern;
+
+import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.checks.AbstractFormatCheck;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * Abstract class for checking that names conform to a specified format.
@@ -29,30 +32,46 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractFormatCheck;
  * @author Rick Giles
  */
 public abstract class AbstractNameCheck
-    extends AbstractFormatCheck {
+    extends Check {
     /**
      * Message key for invalid pattern error.
      */
     public static final String MSG_INVALID_PATTERN = "name.invalidPattern";
+
+    /** The format string of the regexp. */
+    private String format;
+
+    /** The regexp to match against. */
+    private Pattern regexp;
 
     /**
      * Creates a new {@code AbstractNameCheck} instance.
      * @param format format to check with
      */
     protected AbstractNameCheck(String format) {
-        super(format);
+        setFormat(format);
+    }
+
+    /**
+     * Set the format to the specified regular expression.
+     * @param format a {@code String} value
+     * @throws org.apache.commons.beanutils.ConversionException unable to parse format
+     */
+    public final void setFormat(String format) {
+        this.format = format;
+        regexp = CommonUtils.createPattern(format);
     }
 
     @Override
     public void visitToken(DetailAST ast) {
         if (mustCheckName(ast)) {
             final DetailAST nameAST = ast.findFirstToken(TokenTypes.IDENT);
-            if (!getRegexp().matcher(nameAST.getText()).find()) {
+            if (!regexp.matcher(nameAST.getText()).find()) {
                 log(nameAST.getLineNo(),
                     nameAST.getColumnNo(),
                     MSG_INVALID_PATTERN,
                     nameAST.getText(),
-                    getFormat());
+                    format);
             }
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
@@ -110,17 +110,6 @@ public class XDocsPagesTest {
 
     private static final List<String> UNDOCUMENTED_PROPERTIES = Arrays.asList(
             "SuppressWithNearbyCommentFilter.fileContents",
-            "ClassTypeParameterNameCheck.compileFlags",
-            "ConstantNameCheck.compileFlags",
-            "InterfaceTypeParameterNameCheck.compileFlags",
-            "LocalFinalVariableNameCheck.compileFlags",
-            "LocalVariableNameCheck.compileFlags",
-            "MemberNameCheck.compileFlags",
-            "MethodNameCheck.compileFlags",
-            "MethodTypeParameterNameCheck.compileFlags",
-            "ParameterNameCheck.compileFlags",
-            "StaticVariableNameCheck.compileFlags",
-            "TypeNameCheck.compileFlags",
             "SuppressionCommentFilter.fileContents",
             "MethodNameCheck.applyToPackage",
             "MethodNameCheck.applyToPrivate",


### PR DESCRIPTION
AbstractNameCheck now extends check. Even though this class will later be removed, this may make fixing the classes that extend this easier in future PRs. Doing this also removed 11 undocumented properties.
AbstractFormatCheck is now deprecated.
