### PR TITLE
Issue 2451: removed excess hierarchy from NPathComplexityCheck and deprecated AbstractComplexityCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.java
@@ -29,10 +29,12 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * Base class for checks the calculate complexity based around methods.
- *
+ * @deprecated Checkstyle will not support abstract checks anymore. Use {@link Check} instead.
  * @author <a href="mailto:simon@redhillconsulting.com.au">Simon Harris</a>
  * @author Oliver Burn
+ * @noinspection AbstractClassNeverImplemented
  */
+@Deprecated
 public abstract class AbstractComplexityCheck
     extends Check {
     /** The initial current value. */


### PR DESCRIPTION
NPathComplexityCheck now extends Check.
Copied methods and fields from abstract class.
Removed `getMessageID`, `leaveTokenHook`, and `visitTokenHook`.
Streamlined `getCurrentValue` and `setCurrentValue` to just use the field directly.


Deprecated AbstractComplexityCheck.