### PR TITLE
Issue 2451: removed excess hierarchy from ImportOrderCheck and deprecated AbstractOptionCheck

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -109,7 +109,7 @@
     <!-- equals() - a lot of fields to check -->
     <suppress checks="CyclomaticComplexity" files="LocalizedMessage\.java" lines="210"/>
     <!-- SWITCH was transformed into IF-ELSE -->
-    <suppress checks="CyclomaticComplexity" files="ImportOrderCheck\.java" lines="331"/>
+    <suppress checks="CyclomaticComplexity" files="ImportOrderCheck\.java" lines="354"/>
 
     <!-- LocalizedMessage class is immutable, we need that amount of arguments. -->
     <suppress checks="ParameterNumber"

--- a/pom.xml
+++ b/pom.xml
@@ -1716,6 +1716,7 @@
                   <!-- deprecated classes -->
                   <exclude>com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector*.class</exclude>
+                  <exclude>com/puppycrawl/tools/checkstyle/checks/AbstractOptionCheck.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalCheck.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalMethodCheck.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.class</exclude>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractOptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractOptionCheck.java
@@ -31,10 +31,13 @@ import com.puppycrawl.tools.checkstyle.api.Check;
  * representation to the {@link Enum} is to {@link String#trim()} the string
  * and convert using {@link String#toUpperCase()} and then look up using
  * {@link Enum#valueOf}.
+ * @deprecated Checkstyle will not support abstract checks anymore. Use {@link Check} instead.
  * @author Oliver Burn
  * @author Rick Giles
  * @param <T> the type of the option.
+ * @noinspection AbstractClassNeverImplemented
  */
+@Deprecated
 public abstract class AbstractOptionCheck<T extends Enum<T>>
     extends Check {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -19,13 +19,16 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.beanutils.ConversionException;
+
+import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.checks.AbstractOptionCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -175,7 +178,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
  */
 public class ImportOrderCheck
-    extends AbstractOptionCheck<ImportOrderOption> {
+    extends Check {
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -217,11 +220,31 @@ public class ImportOrderCheck
     /** Whether static imports should be sorted alphabetically or not. */
     private boolean sortStaticImportsAlphabetically;
 
+    /** The policy to enforce. */
+    private ImportOrderOption option = ImportOrderOption.UNDER;
+
     /**
-     * Groups static imports under each group.
+     * Set the option to enforce.
+     * @param optionStr string to decode option from
+     * @throws ConversionException if unable to decode
      */
-    public ImportOrderCheck() {
-        super(ImportOrderOption.UNDER, ImportOrderOption.class);
+    public void setOption(String optionStr) {
+        try {
+            option = ImportOrderOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));
+        }
+        catch (IllegalArgumentException iae) {
+            throw new ConversionException("unable to parse " + optionStr, iae);
+        }
+    }
+
+    /**
+     * Gets option set.
+     * @return the {@code option} set
+     */
+    public ImportOrderOption getAbstractOption() {
+        // WARNING!! Do not rename this method to getOption(). It breaks
+        // BeanUtils, which will silently not call setOption. Very annoying!
+        return option;
     }
 
     /**


### PR DESCRIPTION
`getAbstractOption` was kept because of the way it is needed in the test. I kept the name the same, and the warning comment, incase it is still true even though the field is named `option` but I wasn't sure if a test will catch it if I was wrong and it is still an issue.