### PR TITLE
Issue #2290: ParameterNameCheck - update checkstyle_checks.xml, fix NPE, add new option

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -329,7 +329,8 @@
     <module name="MethodTypeParameterName"/>
     <module name="PackageName"/>
     <module name="ParameterName">
-      <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+      <property name="format" value="^[a-z][a-zA-Z0-9]+$"/>
+      <property name="ignoreOverridden" value="true"/>
     </module>
     <module name="StaticVariableName">
       <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -118,11 +118,13 @@ public class ParameterNameCheck
     private static boolean isOverriddenMethod(DetailAST ast) {
         boolean overridden = false;
         final DetailAST parent = ast.getParent().getParent();
-        final DetailAST annotation = parent.getFirstChild().getFirstChild();
-        if (annotation.getType() == TokenTypes.ANNOTATION) {
-            final DetailAST overrideToken = annotation.findFirstToken(TokenTypes.IDENT);
-            if ("Override".equals(overrideToken.getText())) {
-                overridden = true;
+        if (parent.getFirstChild().getFirstChild() != null) {
+            final DetailAST annotation = parent.getFirstChild().getFirstChild();
+            if (annotation.getType() == TokenTypes.ANNOTATION) {
+                final DetailAST overrideToken = annotation.findFirstToken(TokenTypes.IDENT);
+                if ("Override".equals(overrideToken.getText())) {
+                    overridden = true;
+                }
             }
         }
         return overridden;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -30,9 +30,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * and defaults to
  * <strong>^[a-z][a-zA-Z0-9]*$</strong>.
  * </p>
- * <p>The check has the following option:</p>
+ * <p>The check has the following options:</p>
  * <p><b>ignoreOverridden</b> - allows to skip methods with Override annotation from
- * validation. Default values is <b>false</b> .</p>
+ * validation. Default value is <b>false</b> .</p>
+ * <p><b>skipCatchParameter</b> - allows to skip catcj parameter from validation. Default value
+ * is <b>true</b> .</p>
  * <p>
  * An example of how to configure the check is:
  * </p>
@@ -57,6 +59,14 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *    &lt;property name="ignoreOverridden" value="true"/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>
+ * An example of how to configure the check to skip catch parameter from validation:
+ * </p>
+ * <pre>
+ * &lt;module name="ParameterName"&gt;
+ *    &lt;property name="skipCatchParameter" value="true"/&gt;
+ * &lt;/module&gt;
+ * </pre>
  *
  * @author Oliver Burn
  * @author Andrei Selkin
@@ -68,6 +78,11 @@ public class ParameterNameCheck
      * Allows to skip methods with Override annotation from validation.
      */
     private boolean ignoreOverridden;
+
+    /**
+     * Allows to skip catch parameter from validation.
+     */
+    private boolean skipCatchParameter = true;
 
     /**
      * Creates a new {@code ParameterNameCheck} instance.
@@ -83,6 +98,14 @@ public class ParameterNameCheck
      */
     public void setIgnoreOverridden(boolean ignoreOverridden) {
         this.ignoreOverridden = ignoreOverridden;
+    }
+
+    /**
+     * Sets whether to skip catch parameter from validation.
+     * @param skipCatchParameter Flag for skipping catch parameter.
+     */
+    public void setSkipCatchParameter(boolean skipCatchParameter) {
+        this.skipCatchParameter = skipCatchParameter;
     }
 
     @Override
@@ -104,7 +127,7 @@ public class ParameterNameCheck
     protected boolean mustCheckName(DetailAST ast) {
         boolean checkName = true;
         if (ignoreOverridden && isOverriddenMethod(ast)
-                || ast.getParent().getType() == TokenTypes.LITERAL_CATCH) {
+                || skipCatchParameter && ast.getParent().getType() == TokenTypes.LITERAL_CATCH) {
             checkName = false;
         }
         return checkName;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -106,6 +106,11 @@ public class ParameterNameCheckTest
         final String[] expected = {
             "11:28: " + getCheckMessage(MSG_INVALID_PATTERN, "object", pattern),
             "15:30: " + getCheckMessage(MSG_INVALID_PATTERN, "aaaa", pattern),
+            "19:19: " + getCheckMessage(MSG_INVALID_PATTERN, "abc", pattern),
+            "19:28: " + getCheckMessage(MSG_INVALID_PATTERN, "bd", pattern),
+            "21:18: " + getCheckMessage(MSG_INVALID_PATTERN, "abc", pattern),
+            "28:33: " + getCheckMessage(MSG_INVALID_PATTERN, "field", pattern),
+            "28:62: " + getCheckMessage(MSG_INVALID_PATTERN, "packageNames", pattern),
             };
         verify(checkConfig, getPath("InputOverrideAnnotation.java"), expected);
     }
@@ -124,6 +129,11 @@ public class ParameterNameCheckTest
             "6:34: " + getCheckMessage(MSG_INVALID_PATTERN, "o", pattern),
             "11:28: " + getCheckMessage(MSG_INVALID_PATTERN, "object", pattern),
             "15:30: " + getCheckMessage(MSG_INVALID_PATTERN, "aaaa", pattern),
+            "19:19: " + getCheckMessage(MSG_INVALID_PATTERN, "abc", pattern),
+            "19:28: " + getCheckMessage(MSG_INVALID_PATTERN, "bd", pattern),
+            "21:18: " + getCheckMessage(MSG_INVALID_PATTERN, "abc", pattern),
+            "28:33: " + getCheckMessage(MSG_INVALID_PATTERN, "field", pattern),
+            "28:62: " + getCheckMessage(MSG_INVALID_PATTERN, "packageNames", pattern),
             };
         verify(checkConfig, getPath("InputOverrideAnnotation.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -137,4 +137,132 @@ public class ParameterNameCheckTest
             };
         verify(checkConfig, getPath("InputOverrideAnnotation.java"), expected);
     }
+
+    @Test
+    public void testSkipCatchParameterTrue()
+        throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ParameterNameCheck.class);
+        checkConfig.addAttribute("format", "^h$");
+        checkConfig.addAttribute("skipCatchParameter", "true");
+
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig, getPath("InputCatchParameter.java"), expected);
+    }
+
+    @Test
+    public void testSkipCatchParameterFalse()
+        throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ParameterNameCheck.class);
+        checkConfig.addAttribute("format", "^h$");
+        checkConfig.addAttribute("skipCatchParameter", "false");
+        final String pattern = "^h$";
+
+        final String[] expected = {
+            "13:26: " + getCheckMessage(MSG_INVALID_PATTERN, "ex", pattern),
+            "22:64: " + getCheckMessage(MSG_INVALID_PATTERN, "ex", pattern),
+        };
+
+        verify(checkConfig, getPath("InputCatchParameter.java"), expected);
+    }
+
+    @Test
+    public void testSkipCatchParameterTrueAndIgnoreOverriddenTrue()
+        throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ParameterNameCheck.class);
+        checkConfig.addAttribute("format", "^h$");
+        checkConfig.addAttribute("skipCatchParameter", "true");
+        checkConfig.addAttribute("ignoreOverridden", "true");
+        final String pattern = "^h$";
+
+        final String[] expected = {
+            "13:29: " + getCheckMessage(MSG_INVALID_PATTERN, "object", pattern),
+            "17:30: " + getCheckMessage(MSG_INVALID_PATTERN, "aaaa", pattern),
+            "21:19: " + getCheckMessage(MSG_INVALID_PATTERN, "abc", pattern),
+            "21:28: " + getCheckMessage(MSG_INVALID_PATTERN, "bd", pattern),
+            "23:18: " + getCheckMessage(MSG_INVALID_PATTERN, "abc", pattern),
+            "30:43: " + getCheckMessage(MSG_INVALID_PATTERN, "field", pattern),
+            "30:62: " + getCheckMessage(MSG_INVALID_PATTERN, "packageNames", pattern),
+            };
+
+        verify(checkConfig, getPath("InputParameterNameMultipleOptions.java"), expected);
+    }
+
+    @Test
+    public void testSkipCatchParameterFalseAndIgnoreOverriddenFalse()
+        throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ParameterNameCheck.class);
+        checkConfig.addAttribute("format", "^h$");
+        checkConfig.addAttribute("skipCatchParameter", "false");
+        checkConfig.addAttribute("ignoreOverridden", "false");
+        final String pattern = "^h$";
+
+        final String[] expected = {
+            "8:34: " + getCheckMessage(MSG_INVALID_PATTERN, "o", pattern),
+            "13:29: " + getCheckMessage(MSG_INVALID_PATTERN, "object", pattern),
+            "17:30: " + getCheckMessage(MSG_INVALID_PATTERN, "aaaa", pattern),
+            "21:19: " + getCheckMessage(MSG_INVALID_PATTERN, "abc", pattern),
+            "21:28: " + getCheckMessage(MSG_INVALID_PATTERN, "bd", pattern),
+            "23:18: " + getCheckMessage(MSG_INVALID_PATTERN, "abc", pattern),
+            "30:43: " + getCheckMessage(MSG_INVALID_PATTERN, "field", pattern),
+            "30:62: " + getCheckMessage(MSG_INVALID_PATTERN, "packageNames", pattern),
+            "36:26: " + getCheckMessage(MSG_INVALID_PATTERN, "ex", pattern),
+            "45:64: " + getCheckMessage(MSG_INVALID_PATTERN, "ex", pattern),
+            };
+
+        verify(checkConfig, getPath("InputParameterNameMultipleOptions.java"), expected);
+    }
+
+    @Test
+    public void testSkipCatchParameterTrueAndIgnoreOverriddenFalse()
+        throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ParameterNameCheck.class);
+        checkConfig.addAttribute("format", "^h$");
+        checkConfig.addAttribute("skipCatchParameter", "true");
+        checkConfig.addAttribute("ignoreOverridden", "false");
+        final String pattern = "^h$";
+
+        final String[] expected = {
+            "8:34: " + getCheckMessage(MSG_INVALID_PATTERN, "o", pattern),
+            "13:29: " + getCheckMessage(MSG_INVALID_PATTERN, "object", pattern),
+            "17:30: " + getCheckMessage(MSG_INVALID_PATTERN, "aaaa", pattern),
+            "21:19: " + getCheckMessage(MSG_INVALID_PATTERN, "abc", pattern),
+            "21:28: " + getCheckMessage(MSG_INVALID_PATTERN, "bd", pattern),
+            "23:18: " + getCheckMessage(MSG_INVALID_PATTERN, "abc", pattern),
+            "30:43: " + getCheckMessage(MSG_INVALID_PATTERN, "field", pattern),
+            "30:62: " + getCheckMessage(MSG_INVALID_PATTERN, "packageNames", pattern),
+            };
+
+        verify(checkConfig, getPath("InputParameterNameMultipleOptions.java"), expected);
+    }
+
+    @Test
+    public void testSkipCatchParameterFalseAndIgnoreOverriddenTrue()
+        throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ParameterNameCheck.class);
+        checkConfig.addAttribute("format", "^h$");
+        checkConfig.addAttribute("skipCatchParameter", "false");
+        checkConfig.addAttribute("ignoreOverridden", "true");
+        final String pattern = "^h$";
+
+        final String[] expected = {
+            "13:29: " + getCheckMessage(MSG_INVALID_PATTERN, "object", pattern),
+            "17:30: " + getCheckMessage(MSG_INVALID_PATTERN, "aaaa", pattern),
+            "21:19: " + getCheckMessage(MSG_INVALID_PATTERN, "abc", pattern),
+            "21:28: " + getCheckMessage(MSG_INVALID_PATTERN, "bd", pattern),
+            "23:18: " + getCheckMessage(MSG_INVALID_PATTERN, "abc", pattern),
+            "30:43: " + getCheckMessage(MSG_INVALID_PATTERN, "field", pattern),
+            "30:62: " + getCheckMessage(MSG_INVALID_PATTERN, "packageNames", pattern),
+            "36:26: " + getCheckMessage(MSG_INVALID_PATTERN, "ex", pattern),
+            "45:64: " + getCheckMessage(MSG_INVALID_PATTERN, "ex", pattern),
+            };
+
+        verify(checkConfig, getPath("InputParameterNameMultipleOptions.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputCatchParameter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputCatchParameter.java
@@ -1,0 +1,27 @@
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class InputCatchParameter {
+
+    void foo1() {
+        try {
+
+        }
+        catch (Exception ex) {
+
+        }
+    }
+
+    void foo2() {
+        try {
+
+        }
+        catch (NullPointerException | IllegalArgumentException ex) {
+            // just to check how the ParentName's option 'skipCahcthParameter' deals with catching
+            // multiple exception types and
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputOverrideAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputOverrideAnnotation.java
@@ -26,6 +26,4 @@ public class InputOverrideAnnotation {
     InputOverrideAnnotation() {} // No NPE here!
 
     InputOverrideAnnotation(int field, java.util.Set<String> packageNames) {} // No NPE here!
-
-
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputOverrideAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputOverrideAnnotation.java
@@ -13,4 +13,19 @@ public class InputOverrideAnnotation {
     }
 
     public void foo2(Integer aaaa) {}
+
+    void foo3() {} // No NPE here!
+
+    void foo4(int abc, int bd) {} // No NPE here!
+
+    int foo5(int abc) {return 1;} // No NPE here!
+
+    private int field;
+    private java.util.Set<String> packageNames;
+
+    InputOverrideAnnotation() {} // No NPE here!
+
+    InputOverrideAnnotation(int field, java.util.Set<String> packageNames) {} // No NPE here!
+
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputParameterNameMultipleOptions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputParameterNameMultipleOptions.java
@@ -1,0 +1,50 @@
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+import java.util.Set;
+
+public class InputParameterNameMultipleOptions {
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @SuppressWarnings("")
+    public void foo1(Object object) {
+
+    }
+
+    public void foo2(Integer aaaa) {}
+
+    void foo3() {} // No NPE here!
+
+    void foo4(int abc, int bd) {} // No NPE here!
+
+    int foo5(int abc) {return 1;} // No NPE here!
+
+    private int field;
+    private Set<String> packageNames;
+
+    InputParameterNameMultipleOptions() {} // No NPE here!
+
+    InputParameterNameMultipleOptions(int field, Set<String> packageNames) {} // No NPE here!
+
+    void foo6() {
+        try {
+
+        }
+        catch (Exception ex) {
+
+        }
+    }
+
+    void foo7() {
+        try {
+
+        }
+        catch (NullPointerException | IllegalArgumentException ex) {
+            // just to check how the ParentName's option 'skipCahcthParameter' deals with catching
+            // multiple exception types and
+        }
+    }
+}

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -923,6 +923,24 @@ public boolean equals(Object o) {
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
+          <tr>
+            <td>skipCatchParameter</td>
+            <td>
+              Allows to skip <code>catch</code> parameter from validation. For example, the
+              following catch parameter will be skipped from validation, if
+              skipCatchParameter is true:
+              <pre>
+try {
+  ...
+}
+catch (Exception ex) {
+  ...
+}
+              </pre>
+            </td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>true</code></td>
+          </tr>
         </table>
       </subsection>
 
@@ -942,6 +960,14 @@ public boolean equals(Object o) {
     &lt;property name="ignoreOverridden" value="true"/&gt;
 &lt;/module&gt;
           </source>
+        <p>
+          An example of how to configure the check to skip catch parameter from validation:
+        </p>
+        <source>
+&lt;module name="ParameterName"&gt;
+    &lt;property name="skipCatchParameter" value="true"/&gt;
+&lt;/module&gt;
+        </source>
       </subsection>
 
       <subsection name="Example of Usage">


### PR DESCRIPTION
@romani 

>2) We need to update default usage of <module name="ParameterName"/> at
https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle_checks.xml#L180
to custom config to enforce name to be 2 or more symbols in size. Format "^[a-z][a-zA-Z0-9]+$".

Done. When I updated checkstyle_checks.xml and ran mvn clean verify the Check through NPE. The problem was caused by constructors and methods with implicit modifiers. Fixed and covered with UTs.

>3) Please refactor this Check and make option "boolean skipCatchParameter = true". TRUE by default to keep compatibility with previous behavior.

Done.

