### PR TITLE
Issue #2451: documented missing properties for MethodNameCheck

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -42,7 +42,7 @@
               files="AbstractClassNameCheckTest.java|AbstractTypeAwareCheckTest.java|AbstractJavadocCheckTest.java|AbstractViolationReporterTest.java"/>
 
     <!-- Tone down the checking for test code -->
-    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="319"/>
+    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="316"/>
     <suppress checks="EmptyBlock" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="ImportControl" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="Javadoc" files=".*[\\/]src[\\/](test|it)[\\/]"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
@@ -112,11 +112,8 @@ public class XDocsPagesTest {
 
     private static final List<String> UNDOCUMENTED_PROPERTIES = Arrays.asList(
             "SuppressWithNearbyCommentFilter.fileContents",
-            "SuppressionCommentFilter.fileContents",
-            "MethodNameCheck.applyToPackage",
-            "MethodNameCheck.applyToPrivate",
-            "MethodNameCheck.applyToProtected",
-            "MethodNameCheck.applyToPublic");
+            "SuppressionCommentFilter.fileContents"
+    );
 
     @Test
     public void testAllChecksPresentOnAvailableChecksPage() throws IOException {

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -725,6 +725,32 @@ class MyClass {
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
+          <tr>
+            <td>applyToPublic</td>
+            <td>Controls whether to apply the check to public member.</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>true</code></td>
+          </tr>
+          <tr>
+            <td>applyToProtected</td>
+            <td>Controls whether to apply the check to protected member.</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>true</code></td>
+          </tr>
+          <tr>
+            <td>applyToPackage</td>
+            <td>
+              Controls whether to apply the check to package-private member.
+            </td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>true</code></td>
+          </tr>
+          <tr>
+            <td>applyToPrivate</td>
+            <td>Controls whether to apply the check to private member.</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>true</code></td>
+          </tr>
         </table>
       </subsection>
 


### PR DESCRIPTION
Added documentation for missing 'MethodNameCheck' properties.
Just a simple copy/paste from another similar check.