### PR TITLE
Issue #2161: unify it input file names for chapter3filestructure

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java
@@ -53,7 +53,7 @@ public class LineLengthTest extends BaseCheckTestSupport {
         };
 
         final Configuration checkConfig = builder.getCheckConfig("LineLength");
-        final String filePath = builder.getFilePath("LineLengthInput2");
+        final String filePath = builder.getFilePath("InputLineLength");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/AvoidStarImportTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/AvoidStarImportTest.java
@@ -48,7 +48,7 @@ public class AvoidStarImportTest extends BaseCheckTestSupport {
         };
 
         final Configuration checkConfig = builder.getCheckConfig("AvoidStarImport");
-        final String filePath = builder.getFilePath("AvoidStarImportInput");
+        final String filePath = builder.getFilePath("InputAvoidStarImport");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java
@@ -49,7 +49,7 @@ public class NoLineWrapTest extends BaseCheckTestSupport {
         };
 
         final Configuration checkConfig = builder.getCheckConfig("NoLineWrap");
-        final String filePath = builder.getFilePath("NoLineWrap_Bad");
+        final String filePath = builder.getFilePath("InputNoLineWrapBad");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
@@ -61,7 +61,7 @@ public class NoLineWrapTest extends BaseCheckTestSupport {
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
         final Configuration checkConfig = builder.getCheckConfig("NoLineWrap");
-        final String filePath = builder.getFilePath("NoLineWrap_Good");
+        final String filePath = builder.getFilePath("InputNoLineWrapGood");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
@@ -83,7 +83,7 @@ public class NoLineWrapTest extends BaseCheckTestSupport {
         };
 
         final Configuration checkConfig = builder.getCheckConfig("LineLength");
-        final String filePath = builder.getFilePath("LineLengthInput2");
+        final String filePath = builder.getFilePath("InputLineLength");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java
@@ -67,7 +67,7 @@ public class CustomImportOrderTest extends BaseCheckTestSupport {
         };
 
         final Configuration checkConfig = builder.getCheckConfig("CustomImportOrder");
-        final String filePath = builder.getFilePath("CustomImportOrderInput_1");
+        final String filePath = builder.getFilePath("InputCustomImportOrder1");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
@@ -92,7 +92,7 @@ public class CustomImportOrderTest extends BaseCheckTestSupport {
         };
 
         final Configuration checkConfig = builder.getCheckConfig("CustomImportOrder");
-        final String filePath = builder.getFilePath("CustomImportOrderInput_2");
+        final String filePath = builder.getFilePath("InputCustomImportOrder2");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
@@ -116,7 +116,7 @@ public class CustomImportOrderTest extends BaseCheckTestSupport {
         };
 
         final Configuration checkConfig = builder.getCheckConfig("CustomImportOrder");
-        final String filePath = builder.getFilePath("CustomImportOrderInput_3");
+        final String filePath = builder.getFilePath("InputCustomImportOrder3");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
@@ -128,7 +128,7 @@ public class CustomImportOrderTest extends BaseCheckTestSupport {
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
         final Configuration checkConfig = builder.getCheckConfig("CustomImportOrder");
-        final String filePath = builder.getFilePath("CustomImportOrderValidInput");
+        final String filePath = builder.getFilePath("InputCustomImportOrderValid");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/OneTopLevelClassTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/OneTopLevelClassTest.java
@@ -55,7 +55,7 @@ public class OneTopLevelClassTest extends BaseCheckTestSupport {
         };
 
         final Configuration checkConfig = builder.getCheckConfig("OneTopLevelClass");
-        final String filePath = builder.getFilePath("OneTopLevelClassInput_Basic");
+        final String filePath = builder.getFilePath("InputOneTopLevelClassBasic");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
@@ -67,7 +67,24 @@ public class OneTopLevelClassTest extends BaseCheckTestSupport {
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
         final Configuration checkConfig = builder.getCheckConfig("OneTopLevelClass");
-        final String filePath = builder.getFilePath("OneTopLevelClassInputGood");
+        final String filePath = builder.getFilePath("InputOneTopLevelClassGood");
+
+        final Integer[] warnList = builder.getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void bad1Test() throws Exception {
+
+        final Class<OneTopLevelClassCheck> clazz = OneTopLevelClassCheck.class;
+        final String messageKey = "one.top.level.class";
+
+        final String[] expected = {
+            "4: " + getCheckMessage(clazz, messageKey, "FooEnum"),
+        };
+
+        final Configuration checkConfig = builder.getCheckConfig("OneTopLevelClass");
+        final String filePath = builder.getFilePath("InputOneTopLevelClassBad1");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
@@ -80,29 +97,12 @@ public class OneTopLevelClassTest extends BaseCheckTestSupport {
         final String messageKey = "one.top.level.class";
 
         final String[] expected = {
-            "4: " + getCheckMessage(clazz, messageKey, "FooEnum"),
-        };
-
-        final Configuration checkConfig = builder.getCheckConfig("OneTopLevelClass");
-        final String filePath = builder.getFilePath("OneTopLevelClassBad2");
-
-        final Integer[] warnList = builder.getLinesWithWarn(filePath);
-        verify(checkConfig, filePath, expected, warnList);
-    }
-
-    @Test
-    public void bad3Test() throws Exception {
-
-        final Class<OneTopLevelClassCheck> clazz = OneTopLevelClassCheck.class;
-        final String messageKey = "one.top.level.class";
-
-        final String[] expected = {
             "5: " + getCheckMessage(clazz, messageKey, "FooIn"),
             "7: " + getCheckMessage(clazz, messageKey, "FooClass"),
         };
 
         final Configuration checkConfig = builder.getCheckConfig("OneTopLevelClass");
-        final String filePath = builder.getFilePath("OneTopLevelClassBad3");
+        final String filePath = builder.getFilePath("InputOneTopLevelClassBad2");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3sourcefile/EmptyLineSeparatorTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3sourcefile/EmptyLineSeparatorTest.java
@@ -57,7 +57,7 @@ public class EmptyLineSeparatorTest extends BaseCheckTestSupport {
         };
 
         final Configuration checkConfig = builder.getCheckConfig("EmptyLineSeparator");
-        final String filePath = builder.getFilePath("EmptyLineSeparatorInput");
+        final String filePath = builder.getFilePath("InputEmptyLineSeparator");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule44cloumunlimit/LineLengthTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule44cloumunlimit/LineLengthTest.java
@@ -53,7 +53,7 @@ public class LineLengthTest extends BaseCheckTestSupport {
         };
 
         final Configuration checkConfig = builder.getCheckConfig("LineLength");
-        final String filePath = builder.getFilePath("LineLengthInput2");
+        final String filePath = builder.getFilePath("InputLineLength");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java
@@ -57,7 +57,7 @@ public class EmptyLineSeparatorTest extends BaseCheckTestSupport {
         };
 
         final Configuration checkConfig = builder.getCheckConfig("EmptyLineSeparator");
-        final String filePath = builder.getFilePath("EmptyLineSeparatorInput");
+        final String filePath = builder.getFilePath("InputEmptyLineSeparator");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule32packagestatement/InputLineLength.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule32packagestatement/InputLineLength.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter3filestructure.rule32packagestatement; // ok
 import java.io.*;
-final class LineLengthInput2
+final class InputLineLength
 {
     // Long line ---------------------------------------------------------------------------------------- //warn
     // Contains a tab ->    <-

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/InputAvoidStarImport.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/InputAvoidStarImport.java
@@ -26,4 +26,4 @@ import java.util.Date;
 import java.util.Calendar;
 import java.util.BitSet;
 
-class AvoidStarImportInput {}
+class InputAvoidStarImport {}

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/InputNoLineWrapBad.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/InputNoLineWrapBad.java
@@ -8,7 +8,7 @@ import javax.accessibility. //warn
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater; //ok
 
 public class
-    NoLineWrap_Bad {
+    InputNoLineWrapBad {
     
     public void
         fooMethod() {

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/InputNoLineWrapGood.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/InputNoLineWrapGood.java
@@ -5,7 +5,7 @@ import com.google.common.annotations.Beta; //ok
 import javax.accessibility.AccessibleAttributeSequence; //ok
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater; //ok
 
-public class NoLineWrap_Good {
+public class InputNoLineWrapGood {
     
     public void fooMethod() {
         //

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/InputCustomImportOrder1.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/InputCustomImportOrder1.java
@@ -19,4 +19,4 @@ import java.io.Reader; //warn
 
 import com.google.common.base.Ascii;
 
-public class CustomImportOrderInput_1 {}
+public class InputCustomImportOrder1 {}

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/InputCustomImportOrder2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/InputCustomImportOrder2.java
@@ -15,5 +15,5 @@ import com.sun.xml.internal.xsom.impl.scd.Iterators; //warn
 
 import com.google.common.reflect.*; //warn
 
-public class CustomImportOrderInput_2 {
+public class InputCustomImportOrder2 {
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/InputCustomImportOrder3.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/InputCustomImportOrder3.java
@@ -15,5 +15,5 @@ import com.sun.xml.internal.xsom.impl.scd.Iterators; //warn
 
 import com.google.common.reflect.*; //warn
 
-public class CustomImportOrderInput_3 {
+public class InputCustomImportOrder3 {
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/InputCustomImportOrderValid.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/InputCustomImportOrderValid.java
@@ -17,5 +17,5 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import javax.accessibility.Accessible;
 
-public class CustomImportOrderValidInput {
+public class InputCustomImportOrderValid {
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassBad1.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassBad1.java
@@ -1,0 +1,4 @@
+package com.google.checkstyle.test.chapter3filestructure.rule341onetoplevel;
+
+class Foo {} //ok
+enum FooEnum {} // warn 

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassBad2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassBad2.java
@@ -1,4 +1,9 @@
 package com.google.checkstyle.test.chapter3filestructure.rule341onetoplevel;
 
-class Foo {} //ok
-enum FooEnum {} // warn 
+public enum InputOneTopLevelClassBad2 {} //ok
+
+interface FooIn {} // warn
+
+class FooClass {} // warn
+
+

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassBad3.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassBad3.java
@@ -1,9 +1,0 @@
-package com.google.checkstyle.test.chapter3filestructure.rule341onetoplevel;
-
-public enum InputOneTopLevelClassBad3 {} //ok
-
-interface FooIn {} // warn
-
-class FooClass {} // warn
-
-

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassBasic.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassBasic.java
@@ -1,7 +1,7 @@
 package com.google.checkstyle.test.chapter3filestructure.rule341onetoplevel;
-public class OneTopLevelClassInput_Basic
+public class InputOneTopLevelClassBasic
 {
-    public OneTopLevelClassInput_Basic() throws CloneNotSupportedException
+    public InputOneTopLevelClassBasic() throws CloneNotSupportedException
     {
         super.equals(new String());
         super.clone();

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassGood.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassGood.java
@@ -1,7 +1,7 @@
 package com.google.checkstyle.test.chapter3filestructure.rule341onetoplevel;
-public class OneTopLevelClassInputGood //ok
+public class InputOneTopLevelClassGood //ok
 {
-    public OneTopLevelClassInputGood() throws CloneNotSupportedException
+    public InputOneTopLevelClassGood() throws CloneNotSupportedException
     {
         super.equals(new String());
         super.clone();

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3sourcefilestructure/InputEmptyLineSeparator.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3sourcefilestructure/InputEmptyLineSeparator.java
@@ -16,7 +16,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ////////////////////////////////////////////////////////////////////////////////
-package com.google.checkstyle.test.chapter4formatting.rule461verticalwhitespace; //warn
+package com.google.checkstyle.test.chapter3filestructure.rule3sourcefilestructure; //warn
 import java.io.Serializable; //warn
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -30,7 +30,7 @@ import com.google.common.io.CharSource;
 import javax.swing.AbstractAction;
 
 import org.apache.commons.beanutils.locale.converters.ByteLocaleConverter;
-class InputEmptyLineSeparatorCheck //warn
+class InputEmptyLineSeparator //warn
 {
 	public static final double FOO_PI = 3.1415;
 	private boolean flag = true; 
@@ -47,12 +47,12 @@ class InputEmptyLineSeparatorCheck //warn
 	 * 
 	 * 
 	 */
-	private InputEmptyLineSeparatorCheck()
+	private InputEmptyLineSeparator()
 	{
 		//empty
 	}
 
-    public int compareTo(InputEmptyLineSeparatorCheck aObject)
+    public int compareTo(InputEmptyLineSeparator aObject)
     {
     	int number = 0;
         return 0;
@@ -98,7 +98,7 @@ class InputEmptyLineSeparatorCheck //warn
     }
 
     class InnerClass3 { //ok
-        public int compareTo(InputEmptyLineSeparatorCheck aObject) //ok
+        public int compareTo(InputEmptyLineSeparator aObject) //ok
         {
             int number = 0;
             return 0;
@@ -107,17 +107,17 @@ class InputEmptyLineSeparatorCheck //warn
     }
 }
 
-class Clazz { //ok
-    private Clazz() {} //ok
+class Class { //ok
+    private Class() {} //ok
 } 
 class Class2{ //warn
-    public int compareTo(InputEmptyLineSeparatorCheck aObject) //ok
+    public int compareTo(InputEmptyLineSeparator aObject) //ok
     {
         int number = 0;
         return 0;
     }
     Class2 anon = new Class2(){ //warn
-        public int compareTo(InputEmptyLineSeparatorCheck aObject) //ok
+        public int compareTo(InputEmptyLineSeparator aObject) //ok
         {
             int number = 0;
             return 0;

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/toolongpackagetotestcoveragegooglesjavastylerool/InputLineLength.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/toolongpackagetotestcoveragegooglesjavastylerool/InputLineLength.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter3filestructure.toolongpackagetotestcoveragegooglesjavastylerool; // ok
 import java.io.*;
-final class LineLengthInput2
+final class InputLineLength
 {
     // Long line ---------------------------------------------------------------------------------------- //warn
     // Contains a tab ->    <-

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputEmptyLineSeparator.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputEmptyLineSeparator.java
@@ -16,7 +16,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ////////////////////////////////////////////////////////////////////////////////
-package com.google.checkstyle.test.chapter3filestructure.rule3sourcefilestructure; //warn
+package com.google.checkstyle.test.chapter4formatting.rule461verticalwhitespace; //warn
 import java.io.Serializable; //warn
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -30,7 +30,7 @@ import com.google.common.io.CharSource;
 import javax.swing.AbstractAction;
 
 import org.apache.commons.beanutils.locale.converters.ByteLocaleConverter;
-class InputEmptyLineSeparatorCheck //warn
+class InputEmptyLineSeparator //warn
 {
 	public static final double FOO_PI = 3.1415;
 	private boolean flag = true; 
@@ -47,12 +47,12 @@ class InputEmptyLineSeparatorCheck //warn
 	 * 
 	 * 
 	 */
-	private InputEmptyLineSeparatorCheck()
+	private InputEmptyLineSeparator()
 	{
 		//empty
 	}
 
-    public int compareTo(InputEmptyLineSeparatorCheck aObject)
+    public int compareTo(InputEmptyLineSeparator aObject)
     {
     	int number = 0;
         return 0;
@@ -98,7 +98,7 @@ class InputEmptyLineSeparatorCheck //warn
     }
 
     class InnerClass3 { //ok
-        public int compareTo(InputEmptyLineSeparatorCheck aObject) //ok
+        public int compareTo(InputEmptyLineSeparator aObject) //ok
         {
             int number = 0;
             return 0;
@@ -107,17 +107,17 @@ class InputEmptyLineSeparatorCheck //warn
     }
 }
 
-class Class { //ok
-    private Class() {} //ok
+class Clazz { //ok
+    private Clazz() {} //ok
 } 
 class Class2{ //warn
-    public int compareTo(InputEmptyLineSeparatorCheck aObject) //ok
+    public int compareTo(InputEmptyLineSeparator aObject) //ok
     {
         int number = 0;
         return 0;
     }
     Class2 anon = new Class2(){ //warn
-        public int compareTo(InputEmptyLineSeparatorCheck aObject) //ok
+        public int compareTo(InputEmptyLineSeparator aObject) //ok
         {
             int number = 0;
             return 0;


### PR DESCRIPTION
Some files were numbered higher than 1, but had no starting 1. So I either renamed them to a lower number or removed the number.

**Comments**
IT's find input file is interesting. We just give it a file name, and it searches all directories and returns the first file it finds. It is not restricted to a specific directory, and I found instances of 2 files with the same name in different directories that are exact copies of each other. Because of the find process, this is hiding one and making it unused.
The 2 files are `LineLengthInput2` and `EmptyLineSeparatorInput`. I left them where they are with their new names in case this is done on purpose.