### PR TITLE
minor: fixed improper put that should be get

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -104,7 +104,7 @@ public final class DefaultConfiguration implements Configuration {
      * @param value the value of the attribute.
      */
     public void addAttribute(String attributeName, String value) {
-        final String current = attributeMap.put(attributeName, value);
+        final String current = attributeMap.get(attributeName);
         if (current == null) {
             attributeMap.put(attributeName, value);
         }


### PR DESCRIPTION
This line should be a 'get' because regardless of the contents of `current` the next statements will do another put, replacing the original put contents. This is similar to assigning a value to a variable, and then re-assigning the same variable with the same or similar value.