### PR TITLE
Issue #2067: Fix false-negatives in EmptyLineSeparatorCheck

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages.properties
@@ -1,5 +1,6 @@
 empty.line.separator=''{0}'' should be separated from previous statement.
 empty.line.separator.multiple.lines=''{0}'' has more than 1 empty lines before.
+empty.line.separator.multiple.lines.after=''{0}'' has more than 1 empty lines after.
 
 containsTab=Line contains a tab character.
 file.containsTab=File contains tab characters (this is the first instance).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_de.properties
@@ -1,4 +1,5 @@
 empty.line.separator=''{0}'' sollte vom vorangehenden Ausdruck getrennt stehen.
+empty.line.separator.multiple.lines.after=''{0}'' hat mehr als 1 Leerzeilen nach.
 
 containsTab=Zeile enthält ein TAB-Zeichen
 file.containsTab=Datei enthält Tabulatorzeichen (diese Stelle ist das erste Vorkommnen).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_es.properties
@@ -13,6 +13,7 @@ ws.typeCast=''conversión de tipos'' no está seguido de espacio en blanco.
 
 empty.line.separator = ''{0}'' debe ser separado de la declaración anterior.
 empty.line.separator.multiple.lines = ''{0}'' cuenta con más de 1 líneas vacías antes.
+empty.line.separator.multiple.lines.after=''{0}'' cuenta con más de 1 líneas vacías después.
 file.containsTab = Archivo contiene caracteres de tabulación (este es el primer ejemplo).
 no.line.wrap = {0} declaración no debe ser la línea envuelto.
 ws.illegalFollow = ''{0}'' es seguido por un carácter ilegal.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_fi.properties
@@ -14,5 +14,6 @@ ws.illegalFollow=''{0}'' seuraa laiton merkki.
 
 empty.line.separator = ''{0}'' olisi erotettava edellisen selonteon.
 empty.line.separator.multiple.lines = ''{0}'' on yli 1 tyhjää riviä ennen.
+empty.line.separator.multiple.lines.after=''{0}'' on yli 1 tyhjää riviä jälkeen.
 file.containsTab = Tiedosto sisältää sarkainmerkeillä (tämä on ensisijaisesti).
 no.line.wrap = {0} lausunto ei pitäisi olla linja-kääritty.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_fr.properties
@@ -14,5 +14,6 @@ ws.illegalFollow=''{0}'' est suivi par un caractère illégal.
 
 empty.line.separator = ''{0}'' doit être séparé de la déclaration précédente.
 empty.line.separator.multiple.lines = ''{0}'' a plus de 1 lignes vides avant.
+empty.line.separator.multiple.lines.after=''{0}'' compte plus de 1 lignes vides après.
 file.containsTab = Fichier contient des caractères de tabulation (ce qui est le premier exemple).
 no.line.wrap = {0} déclaration ne devrait pas être sur des lignes enveloppé.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_ja.properties
@@ -14,5 +14,6 @@ ws.illegalFollow=が ''{0}'' 不正な文字が続いています。
 
 empty.line.separator = ''{0}'' 前の文から分離する必要があります。
 empty.line.separator.multiple.lines = ''{0}'' の前に1以上の空行を持っています。
+empty.line.separator.multiple.lines.after=''{0}'' 後の1以上の空行を持っています。
 file.containsTab = ファイルが（これが最初のインスタンスである）タブ文字が含まれています。
 no.line.wrap = {0} 文は、行ラップされてはなりません。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_pt.properties
@@ -14,5 +14,6 @@ ws.illegalFollow=''{0}'' é seguido por um carácter ilegal.
 
 empty.line.separator = ''{0}'' deve ser separada da declaração anterior.
 empty.line.separator.multiple.lines = ''{0}'' tem mais de 1 linhas vazias antes.
+empty.line.separator.multiple.lines.after=''{0}'' tem mais de 1 linhas vazias depois.
 file.containsTab = Arquivo contém caracteres de tabulação (esta é a primeira instância).
 no.line.wrap = {0} afirmação não deve ser linha-embrulhado.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_tr.properties
@@ -18,4 +18,5 @@ ws.typeCast=''türü dönüştürme'' ifadesinden sonra boşluk kullanılmamış
 
 empty.line.separator = {0} 'Bir önceki deyimi ayrılmalıdır.
 empty.line.separator.multiple.lines = {0} daha önce en fazla 1 boş hatları vardır.
+empty.line.separator.multiple.lines.after=''{0}'' sonra 1'den fazla boş hatları vardır.
 no.line.wrap = {0} ifadesi hattı sarılı olmamalıdır.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck.MSG_MULTIPLE_LINES;
+import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck.MSG_MULTIPLE_LINES_AFTER;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck.MSG_SHOULD_BE_SEPARATED;
 import static org.junit.Assert.assertArrayEquals;
 
@@ -100,9 +101,11 @@ public class EmptyLineSeparatorCheckTest
         final String[] expected = {
             "21: " + getCheckMessage(MSG_MULTIPLE_LINES, "package"),
             "24: " + getCheckMessage(MSG_MULTIPLE_LINES, "import"),
+            "29: " + getCheckMessage(MSG_MULTIPLE_LINES, "CLASS_DEF"),
             "33: " + getCheckMessage(MSG_MULTIPLE_LINES, "VARIABLE_DEF"),
             "38: " + getCheckMessage(MSG_MULTIPLE_LINES, "VARIABLE_DEF"),
             "43: " + getCheckMessage(MSG_MULTIPLE_LINES, "METHOD_DEF"),
+            "45: " + getCheckMessage(MSG_MULTIPLE_LINES_AFTER, "METHOD_DEF"),
         };
         verify(checkConfig, getPath("InputEmptyLineSeparatorMultipleEmptyLines.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputEmptyLineSeparatorMultipleEmptyLines.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputEmptyLineSeparatorMultipleEmptyLines.java
@@ -43,5 +43,6 @@ public class InputEmptyLineSeparatorMultipleEmptyLines
     private static void foo() {}
     
     private static void foo1() {}
-    
+
+
 }


### PR DESCRIPTION
Report against CS, Sevntu-CS, Guava, pmd, Orekit:
http://vladlis.github.io/reports/emptyLine/

The report looks OK, I've confirmed about a half of violations