### PR TITLE
Issue #2546: added new check RegexpOnFilenameCheck

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -93,6 +93,25 @@
       <property name="fileExtensions" value="java"/>
       <property name="message" value="First sentence in a comment should start with a capital letter"/>
   </module>
+  <module name="RegexpOnFilename" />
+  <module name="RegexpOnFilename">
+      <property name="folderPattern" value="[\\/]src[\\/]\w+[\\/]java[\\/]"/>
+      <property name="fileNamePattern" value="\.java$"/>
+      <property name="match" value="false"/>
+      <message key="regexp.filepath.mismatch" value="Only java files should be located in the ''src/*/java'' folders."/>
+  </module>
+  <module name="RegexpOnFilename">
+      <property name="folderPattern" value="[\\/]src[\\/]xdocs[\\/]"/>
+      <property name="fileNamePattern" value="\.(xml)|(vm)$"/>
+      <property name="match" value="false"/>
+      <message key="regexp.filepath.mismatch" value="All files in the ''src/xdocs'' folder should have the ''xml'' or ''vm'' extension."/>
+  </module>
+  <module name="RegexpOnFilename">
+      <property name="folderPattern" value="[\\/]src[\\/]it[\\/]java[\\/]"/>
+      <property name="fileNamePattern" value="^((\w+Test)|(Base\w+))\.java$"/>
+      <property name="match" value="false"/>
+      <message key="regexp.filepath.mismatch" value="All files in the ''src/it/java'' folder should be named ''*Test.java'' or ''Base*.java''."/>
+  </module>
 
   <!-- Size Violations -->
   <module name="FileLength">
@@ -288,7 +307,9 @@
 
     <!-- Misc -->
     <module name="ArrayTypeStyle"/>
-    <module name="AvoidEscapedUnicodeCharacters"/>
+    <module name="AvoidEscapedUnicodeCharacters">
+      <property name="allowIfAllCharactersEscaped" value="true"/>
+    </module>
     <module name="CommentsIndentation"/>
     <module name="DescendantToken"/>
     <module name="FileContentsHolder"/>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -74,7 +74,7 @@
               files="AbstractClassNameCheckTest.java|AbstractTypeAwareCheckTest.java|AbstractJavadocCheckTest.java|AbstractViolationReporterTest.java"/>
 
     <!-- Tone down the checking for test code -->
-    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="298"/>
+    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="299"/>
     <suppress checks="IllegalCatch" files="[\\/]internal[\\/]\w+Util\.java"/>
     <suppress checks="EmptyBlock" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="ImportControl" files=".*[\\/]src[\\/](test|it)[\\/]"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
@@ -1,0 +1,384 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.regexp;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import com.google.common.io.Files;
+import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+/**
+ * <p>
+ * Implementation of a check that looks for a file name and/or path match (or
+ * mis-match) against specified patterns. It can also be used to verify files
+ * match specific naming patterns not covered by other checks (Ex: properties,
+ * xml, etc.).
+ * </p>
+ *
+ * <p>
+ * When customizing the check, the properties are applied in a specific order.
+ * The fileExtensions property first picks only files that match any of the
+ * specific extensions supplied. Once files are matched against the
+ * fileExtensions, the match property is then used in conjuction with the
+ * patterns to determine if the check is looking for a match or mis-match on
+ * those files. If the fileNamePattern is supplied, the matching is only applied
+ * to the fileNamePattern and not the folderPattern. If no fileNamePattern is
+ * supplied, then matching is applied to the folderPattern only and will result
+ * in all files in a folder to be reported on violations. If no folderPattern is
+ * supplied, then all folders that checkstyle finds are examined for violations.
+ * The ignoreFileNameExtensions property drops the file extension and applies
+ * the fileNamePattern only to the rest of file name. For example, if the file
+ * is named 'test.java' and this property is turned on, the pattern is only
+ * applied to 'test'.
+ * </p>
+ *
+ * <p>
+ * If this check is configured with no properties, then the default behavior of
+ * this check is to report file names with spaces in them. When at least one
+ * pattern property is supplied, the entire check is under the user's control to
+ * allow them to fully customize the behavior.
+ * </p>
+ *
+ * <p>
+ * It is recommended that if you create your own pattern, to also specify a
+ * custom error message. This allows the error message printed to be clear what
+ * the violation is, especially if multiple RegexpOnFilename checks are used.
+ * Argument 0 for the message populates the check's folderPattern. Argument 1
+ * for the message populates the check's fileNamePattern. The file name is not
+ * passed as an argument since it is part of CheckStyle's default error
+ * messages.
+ * </p>
+ *
+ * <p>
+ * Check have following options:
+ * </p>
+ * <ul>
+ * <li>
+ * folderPattern - Regular expression to match the folder path against. Default
+ * value is null.</li>
+ *
+ * <li>
+ * fileNamePattern - Regular expression to match the file name against. Default
+ * value is null.</li>
+ *
+ * <li>
+ * match - Whether to look for a match or mis-match on the file name, if the
+ * fileNamePattern is supplied, otherwise it is applied on the folderPattern.
+ * Default value is true.</li>
+ *
+ * <li>
+ * ignoreFileNameExtensions - Whether to ignore the file extension for the file
+ * name match. Default value is false.</li>
+ *
+ * <li>
+ * fileExtensions - File type extension of files to process. If this is
+ * specified, then only files that match these types are examined with the other
+ * patterns. Default value is {}.</li>
+ * </ul>
+ * <br>
+ *
+ * <p>
+ * To configure the check to report file names that contain a space:
+ * </p>
+ *
+ * <pre>
+ * &lt;module name=&quot;RegexpOnFilename&quot;/&gt;
+ * </pre>
+ * <p>
+ * To configure the check to force picture files to not be 'gif':
+ * </p>
+ *
+ * <pre>
+ * &lt;module name=&quot;RegexpOnFilename&quot;&gt;
+ *   &lt;property name=&quot;fileNamePattern&quot; value=&quot;\\.gif$&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * OR:
+ * </p>
+ *
+ * <pre>
+ * &lt;module name=&quot;RegexpOnFilename&quot;&gt;
+ *   &lt;property name=&quot;fileNamePattern&quot; value=&quot;.&quot;/&gt;
+ *   &lt;property name=&quot;fileExtensions&quot; value=&quot;gif&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ *
+ * <p>
+ * To configure the check to only allow property and xml files to be located in
+ * the resource folder:
+ * </p>
+ *
+ * <pre>
+ * &lt;module name=&quot;RegexpOnFilename&quot;&gt;
+ *   &lt;property name=&quot;folderPattern&quot;
+ *     value=&quot;[\\/]src[\\/]\\w+[\\/]resources[\\/]&quot;/&gt;
+ *   &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
+ *   &lt;property name=&quot;fileExtensions&quot; value=&quot;properties, xml&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ *
+ * <p>
+ * To configure the check to only allow Java and XML files in your folders use
+ * the below.
+ * </p>
+ *
+ * <pre>
+ * &lt;module name=&quot;RegexpOnFilename&quot;&gt;
+ *   &lt;property name=&quot;fileNamePattern&quot; value=&quot;\\.(java|xml)$&quot;/&gt;
+ *   &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * To configure the check to only allow Java and XML files only in your source
+ * folder and ignore any other folders:
+ * </p>
+ *
+ * <p>
+ * <b>Note:</b> 'folderPattern' must be specified if checkstyle is analyzing
+ * more than the normal source folder, like the 'bin' folder where class files
+ * can be located.
+ * </p>
+ *
+ * <pre>
+ * &lt;module name=&quot;RegexpOnFilename&quot;&gt;
+ *   &lt;property name=&quot;folderPattern&quot; value=&quot;[\\/]src[\\/]&quot;/&gt;
+ *   &lt;property name=&quot;fileNamePattern&quot; value=&quot;\\.(java|xml)$&quot;/&gt;
+ *   &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * To configure the check to only allow file names to be camel case:
+ * </p>
+ *
+ * <pre>
+ * &lt;module name=&quot;RegexpOnFilename&quot;&gt;
+ *   &lt;property name=&quot;fileNamePattern&quot;
+ *     value=&quot;^([A-Z][a-z0-9]+\.?)+$&quot;/&gt;
+ *   &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
+ *   &lt;property name=&quot;ignoreFileNameExtensions&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ *
+ * @author Richard Veach
+ */
+public class RegexpOnFilenameCheck extends AbstractFileSetCheck {
+    /**
+     * A key is pointing to the warning message text in "messages.properties"
+     * file.
+     */
+    public static final String MSG_MATCH = "regexp.filename.match";
+    /**
+     * A key is pointing to the warning message text in "messages.properties"
+     * file.
+     */
+    public static final String MSG_MISMATCH = "regexp.filename.mismatch";
+
+    /** Compiled regexp to match a folder. */
+    private Pattern folderPattern;
+    /** Compiled regexp to match a file. */
+    private Pattern fileNamePattern;
+    /** Whether to look for a file name match or mismatch. */
+    private boolean match = true;
+    /** Whether to ignore the file's extension when looking for matches. */
+    private boolean ignoreFileNameExtensions;
+
+    /**
+     * Setter for folder format.
+     *
+     * @param folderPattern format of folder.
+     * @throws org.apache.commons.beanutils.ConversionException if unable to
+     *         create Pattern object.
+     */
+    public void setFolderPattern(String folderPattern) {
+        this.folderPattern = CommonUtils.createPattern(folderPattern);
+    }
+
+    /**
+     * Setter for file name format.
+     *
+     * @param fileNamePattern format of file.
+     * @throws org.apache.commons.beanutils.ConversionException if unable to
+     *         create Pattern object.
+     */
+    public void setFileNamePattern(String fileNamePattern) {
+        this.fileNamePattern = CommonUtils.createPattern(fileNamePattern);
+    }
+
+    /**
+     * Sets whether the check should look for a file name match or mismatch.
+     *
+     * @param match check's option for matching file names.
+     */
+    public void setMatch(boolean match) {
+        this.match = match;
+    }
+
+    /**
+     * Sets whether file name matching should drop the file extension or not.
+     *
+     * @param ignoreFileNameExtensions check's option for ignoring file extension.
+     */
+    public void setIgnoreFileNameExtensions(boolean ignoreFileNameExtensions) {
+        this.ignoreFileNameExtensions = ignoreFileNameExtensions;
+    }
+
+    @Override
+    public void init() {
+        if (fileNamePattern == null && folderPattern == null) {
+            fileNamePattern = CommonUtils.createPattern("\\s");
+        }
+    }
+
+    @Override
+    protected void processFiltered(File file, List<String> lines) throws CheckstyleException {
+        final String fileName = getFileName(file);
+        final String folderPath = getFolderPath(file);
+
+        if (isMatchFolder(folderPath) && isMatchFile(fileName)) {
+            log();
+        }
+    }
+
+    /**
+     * Retrieves the file name from the given {@code file}.
+     *
+     * @param file Input file to examine.
+     * @return The file name.
+     */
+    private String getFileName(File file) {
+        String fileName = file.getName();
+
+        if (ignoreFileNameExtensions) {
+            fileName = Files.getNameWithoutExtension(fileName);
+        }
+
+        return fileName;
+    }
+
+    /**
+     * Retrieves the folder path from the given {@code file}.
+     *
+     * @param file Input file to examine.
+     * @return The folder path.
+     * @throws CheckstyleException if there is an error getting the canonical
+     *         path of the {@code file}.
+     */
+    private static String getFolderPath(File file) throws CheckstyleException {
+        try {
+            return file.getParentFile().getCanonicalPath();
+        }
+        catch (IOException ex) {
+            throw new CheckstyleException("unable to create canonical path names for "
+                    + file.getAbsolutePath(), ex);
+        }
+    }
+
+    /**
+     * Checks if the given {@code folderPath} matches the specified
+     * {@link #folderPattern}.
+     *
+     * @param folderPath Input folder path to examine.
+     * @return true if they do match.
+     */
+    private boolean isMatchFolder(String folderPath) {
+        final boolean result;
+
+        // null pattern always matches, regardless of value of 'match'
+        if (folderPattern == null) {
+            result = true;
+        }
+        else {
+            final boolean useMatch;
+
+            // null pattern means 'match' applies to the folderPattern matching
+            if (fileNamePattern == null) {
+                useMatch = match;
+            }
+            else {
+                useMatch = true;
+            }
+
+            result = folderPattern.matcher(folderPath).find() == useMatch;
+        }
+
+        return result;
+    }
+
+    /**
+     * Checks if the given {@code fileName} matches the specified
+     * {@link #fileNamePattern}.
+     *
+     * @param fileName Input file name to examine.
+     * @return true if they do match.
+     */
+    private boolean isMatchFile(String fileName) {
+        final boolean result;
+
+        // null pattern always matches, regardless of value of 'match'
+        if (fileNamePattern == null) {
+            result = true;
+        }
+        else {
+            result = fileNamePattern.matcher(fileName).find() == match;
+        }
+
+        return result;
+    }
+
+    /** Logs the errors for the check. */
+    private void log() {
+        final String folder = getStringOrDefault(folderPattern, "");
+        final String fileName = getStringOrDefault(fileNamePattern, "");
+
+        if (match) {
+            log(0, MSG_MATCH, folder, fileName);
+        }
+        else {
+            log(0, MSG_MISMATCH, folder, fileName);
+        }
+    }
+
+    /**
+     * Retrieves the String form of the {@code pattern} or {@code defaultString}
+     * if null.
+     *
+     * @param pattern The pattern to convert.
+     * @param defaultString The result to use if {@code pattern} is null.
+     * @return The String form of the {@code pattern}.
+     */
+    private static String getStringOrDefault(Pattern pattern, String defaultString) {
+        final String result;
+
+        if (pattern == null) {
+            result = defaultString;
+        }
+        else {
+            result = pattern.toString();
+        }
+
+        return result;
+    }
+}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages.properties
@@ -8,3 +8,5 @@ duplicate.regexp=Found duplicate pattern ''{0}''.
 regexp.empty=Empty (null) pattern.
 regexp.StackOverflowError=java.util.regex.Matcher caused a java.lang.StackOverflowError for pattern ''{1}'' (you may be scanning a binary file instead of text?).
 
+regexp.filename.match=File match folder pattern ''{0}'' and file pattern ''{1}''.
+regexp.filename.mismatch=File not match folder pattern ''{0}'' and file pattern ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages_de.properties
@@ -5,3 +5,6 @@ required.regexp=Keine Zeile entspricht dem Muster ''{0}''.
 duplicate.regexp=Duplikat gefunden nach dem Muster ''{0}''.
 regexp.empty = Leer (null) Muster.
 regexp.StackOverflowError = java.util.regex.Matcher verursachte eine java.lang.StackOverflowError für Muster ''{1}'' (Sie werden das Scannen eines Binär-Datei anstelle von Text?).
+
+regexp.filename.match=Datei- Spiel Ordner Muster ''{0}'' und Dateimuster ''{1}''.
+regexp.filename.mismatch=Datei nicht �bereinstimmen Ordner Muster ''{0}'' und Dateimuster ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages_es.properties
@@ -5,3 +5,6 @@ regexp.minimum = Archivo no contiene al menos {0} coincide para el patr贸n ''{1}
 duplicate.regexp = Encontrado patr贸n duplicado ''{0}''.
 regexp.empty = Vac铆o (nulo) patr贸n.
 regexp.StackOverflowError = java.util.regex.Matcher caus贸 una java.lang.StackOverflowError para el patr贸n ''{1}'' (se le puede escanear un archivo binario en lugar de texto?).
+
+regexp.filename.match=Archivo patr髇 carpeta partido ''{0}'' y el archivo de patr髇 ''{1}''.
+regexp.filename.mismatch=Archivo no coincida con el patr髇 carpeta ''{0}'' y archivo de patrones ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages_fi.properties
@@ -6,3 +6,5 @@ duplicate.regexp = Löydetty kaksoiskappale malli ''{0}''.
 regexp.empty = Tyhjä (null) kuvio.
 regexp.StackOverflowError = java.util.regex.Matcher aiheutti java.lang.StackOverflowError lauseketta ''{1}'' (saatat olla skannaus binaaritiedoston tekstin sijasta?).
 
+regexp.filename.match=Tiedoston ottelu kansio malli ''{0}'' ja tiedostojen malli ''{1}''.
+regexp.filename.mismatch=Tiedostoa ei vastaa kansiota mallia ''{0}'' ja tiedostojen malli ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages_fr.properties
@@ -5,3 +5,6 @@ regexp.minimum = Le fichier ne contient pas au moins {0} correspond pour le mod√
 duplicate.regexp = Trouv√© mod√®le double ''{0}''.
 regexp.empty = Vide (null) motif.
 regexp.StackOverflowError = java.util.regex.Matcher provoqu√© une java.lang.StackOverflowError pour le mod√®le ''{1}'' (vous pouvez num√©riser un fichier binaire au lieu du texte?).
+
+regexp.filename.match=Fichier dossier de match de modËle ''{0}'' et le fichier modËle ''{1}''.
+regexp.filename.mismatch=Fichier non correspondre dossier motif ''{0}'' et le fichier modËle ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages_ja.properties
@@ -5,3 +5,6 @@ required.regexp = 必要なパターン ''{0}''ファイルに欠落していま
 duplicate.regexp = 見つかった重複パターン ''{0}''。
 regexp.empty = 空（NULL）のパターン。
 regexp.StackOverflowError = java.util.regex.Matcherは、パターンのためjava.lang.StackOverflowErrorを に起因 ''{1}''（あなたがテキストの代わりにバイナリファイルをスキャンしている可能性がありますか？）。
+
+regexp.filename.match=ファイルのマッチフォルダパターン ''{0}'' とファイルパターン ''{1}''。
+regexp.filename.mismatch=フォルダパターン ''{0}'' とファイルパターン'と一致しませファイル ''{1}''。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages_pt.properties
@@ -5,3 +5,6 @@ required.regexp = Padr√£o exigido ''{0}'' falta em arquivo.
 duplicate.regexp = Encontrado padr√£o duplicado ''{0}''.
 regexp.empty = Empty (null) padr√£o.
 regexp.StackOverflowError = java.util.regex.Matcher causou uma java.lang.StackOverflowError para o padr√£o ''{1}'' (voc√™ pode estar verificando um arquivo bin√°rio em vez de texto?).
+
+regexp.filename.match=Arquivo padr„o pasta jogo ''{0}'' e arquivo padr„o ''{1}''.
+regexp.filename.mismatch=Arquivo n„o correspondem ao padr„o pasta ''{0}'' e arquivo padr„o ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/regexp/messages_tr.properties
@@ -5,3 +5,6 @@ required.regexp = Dosyada olması gereken ''{0}'' kalıbı yok.
 duplicate.regexp = Tekrarlanmýþbir kalıp bulundu: ''{0}''.
 regexp.empty = Boş (null) desen.
 regexp.StackOverflowError = java.util.regex.Matcher model için bir java.lang.StackOverflowError neden ''{1}'' (metin yerine bir ikili dosya tarıyor olabilir?).
+
+regexp.filename.match=Dosya ma� klas�r model ''{0}'' ve dosya deseni ''{1}''.
+regexp.filename.mismatch=Klasör deseni ''{0}'' ve dosya deseni ' eşleşmiyor Dosya ''{1}''.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheckTest.java
@@ -1,0 +1,241 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.regexp;
+
+import static com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck.MSG_MATCH;
+import static com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck.MSG_MISMATCH;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.BaseFileSetCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+
+public class RegexpOnFilenameCheckTest extends BaseFileSetCheckTestSupport {
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("checks" + File.separator + "regexp" + File.separator + filename);
+    }
+
+    @Test
+    public void testDefaultConfigurationOnValidInput() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        verify(checkConfig, getPath("InputSemantic.java"), ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testDefaultProperties() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        final String path = getPath("Input Space.properties");
+        final String[] expected = {
+            "0: " + getCheckMessage(MSG_MATCH, "", "\\s"),
+        };
+        verify(checkConfig, path, expected);
+    }
+
+    @Test
+    public void testMatchFileMatches() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "true");
+        checkConfig.addAttribute("fileNamePattern", ".*\\.java");
+        final String path = getPath("InputSemantic.java");
+        final String[] expected = {
+            "0: " + getCheckMessage(MSG_MATCH, "", ".*\\.java"),
+        };
+        verify(checkConfig, path, expected);
+    }
+
+    @Test
+    public void testMatchFileNotMatches() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "true");
+        checkConfig.addAttribute("fileNamePattern", "BAD.*");
+        verify(checkConfig, getPath("InputSemantic.java"), ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testNotMatchFileMatches() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "false");
+        checkConfig.addAttribute("fileNamePattern", ".*\\.properties");
+        final String path = getPath("InputSemantic.java");
+        final String[] expected = {
+            "0: " + getCheckMessage(MSG_MISMATCH, "", ".*\\.properties"),
+        };
+        verify(checkConfig, path, expected);
+    }
+
+    @Test
+    public void testNotMatchFileNotMatches() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "false");
+        checkConfig.addAttribute("fileNamePattern", ".*\\.java");
+        verify(checkConfig, getPath("InputSemantic.java"), ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testMatchFolderMatches() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "true");
+        checkConfig.addAttribute("folderPattern", ".*[\\\\/]resources[\\\\/].*");
+        final String path = getPath("InputSemantic.java");
+        final String[] expected = {
+            "0: " + getCheckMessage(MSG_MATCH, ".*[\\\\/]resources[\\\\/].*", ""),
+        };
+        verify(checkConfig, path, expected);
+    }
+
+    @Test
+    public void testMatchFolderNotMatches() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "true");
+        checkConfig.addAttribute("folderPattern", "BAD.*");
+        verify(checkConfig, getPath("InputSemantic.java"), ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testNotMatchFolderMatches() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "false");
+        checkConfig.addAttribute("folderPattern", ".*[\\\\/]gov[\\\\/].*");
+        final String path = getPath("InputSemantic.java");
+        final String[] expected = {
+            "0: " + getCheckMessage(MSG_MISMATCH, ".*[\\\\/]gov[\\\\/].*", ""),
+        };
+        verify(checkConfig, path, expected);
+    }
+
+    @Test
+    public void testNotMatchFolderNotMatches() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "false");
+        checkConfig.addAttribute("folderPattern", ".*[\\\\/]resources[\\\\/].*");
+        verify(checkConfig, getPath("InputSemantic.java"), ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testMatchFolderAndFileMatches() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "true");
+        checkConfig.addAttribute("folderPattern", ".*[\\\\/]resources[\\\\/].*");
+        checkConfig.addAttribute("fileNamePattern", ".*\\.java");
+        final String path = getPath("InputSemantic.java");
+        final String[] expected = {
+            "0: " + getCheckMessage(MSG_MATCH, ".*[\\\\/]resources[\\\\/].*", ".*\\.java"),
+        };
+        verify(checkConfig, path, expected);
+    }
+
+    @Test
+    public void testMatchFolderAndFileNotMatchesBoth() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "true");
+        checkConfig.addAttribute("folderPattern", "BAD.*");
+        checkConfig.addAttribute("fileNamePattern", ".*\\.properties");
+        verify(checkConfig, getPath("InputSemantic.java"), ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testMatchFolderAndFileNotMatchesFile() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "true");
+        checkConfig.addAttribute("folderPattern", ".*[\\\\/]resources[\\\\/].*");
+        checkConfig.addAttribute("fileNamePattern", ".*\\.properties");
+        verify(checkConfig, getPath("InputSemantic.java"), ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testMatchFolderAndFileNotMatchesFolder() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "true");
+        checkConfig.addAttribute("folderPattern", "BAD.*");
+        checkConfig.addAttribute("fileNamePattern", ".*\\.java");
+        verify(checkConfig, getPath("InputSemantic.java"), ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testNotMatchFolderAndFileMatches() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "false");
+        checkConfig.addAttribute("folderPattern", ".*[\\\\/]com[\\\\/].*");
+        checkConfig.addAttribute("fileNamePattern", ".*\\.dat");
+        final String path = getPath("InputSemantic.java");
+        final String[] expected = {
+            "0: " + getCheckMessage(MSG_MISMATCH, ".*[\\\\/]com[\\\\/].*", ".*\\.dat"),
+        };
+        verify(checkConfig, path, expected);
+    }
+
+    @Test
+    public void testNotMatchFolderAndFileNotMatchesFolder() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "false");
+        checkConfig.addAttribute("folderPattern", ".*[\\\\/]java[\\\\/].*");
+        checkConfig.addAttribute("fileNamePattern", ".*\\.dat");
+        verify(checkConfig, getPath("InputSemantic.java"), ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testNotMatchFolderAndFileNotMatchesFile() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("match", "false");
+        checkConfig.addAttribute("folderPattern", ".*[\\\\/]gov[\\\\/].*");
+        checkConfig.addAttribute("fileNamePattern", ".*\\.java");
+        verify(checkConfig, getPath("InputSemantic.java"), ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testIgnoreExtension() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("fileNamePattern", ".*\\.java");
+        checkConfig.addAttribute("ignoreFileNameExtensions", "true");
+        verify(checkConfig, getPath("InputSemantic.java"), ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testIgnoreExtensionNoExtension() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RegexpOnFilenameCheck.class);
+        checkConfig.addAttribute("fileNamePattern", "\\.");
+        checkConfig.addAttribute("ignoreFileNameExtensions", "true");
+        verify(checkConfig, getPath("InputNoExtension"), ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testException() throws Exception {
+        // escape character needed for testing IOException from File.getCanonicalPath on all OSes
+        final File file = new File(getPath("") + "\u0000" + File.separatorChar + "Test");
+        try {
+            final RegexpOnFilenameCheck check = new RegexpOnFilenameCheck();
+            check.setFileNamePattern("BAD");
+            check.process(file, null);
+            fail("CheckstyleException expected");
+        }
+        catch (CheckstyleException ex) {
+            assertEquals("unable to create canonical path names for " + file.getAbsolutePath(),
+                    ex.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
@@ -98,6 +98,7 @@ public class XDocsPagesTest {
             "name=\"SuppressWithNearbyCommentFilter\"",
             "name=\"SuppressWarningsFilter\"",
             "name=\"RegexpHeader\"",
+            "name=\"RegexpOnFilename\"",
             "name=\"RegexpSingleline\"",
             "name=\"RegexpMultiline\"",
             "name=\"JavadocPackage\"",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/Input Space.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/Input Space.properties
@@ -1,0 +1,1 @@
+this=bad

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -638,6 +638,10 @@
         any file type.</td>
       </tr>
       <tr>
+        <td><a href="config_regexp.html#RegexpOnFilename">RegexpOnFilename</a></td>
+        <td>Implementation of a check that matches based on file and/or folder path.</td>
+      </tr>
+      <tr>
         <td><a href="config_regexp.html#RegexpSingleline">RegexpSingleline</a></td>
         <td>Implementation of a check that looks for a single line in any file type.</td>
       </tr>

--- a/src/xdocs/config_regexp.xml
+++ b/src/xdocs/config_regexp.xml
@@ -554,6 +554,181 @@
       </subsection>
     </section>
 
+    <section name="RegexpOnFilename">
+      <subsection name="Description">
+        <p>
+          Implementation of a check that looks for a file name and/or path match (or mis-match)
+          against specified patterns. It can also be used to verify files match specific naming
+          patterns not covered by other checks (Ex: properties, xml, etc.).
+        </p>
+        <p>
+          When customizing the check, the properties are applied in a specific order.
+          The fileExtensions property first picks only files that match any of the
+          specific extensions supplied.
+          Once files are matched against the fileExtensions, the match property is then
+          used in conjuction with the patterns to determine if the check is looking
+          for a match or mis-match on those files. If the fileNamePattern is
+          supplied, the matching is only applied to the fileNamePattern and not the
+          folderPattern. If no fileNamePattern is supplied, then matching is applied
+          to the folderPattern only and will result in all files in a folder to be
+          reported on violations. If no folderPattern is supplied, then all folders
+          that checkstyle finds are examined for violations.
+          The ignoreFileNameExtensions property drops the file extension and applies
+          the fileNamePattern only to the rest of file name. For example, if the file is
+          named 'test.java' and this property is turned on, the pattern is only applied
+          to 'test'.
+        </p>
+        <p>
+          If this check is configured with no properties, then the default behavior
+          of this check is to report file names with spaces in them.
+          When at least one pattern property is supplied, the entire check is under
+          the user's control to allow them to fully customize the behavior.
+        </p>
+        <p>
+          It is recommended that if you create your own pattern, to also
+          specify a custom error message. This allows the error message printed
+          to be clear what the violation is, especially if multiple RegexpOnFilename
+          checks are used.
+          Argument 0 for the message populates the check's folderPattern.
+          Argument 1 for the message populates the check's fileNamePattern.
+          The file name is not passed as an argument since it is part of CheckStyle's
+          default error messages.
+        </p>
+      </subsection>
+
+      <subsection name="Properties">
+        <table>
+          <tr>
+            <th>name</th>
+            <th>description</th>
+            <th>type</th>
+            <th>default value</th>
+          </tr>
+          <tr>
+            <td>folderPattern</td>
+            <td>Regular expression to match the folder path against.</td>
+            <td><a href="property_types.html#regexp">regular expression</a></td>
+            <td><code>null</code></td>
+          </tr>
+          <tr>
+            <td>fileNamePattern</td>
+            <td>Regular expression to match the file name against.</td>
+            <td><a href="property_types.html#regexp">regular expression</a></td>
+            <td><code>null</code></td>
+          </tr>
+          <tr>
+            <td>match</td>
+            <td>Whether to look for a match or mis-match on the file name, if the
+            fileNamePattern is supplied, otherwise it is applied on the folderPattern.</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>true</code></td>
+          </tr>
+          <tr>
+            <td>ignoreFileNameExtensions</td>
+            <td>Whether to ignore the file extension for the file name match.</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>false</code></td>
+          </tr>
+          <tr>
+            <td>fileExtensions</td>
+            <td>File type extension of files to process. If this is specified, then
+            only files that match these types are examined with the other patterns.</td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
+            <td><code>{}</code></td>
+          </tr>
+        </table>
+      </subsection>
+
+      <subsection name="Examples">
+        <p>
+          To configure the check to report file names that contain a space:
+        </p>
+        <source>
+&lt;module name=&quot;RegexpOnFilename&quot;/&gt;
+        </source>
+        <p>
+          To configure the check to force picture files to not be 'gif':
+        </p>
+        <source>
+&lt;module name=&quot;RegexpOnFilename&quot;&gt;
+  &lt;property name=&quot;fileNamePattern&quot; value=&quot;\\.gif$&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          OR:
+        </p>
+        <source>
+&lt;module name=&quot;RegexpOnFilename&quot;&gt;
+  &lt;property name=&quot;fileNamePattern&quot; value=&quot;.&quot;/&gt;
+  &lt;property name=&quot;fileExtensions&quot; value=&quot;gif&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          To configure the check to only allow property and xml files to be located in the resource folder:
+        </p>
+        <source>
+&lt;module name=&quot;RegexpOnFilename&quot;&gt;
+  &lt;property name=&quot;folderPattern&quot; value=&quot;[\\/]src[\\/]\\w+[\\/]resources[\\/]&quot;/&gt;
+  &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
+  &lt;property name=&quot;fileExtensions&quot; value=&quot;properties, xml&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          To configure the check to only allow Java and XML files in your folders use the below.
+        </p>
+        <source>
+&lt;module name=&quot;RegexpOnFilename&quot;&gt;
+  &lt;property name=&quot;fileNamePattern&quot; value=&quot;\\.(java|xml)$&quot;/&gt;
+  &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          To configure the check to only allow Java and XML files only in your source folder
+          and ignore any other folders:<br />
+          <b>Note:</b> 'folderPattern' must be specified if checkstyle is analyzing more than
+          the normal source folder, like the 'bin' folder where class files can be located.
+        </p>
+        <source>
+&lt;module name=&quot;RegexpOnFilename&quot;&gt;
+  &lt;property name=&quot;folderPattern&quot; value=&quot;[\\/]src[\\/]&quot;/&gt;
+  &lt;property name=&quot;fileNamePattern&quot; value=&quot;\\.(java|xml)$&quot;/&gt;
+  &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          To configure the check to only allow file names to be camel case:
+        </p>
+        <source>
+&lt;module name=&quot;RegexpOnFilename&quot;&gt;
+  &lt;property name=&quot;fileNamePattern&quot; value=&quot;^([A-Z][a-z0-9]+\.?)+$&quot;/&gt;
+  &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
+  &lt;property name=&quot;ignoreFileNameExtensions&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RegexpOnFilename">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.regexp
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module">
+        <p>
+          <a href="config.html#Checker">Checker</a>
+        </p>
+      </subsection>
+    </section>
+
     <section name="RegexpSingleline">
       <subsection name="Description">
         <p>


### PR DESCRIPTION
Start of Check.
No documentation until requirements are confirmed.

**Properties**:
match:  true/false. report matching or mismatching of folders and/or files by Patern, default is matching
folderPattern: regular expression. folder pattern to use, default is all folders regardless of match
fileNamePattern: regular expression. file name pattern to use, default is all files regardless of match

All properties are optional. If none are set, fileNamePattern defaults to "\s" and "match" defaults to true.

**Explanation**:
1) If users don't specify a file or folder pattern, it defaults to looking for spaces in file names of all folders.

2) If users don't specify a folder pattern, all files using the file name pattern is matched against.
If a file matches the pattern and match is true, it will report the file. If a file doesn't match the pattern and match is false, it will report the file.
Like the original example, this can be used for preventing file extensions anywhere: "{0} must be in PNG format, not GIF."
````
Example: Match all GIF files
match = true
fileNamePattern = ".*\\.gif"
````

3) If users don't specify a file pattern, all folders using the folder pattern is matched against.
If a folder matches the pattern and match is true, it will report all files in the folder. If a folder doesn't match the pattern and match is false, it will report all files in the folder.
This wasn't in the original example. This can be used to for prevent folder names, folders from appearing in certain locations, or files in a specific folder.
````
Example: Match all files that are in a directory with an uppercase letter
match = true
folderPattern = "[A-Z]"
````

4) If the users specify a folder and a file pattern:
A) All folders are looking for a match. (No mismatching allowed like without fileNamePattern)
B) If the folder matches, all files follow its normal matching/mismatching rules.

Like the original example, this can be used for requiring files in specific folders or specific names.
````
Example: Match all files in resource directory that don't start with "Input". (CS case)
match = false
folderPattern = "[\\/]src[\\/]\\w+[\\/]resources[\\/]"
fileNamePattern = "^Input"
````


For A):  I was originally going to go with its default way of matching/mismatching, but I am not sure if this made it too confusing to understand and I'm not sure I can come up with a valid use. Let me know if I should re-implement it.
````
Example: Match all non-properties files not in a "resource" directory. 
match = false
folderPattern = "[\\/]resource[\\/]"
fileNamePattern = "^.*\\.properties$"
````
With the way the code is implemented now, it matches all non-properties files in "resource" directories.

**Changes**:
> targetFolderPattern 

I renamed this to folderPattern to match fileNamePattern's name, since they are so similar.

**Other**:
Any ideas for a default message for "regexp.filepath.match" and "regexp.filepath.mismatch"?
Original forum has "File {0} does not match '{1}' pattern", which sorta works if we combine file pattern and folder pattern in "{1}".