### PR TITLE
Issue 2451 24: removed excess hierarchy from MethodTypeParameterNameCheck and deprecated AbstractTypeParameterNameCheck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1735,6 +1735,7 @@
                   <exclude>com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalCheck.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalMethodCheck.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.class</exclude>
+                  <exclude>com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.class</exclude>
                 </excludes>
               </instrumentation>
             </configuration>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.java
@@ -29,9 +29,12 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  *
  * <p>This class extends {@link AbstractNameCheck}</p>
- *
+ * @deprecated Checkstyle will not support abstract checks anymore. Use
+ *             {@link AbstractNameCheck} instead.
  * @author Travis Schneeberger
+ * @noinspection AbstractClassNeverImplemented
  */
+@Deprecated
 public abstract class AbstractTypeParameterNameCheck
     extends AbstractNameCheck {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodTypeParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodTypeParameterNameCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
@@ -47,21 +48,33 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * @author Travis Schneeberger
  */
 public class MethodTypeParameterNameCheck
-    extends AbstractTypeParameterNameCheck {
+    extends AbstractNameCheck {
     /** Creates a new {@code MethodTypeParameterNameCheck} instance. */
     public MethodTypeParameterNameCheck() {
         super("^[A-Z]$");
     }
 
     @Override
-    public int[] getRequiredTokens() {
+    public int[] getDefaultTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
         return new int[] {
             TokenTypes.TYPE_PARAMETER,
         };
     }
 
     @Override
-    protected final int getLocation() {
-        return TokenTypes.METHOD_DEF;
+    public int[] getRequiredTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    protected final boolean mustCheckName(DetailAST ast) {
+        final DetailAST location =
+            ast.getParent().getParent();
+        return location.getType() == TokenTypes.METHOD_DEF;
     }
 }


### PR DESCRIPTION
MethodTypeParameterNameCheck extends AbstractNameCheck.
Copied methods over, and removed getLocation.
Deprecated AbstractTypeParameterNameCheck.