### PR TITLE
Issue 2451 removed excess hierarchy from NestedTryDepthCheckTest and deprecated AbstractNestedDepthCheck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1734,6 +1734,7 @@
                   <exclude>com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector*.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalCheck.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalMethodCheck.class</exclude>
+                  <exclude>com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.class</exclude>
                 </excludes>
               </instrumentation>
             </configuration>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.java
@@ -24,9 +24,11 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 
 /**
  * Abstract class which provides helpers functionality for nested checks.
- *
+ * @deprecated Checkstyle will not support abstract checks anymore. Use {@link Check} instead.
  * @author <a href="mailto:simon@redhillconsulting.com.au">Simon Harris</a>
+ * @noinspection AbstractClassNeverImplemented
  */
+@Deprecated
 public abstract class AbstractNestedDepthCheck extends Check {
     /** Maximum allowed nesting depth. */
     private int max;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedTryDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedTryDepthCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
@@ -26,7 +27,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Restricts nested try-catch-finally blocks to a specified depth (default = 1).
  * @author <a href="mailto:simon@redhillconsulting.com.au">Simon Harris</a>
  */
-public final class NestedTryDepthCheck extends AbstractNestedDepthCheck {
+public final class NestedTryDepthCheck extends Check {
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -34,17 +35,22 @@ public final class NestedTryDepthCheck extends AbstractNestedDepthCheck {
      */
     public static final String MSG_KEY = "nested.try.depth";
 
-    /** Default allowed nesting depth. */
-    private static final int DEFAULT_MAX = 1;
+    /** Maximum allowed nesting depth. */
+    private int max = 1;
+    /** Current nesting depth. */
+    private int depth;
 
-    /** Creates new check instance with default allowed nesting depth. */
-    public NestedTryDepthCheck() {
-        super(DEFAULT_MAX);
+    /**
+     * Setter for maximum allowed nesting depth.
+     * @param max maximum allowed nesting depth.
+     */
+    public void setMax(int max) {
+        this.max = max;
     }
 
     @Override
     public int[] getDefaultTokens() {
-        return new int[] {TokenTypes.LITERAL_TRY};
+        return getAcceptableTokens();
     }
 
     @Override
@@ -53,13 +59,26 @@ public final class NestedTryDepthCheck extends AbstractNestedDepthCheck {
     }
 
     @Override
+    public int[] getRequiredTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public void beginTree(DetailAST rootAST) {
+        depth = 0;
+    }
+
+    @Override
     public void visitToken(DetailAST literalTry) {
-        nestIn(literalTry, MSG_KEY);
+        if (depth > max) {
+            log(literalTry, MSG_KEY, depth, max);
+        }
+        ++depth;
     }
 
     @Override
     public void leaveToken(DetailAST literalTry) {
-        nestOut();
+        --depth;
     }
 
 }


### PR DESCRIPTION
same as the others + the deprecation