### PR TITLE
Issue 2451: removed excess hierarchy from NoFinalizerCheck and deprecated AbstractIllegalMethodCheck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1732,6 +1732,7 @@
                   <!-- deprecated classes -->
                   <exclude>com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalCheck.class</exclude>
+                  <exclude>com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalMethodCheck.class</exclude>
                 </excludes>
               </instrumentation>
             </configuration>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalMethodCheck.java
@@ -26,8 +26,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 /**
  * Provide support for checking for a method with a specified name and no
  * arguments.
+ * @deprecated Checkstyle will not support abstract checks anymore. Use {@link Check} instead.
  * @author Oliver Burn
+ * @noinspection AbstractClassNeverImplemented
  */
+@Deprecated
 public abstract class AbstractIllegalMethodCheck extends Check {
     /** Name of method to disallow. */
     private final String methodName;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoFinalizerCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoFinalizerCheck.java
@@ -19,6 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import com.puppycrawl.tools.checkstyle.api.Check;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
 /**
  * Checks that no method having zero parameters is defined
  * using the name <em>finalize</em>.
@@ -27,7 +31,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
  * @author smckay@google.com (Steve McKay)
  * @author lkuehne
  */
-public class NoFinalizerCheck extends AbstractIllegalMethodCheck {
+public class NoFinalizerCheck extends Check {
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -35,10 +39,35 @@ public class NoFinalizerCheck extends AbstractIllegalMethodCheck {
      */
     public static final String MSG_KEY = "avoid.finalizer.method";
 
-    /**
-     * Creates an instance.
-     */
-    public NoFinalizerCheck() {
-        super("finalize", MSG_KEY);
+    @Override
+    public int[] getDefaultTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return new int[] {TokenTypes.METHOD_DEF};
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public void visitToken(DetailAST aAST) {
+        final DetailAST mid = aAST.findFirstToken(TokenTypes.IDENT);
+        final String name = mid.getText();
+
+        if ("finalize".equals(name)) {
+
+            final DetailAST params = aAST.findFirstToken(TokenTypes.PARAMETERS);
+            final boolean hasEmptyParamList =
+                !params.branchContains(TokenTypes.PARAMETER_DEF);
+
+            if (hasEmptyParamList) {
+                log(aAST.getLineNo(), MSG_KEY);
+            }
+        }
     }
 }


### PR DESCRIPTION
NoFinalizerCheck extends Check.
Not a full direct copy from AbstractIllegalMethodCheck.
"methodName" and "errorKey" fields were removed.

AbstractIllegalMethodCheck is now deprecated.