### PR TITLE
Issue #2451: removed excess hierarchy from NoCloneCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheck.java
@@ -19,6 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import com.puppycrawl.tools.checkstyle.api.Check;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
 /**
  * <p>
  * Checks that the clone method is not overridden from the
@@ -112,7 +116,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
  * @author Travis Schneeberger
  * @see Object#clone()
  */
-public class NoCloneCheck extends AbstractIllegalMethodCheck {
+public class NoCloneCheck extends Check {
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -120,10 +124,35 @@ public class NoCloneCheck extends AbstractIllegalMethodCheck {
      */
     public static final String MSG_KEY = "avoid.clone.method";
 
-    /**
-     * Creates an instance.
-     */
-    public NoCloneCheck() {
-        super("clone", MSG_KEY);
+    @Override
+    public int[] getDefaultTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return new int[] {TokenTypes.METHOD_DEF};
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public void visitToken(DetailAST aAST) {
+        final DetailAST mid = aAST.findFirstToken(TokenTypes.IDENT);
+        final String name = mid.getText();
+
+        if ("clone".equals(name)) {
+
+            final DetailAST params = aAST.findFirstToken(TokenTypes.PARAMETERS);
+            final boolean hasEmptyParamList =
+                !params.branchContains(TokenTypes.PARAMETER_DEF);
+
+            if (hasEmptyParamList) {
+                log(aAST.getLineNo(), MSG_KEY);
+            }
+        }
     }
 }


### PR DESCRIPTION
Not a full direct copy from AbstractIllegalMethodCheck.
"methodName" and "errorKey" fields were removed.

**Comments**
I don't really agree with removing the hierarchy, but without the check being more type aware for knowing the class that is calling the method, I don't think it could made that more useful as its own Check.

Example: "AbstractIllegalMethodCheck" could be changed into a concrete "IllegalMethodCheck" where the user specifies the methodName, possibly the className, and the parameterCount and it would warn on lines that it matches. NoCloneCheck class would then extend it.