### PR TITLE
xdoc: added verification of google/sun checks in config

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -74,7 +74,7 @@
               files="AbstractClassNameCheckTest.java|AbstractTypeAwareCheckTest.java|AbstractJavadocCheckTest.java|AbstractViolationReporterTest.java"/>
 
     <!-- Tone down the checking for test code -->
-    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="292"/>
+    <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java" lines="298"/>
     <suppress checks="IllegalCatch" files="[\\/]internal[\\/]\w+Util\.java"/>
     <suppress checks="EmptyBlock" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="ImportControl" files=".*[\\/]src[\\/](test|it)[\\/]"/>

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/SummaryJavadocTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/SummaryJavadocTest.java
@@ -42,7 +42,7 @@ public class SummaryJavadocTest extends BaseCheckTestSupport {
 
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("SummaryJavadocCheck");
+        final Configuration checkConfig = getCheckConfig("SummaryJavadoc");
         final String filePath = getPath("InputCorrectSummaryJavaDocCheck.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -67,7 +67,7 @@ public class SummaryJavadocTest extends BaseCheckTestSupport {
             "103: " + msgFirstSentence,
         };
 
-        final Configuration checkConfig = getCheckConfig("SummaryJavadocCheck");
+        final Configuration checkConfig = getCheckConfig("SummaryJavadoc");
         final String filePath = getPath("InputIncorrectSummaryJavaDocCheck.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -178,7 +178,7 @@
         </module>
         <module name="NonEmptyAtclauseDescription"/>
         <module name="JavadocTagContinuationIndentation"/>
-        <module name="SummaryJavadocCheck">
+        <module name="SummaryJavadoc">
             <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
         </module>
         <module name="JavadocParagraph"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CheckUtil.java
@@ -28,13 +28,11 @@ import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.ClassPath;
@@ -46,15 +44,15 @@ public final class CheckUtil {
     private CheckUtil() {
     }
 
-    public static Set<String> getConfigCheckStyleChecks() throws Exception {
+    public static Set<String> getConfigCheckStyleChecks() {
         return getCheckStyleChecksReferencedInConfig("config/checkstyle_checks.xml");
     }
 
-    public static Set<String> getConfigSunStyleChecks() throws Exception {
+    public static Set<String> getConfigSunStyleChecks() {
         return getCheckStyleChecksReferencedInConfig("src/main/resources/sun_checks.xml");
     }
 
-    public static Set<String> getConfigGoogleStyleChecks() throws Exception {
+    public static Set<String> getConfigGoogleStyleChecks() {
         return getCheckStyleChecksReferencedInConfig("src/main/resources/google_checks.xml");
     }
 
@@ -64,49 +62,49 @@ public final class CheckUtil {
      * @param configFilePath
      *            file path of checkstyle_checks.xml.
      * @return names of checkstyle's checks which are referenced in checkstyle_checks.xml.
-     * @throws ParserConfigurationException if a DocumentBuilder cannot be created which satisfies
-     *              the configuration requested.
-     * @throws IOException if any IO errors occur.
-     * @throws SAXException if any parse errors occur.
      */
-    private static Set<String> getCheckStyleChecksReferencedInConfig(
-            String configFilePath) throws Exception {
-        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    private static Set<String> getCheckStyleChecksReferencedInConfig(String configFilePath) {
+        try {
+            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
-        // Validations of XML file make parsing too slow, that is why we disable all
-        // validations.
-        factory.setNamespaceAware(false);
-        factory.setValidating(false);
-        factory.setFeature("http://xml.org/sax/features/namespaces", false);
-        factory.setFeature("http://xml.org/sax/features/validation", false);
-        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar",
-                false);
-        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd",
-                false);
+            // Validations of XML file make parsing too slow, that is why we
+            // disable all validations.
+            factory.setNamespaceAware(false);
+            factory.setValidating(false);
+            factory.setFeature("http://xml.org/sax/features/namespaces", false);
+            factory.setFeature("http://xml.org/sax/features/validation", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar",
+                    false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd",
+                    false);
 
-        final DocumentBuilder builder = factory.newDocumentBuilder();
-        final Document document = builder.parse(new File(configFilePath));
+            final DocumentBuilder builder = factory.newDocumentBuilder();
+            final Document document = builder.parse(new File(configFilePath));
 
-        // optional, but recommended
-        // FYI:
-        // http://stackoverflow.com/questions/13786607/normalization-in-dom-parsing-with-java-how-
-        // does-it-work
-        document.getDocumentElement().normalize();
+            // optional, but recommended
+            // FYI:
+            // http://stackoverflow.com/questions/13786607/normalization-in-dom-parsing-with-java-
+            // how-does-it-work
+            document.getDocumentElement().normalize();
 
-        final NodeList nodeList = document.getElementsByTagName("module");
+            final NodeList nodeList = document.getElementsByTagName("module");
 
-        final Set<String> checksReferencedInCheckstyleChecksXml = new HashSet<>();
-        for (int i = 0; i < nodeList.getLength(); i++) {
-            final Node currentNode = nodeList.item(i);
-            if (currentNode.getNodeType() == Node.ELEMENT_NODE) {
-                final Element module = (Element) currentNode;
-                final String checkName = module.getAttribute("name");
-                if (!"Checker".equals(checkName) && !"TreeWalker".equals(checkName)) {
-                    checksReferencedInCheckstyleChecksXml.add(checkName);
+            final Set<String> checksReferencedInCheckstyleChecksXml = new HashSet<>();
+            for (int i = 0; i < nodeList.getLength(); i++) {
+                final Node currentNode = nodeList.item(i);
+                if (currentNode.getNodeType() == Node.ELEMENT_NODE) {
+                    final Element module = (Element) currentNode;
+                    final String checkName = module.getAttribute("name");
+                    if (!"Checker".equals(checkName) && !"TreeWalker".equals(checkName)) {
+                        checksReferencedInCheckstyleChecksXml.add(checkName);
+                    }
                 }
             }
+            return checksReferencedInCheckstyleChecksXml;
         }
-        return checksReferencedInCheckstyleChecksXml;
+        catch (Exception exception) {
+            throw new IllegalStateException(exception);
+        }
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
@@ -47,6 +47,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
@@ -113,6 +114,11 @@ public class XDocsPagesTest {
             "SuppressWithNearbyCommentFilter.fileContents",
             "SuppressionCommentFilter.fileContents"
     );
+
+    private static final Set<String> SUN_CHECKS = ImmutableSet.copyOf(CheckUtil
+            .getConfigSunStyleChecks());
+    private static final Set<String> GOOGLE_CHECKS = ImmutableSet.copyOf(CheckUtil
+            .getConfigGoogleStyleChecks());
 
     @Test
     public void testAllChecksPresentOnAvailableChecksPage() throws IOException {
@@ -496,12 +502,20 @@ public class XDocsPagesTest {
                         + "path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+"
                         + "repo%3Acheckstyle%2Fcheckstyle+"
                         + sectionName;
+
+                Assert.assertTrue(fileName + " section '" + sectionName
+                        + "' should be in google_checks.xml or not reference 'Google Style'",
+                        GOOGLE_CHECKS.contains(sectionName));
             }
             else if ("Sun Style".equals(linkText)) {
                 expectedUrl = "https://github.com/search?q="
                         + "path%3Asrc%2Fmain%2Fresources+filename%3Asun_checks.xml+"
                         + "repo%3Acheckstyle%2Fcheckstyle+"
                         + sectionName;
+
+                Assert.assertTrue(fileName + " section '" + sectionName
+                        + "' should be in sun_checks.xml or not reference 'Sun Style'",
+                        SUN_CHECKS.contains(sectionName));
             }
 
             Assert.assertEquals(fileName + " section '" + sectionName


### PR DESCRIPTION
Requested by mkordas from #2616.

If a xdoc specifies google/sun, then it must appear in the google/sun configuration file.

I'm not happy about the new suppression, but I didn't want to pass the new list around as a parameter or recreate it ever new file/section.

`getCheckStyleChecksReferencedInConfig` throws was changed because of the requirements of ThrowsCountCheck on the method being changed to public.

I plan to make a new issue to re-organize the internal tests.