### PR TITLE
minor: fixed indentation documentation and method names

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
@@ -42,7 +42,7 @@ public class ArrayInitHandler extends BlockParentHandler {
     }
 
     @Override
-    protected IndentLevel getLevelImpl() {
+    protected IndentLevel getIndentImpl() {
         final DetailAST parentAST = getMainAst().getParent();
         final int type = parentAST.getType();
         if (type == TokenTypes.LITERAL_NEW || type == TokenTypes.ASSIGN) {
@@ -51,7 +51,7 @@ public class ArrayInitHandler extends BlockParentHandler {
         }
         else {
             // at this point getParent() is instance of BlockParentHandler
-            return ((BlockParentHandler) getParent()).getChildrenExpectedLevel();
+            return ((BlockParentHandler) getParent()).getChildrenExpectedIndent();
         }
     }
 
@@ -66,8 +66,8 @@ public class ArrayInitHandler extends BlockParentHandler {
     }
 
     @Override
-    protected IndentLevel curlyLevel() {
-        final IndentLevel level = new IndentLevel(getLevel(), getBraceAdjustment());
+    protected IndentLevel curlyIndent() {
+        final IndentLevel level = new IndentLevel(getIndent(), getBraceAdjustment());
         level.addAcceptedIndent(level.getLastIndentLevel() + getLineWrappingIndentation());
         return level;
     }
@@ -93,9 +93,9 @@ public class ArrayInitHandler extends BlockParentHandler {
     }
 
     @Override
-    protected IndentLevel getChildrenExpectedLevel() {
+    protected IndentLevel getChildrenExpectedIndent() {
         final IndentLevel expectedIndent =
-            new IndentLevel(getLevel(), getIndentCheck().getArrayInitIndent(),
+            new IndentLevel(getIndent(), getIndentCheck().getArrayInitIndent(),
                     getIndentCheck().getLineWrappingIndentation());
 
         final int firstLine = getFirstLine(Integer.MAX_VALUE, getListChild());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -93,7 +93,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
         final DetailAST topLevel = getTopLevelAst();
 
         if (topLevel == null
-            || getLevel().isAcceptable(expandedTabsColumnNo(topLevel)) || hasLabelBefore()) {
+            || getIndent().isAcceptable(expandedTabsColumnNo(topLevel)) || hasLabelBefore()) {
             return;
         }
         if (!shouldTopLevelStartLine() && !isOnStartOfLine(topLevel)) {
@@ -158,7 +158,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
         final DetailAST lcurly = getLCurly();
         final int lcurlyPos = expandedTabsColumnNo(lcurly);
 
-        if (curlyLevel().isAcceptable(lcurlyPos) || !isOnStartOfLine(lcurly)) {
+        if (curlyIndent().isAcceptable(lcurlyPos) || !isOnStartOfLine(lcurly)) {
             return;
         }
 
@@ -170,8 +170,8 @@ public class BlockParentHandler extends AbstractExpressionHandler {
      *
      * @return the curly brace indentation level
      */
-    protected IndentLevel curlyLevel() {
-        return new IndentLevel(getLevel(), getBraceAdjustment());
+    protected IndentLevel curlyIndent() {
+        return new IndentLevel(getIndent(), getBraceAdjustment());
     }
 
     /**
@@ -202,12 +202,12 @@ public class BlockParentHandler extends AbstractExpressionHandler {
         final DetailAST rcurly = getRCurly();
         final int rcurlyPos = expandedTabsColumnNo(rcurly);
 
-        if (curlyLevel().isAcceptable(rcurlyPos)
+        if (curlyIndent().isAcceptable(rcurlyPos)
             || !shouldStartWithRCurly() && !isOnStartOfLine(rcurly)
             || areOnSameLine(rcurly, lcurly)) {
             return;
         }
-        logError(rcurly, "rcurly", rcurlyPos, curlyLevel());
+        logError(rcurly, "rcurly", rcurlyPos, curlyIndent());
     }
 
     /**
@@ -228,7 +228,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
             return;
         }
 
-        final IndentLevel expected = new IndentLevel(getLevel(), getBasicOffset());
+        final IndentLevel expected = new IndentLevel(getIndent(), getBasicOffset());
         checkExpressionSubtree(nonList, expected, false, false);
     }
 
@@ -278,7 +278,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
             if (!hasCurlies() || !areOnSameLine(getLCurly(), getRCurly())) {
                 checkChildren(listChild,
                         getCheckedChildren(),
-                        getChildrenExpectedLevel(),
+                        getChildrenExpectedIndent(),
                         true,
                         canChildrenBeNested());
             }
@@ -289,17 +289,17 @@ public class BlockParentHandler extends AbstractExpressionHandler {
      * Gets indentation level expected for children.
      * @return indentation level expected for children
      */
-    protected IndentLevel getChildrenExpectedLevel() {
-        IndentLevel indentLevel = new IndentLevel(getLevel(), getBasicOffset());
+    protected IndentLevel getChildrenExpectedIndent() {
+        IndentLevel indentLevel = new IndentLevel(getIndent(), getBasicOffset());
         // if we have multileveled expected level then we should
         // try to suggest single level to children using curlies'
         // levels.
-        if (getLevel().isMultiLevel() && hasCurlies()) {
+        if (getIndent().isMultiLevel() && hasCurlies()) {
             if (isOnStartOfLine(getLCurly())) {
                 indentLevel = new IndentLevel(expandedTabsColumnNo(getLCurly()) + getBasicOffset());
             }
             else if (isOnStartOfLine(getRCurly())) {
-                final IndentLevel level = new IndentLevel(curlyLevel(), getBasicOffset());
+                final IndentLevel level = new IndentLevel(curlyIndent(), getBasicOffset());
                 level.addAcceptedIndent(level.getFirstIndentLevel() + getLineWrappingIndent());
                 indentLevel = level;
             }
@@ -308,8 +308,8 @@ public class BlockParentHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
-        return getChildrenExpectedLevel();
+    public IndentLevel getSuggestedChildIndent(AbstractExpressionHandler child) {
+        return getChildrenExpectedIndent();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CaseHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CaseHandler.java
@@ -50,8 +50,8 @@ public class CaseHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    protected IndentLevel getLevelImpl() {
-        return new IndentLevel(getParent().getLevel(),
+    protected IndentLevel getIndentImpl() {
+        return new IndentLevel(getParent().getIndent(),
                                getIndentCheck().getCaseIndent());
     }
 
@@ -59,12 +59,12 @@ public class CaseHandler extends AbstractExpressionHandler {
      * Check the indentation of the case statement.
      */
     private void checkCase() {
-        checkChildren(getMainAst(), CASE_CHILDREN, getLevel(), true, false);
+        checkChildren(getMainAst(), CASE_CHILDREN, getIndent(), true, false);
     }
 
     @Override
-    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
-        return getLevel();
+    public IndentLevel getSuggestedChildIndent(AbstractExpressionHandler child) {
+        return getIndent();
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CatchHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CatchHandler.java
@@ -52,7 +52,7 @@ public class CatchHandler extends BlockParentHandler {
     private void checkCondExpr() {
         final DetailAST condAst = getMainAst().findFirstToken(TokenTypes.LPAREN)
             .getNextSibling();
-        checkExpressionSubtree(condAst, getLevel(), false, false);
+        checkExpressionSubtree(condAst, getIndent(), false, false);
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java
@@ -71,7 +71,7 @@ public class ClassDefHandler extends BlockParentHandler {
         if (modifiers.getChildCount() == 0) {
             final DetailAST ident = getMainAst().findFirstToken(TokenTypes.IDENT);
             final int lineStart = getLineStart(ident);
-            if (!getLevel().isAcceptable(lineStart)) {
+            if (!getIndent().isAcceptable(lineStart)) {
                 logError(ident, "ident", lineStart);
             }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/DoWhileHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/DoWhileHandler.java
@@ -47,7 +47,7 @@ public class DoWhileHandler extends BlockParentHandler {
     private void checkCondExpr() {
         final DetailAST condAst = getMainAst()
             .findFirstToken(TokenTypes.LPAREN).getNextSibling();
-        checkExpressionSubtree(condAst, getLevel(), false, false);
+        checkExpressionSubtree(condAst, getIndent(), false, false);
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ForHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ForHandler.java
@@ -46,7 +46,7 @@ public class ForHandler extends BlockParentHandler {
      */
     private void checkForParams() {
         final IndentLevel expected =
-            new IndentLevel(getLevel(), getBasicOffset());
+            new IndentLevel(getIndent(), getBasicOffset());
         final DetailAST init = getMainAst().findFirstToken(TokenTypes.FOR_INIT);
 
         if (init == null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IfHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IfHandler.java
@@ -42,19 +42,19 @@ public class IfHandler extends BlockParentHandler {
     }
 
     @Override
-    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildIndent(AbstractExpressionHandler child) {
         if (child instanceof ElseHandler) {
-            return getLevel();
+            return getIndent();
         }
-        return super.getSuggestedChildLevel(child);
+        return super.getSuggestedChildIndent(child);
     }
 
     @Override
-    protected IndentLevel getLevelImpl() {
+    protected IndentLevel getIndentImpl() {
         if (isIfAfterElse()) {
-            return getParent().getLevel();
+            return getParent().getIndent();
         }
-        return super.getLevelImpl();
+        return super.getIndentImpl();
     }
 
     /**
@@ -86,7 +86,7 @@ public class IfHandler extends BlockParentHandler {
         final DetailAST condAst = getMainAst().findFirstToken(TokenTypes.LPAREN)
             .getNextSibling();
         final IndentLevel expected =
-            new IndentLevel(getLevel(), getBasicOffset());
+            new IndentLevel(getIndent(), getBasicOffset());
         checkExpressionSubtree(condAst, expected, false, false);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ImportHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ImportHandler.java
@@ -48,7 +48,7 @@ public class ImportHandler extends AbstractExpressionHandler {
         final int lineEnd = semi.getLineNo();
 
         if (getMainAst().getLineNo() != lineEnd) {
-            checkLinesIndent(lineStart, lineEnd, getLevel());
+            checkLinesIndent(lineStart, lineEnd, getIndent());
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
@@ -66,7 +66,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
  *   - suggest child indent level
  *   - allows for some tokens to be on same line (ie inner classes OBJBLOCK)
  *     and not increase indentation level
- *   - looked at using double dispatch for getSuggestedChildLevel(), but it
+ *   - looked at using double dispatch for getSuggestedChildIndent(), but it
  *     doesn't seem worthwhile, at least now
  *   - both tabs and spaces are considered whitespace in front of the line...
  *     tabs are converted to spaces

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LabelHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LabelHandler.java
@@ -49,9 +49,9 @@ public class LabelHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    protected IndentLevel getLevelImpl() {
-        final IndentLevel level = new IndentLevel(super.getLevelImpl(), -getBasicOffset());
-        level.addAcceptedIndent(super.getLevelImpl());
+    protected IndentLevel getIndentImpl() {
+        final IndentLevel level = new IndentLevel(super.getIndentImpl(), -getBasicOffset());
+        level.addAcceptedIndent(super.getIndentImpl());
         return level;
     }
 
@@ -59,7 +59,7 @@ public class LabelHandler extends AbstractExpressionHandler {
      * Check the indentation of the label.
      */
     private void checkLabel() {
-        checkChildren(getMainAst(), LABEL_CHILDREN, getLevel(), true, false);
+        checkChildren(getMainAst(), LABEL_CHILDREN, getIndent(), true, false);
     }
 
     @Override
@@ -69,7 +69,7 @@ public class LabelHandler extends AbstractExpressionHandler {
         final DetailAST parent = getMainAst().getFirstChild().getNextSibling();
 
         final IndentLevel expected =
-            new IndentLevel(getLevel(), getBasicOffset());
+            new IndentLevel(getIndent(), getBasicOffset());
 
         checkExpressionSubtree(parent, expected, true, false);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LambdaHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LambdaHandler.java
@@ -41,14 +41,14 @@ public class LambdaHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
-        return getLevel();
+    public IndentLevel getSuggestedChildIndent(AbstractExpressionHandler child) {
+        return getIndent();
     }
 
     @Override
-    protected IndentLevel getLevelImpl() {
+    protected IndentLevel getIndentImpl() {
         if (getParent() instanceof MethodCallHandler) {
-            return getParent().getSuggestedChildLevel(this);
+            return getParent().getSuggestedChildIndent(this);
         }
 
         DetailAST parent = getMainAst().getParent();
@@ -74,7 +74,7 @@ public class LambdaHandler extends AbstractExpressionHandler {
         // If the argument list is the first element on the line
         final DetailAST firstChild = getMainAst().getFirstChild();
         if (getLineStart(firstChild) == firstChild.getColumnNo()) {
-            final IndentLevel level = getLevel();
+            final IndentLevel level = getIndent();
             if (!level.isAcceptable(firstChild.getColumnNo())) {
                 logError(firstChild, "arguments", firstChild.getColumnNo(), level);
             }
@@ -83,7 +83,7 @@ public class LambdaHandler extends AbstractExpressionHandler {
         // If the "->" is the first element on the line, assume line wrapping.
         if (getLineStart(getMainAst()) == getMainAst().getColumnNo()) {
             final IndentLevel level =
-                new IndentLevel(getLevel(), getIndentCheck().getLineWrappingIndentation());
+                new IndentLevel(getIndent(), getIndentCheck().getLineWrappingIndentation());
             if (!level.isAcceptable(getMainAst().getColumnNo())) {
                 logError(getMainAst(), "", getMainAst().getColumnNo(), level);
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
@@ -59,15 +59,15 @@ public class MemberDefHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
-        return getLevel();
+    public IndentLevel getSuggestedChildIndent(AbstractExpressionHandler child) {
+        return getIndent();
     }
 
     @Override
     protected void checkModifiers() {
         final DetailAST modifier = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
         if (isOnStartOfLine(modifier)
-            && !getLevel().isAcceptable(expandedTabsColumnNo(modifier))) {
+            && !getIndent().isAcceptable(expandedTabsColumnNo(modifier))) {
             logError(modifier, "modifier", expandedTabsColumnNo(modifier));
         }
     }
@@ -79,7 +79,7 @@ public class MemberDefHandler extends AbstractExpressionHandler {
         final DetailAST type = getMainAst().findFirstToken(TokenTypes.TYPE);
         final DetailAST ident = AbstractExpressionHandler.getFirstToken(type);
         final int columnNo = expandedTabsColumnNo(ident);
-        if (isOnStartOfLine(ident) && !getLevel().isAcceptable(columnNo)) {
+        if (isOnStartOfLine(ident) && !getIndent().isAcceptable(columnNo)) {
             logError(ident, "type", columnNo);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -42,7 +42,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    protected IndentLevel getLevelImpl() {
+    protected IndentLevel getIndentImpl() {
         IndentLevel indentLevel;
         // if inside a method call's params, this could be part of
         // an expression, so get the previous line's start
@@ -51,12 +51,12 @@ public class MethodCallHandler extends AbstractExpressionHandler {
                     (MethodCallHandler) getParent();
             if (areOnSameLine(container.getMainAst(), getMainAst())
                     || isChainedMethodCallWrapped()) {
-                indentLevel = container.getLevel();
+                indentLevel = container.getIndent();
             }
             // we should increase indentation only if this is the first
             // chained method call which was moved to the next line
             else {
-                indentLevel = new IndentLevel(container.getLevel(), getBasicOffset());
+                indentLevel = new IndentLevel(container.getIndent(), getBasicOffset());
             }
         }
         else {
@@ -67,7 +67,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
             final int firstCol = lines.firstLineCol();
             final int lineStart = getLineStart(getFirstAst(getMainAst()));
             if (lineStart == firstCol) {
-                indentLevel = super.getLevelImpl();
+                indentLevel = super.getIndentImpl();
             }
             else {
                 indentLevel = new IndentLevel(lineStart);
@@ -116,7 +116,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildIndent(AbstractExpressionHandler child) {
         // for whatever reason a method that crosses lines, like asList
         // here:
         //            System.out.println("methods are: " + Arrays.asList(
@@ -137,7 +137,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
         final DetailAST rparen = getMainAst().findFirstToken(TokenTypes.RPAREN);
         if (getLineStart(rparen) == rparen.getColumnNo()) {
             suggestedLevel.addAcceptedIndent(new IndentLevel(
-                    getParent().getSuggestedChildLevel(this),
+                    getParent().getSuggestedChildIndent(this),
                     getIndentCheck().getLineWrappingIndentation()
             ));
         }
@@ -152,7 +152,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
             return;
         }
         final DetailAST methodName = getMainAst().getFirstChild();
-        checkExpressionSubtree(methodName, getLevel(), false, false);
+        checkExpressionSubtree(methodName, getIndent(), false, false);
 
         final DetailAST lparen = getMainAst();
         final DetailAST rparen = getMainAst().findFirstToken(TokenTypes.RPAREN);
@@ -164,7 +164,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
 
         checkExpressionSubtree(
             getMainAst().findFirstToken(TokenTypes.ELIST),
-            new IndentLevel(getLevel(), getBasicOffset()),
+            new IndentLevel(getIndent(), getBasicOffset()),
             false, true);
 
         checkRParen(lparen, rparen);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
@@ -52,7 +52,7 @@ public class MethodDefHandler extends BlockParentHandler {
     protected void checkModifiers() {
         final DetailAST modifier = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
         if (isOnStartOfLine(modifier)
-            && !getLevel().isAcceptable(expandedTabsColumnNo(modifier))) {
+            && !getIndent().isAcceptable(expandedTabsColumnNo(modifier))) {
             logError(modifier, "modifier", expandedTabsColumnNo(modifier));
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
@@ -46,7 +46,7 @@ public class NewHandler extends AbstractExpressionHandler {
     public void checkIndentation() {
         final DetailAST type = getMainAst().getFirstChild();
         if (type != null) {
-            checkExpressionSubtree(type, getLevel(), false, false);
+            checkExpressionSubtree(type, getIndent(), false, false);
         }
 
         final DetailAST lparen = getMainAst().findFirstToken(TokenTypes.LPAREN);
@@ -54,13 +54,13 @@ public class NewHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    protected IndentLevel getLevelImpl() {
+    protected IndentLevel getIndentImpl() {
         // if our expression isn't first on the line, just use the start
         // of the line
         if (getLineStart(getMainAst()) != getMainAst().getColumnNo()) {
             return new IndentLevel(getLineStart(getMainAst()));
         }
-        return super.getLevelImpl();
+        return super.getIndentImpl();
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
@@ -62,14 +62,14 @@ public class ObjectBlockHandler extends BlockParentHandler {
     }
 
     @Override
-    protected IndentLevel getLevelImpl() {
+    protected IndentLevel getIndentImpl() {
         final DetailAST parentAST = getMainAst().getParent();
-        IndentLevel indent = getParent().getLevel();
+        IndentLevel indent = getParent().getIndent();
         if (parentAST.getType() == TokenTypes.LITERAL_NEW) {
-            indent.addAcceptedIndent(super.getLevelImpl());
+            indent.addAcceptedIndent(super.getIndentImpl());
         }
         else if (parentAST.getType() == TokenTypes.ENUM_CONSTANT_DEF) {
-            indent = super.getLevelImpl();
+            indent = super.getIndentImpl();
         }
         return indent;
     }
@@ -92,11 +92,11 @@ public class ObjectBlockHandler extends BlockParentHandler {
     protected void checkRCurly() {
         final DetailAST rcurly = getRCurly();
         final int rcurlyPos = expandedTabsColumnNo(rcurly);
-        final IndentLevel level = curlyLevel();
+        final IndentLevel level = curlyIndent();
         level.addAcceptedIndent(level.getFirstIndentLevel() + getLineWrappingIndentation());
 
         if (!level.isAcceptable(rcurlyPos) && isOnStartOfLine(rcurly)) {
-            logError(rcurly, "rcurly", rcurlyPos, curlyLevel());
+            logError(rcurly, "rcurly", rcurlyPos, curlyIndent());
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/PackageDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/PackageDefHandler.java
@@ -44,12 +44,12 @@ public class PackageDefHandler extends AbstractExpressionHandler {
     @Override
     public void checkIndentation() {
         final int columnNo = expandedTabsColumnNo(getMainAst());
-        if (!getLevel().isAcceptable(columnNo)) {
+        if (!getIndent().isAcceptable(columnNo)) {
             logError(getMainAst(), "", columnNo);
         }
 
         checkLinesIndent(getMainAst().getLineNo(),
             getMainAst().findFirstToken(TokenTypes.SEMI).getLineNo(),
-            getLevel());
+            getIndent());
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/PrimordialHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/PrimordialHandler.java
@@ -40,12 +40,12 @@ public class PrimordialHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildIndent(AbstractExpressionHandler child) {
         return new IndentLevel(0);
     }
 
     @Override
-    protected IndentLevel getLevelImpl() {
+    protected IndentLevel getIndentImpl() {
         return new IndentLevel(0);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
@@ -68,7 +68,7 @@ public class SlistHandler extends BlockParentHandler {
     }
 
     @Override
-    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildIndent(AbstractExpressionHandler child) {
         // this is:
         //  switch (var) {
         //     case 3: {
@@ -83,9 +83,9 @@ public class SlistHandler extends BlockParentHandler {
                 && !(getParent() instanceof SlistHandler)
             || getParent() instanceof CaseHandler
                 && child instanceof SlistHandler) {
-            return getParent().getSuggestedChildLevel(child);
+            return getParent().getSuggestedChildIndent(child);
         }
-        return super.getSuggestedChildLevel(child);
+        return super.getSuggestedChildIndent(child);
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SwitchHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SwitchHandler.java
@@ -71,7 +71,7 @@ public class SwitchHandler extends BlockParentHandler {
     private void checkSwitchExpr() {
         checkExpressionSubtree(
             getMainAst().findFirstToken(TokenTypes.LPAREN).getNextSibling(),
-            getLevel(),
+            getIndent(),
             false,
             false);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SynchronizedHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SynchronizedHandler.java
@@ -67,7 +67,7 @@ public class SynchronizedHandler extends BlockParentHandler {
         final DetailAST syncAst = getMainAst().findFirstToken(TokenTypes.LPAREN)
                 .getNextSibling();
         final IndentLevel expected =
-                new IndentLevel(getLevel(), getBasicOffset());
+                new IndentLevel(getIndent(), getBasicOffset());
         checkExpressionSubtree(syncAst, expected, false, false);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler.java
@@ -41,11 +41,11 @@ public class TryHandler extends BlockParentHandler {
     }
 
     @Override
-    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildIndent(AbstractExpressionHandler child) {
         if (child instanceof CatchHandler
             || child instanceof FinallyHandler) {
-            return getLevel();
+            return getIndent();
         }
-        return super.getSuggestedChildLevel(child);
+        return super.getSuggestedChildIndent(child);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/WhileHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/WhileHandler.java
@@ -47,7 +47,7 @@ public class WhileHandler extends BlockParentHandler {
     private void checkCondExpr() {
         final DetailAST condAst = getMainAst().findFirstToken(TokenTypes.EXPR);
         final IndentLevel expected =
-            new IndentLevel(getLevel(), getBasicOffset());
+            new IndentLevel(getIndent(), getBasicOffset());
         checkExpressionSubtree(condAst, expected, false, false);
     }
 


### PR DESCRIPTION
Fixed method names so they are more understandable and reflect what the method does. All these changes are contained to `AbstractExpressionHandler` and `LineWrappingHandler` and `BlockParentHandler`.
Improving javadocs of all indentation classes so it may be easier to others to follow what is going on.

**Actual Logic Changes:**
`AbstractExpressionHandler.findSubtreeLines` (now called `addAllSubtreeLines`) had a parameter `allowNesting` but its only use was to send to itself. The method is final, so no one can override the method and make use of the parameter, so I removed it.