### PR TITLE
Issue #2451: removed excess hierarchy from SeparatorWrapCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
@@ -19,11 +19,14 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
+import java.util.Locale;
+
+import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.lang3.ArrayUtils;
 
+import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.checks.AbstractOptionCheck;
 
 /**
  * <p>
@@ -80,7 +83,7 @@ import com.puppycrawl.tools.checkstyle.checks.AbstractOptionCheck;
  * @author maxvetrenko
  */
 public class SeparatorWrapCheck
-    extends AbstractOptionCheck<WrapOption> {
+    extends Check {
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -94,11 +97,21 @@ public class SeparatorWrapCheck
      */
     public static final String LINE_NEW = "line.new";
 
+    /** The policy to enforce. */
+    private WrapOption option = WrapOption.EOL;
+
     /**
-     * Sets the comma wrap option to end of the line.
+     * Set the option to enforce.
+     * @param optionStr string to decode option from
+     * @throws ConversionException if unable to decode
      */
-    public SeparatorWrapCheck() {
-        super(WrapOption.EOL, WrapOption.class);
+    public void setOption(String optionStr) {
+        try {
+            option = WrapOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));
+        }
+        catch (IllegalArgumentException iae) {
+            throw new ConversionException("unable to parse " + optionStr, iae);
+        }
     }
 
     @Override
@@ -139,13 +152,12 @@ public class SeparatorWrapCheck
                 currentLine.substring(colNo + text.length()).trim();
         final String substringBeforeToken =
                 currentLine.substring(0, colNo).trim();
-        final WrapOption wSp = getAbstractOption();
 
-        if (wSp == WrapOption.EOL
+        if (option == WrapOption.EOL
                 && substringBeforeToken.isEmpty()) {
             log(lineNo, colNo, LINE_PREVIOUS, text);
         }
-        else if (wSp == WrapOption.NL
+        else if (option == WrapOption.NL
                  && substringAfterToken.isEmpty()) {
             log(lineNo, colNo, LINE_NEW, text);
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
@@ -25,12 +25,14 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapChe
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class SeparatorWrapCheckTest
@@ -78,5 +80,13 @@ public class SeparatorWrapCheckTest
             TokenTypes.COMMA,
         };
         Assert.assertArrayEquals(expected, actual);
+    }
+
+    @Test(expected = CheckstyleException.class)
+    public void testInvalidOption() throws Exception {
+        checkConfig.addAttribute("option", "invalid_option");
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig, getPath("InputSeparatorWrap.java"), expected);
     }
 }


### PR DESCRIPTION
SeparatorWrapCheck now extends Check.
Copied methods and fields from abstract.
Added test for missing coverage.