### PR TITLE
Issue #2451: removed excess hierarchy from EmptyForIteratorPadCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
@@ -19,9 +19,13 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
+import java.util.Locale;
+
+import org.apache.commons.beanutils.ConversionException;
+
+import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.checks.AbstractOptionCheck;
 
 /**
  * <p>Checks the padding of an empty for iterator; that is whether a
@@ -47,7 +51,7 @@ for (Iterator foo = very.long.line.iterator();
  * @author Rick Giles
  */
 public class EmptyForIteratorPadCheck
-    extends AbstractOptionCheck<PadOption> {
+    extends Check {
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -61,11 +65,24 @@ public class EmptyForIteratorPadCheck
      */
     public static final String WS_NOT_FOLLOWED = "ws.notFollowed";
 
+    /** Semicolon literal. */
+    private static final String SEMICOLON = ";";
+
+    /** The policy to enforce. */
+    private PadOption option = PadOption.NOSPACE;
+
     /**
-     * Sets the paren pad option to nospace.
+     * Set the option to enforce.
+     * @param optionStr string to decode option from
+     * @throws ConversionException if unable to decode
      */
-    public EmptyForIteratorPadCheck() {
-        super(PadOption.NOSPACE, PadOption.class);
+    public void setOption(String optionStr) {
+        try {
+            option = PadOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));
+        }
+        catch (IllegalArgumentException iae) {
+            throw new ConversionException("unable to parse " + optionStr, iae);
+        }
     }
 
     @Override
@@ -92,11 +109,11 @@ public class EmptyForIteratorPadCheck
             final int after = semi.getColumnNo() + 1;
             //don't check if at end of line
             if (after < line.length()) {
-                if (getAbstractOption() == PadOption.NOSPACE
+                if (option == PadOption.NOSPACE
                     && Character.isWhitespace(line.charAt(after))) {
                     log(semi.getLineNo(), after, WS_FOLLOWED, SEMICOLON);
                 }
-                else if (getAbstractOption() == PadOption.SPACE
+                else if (option == PadOption.SPACE
                          && !Character.isWhitespace(line.charAt(after))) {
                     log(semi.getLineNo(), after, WS_NOT_FOLLOWED, SEMICOLON);
                 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
@@ -26,11 +26,13 @@ import static org.junit.Assert.assertArrayEquals;
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class EmptyForIteratorPadCheckTest
@@ -82,5 +84,13 @@ public class EmptyForIteratorPadCheckTest
             TokenTypes.FOR_ITERATOR,
         };
         assertArrayEquals(expected, actual);
+    }
+
+    @Test(expected = CheckstyleException.class)
+    public void testInvalidOption() throws Exception {
+        checkConfig.addAttribute("option", "invalid_option");
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig, getPath("InputForWhitespace.java"), expected);
     }
 }


### PR DESCRIPTION
EmptyForIteratorPadCheck now extends Check.
Copied methods and fields from abstract.
Added test for missing coverage.