### PR TITLE
Issue 2557

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -42,7 +42,7 @@
               files="AbstractClassNameCheckTest.java|AbstractTypeAwareCheckTest.java|AbstractJavadocCheckTest.java|AbstractViolationReporterTest.java"/>
 
     <!-- Tone down the checking for test code -->
-    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="317"/>
+    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="319"/>
     <suppress checks="EmptyBlock" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="ImportControl" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="Javadoc" files=".*[\\/]src[\\/](test|it)[\\/]"/>

--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule233nonascii/AvoidEscapedUnicodeCharactersTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule233nonascii/AvoidEscapedUnicodeCharactersTest.java
@@ -29,7 +29,7 @@ import com.google.checkstyle.test.base.ConfigurationBuilder;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck;
 
-public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport {
+public class AvoidEscapedUnicodeCharactersTest extends BaseCheckTestSupport {
 
     private static ConfigurationBuilder builder;
 

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyTest.java
@@ -20,24 +20,18 @@
 package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
 import static com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck.MSG_KEY_LINE_PREVIOUS;
-import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_ALONE;
-import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_NEW;
 
 import java.io.File;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.BaseCheckTestSupport;
 import com.google.checkstyle.test.base.ConfigurationBuilder;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck;
-import com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck;
-import com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyOption;
 
-public class LeftCurlyRightCurlyTest extends BaseCheckTestSupport {
+public class LeftCurlyTest extends BaseCheckTestSupport {
 
     private static ConfigurationBuilder builder;
 
@@ -110,36 +104,5 @@ public class LeftCurlyRightCurlyTest extends BaseCheckTestSupport {
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
-    }
-
-    @Test
-    public void rightCurlyTestAlone() throws Exception {
-        final DefaultConfiguration newCheckConfig = createCheckConfig(RightCurlyCheck.class);
-        newCheckConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
-        newCheckConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF");
-
-        final String[] expected = {
-            "97:5: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 5),
-            "97:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_NEW, "}", 6),
-            "108:5: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 5),
-            "108:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_NEW, "}", 6),
-            "122:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_NEW, "}", 6),
-        };
-
-        final String filePath = builder.getFilePath("InputRightCurlyOther");
-        final Integer[] warnList = builder.getLinesWithWarn(filePath);
-        verify(newCheckConfig, filePath, expected, warnList);
-    }
-
-    @Test
-    public void rightCurlyTestSame() throws Exception {
-        final DefaultConfiguration newCheckConfig = createCheckConfig(RightCurlyCheck.class);
-        newCheckConfig.addAttribute("option", RightCurlyOption.SAME.toString());
-
-        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
-
-        final String filePath = builder.getFilePath("InputRightCurlySame");
-        final Integer[] warnList = builder.getLinesWithWarn(filePath);
-        verify(newCheckConfig, filePath, expected, warnList);
     }
 }

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
@@ -1,0 +1,76 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
+
+import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_ALONE;
+import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_NEW;
+
+import java.io.File;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.checkstyle.test.base.BaseCheckTestSupport;
+import com.google.checkstyle.test.base.ConfigurationBuilder;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck;
+import com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyOption;
+
+public class RightCurlyTest extends BaseCheckTestSupport {
+
+    private static ConfigurationBuilder builder;
+
+    @BeforeClass
+    public static void setConfigurationBuilder() {
+        builder = new ConfigurationBuilder(new File("src/it/"));
+    }
+
+    @Test
+    public void rightCurlyTestAlone() throws Exception {
+        final DefaultConfiguration newCheckConfig = createCheckConfig(RightCurlyCheck.class);
+        newCheckConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
+        newCheckConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF");
+
+        final String[] expected = {
+            "97:5: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 5),
+            "97:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_NEW, "}", 6),
+            "108:5: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 5),
+            "108:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_NEW, "}", 6),
+            "122:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_NEW, "}", 6),
+        };
+
+        final String filePath = builder.getFilePath("InputRightCurlyOther");
+        final Integer[] warnList = builder.getLinesWithWarn(filePath);
+        verify(newCheckConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void rightCurlyTestSame() throws Exception {
+        final DefaultConfiguration newCheckConfig = createCheckConfig(RightCurlyCheck.class);
+        newCheckConfig.addAttribute("option", RightCurlyOption.SAME.toString());
+
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+
+        final String filePath = builder.getFilePath("InputRightCurlySame");
+        final Integer[] warnList = builder.getLinesWithWarn(filePath);
+        verify(newCheckConfig, filePath, expected, warnList);
+    }
+}

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/GenericWhitespaceTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/GenericWhitespaceTest.java
@@ -1,0 +1,114 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
+
+import java.io.File;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.checkstyle.test.base.BaseCheckTestSupport;
+import com.google.checkstyle.test.base.ConfigurationBuilder;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+
+public class GenericWhitespaceTest extends BaseCheckTestSupport {
+
+    private static ConfigurationBuilder builder;
+
+    @BeforeClass
+    public static void setConfigurationBuilder() {
+        builder = new ConfigurationBuilder(new File("src/it/"));
+    }
+
+    @Test
+    public void whitespaceAroundGenericsTest() throws Exception {
+
+        final String msgPreceded = "ws.preceded";
+        final String msgFollowed = "ws.followed";
+        final Configuration checkConfig = builder.getCheckConfig("GenericWhitespace");
+
+        final String[] expected = {
+            "12:16: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
+            "12:18: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
+            "12:36: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
+            "12:38: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
+            "12:47: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
+            "12:49: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
+            "12:49: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
+            "14:32: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
+            "14:34: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
+            "14:45: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
+            "15:32: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
+            "15:34: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
+            "15:45: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
+            "20:38: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
+            "20:40: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
+            "20:61: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
+        };
+
+        final String filePath = builder.getFilePath("WhitespaceAroundInput_Generics");
+
+        final Integer[] warnList = builder.getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void genericWhitespaceTest() throws Exception {
+        final String msgPreceded = "ws.preceded";
+        final String msgFollowed = "ws.followed";
+        final String msgNotPreceded = "ws.notPreceded";
+        final String msgIllegalFollow = "ws.illegalFollow";
+        final Configuration checkConfig = builder.getCheckConfig("GenericWhitespace");
+
+        final String[] expected = {
+            "16:13: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
+            "16:15: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
+            "16:23: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
+            "16:43: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
+            "16:45: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
+            "16:53: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
+            "17:13: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
+            "17:15: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
+            "17:20: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
+            "17:22: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
+            "17:30: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
+            "17:32: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
+            "17:32: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
+            "17:52: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
+            "17:54: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
+            "17:59: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
+            "17:61: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
+            "17:69: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
+            "17:71: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
+            "17:71: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
+            "30:17: " + getCheckMessage(checkConfig.getMessages(), msgNotPreceded, "<"),
+            "30:21: " + getCheckMessage(checkConfig.getMessages(), msgIllegalFollow, ">"),
+            "42:21: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
+            "42:30: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
+            "60:60: " + getCheckMessage(checkConfig.getMessages(), msgNotPreceded, "&"),
+            "63:60: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
+        };
+
+        final String filePath = builder.getFilePath("GenericWhitespaceInput");
+
+        final Integer[] warnList = builder.getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+}

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
@@ -75,87 +75,12 @@ public class WhitespaceAroundTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void whitespaceAroundGenericsTest() throws Exception {
-
-        final String msgPreceded = "ws.preceded";
-        final String msgFollowed = "ws.followed";
-        final Configuration checkConfig = builder.getCheckConfig("GenericWhitespace");
-
-        final String[] expected = {
-            "12:16: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "12:18: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "12:36: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "12:38: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "12:47: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "12:49: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
-            "12:49: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "14:32: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "14:34: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "14:45: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "15:32: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "15:34: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "15:45: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "20:38: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "20:40: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "20:61: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-        };
-
-        final String filePath = builder.getFilePath("WhitespaceAroundInput_Generics");
-
-        final Integer[] warnList = builder.getLinesWithWarn(filePath);
-        verify(checkConfig, filePath, expected, warnList);
-    }
-
-    @Test
     public void whitespaceAroundEmptyTypesCyclesTest() throws Exception {
 
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
         final Configuration checkConfig = builder.getCheckConfig("WhitespaceAround");
         final String filePath = builder.getFilePath("WhitespaceAroundInput_EmptyTypesAndCycles");
-
-        final Integer[] warnList = builder.getLinesWithWarn(filePath);
-        verify(checkConfig, filePath, expected, warnList);
-    }
-
-    @Test
-    public void genericWhitespaceTest() throws Exception {
-        final String msgPreceded = "ws.preceded";
-        final String msgFollowed = "ws.followed";
-        final String msgNotPreceded = "ws.notPreceded";
-        final String msgIllegalFollow = "ws.illegalFollow";
-        final Configuration checkConfig = builder.getCheckConfig("GenericWhitespace");
-
-        final String[] expected = {
-            "16:13: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "16:15: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "16:23: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "16:43: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "16:45: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "16:53: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "17:13: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "17:15: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "17:20: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "17:22: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "17:30: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "17:32: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
-            "17:32: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "17:52: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "17:54: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "17:59: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "17:61: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "17:69: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "17:71: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
-            "17:71: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "30:17: " + getCheckMessage(checkConfig.getMessages(), msgNotPreceded, "<"),
-            "30:21: " + getCheckMessage(checkConfig.getMessages(), msgIllegalFollow, ">"),
-            "42:21: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "42:30: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
-            "60:60: " + getCheckMessage(checkConfig.getMessages(), msgNotPreceded, "&"),
-            "63:60: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
-        };
-
-        final String filePath = builder.getFilePath("GenericWhitespaceInput");
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassTypeParameterNameTest.java
@@ -29,7 +29,7 @@ import com.google.checkstyle.test.base.ConfigurationBuilder;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 
-public class ClassMethodTypeParameterNameTest extends BaseCheckTestSupport {
+public class ClassTypeParameterNameTest extends BaseCheckTestSupport {
 
     private static final String MSG_KEY = "name.invalidPattern";
     private static ConfigurationBuilder builder;
@@ -56,25 +56,5 @@ public class ClassMethodTypeParameterNameTest extends BaseCheckTestSupport {
 
         final Integer[] warnList = builder.getLinesWithWarn(filePath);
         verify(configuration, filePath, expected, warnList);
-    }
-
-    @Test
-    public void testMethodDefault() throws Exception {
-
-        final Configuration checkConfig = builder.getCheckConfig("MethodTypeParameterName");
-
-        final String[] expected = {
-            "9:6: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "e_e", format),
-            "19:6: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "Tfo$o2T", format),
-            "23:6: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "foo_", format),
-            "28:10: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_abc", format),
-            "37:14: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "T$", format),
-            "42:14: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "EE", format),
-        };
-
-        final String filePath = builder.getFilePath("MethodTypeParameterNameInput");
-
-        final Integer[] warnList = builder.getLinesWithWarn(filePath);
-        verify(checkConfig, filePath, expected, warnList);
     }
 }

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/MethodTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/MethodTypeParameterNameTest.java
@@ -1,0 +1,65 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.google.checkstyle.test.chapter5naming.rule528typevariablenames;
+
+import java.io.File;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.checkstyle.test.base.BaseCheckTestSupport;
+import com.google.checkstyle.test.base.ConfigurationBuilder;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+
+public class MethodTypeParameterNameTest extends BaseCheckTestSupport {
+
+    private static final String MSG_KEY = "name.invalidPattern";
+    private static ConfigurationBuilder builder;
+    private static Configuration configuration;
+    private static String format;
+
+    @BeforeClass
+    public static void setConfigurationBuilder() throws CheckstyleException {
+        builder = new ConfigurationBuilder(new File("src/it/"));
+        configuration = builder.getCheckConfig("ClassTypeParameterName");
+        format = configuration.getAttribute("format");
+    }
+
+    @Test
+    public void testMethodDefault() throws Exception {
+
+        final Configuration checkConfig = builder.getCheckConfig("MethodTypeParameterName");
+
+        final String[] expected = {
+            "9:6: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "e_e", format),
+            "19:6: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "Tfo$o2T", format),
+            "23:6: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "foo_", format),
+            "28:10: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_abc", format),
+            "37:14: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "T$", format),
+            "42:14: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "EE", format),
+        };
+
+        final String filePath = builder.getFilePath("MethodTypeParameterNameInput");
+
+        final Integer[] warnList = builder.getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+}

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -195,14 +195,14 @@
                                 <img
                                     src="images/ok_green.png"
                                     alt="" />
-                                <a href="config_misc.html#AvoidEscapedUnicodeCharacters">AvoidEscapedUnicodeCharactersCheck</a>
+                                <a href="config_misc.html#AvoidEscapedUnicodeCharacters">AvoidEscapedUnicodeCharacters</a>
                             </td>
                             <td>
                                 <a
-                                    href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidEscapedUnicodeCharactersCheck">config</a>
+                                    href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidEscapedUnicodeCharacters">config</a>
                                 <br />
                                 <a
-                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule233nonascii/AvoidEscapedUnicodeCharactersCheckTest.java">test</a>
+                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule233nonascii/AvoidEscapedUnicodeCharactersTest.java">test</a>
                             </td>
                         </tr>
                         <tr>
@@ -217,11 +217,11 @@
                                 <img
                                     src="images/ok_green.png"
                                     alt="" />
-                                <a href="config_whitespace.html#EmptyLineSeparator">EmptyLineSeparatorCheck</a>
+                                <a href="config_whitespace.html#EmptyLineSeparator">EmptyLineSeparator</a>
                             </td>
                             <td>
                                 <a
-                                    href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyLineSeparatorCheck">config</a>
+                                    href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyLineSeparator">config</a>
                                 <br />
                                 <a
                                     href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java">test</a>
@@ -253,7 +253,7 @@
                                 <img
                                     src="images/ok_green.png"
                                     alt="" />
-                                <a href="config_whitespace.html#NoLineWrap">NoLineWrapCheck</a>
+                                <a href="config_whitespace.html#NoLineWrap">NoLineWrap</a>
                             </td>
                             <td>
                                 <a
@@ -263,7 +263,7 @@
                                     href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java">test</a>
                                 <br />
                                 <a
-                                    href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrapCheck">config</a>
+                                    href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrap">config</a>
                                 <br />
                                 <a
                                     href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java">test</a>
@@ -318,7 +318,7 @@
                                 <img
                                     src="images/ok_green.png"
                                     alt="" />
-                                <a href="config_whitespace.html#NoLineWrap">NoLineWrapCheck</a>
+                                <a href="config_whitespace.html#NoLineWrap">NoLineWrap</a>
                                 <br />
                             </td>
                             <td>
@@ -329,7 +329,7 @@
                                     href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java">test</a>
                                 <br />
                                 <a
-                                    href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrapCheck">config</a>
+                                    href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrap">config</a>
                                 <br />
                                 <a
                                     href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java">test</a>
@@ -345,14 +345,14 @@
                                 <img
                                     src="images/ok_green.png"
                                     alt="" />
-                                <a href="config_imports.html#CustomImportOrder">CustomImportOrderCheck</a>
+                                <a href="config_imports.html#CustomImportOrder">CustomImportOrder</a>
                             </td>
                             <td>
                                 <a
-                                    href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CustomImportOrderCheck">config</a>
+                                    href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CustomImportOrder">config</a>
                                 <br />
                                 <a
-                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandsoacing/CustomImportOrderTest.java">test</a>
+                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/CustomImportOrderTest.java">test</a>
                             </td>
                         </tr>
                         <tr>
@@ -405,7 +405,7 @@
                                 <img
                                     src="images/ok_green.png"
                                     alt="" />
-                                <a href="config_coding.html#OverloadMethodsDeclarationOrder">OverloadMethodsDeclarationOrderCheck</a>
+                                <a href="config_coding.html#OverloadMethodsDeclarationOrder">OverloadMethodsDeclarationOrder</a>
                             </td>
                             <td>
                                 <a
@@ -481,10 +481,13 @@
                                     href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LeftCurly">config</a>
                                 <br/>
                                 <a
+                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyTest.java">test</a>
+                                <br/>
+                                <a
                                     href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RightCurly">config</a>
                                 <br/>
                                 <a
-                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyRightCurlyTest.java">test</a>
+                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java">test</a>
                             </td>
                         </tr>
                         <tr>
@@ -619,13 +622,13 @@
                                     href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OperatorWrap">config</a>
                                 <br />
                                 <a
-                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreack/OperatorWrapTest.java">test</a>
+                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/OperatorWrapTest.java">test</a>
                                 <br />
                                 <a
                                     href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SeparatorWrap">config</a>
                                 <br />
                                 <a
-                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreack/SeparatorWrapTest.java">test</a>
+                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/SeparatorWrapTest.java">test</a>
                             </td>
                         </tr>
                         <tr>
@@ -668,7 +671,7 @@
                                 <img
                                     src="images/ok_green.png"
                                     alt="" />
-                                <a href="config_whitespace.html#EmptyLineSeparator">EmptyLineSeparatorCheck</a>
+                                <a href="config_whitespace.html#EmptyLineSeparator">EmptyLineSeparator</a>
                             </td>
                             <td>
                                 <a
@@ -708,7 +711,7 @@
                                     href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+GenericWhitespace">config</a>
                                 <br />
                                 <a
-                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java">test</a>
+                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/GenericWhitespaceTest.java">test</a>
                             </td>
                         </tr>
                         <tr>
@@ -776,7 +779,7 @@
                                     href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleVariableDeclarations">config</a>
                                 <br />
                                 <a
-                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4821onevariablepreline/MultipleVariableDeclarationsTest.java">test</a>
+                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4821onevariableperline/MultipleVariableDeclarationsTest.java">test</a>
                             </td>
                         </tr>
                         <tr>
@@ -888,7 +891,7 @@
                                     href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FallThrough">config</a>
                                 <br />
                                 <a
-                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4842fallthrow/FallThroughTest.java">test</a>
+                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4842fallthrough/FallThroughTest.java">test</a>
                             </td>
                         </tr>
                         <tr>
@@ -1192,10 +1195,13 @@
                                     href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodTypeParameterName">config</a>
                                 <br />
                                 <a
+                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/MethodTypeParameterNameTest.java">test</a>
+                                <br />
+                                <a
                                     href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ClassTypeParameterName">config</a>
                                 <br />
                                 <a
-                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassMethodTypeParameterNameTest.java">test</a>
+                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassTypeParameterNameTest.java">test</a>
                             </td>
                         </tr>
                         <tr>
@@ -1356,11 +1362,11 @@
                             <img
                                     src="images/ok_green.png"
                                     alt="" />
-                                <a href="config_javadoc.html#JavadocParagraph">JavaDocParagraph</a>
+                                <a href="config_javadoc.html#JavadocParagraph">JavadocParagraph</a>
                             </td>
                             <td>
                             <a
-                                    href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavaDocParagraph">config</a><br/>
+                                    href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocParagraph">config</a><br/>
                                 <a
                                     href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/JavadocParagraphTest.java">test</a>
                                     </td>

--- a/src/xdocs/sun_style.xml
+++ b/src/xdocs/sun_style.xml
@@ -35,13 +35,15 @@
             <table>
                <thead>
                   <tr>
-                     <th>Sun Style Rule</th>
+                     <th/>
+                     <th>Sun's Java Style Rule</th>
                      <th>Checkstyle Check</th>
                      <th>Applied to config</th>
                   </tr>
                </thead>
                <tbody>
                   <tr>
+                     <td/>
                      <td> --  </td>
                      <td> --  </td>
                      <td> --  </td>


### PR DESCRIPTION
**added xdoc style validation**:
Rules must be in order.
Check names shouldn't end with "Check".
Configs should to be in order of: config, test
Config urls should match a defined pattern.
Test urls should be a file that exists.

**unified test file names**:
I went with `*Test` instead of `*CheckTest` because all but one follows this pattern, and it keeps conflicts from test folder down.

**made tests only cover one subject**:
Move code around so one test covers one check.

**fixed xdoc style errors**:
sun_style.xml has minor modifications to look more like google's.
