### PR TITLE
Issue #2616: Add CatchParameterName check for catch blocks parameters

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -338,6 +338,9 @@
       <property name="format" value="^[a-z][a-zA-Z0-9]+$"/>
       <property name="ignoreOverridden" value="true"/>
     </module>
+    <module name="CatchParameterName">
+      <property name="format" value="^(ex|[a-z][a-z][a-zA-Z]+)$"/>
+    </module>
     <module name="StaticVariableName">
       <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
     </module>

--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -165,7 +165,7 @@ public class BaseCheckTestSupport {
         try {
             pr.load(aClass.getResourceAsStream("messages.properties"));
         }
-        catch (IOException e) {
+        catch (IOException ex) {
             return null;
         }
         final MessageFormat formatter = new MessageFormat(pr.getProperty(messageKey),

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule51identifiernames/CatchParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule51identifiernames/CatchParameterNameTest.java
@@ -1,0 +1,55 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.google.checkstyle.test.chapter5naming.rule51identifiernames;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.google.checkstyle.test.base.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+
+public class CatchParameterNameTest extends BaseCheckTestSupport {
+    @Override
+    protected String getPath(String fileName) throws IOException {
+        return super.getPath("chapter5naming" + File.separator + "rule51identifiernames"
+            + File.separator + fileName);
+    }
+
+    @Test
+    public void catchParameterNameTest() throws Exception {
+        final Configuration checkConfig = getCheckConfig("CatchParameterName");
+        final String msgKey = "name.invalidPattern";
+        final String format = "^[a-z][a-z0-9][a-zA-Z0-9]*$";
+
+        final String[] expected = {
+            "6:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "e", format),
+            "24:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "t", format),
+            "47:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "iException", format),
+            "50:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "x", format),
+        };
+
+        final String filePath = getPath("InputCatchParameterName.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule51identifiernames/InputCatchParameterName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule51identifiernames/InputCatchParameterName.java
@@ -1,0 +1,53 @@
+package com.google.checkstyle.test.chapter5naming.rule51identifiernames;
+
+public class InputCatchParameterName {
+    {
+        try {
+        } catch (Exception e) { // warn
+        }
+        try {
+        } catch (Exception ex) { // ok
+        }
+        try {
+        } catch (Error | Exception err) { // ok
+        }
+        try {
+        } catch (Exception exception) { // ok
+        }
+        try {
+        } catch (Exception exception1) { // ok
+        }
+        try {
+        } catch (Exception noWorries) { // ok
+        }
+        try {
+        } catch (Throwable t) { // warn
+        }
+        try {
+            throw new InterruptedException("interruptedException");
+        } catch (InterruptedException ie) { // ok
+        }
+        try {
+        } catch (Exception ok) { // ok
+            // appropriate to take no action here
+        }
+        try {
+        } catch (Exception e1) { // ok
+            try {
+            } catch (Exception e2) { // ok
+            }
+        }
+        try {
+        } catch (Throwable t1) { // ok
+            try {
+            } catch (Throwable t2) { // ok
+            }
+        }
+        try {
+        } catch (Exception iException) { // warn
+        }
+        try {
+        } catch (Exception x) { // warn
+        }
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -231,14 +231,14 @@ public final class ConfigurationLoader {
             loader.parseInputSource(configSource);
             return loader.configuration;
         }
-        catch (final SAXParseException e) {
+        catch (final SAXParseException ex) {
             final String message = String.format(Locale.ROOT, "%s - %s:%s:%s",
                     UNABLE_TO_PARSE_EXCEPTION_PREFIX,
-                    e.getMessage(), e.getLineNumber(), e.getColumnNumber());
-            throw new CheckstyleException(message, e);
+                    ex.getMessage(), ex.getLineNumber(), ex.getColumnNumber());
+            throw new CheckstyleException(message, ex);
         }
-        catch (final ParserConfigurationException | IOException | SAXException e) {
-            throw new CheckstyleException(UNABLE_TO_PARSE_EXCEPTION_PREFIX, e);
+        catch (final ParserConfigurationException | IOException | SAXException ex) {
+            throw new CheckstyleException(UNABLE_TO_PARSE_EXCEPTION_PREFIX, ex);
         }
     }
 
@@ -482,8 +482,8 @@ public final class ConfigurationLoader {
                     final String severity = recentModule.getAttribute(SEVERITY);
                     level = SeverityLevel.getInstance(severity);
                 }
-                catch (final CheckstyleException e) {
-                    LOG.debug("Severity not set, ignoring exception", e);
+                catch (final CheckstyleException ex) {
+                    LOG.debug("Severity not set, ignoring exception", ex);
                 }
 
                 // omit this module if these should be omitted and the module

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -129,10 +129,10 @@ public final class Main {
             System.out.println(pex.getMessage());
             printUsage();
         }
-        catch (CheckstyleException e) {
+        catch (CheckstyleException ex) {
             exitStatus = EXIT_WITH_CHECKSTYLE_EXCEPTION_CODE;
             errorCounter = 1;
-            e.printStackTrace();
+            ex.printStackTrace();
         }
         finally {
             // return exit code base on validation of Checker
@@ -300,9 +300,9 @@ public final class Main {
             fis = new FileInputStream(file);
             properties.load(fis);
         }
-        catch (final IOException e) {
+        catch (final IOException ex) {
             throw new CheckstyleException(String.format(
-                    "Unable to load properties from file '%s'.", file.getAbsolutePath()), e);
+                    "Unable to load properties from file '%s'.", file.getAbsolutePath()), ex);
         }
         finally {
             Closeables.closeQuietly(fis);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -149,8 +149,8 @@ public final class PackageNamesLoader
                     final InputSource source = new InputSource(stream);
                     namesLoader.parseInputSource(source);
                 }
-                catch (IOException e) {
-                    throw new CheckstyleException("unable to open " + packageFile, e);
+                catch (IOException ex) {
+                    throw new CheckstyleException("unable to open " + packageFile, ex);
                 }
                 finally {
                     Closeables.closeQuietly(stream);
@@ -160,11 +160,11 @@ public final class PackageNamesLoader
             result = namesLoader.packageNames;
 
         }
-        catch (IOException e) {
-            throw new CheckstyleException("unable to get package file resources", e);
+        catch (IOException ex) {
+            throw new CheckstyleException("unable to get package file resources", ex);
         }
-        catch (ParserConfigurationException | SAXException e) {
-            throw new CheckstyleException("unable to open one of package files", e);
+        catch (ParserConfigurationException | SAXException ex) {
+            throw new CheckstyleException("unable to open one of package files", ex);
         }
 
         return result;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -157,12 +157,12 @@ class PackageObjectFactory implements ModuleFactory {
             try {
                 return doMakeObject(name + "Check");
             }
-            catch (final CheckstyleException ex2) {
+            catch (final CheckstyleException ex) {
                 final LocalizedMessage exceptionMessage = new LocalizedMessage(0,
                     Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
                     new String[] {name, joinPackageNamesWithClassName(name)},
                     null, getClass(), null);
-                throw new CheckstyleException(exceptionMessage.getMessage(), ex2);
+                throw new CheckstyleException(exceptionMessage.getMessage(), ex);
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -482,8 +482,8 @@ public final class TreeWalker
             try {
                 cache.persist();
             }
-            catch (IOException e) {
-                throw new IllegalStateException("Unable to persist cache file", e);
+            catch (IOException ex) {
+                throw new IllegalStateException("Unable to persist cache file", ex);
             }
         }
         super.destroy();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -364,8 +364,8 @@ public class CheckstyleAntTask extends Task {
             log("To process the files took " + (processingEndTime - processingStartTime)
                 + TIME_SUFFIX, Project.MSG_VERBOSE);
         }
-        catch (CheckstyleException e) {
-            throw new BuildException("Unable to process files: " + files, e);
+        catch (CheckstyleException ex) {
+            throw new BuildException("Unable to process files: " + files, ex);
         }
         final int numWarnings = warningCounter.getCount();
         final boolean okStatus = numErrs <= maxErrors && numWarnings <= maxWarnings;
@@ -412,9 +412,9 @@ public class CheckstyleAntTask extends Task {
             checker.contextualize(context);
             checker.configure(config);
         }
-        catch (final CheckstyleException e) {
+        catch (final CheckstyleException ex) {
             throw new BuildException(String.format(Locale.ROOT, "Unable to create a Checker: "
-                    + "configLocation {%s}, classpath {%s}.", configLocation, classpath), e);
+                    + "configLocation {%s}, classpath {%s}.", configLocation, classpath), ex);
         }
         return checker;
     }
@@ -435,9 +435,9 @@ public class CheckstyleAntTask extends Task {
                 inStream = new FileInputStream(properties);
                 returnValue.load(inStream);
             }
-            catch (final IOException e) {
+            catch (final IOException ex) {
                 throw new BuildException("Error loading Properties file '"
-                        + properties + "'", e, getLocation());
+                        + properties + "'", ex, getLocation());
             }
             finally {
                 Closeables.closeQuietly(inStream);
@@ -482,9 +482,9 @@ public class CheckstyleAntTask extends Task {
                 }
             }
         }
-        catch (IOException e) {
+        catch (IOException ex) {
             throw new BuildException(String.format(Locale.ROOT, "Unable to create listeners: "
-                    + "formatters {%s}.", formatters), e);
+                    + "formatters {%s}.", formatters), ex);
         }
         return listeners;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -169,19 +169,19 @@ public class AutomaticBean
             beanUtils.copyProperty(this, key, value);
         }
         catch (final InvocationTargetException | IllegalAccessException
-                | NoSuchMethodException e) {
+                | NoSuchMethodException ex) {
             // There is no way to catch IllegalAccessException | NoSuchMethodException
             // as we do PropertyUtils.getPropertyDescriptor before beanUtils.copyProperty
             // so we have to join these exceptions with InvocationTargetException
             // to satisfy UTs coverage
             final String message = String.format(Locale.ROOT,
                     "Cannot set property '%s' to '%s' in module %s", key, value, moduleName);
-            throw new CheckstyleException(message, e);
+            throw new CheckstyleException(message, ex);
         }
-        catch (final IllegalArgumentException | ConversionException e) {
+        catch (final IllegalArgumentException | ConversionException ex) {
             final String message = String.format(Locale.ROOT, "illegal value '%s' for property "
                     + "'%s' of module %s", value, key, moduleName);
-            throw new CheckstyleException(message, e);
+            throw new CheckstyleException(message, ex);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractFormatCheck.java
@@ -111,8 +111,8 @@ public abstract class AbstractFormatCheck
             format = regexpFormat;
             compileFlags |= compileFlagsParam;
         }
-        catch (final PatternSyntaxException e) {
-            throw new ConversionException("unable to parse " + regexpFormat, e);
+        catch (final PatternSyntaxException ex) {
+            throw new ConversionException("unable to parse " + regexpFormat, ex);
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -390,8 +390,8 @@ public class TranslationCheck
                 keys.add(element.nextElement());
             }
         }
-        catch (final IOException e) {
-            logIoException(e, file);
+        catch (final IOException ex) {
+            logIoException(ex, file);
         }
         finally {
             Closeables.closeQuietly(inStream);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -76,9 +76,9 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
                 fileInputStream.close();
             }
         }
-        catch (IOException e) {
+        catch (IOException ex) {
             log(0, IO_EXCEPTION_KEY, file.getPath(),
-                    e.getLocalizedMessage());
+                    ex.getLocalizedMessage());
         }
 
         for (Entry<String> duplication : properties

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheck.java
@@ -88,7 +88,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * {@code
  * try {
  *     throw new RuntimeException();
- * } catch (RuntimeException e) {
+ * } catch (RuntimeException ex) {
  *     //This is expected
  * }
  * }
@@ -110,7 +110,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * {@code
  * try {
  *     throw new RuntimeException();
- * } catch (RuntimeException e) {
+ * } catch (RuntimeException ex) {
  *     //This is expected
  * }
  * }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -147,11 +147,11 @@ final class ImportControlLoader extends AbstractLoader {
         try {
             inputStream = uri.toURL().openStream();
         }
-        catch (final MalformedURLException e) {
-            throw new CheckstyleException("syntax error in url " + uri, e);
+        catch (final MalformedURLException ex) {
+            throw new CheckstyleException("syntax error in url " + uri, ex);
         }
-        catch (final IOException e) {
-            throw new CheckstyleException("unable to find " + uri, e);
+        catch (final IOException ex) {
+            throw new CheckstyleException("unable to find " + uri, ex);
         }
         final InputSource source = new InputSource(inputStream);
         return load(source, uri);
@@ -171,12 +171,12 @@ final class ImportControlLoader extends AbstractLoader {
             loader.parseInputSource(source);
             return loader.getRoot();
         }
-        catch (final ParserConfigurationException | SAXException e) {
+        catch (final ParserConfigurationException | SAXException ex) {
             throw new CheckstyleException("unable to parse " + uri
-                    + " - " + e.getMessage(), e);
+                    + " - " + ex.getMessage(), ex);
         }
-        catch (final IOException e) {
-            throw new CheckstyleException("unable to read " + uri, e);
+        catch (final IOException ex) {
+            throw new CheckstyleException("unable to read " + uri, ex);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -233,7 +233,7 @@ public abstract class AbstractJavadocCheck extends Check {
             final DetailNode tree = convertParseTreeToDetailNode(parseTree);
             result.setTree(tree);
         }
-        catch (ParseCancellationException e) {
+        catch (ParseCancellationException ex) {
             // If syntax error occurs then message is printed by error listener
             // and parser throws this runtime exception to stop parsing.
             // Just stop processing current Javadoc comment.
@@ -243,7 +243,7 @@ public abstract class AbstractJavadocCheck extends Check {
             if (parseErrorMessage == null) {
                 parseErrorMessage = new ParseErrorMessage(javadocCommentAst.getLineNo(),
                         UNRECOGNIZED_ANTLR_ERROR_MESSAGE_KEY,
-                        javadocCommentAst.getColumnNo(), e.getMessage());
+                        javadocCommentAst.getColumnNo(), ex.getMessage());
             }
 
             result.setParseErrorMessage(parseErrorMessage);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheck.java
@@ -1,0 +1,91 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * <p>
+ * Checks that {@code catch} parameter names conform to a format specified by the format property.
+ * The format is a {@link java.util.regex.Pattern regular expression} and defaults to
+ * <strong>^(e|t|ex|[a-z][a-z][a-zA-Z]+)$</strong>.
+ * </p>
+ * <p>
+ * Default pattern has the following characteristic:
+ * </p>
+ * <ul>
+ * <li>allows names beginning with two lowercase letters followed by at least one uppercase or
+ * lowercase letter</li>
+ * <li>allows {@code e} abbreviation (suitable for exceptions end errors)</li>
+ * <li>allows {@code ex} abbreviation (suitable for exceptions)</li>
+ * <li>allows {@code t} abbreviation (suitable for throwables)</li>
+ * <li>prohibits numbered abbreviations like {@code e1} or {@code t2}</li>
+ * <li>prohibits one letter prefixes like {@code pException}</li>
+ * <li>prohibits two letter abbreviations like {@code ie} or {@code ee}</li>
+ * <li>prohibits any other characters than letters</li>
+ * </ul>
+ * <p>
+ * An example of how to configure the check is:
+ * </p>
+ * <pre>
+ * &lt;module name="CatchParameterName"/&gt;
+ * </pre>
+ * <p>
+ * An example of how to configure the check for names that begin with a lower case letter,
+ * followed by any letters or digits is:
+ * </p>
+ * <pre>
+ * &lt;module name="CatchParameterName"&gt;
+ *    &lt;property name="format" value="^[a-z][a-zA-Z0-9]+$"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ *
+ * @author Michal Kordas
+ */
+public class CatchParameterNameCheck extends AbstractNameCheck {
+
+    /**
+     * Creates a new {@code CatchParameterNameCheck} instance.
+     */
+    public CatchParameterNameCheck() {
+        super("^(e|t|ex|[a-z][a-z][a-zA-Z]+)$");
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return new int[]{TokenTypes.PARAMETER_DEF};
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    protected boolean mustCheckName(DetailAST ast) {
+        return ast.getParent().getType() == TokenTypes.LITERAL_CATCH;
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -62,7 +62,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * <pre>
  *   try {
  *     thirdPartyLibrary.method();
- *   } catch (RuntimeException e) {
+ *   } catch (RuntimeException ex) {
  *     // ALLOW ILLEGAL CATCH BECAUSE third party API wraps everything
  *     // in RuntimeExceptions.
  *     ...
@@ -340,10 +340,10 @@ public class SuppressWithNearbyCommentFilter
                     }
                     influence = Integer.parseInt(format);
                 }
-                catch (final NumberFormatException e) {
+                catch (final NumberFormatException ex) {
                     throw new ConversionException(
                         "unable to parse influence from '" + text
-                            + "' using " + filter.influenceFormat, e);
+                            + "' using " + filter.influenceFormat, ex);
                 }
                 if (influence >= 0) {
                     firstLine = line;
@@ -354,10 +354,10 @@ public class SuppressWithNearbyCommentFilter
                     lastLine = line;
                 }
             }
-            catch (final PatternSyntaxException e) {
+            catch (final PatternSyntaxException ex) {
                 throw new ConversionException(
                     "unable to parse expanded comment " + format,
-                    e);
+                    ex);
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -363,10 +363,10 @@ public class SuppressionCommentFilter
                     }
                 }
             }
-            catch (final PatternSyntaxException e) {
+            catch (final PatternSyntaxException ex) {
                 throw new ConversionException(
                     "unable to parse expanded comment " + format,
-                    e);
+                    ex);
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -144,21 +144,21 @@ public final class SuppressionsLoader
             suppressionsLoader.parseInputSource(source);
             return suppressionsLoader.filterChain;
         }
-        catch (final FileNotFoundException e) {
-            throw new CheckstyleException(UNABLE_TO_FIND_ERROR_MESSAGE + sourceName, e);
+        catch (final FileNotFoundException ex) {
+            throw new CheckstyleException(UNABLE_TO_FIND_ERROR_MESSAGE + sourceName, ex);
         }
-        catch (final ParserConfigurationException | SAXException e) {
+        catch (final ParserConfigurationException | SAXException ex) {
             final String message = String.format(Locale.ROOT, "Unable to parse %s - %s",
-                    sourceName, e.getMessage());
-            throw new CheckstyleException(message, e);
+                    sourceName, ex.getMessage());
+            throw new CheckstyleException(message, ex);
         }
-        catch (final IOException e) {
-            throw new CheckstyleException("Unable to read " + sourceName, e);
+        catch (final IOException ex) {
+            throw new CheckstyleException("Unable to read " + sourceName, ex);
         }
-        catch (final NumberFormatException e) {
+        catch (final NumberFormatException ex) {
             final String message = String.format(Locale.ROOT, "Number format exception %s - %s",
-                    sourceName, e.getMessage());
-            throw new CheckstyleException(message, e);
+                    sourceName, ex.getMessage());
+            throw new CheckstyleException(message, ex);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
@@ -202,9 +202,9 @@ public final class CommonUtils {
         try {
             return Pattern.compile(pattern, flags);
         }
-        catch (final PatternSyntaxException e) {
+        catch (final PatternSyntaxException ex) {
             throw new ConversionException(
-                    "Failed to initialise regular expression " + pattern, e);
+                    "Failed to initialise regular expression " + pattern, ex);
         }
     }
 
@@ -333,8 +333,8 @@ public final class CommonUtils {
         try {
             closeable.close();
         }
-        catch (IOException e) {
-            throw new IllegalStateException("Cannot close the stream", e);
+        catch (IOException ex) {
+            throw new IllegalStateException("Cannot close the stream", ex);
         }
     }
 
@@ -370,8 +370,8 @@ public final class CommonUtils {
                     }
                     uri = configUrl.toURI();
                 }
-                catch (final URISyntaxException e) {
-                    throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename, e);
+                catch (final URISyntaxException ex) {
+                    throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename, ex);
                 }
             }
         }

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -112,6 +112,11 @@
             <message key="name.invalidPattern"
              value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
         <module name="LocalVariableName">
             <property name="tokens" value="VARIABLE_DEF"/>
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -269,7 +269,7 @@ public class BaseCheckTestSupport {
         try {
             pr.load(getClass().getResourceAsStream("messages.properties"));
         }
-        catch (IOException e) {
+        catch (IOException ex) {
             return null;
         }
         final MessageFormat formatter = new MessageFormat(pr.getProperty(messageKey),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CommitValidationTest.java
@@ -193,7 +193,7 @@ public class CommitValidationTest {
                     new RevCommitsPair(new OmitMergeCommitsIterator(first),
                             new OmitMergeCommitsIterator(second));
         }
-        catch (GitAPIException | IOException e) {
+        catch (GitAPIException | IOException ex) {
             revCommitIteratorPair = new RevCommitsPair();
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -381,9 +381,9 @@ public class ConfigurationLoaderTest {
             fail("Exception is expected");
 
         }
-        catch (InvocationTargetException e) {
-            assertTrue(e.getCause() instanceof IllegalStateException);
-            assertEquals("Unknown name:" + "hello" + ".", e.getCause().getMessage());
+        catch (InvocationTargetException ex) {
+            assertTrue(ex.getCause() instanceof IllegalStateException);
+            assertEquals("Unknown name:" + "hello" + ".", ex.getCause().getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -453,14 +453,14 @@ public class MainTest {
             }
             fail("Exception was expected");
         }
-        catch (InvocationTargetException e) {
-            assertTrue(e.getCause() instanceof CheckstyleException);
+        catch (InvocationTargetException ex) {
+            assertTrue(ex.getCause() instanceof CheckstyleException);
             // We do separate validation for message as in Windows
             // disk drive letter appear in message,
             // so we skip that drive letter for compatibility issues
-            assertTrue(e.getCause().getMessage()
+            assertTrue(ex.getCause().getMessage()
                     .startsWith("Unable to load properties from file '"));
-            assertTrue(e.getCause().getMessage().endsWith(":invalid'."));
+            assertTrue(ex.getCause().getMessage().endsWith(":invalid'."));
         }
     }
 
@@ -473,9 +473,9 @@ public class MainTest {
             method.invoke(null, "myformat", null);
             fail();
         }
-        catch (InvocationTargetException e) {
-            assertTrue(e.getCause() instanceof IllegalStateException);
-            assertTrue(e.getCause().getMessage().startsWith("Invalid output format. Found"));
+        catch (InvocationTargetException ex) {
+            assertTrue(ex.getCause() instanceof IllegalStateException);
+            assertTrue(ex.getCause().getMessage().startsWith("Invalid output format. Found"));
         }
     }
 
@@ -489,9 +489,9 @@ public class MainTest {
             method.invoke(null, "myformat", outDir);
             fail();
         }
-        catch (InvocationTargetException e) {
-            assertTrue(e.getCause() instanceof IllegalStateException);
-            assertTrue(e.getCause().getMessage().startsWith("Invalid output format. Found"));
+        catch (InvocationTargetException ex) {
+            assertTrue(ex.getCause() instanceof IllegalStateException);
+            assertTrue(ex.getCause().getMessage().startsWith("Invalid output format. Found"));
         }
         finally {
             // method creates output folder

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -109,9 +109,9 @@ public class PropertyCacheFileTest {
             method.invoke(cache, config);
             fail();
         }
-        catch (InvocationTargetException e) {
-            assertTrue(e.getCause().getCause() instanceof NoSuchAlgorithmException);
-            assertEquals("Unable to calculate hashcode.", e.getCause().getMessage());
+        catch (InvocationTargetException ex) {
+            assertTrue(ex.getCause().getCause() instanceof NoSuchAlgorithmException);
+            assertEquals("Unable to calculate hashcode.", ex.getCause().getMessage());
         }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -93,8 +93,8 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
             verify(checkConfig, getPath("InputMain.java"), expected);
             fail();
         }
-        catch (CheckstyleException e) {
-            final String errorMsg = e.getMessage();
+        catch (CheckstyleException ex) {
+            final String errorMsg = ex.getMessage();
             assertTrue(errorMsg.contains("cannot initialize module"
                     + " com.puppycrawl.tools.checkstyle.TreeWalker - Token \"IMPORT\""
                     + " was not found in Acceptable tokens list in check"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XDocsPagesTest.java
@@ -222,8 +222,8 @@ public class XDocsPagesTest {
 
             return builder.parse(new InputSource(new StringReader(code)));
         }
-        catch (IOException | SAXException e) {
-            Assert.fail(fileName + " has invalid xml (" + e.getMessage() + "): "
+        catch (IOException | SAXException ex) {
+            Assert.fail(fileName + " has invalid xml (" + ex.getMessage() + "): "
                     + unserializedSource);
         }
 
@@ -261,8 +261,8 @@ public class XDocsPagesTest {
                 checker.destroy();
             }
         }
-        catch (CheckstyleException e) {
-            Assert.fail(fileName + " has invalid Checkstyle xml (" + e.getMessage() + "): "
+        catch (CheckstyleException ex) {
+            Assert.fail(fileName + " has invalid Checkstyle xml (" + ex.getMessage() + "): "
                     + unserializedSource);
         }
     }
@@ -320,7 +320,7 @@ public class XDocsPagesTest {
         try {
             instance = moduleFactory.createModule(sectionName);
         }
-        catch (CheckstyleException e) {
+        catch (CheckstyleException ex) {
             Assert.fail(fileName + " couldn't find class: " + sectionName);
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -37,8 +37,8 @@ public class FileTextTest {
             new FileText(new File("any name"), charsetName);
             fail();
         }
-        catch (UnsupportedEncodingException e) {
-            assertEquals("Unsupported charset: " + charsetName, e.getMessage());
+        catch (UnsupportedEncodingException ex) {
+            assertEquals("Unsupported charset: " + charsetName, ex.getMessage());
         }
 
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/ClassResolverTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/ClassResolverTest.java
@@ -52,7 +52,7 @@ public class ClassResolverTest {
             classResolver.resolve("who.will.win.the.world.cup", "");
             fail("Should not resolve class");
         }
-        catch (ClassNotFoundException e) {
+        catch (ClassNotFoundException ex) {
             // expected
         }
         classResolver.resolve("java.lang.String", "");
@@ -63,7 +63,7 @@ public class ClassResolverTest {
             classResolver.resolve("ChoiceFormat", "");
             fail();
         }
-        catch (ClassNotFoundException e) {
+        catch (ClassNotFoundException ex) {
             // expected
         }
 
@@ -79,7 +79,7 @@ public class ClassResolverTest {
             javaUtilClassResolver.resolve("two.nil.england", "");
             fail();
         }
-        catch (ClassNotFoundException e) {
+        catch (ClassNotFoundException ex) {
             // expected
         }
     }
@@ -96,9 +96,9 @@ public class ClassResolverTest {
             classResolver.resolve("someClass", "");
             fail("Exception expected");
         }
-        catch (ClassNotFoundException e) {
+        catch (ClassNotFoundException ex) {
             // expected
-            assertEquals("someClass", e.getMessage());
+            assertEquals("someClass", ex.getMessage());
         }
     }
 
@@ -144,10 +144,10 @@ public class ClassResolverTest {
             classResolver.resolve("someClass", "");
             fail("Exception expected");
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ex) {
             // expected
-            assertTrue(e.getCause() instanceof ClassNotFoundException);
-            assertTrue(e.getMessage().endsWith("expected exception"));
+            assertTrue(ex.getCause() instanceof ClassNotFoundException);
+            assertTrue(ex.getMessage().endsWith("expected exception"));
         }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -180,7 +180,7 @@ public class FinalLocalVariableCheckTest
             check.visitToken(lambdaAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ex) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
@@ -185,7 +185,7 @@ public class IllegalInstantiationCheckTest
             check.visitToken(lambdaAst);
             Assert.fail();
         }
-        catch (IllegalArgumentException e) {
+        catch (IllegalArgumentException ex) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -212,7 +212,7 @@ public class IllegalTypeCheckTest extends BaseCheckTestSupport {
             check.visitToken(classDefAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ex) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
@@ -100,7 +100,7 @@ public class ModifiedControlVariableCheckTest
             check.visitToken(classDefAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ex) {
             // it is OK
         }
 
@@ -108,7 +108,7 @@ public class ModifiedControlVariableCheckTest
             check.leaveToken(classDefAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ex) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
@@ -73,7 +73,7 @@ public class ParameterAssignmentCheckTest extends BaseCheckTestSupport {
             check.visitToken(classDefAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ex) {
             // it is OK
         }
 
@@ -81,7 +81,7 @@ public class ParameterAssignmentCheckTest extends BaseCheckTestSupport {
             check.leaveToken(classDefAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ex) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
@@ -126,7 +126,7 @@ public class ReturnCountCheckTest extends BaseCheckTestSupport {
             check.visitToken(classDefAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ex) {
             // it is OK
         }
 
@@ -134,7 +134,7 @@ public class ReturnCountCheckTest extends BaseCheckTestSupport {
             check.leaveToken(classDefAst);
             Assert.fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ex) {
             // it is OK
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
@@ -101,7 +101,7 @@ public class MutableExceptionCheckTest extends BaseCheckTestSupport {
             obj.visitToken(ast);
             fail();
         }
-        catch (IllegalStateException e) {
+        catch (IllegalStateException ex) {
             //expected
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
@@ -92,8 +92,8 @@ public class ThrowsCountCheckTest extends BaseCheckTestSupport {
             obj.visitToken(ast);
             fail();
         }
-        catch (IllegalStateException e) {
-            assertEquals(ast.toString(), e.getMessage());
+        catch (IllegalStateException ex) {
+            assertEquals(ast.toString(), ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
@@ -78,8 +78,8 @@ public class ImportControlLoaderTest {
             privateMethod.invoke(null, attr, "you_cannot_find_me");
         }
         catch (IllegalAccessException | IllegalArgumentException
-                | NoSuchMethodException | SecurityException e) {
-            throw new IllegalStateException(e);
+                | NoSuchMethodException | SecurityException ex) {
+            throw new IllegalStateException(ex);
         }
     }
 
@@ -98,8 +98,8 @@ public class ImportControlLoaderTest {
                     new File(getPath("import-control_complete.xml")).toURI());
         }
         catch (IllegalAccessException | IllegalArgumentException
-                | NoSuchMethodException | SecurityException e) {
-            throw new IllegalStateException(e);
+                | NoSuchMethodException | SecurityException ex) {
+            throw new IllegalStateException(ex);
         }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
@@ -195,8 +195,8 @@ public class CommentsIndentationCheckTest extends BaseCheckTestSupport {
             check.visitToken(methodDef);
             Assert.fail("IllegalArgumentException should have been thrown!");
         }
-        catch (IllegalArgumentException e) {
-            final String msg = e.getMessage();
+        catch (IllegalArgumentException ex) {
+            final String msg = ex.getMessage();
             Assert.assertEquals("Unexpected token type: methodStub", msg);
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheckTest.java
@@ -1,0 +1,102 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+public class CatchParameterNameCheckTest extends BaseCheckTestSupport {
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("checks" + File.separator + "naming" + File.separator + filename);
+    }
+
+    @Test
+    public void testTokens() {
+        final CatchParameterNameCheck catchParameterNameCheck = new CatchParameterNameCheck();
+        final int[] expected = {TokenTypes.PARAMETER_DEF};
+
+        assertArrayEquals(expected, catchParameterNameCheck.getRequiredTokens());
+        assertArrayEquals(expected, catchParameterNameCheck.getAcceptableTokens());
+    }
+
+    @Test
+    public void testDefaultConfigurationOnCorrectFile() throws Exception {
+        final Configuration checkConfig = createCheckConfig(CatchParameterNameCheck.class);
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig, getPath("InputSimple.java"), expected);
+    }
+
+    @Test
+    public void testDefaultConfigurationOnFileWithViolations() throws Exception {
+        final Configuration checkConfig = createCheckConfig(CatchParameterNameCheck.class);
+        final String defaultFormat = "^(e|t|ex|[a-z][a-z][a-zA-Z]+)$";
+
+        final String[] expected = {
+            "18:28: " + getCheckMessage(MSG_INVALID_PATTERN, "exception1", defaultFormat),
+            "28:39: " + getCheckMessage(MSG_INVALID_PATTERN, "ie", defaultFormat),
+            "31:28: " + getCheckMessage(MSG_INVALID_PATTERN, "iException", defaultFormat),
+            "34:28: " + getCheckMessage(MSG_INVALID_PATTERN, "ok", defaultFormat),
+            "38:28: " + getCheckMessage(MSG_INVALID_PATTERN, "e1", defaultFormat),
+            "40:32: " + getCheckMessage(MSG_INVALID_PATTERN, "e2", defaultFormat),
+            "44:28: " + getCheckMessage(MSG_INVALID_PATTERN, "t1", defaultFormat),
+            "46:32: " + getCheckMessage(MSG_INVALID_PATTERN, "t2", defaultFormat),
+        };
+
+        verify(checkConfig, getPath("InputCatchParameterName.java"), expected);
+    }
+
+    @Test
+    public void testCustomFormatFromJavadoc() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(CatchParameterNameCheck.class);
+        final String format = "^[a-z][a-zA-Z0-9]+$";
+        checkConfig.addAttribute("format", format);
+
+        final String[] expected = {
+            "6:28: " + getCheckMessage(MSG_INVALID_PATTERN, "e", format),
+            "24:28: " + getCheckMessage(MSG_INVALID_PATTERN, "t", format),
+        };
+
+        verify(checkConfig, getPath("InputCatchParameterName.java"), expected);
+    }
+
+    @Test
+    public void testCustomFormatWithNoAnchors() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(CatchParameterNameCheck.class);
+        final String format = "[a-z]";
+        checkConfig.addAttribute("format", format);
+
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig, getPath("InputCatchParameterName.java"), expected);
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
@@ -204,8 +204,8 @@ public class NoWhitespaceAfterCheckTest
             check.visitToken(astArrayDeclarator);
             fail("no intended exception thrown");
         }
-        catch (IllegalStateException e) {
-            assertEquals("unexpected ast syntaximport[0x-1]", e.getMessage());
+        catch (IllegalStateException ex) {
+            assertEquals("unexpected ast syntaximport[0x-1]", ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -198,7 +198,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
             final HttpURLConnection urlConnect = (HttpURLConnection) verifiableUrl.openConnection();
             urlConnect.getContent();
         }
-        catch (IOException e) {
+        catch (IOException ex) {
             return false;
         }
         return true;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParseTreeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParseTreeTest.java
@@ -287,7 +287,7 @@ public class JavadocParseTreeTest {
         public void syntaxError(
                 Recognizer<?, ?> recognizer, Object offendingSymbol,
                 int line, int charPositionInLine,
-                String msg, RecognitionException e) {
+                String msg, RecognitionException ex) {
             Assert.fail("[" + line + ", " + charPositionInLine + "] " + msg);
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilsTest.java
@@ -103,7 +103,7 @@ public class TokenUtilsTest {
             assertEquals("given id " + id, expected.getMessage());
 
         }
-        catch (IllegalAccessException | NoSuchFieldException e) {
+        catch (IllegalAccessException | NoSuchFieldException ex) {
             fail();
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputCatchParameterName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputCatchParameterName.java
@@ -1,0 +1,50 @@
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+public class InputCatchParameterName {
+    {
+        try {
+        } catch (Exception e) {
+        }
+        try {
+        } catch (Exception ex) {
+        }
+        try {
+        } catch (Error | Exception err) {
+        }
+        try {
+        } catch (Exception exception) {
+        }
+        try {
+        } catch (Exception exception1) {
+        }
+        try {
+        } catch (Exception noWorries) {
+        }
+        try {
+        } catch (Throwable t) {
+        }
+        try {
+            throw new InterruptedException("interruptedException");
+        } catch (InterruptedException ie) { // violation with default config
+        }
+        try {
+        } catch (Exception iException) { // violation with default config
+        }
+        try {
+        } catch (Exception ok) {
+            // appropriate to take no action here
+        }
+        try {
+        } catch (Exception e1) {
+            try {
+            } catch (Exception e2) {
+            }
+        }
+        try {
+        } catch (Throwable t1) {
+            try {
+            } catch (Throwable t2) {
+            }
+        }
+    }
+}

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -95,6 +95,10 @@
         </td>
       </tr>
       <tr>
+        <td><a href="config_naming.html#CatchParameterName">CatchParameterName</a></td>
+        <td>Checks that catch parameter names conform to a format specified by the format property.</td>
+      </tr>
+      <tr>
         <td><a href="config_metrics.html#ClassDataAbstractionCoupling">ClassDataAbstractionCoupling</a></td>
         <td>This metric measures the number of instantiations of other classes within the given class.</td>
       </tr>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -230,6 +230,90 @@
       </subsection>
     </section>
 
+    <section name="CatchParameterName">
+      <subsection name="Description">
+        <p>
+          Checks that catch parameter names conform to a format specified by the format property.
+          Default pattern has the following characteristic:
+        </p>
+        <ul>
+          <li>allows names beginning with two lowercase letters followed by at least one uppercase
+            or lowercase letter</li>
+          <li>allows <code>e</code> abbreviation (suitable for exceptions end errors)</li>
+          <li>allows <code>ex</code> abbreviation (suitable for exceptions)</li>
+          <li>allows <code>t</code> abbreviation (suitable for throwables)</li>
+          <li>prohibits numbered abbreviations like <code>e1</code> or <code>t2</code></li>
+          <li>prohibits one letter prefixes like <code>pException</code></li>
+          <li>prohibits two letter abbreviations like <code>ie</code> or <code>ee</code></li>
+          <li>prohibits any other characters than letters</li>
+        </ul>
+      </subsection>
+
+      <subsection name="Properties">
+        <table>
+          <tr>
+            <th>name</th>
+            <th>description</th>
+            <th>type</th>
+            <th>default value</th>
+          </tr>
+          <tr>
+            <td>format</td>
+            <td>Specifies valid identifiers.</td>
+            <td>
+              <a href="property_types.html#regexp">regular expression</a>
+            </td>
+            <td>
+              <code>^(e|t|ex|[a-z][a-z][a-zA-Z]+)$</code>
+            </td>
+          </tr>
+        </table>
+      </subsection>
+
+      <subsection name="Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name=&quot;CatchParameterName&quot;/&gt;
+        </source>
+        <p>
+          An example of how to configure the check for names that begin with
+          a lower case letter, followed by letters and digits is:
+        </p>
+        <source>
+&lt;module name="ParameterName"&gt;
+    &lt;property name="format" value="^[a-z][a-zA-Z0-9]+$"/&gt;
+&lt;/module&gt;
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CatchParameterName">
+              Google Style
+            </a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CatchParameterName">
+              Checkstyle Style
+            </a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Package">
+        <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
+      </subsection>
+
+      <subsection name="Parent Module">
+        <p>
+          <a href="config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+
     <section name="ClassTypeParameterName">
       <subsection name="Description">
         <p>Validates identifiers for class type parameters.</p>

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -1144,6 +1144,10 @@
                                     src="images/ok_green.png"
                                     alt="" />
                                 <a href="config_naming.html#ParameterName">ParameterName</a>
+                                <br/>
+                                <br/>
+                                <img src="images/ok_green.png" alt=""/>
+                                <a href="config_naming.html#CatchParameterName">CatchParameterName</a>
                             </td>
                             <td>
                                 <a
@@ -1151,6 +1155,14 @@
                                 <br />
                                 <a
                                     href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java">test</a>
+                                <br/>
+                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CatchParameterName">
+                                    config
+                                </a>
+                                <br/>
+                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule51identifiernames/CatchParameterNameTest.java">
+                                    test
+                                </a>
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
I've set the default pattern to the very strict one: `^(e|ex|[a-z][a-z][a-zA-Z]*)$`. I'm aware, that most probably it's too controversial, but I'm waiting for your opinions @romani @rnveach @Vladlis @MEZk 

This is early version of the check - any input/review is welcome.