### PR TITLE
Issue #2080: Replace dangling Javadoc with plain comment

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -480,7 +480,7 @@
     <inspection_tool class="CyclomaticComplexityJS" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="m_limit" value="10" />
     </inspection_tool>
-    <inspection_tool class="DanglingJavadoc" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="DanglingJavadoc" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="DataProviderReturnType" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DateToString" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="DebuggerStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CommitValidationTest.java
@@ -124,10 +124,10 @@ public class CommitValidationTest {
             final String commitMessage = commit.getFullMessage();
             final Matcher matcher = NEWLINE_PATTERN.matcher(commitMessage);
             if (matcher.find()) {
-                /**
-                 * Git by default put newline character at the end of commit message. To check
-                 * if commit message has a single line we have to make sure that the only
-                 * newline character found is in the end of commit message.
+                /*
+                  Git by default put newline character at the end of commit message. To check
+                  if commit message has a single line we have to make sure that the only
+                  newline character found is in the end of commit message.
                  */
                 final boolean isFoundNewLineCharacterAtTheEndOfMessage =
                         matcher.end() == commitMessage.length();


### PR DESCRIPTION
Fixes DanglingJavadoc rule violations.

Description:
>Reports dangling Javadoc comments. Javadoc comment are dangling if they don't belong to any class, method or field. For example a Javadoc comment in between method declarations that have their own javadoc comments.

This PR relates to #2080.