### PR TITLE
Issue #2080: Fix or suppress ErrorRethrown rule violations

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -616,7 +616,7 @@
     <inspection_tool class="EqualsUsesNonFinalVariable" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="EqualsWhichDoesntCheckParameterClass" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="EqualsWithItself" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ErrorRethrown" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="ErrorRethrown" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="Eslint" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ExceptionCaughtLocallyJS" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ExceptionFromCatchWhichDoesntWrap" enabled="true" level="WARNING" enabled_by_default="true">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -131,7 +131,7 @@ class PackageObjectFactory implements ModuleFactory {
             declaredConstructor.setAccessible(true);
             return declaredConstructor.newInstance();
         }
-        catch (final ReflectiveOperationException | NoClassDefFoundError exception) {
+        catch (final ReflectiveOperationException exception) {
             throw new CheckstyleException("Unable to find class for " + className, exception);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
@@ -89,7 +89,11 @@ class MultilineDetector {
         }
     }
 
-    /** Method that finds the matches. */
+    /**
+     * Method that finds the matches.
+     *
+     * @noinspection ErrorRethrown
+     */
     private void findMatch() {
         try {
             boolean foundMatch = matcher.find();


### PR DESCRIPTION
Rule description:
> Reports try statements which catch java.lang.Error or any subclass and which do not rethrow the error. Statements which catch java.lang.ThreadDeath are not reported by this inspection.

This PR connects to #2080.