### PR TITLE
Fix 'tokens' property in JavadocStyle check

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -26,6 +26,8 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import com.google.common.collect.ImmutableSortedSet;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -117,22 +119,22 @@ public class JavadocStyleCheck
     @Override
     public int[] getAcceptableTokens() {
         return new int[] {
-            TokenTypes.INTERFACE_DEF,
-            TokenTypes.CLASS_DEF,
             TokenTypes.ANNOTATION_DEF,
-            TokenTypes.ENUM_DEF,
-            TokenTypes.METHOD_DEF,
-            TokenTypes.CTOR_DEF,
-            TokenTypes.VARIABLE_DEF,
-            TokenTypes.ENUM_CONSTANT_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.METHOD_DEF,
             TokenTypes.PACKAGE_DEF,
+            TokenTypes.VARIABLE_DEF,
         };
     }
 
     @Override
     public int[] getRequiredTokens() {
-        return getAcceptableTokens();
+        return ArrayUtils.EMPTY_INT_ARRAY;
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -46,40 +46,21 @@ public class JavadocStyleCheckTest
     }
 
     @Test
-    public void testGetRequiredTokens() {
-        final JavadocStyleCheck javadocStyleCheck = new JavadocStyleCheck();
-        final int[] actual = javadocStyleCheck.getRequiredTokens();
-        final int[] expected = {
-            TokenTypes.INTERFACE_DEF,
-            TokenTypes.CLASS_DEF,
-            TokenTypes.ANNOTATION_DEF,
-            TokenTypes.ENUM_DEF,
-            TokenTypes.METHOD_DEF,
-            TokenTypes.CTOR_DEF,
-            TokenTypes.VARIABLE_DEF,
-            TokenTypes.ENUM_CONSTANT_DEF,
-            TokenTypes.ANNOTATION_FIELD_DEF,
-            TokenTypes.PACKAGE_DEF,
-        };
-        assertArrayEquals(expected, actual);
-    }
-
-    @Test
     public void testGetAcceptableTokens() {
         final JavadocStyleCheck javadocStyleCheck = new JavadocStyleCheck();
 
         final int[] actual = javadocStyleCheck.getAcceptableTokens();
         final int[] expected = {
-            TokenTypes.INTERFACE_DEF,
-            TokenTypes.CLASS_DEF,
             TokenTypes.ANNOTATION_DEF,
-            TokenTypes.ENUM_DEF,
-            TokenTypes.METHOD_DEF,
-            TokenTypes.CTOR_DEF,
-            TokenTypes.VARIABLE_DEF,
-            TokenTypes.ENUM_CONSTANT_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.METHOD_DEF,
             TokenTypes.PACKAGE_DEF,
+            TokenTypes.VARIABLE_DEF,
         };
 
         assertArrayEquals(expected, actual);
@@ -403,5 +384,21 @@ public class JavadocStyleCheckTest
         verify(createChecker(checkConfig),
                getPath("pkginfo" + File.separator + "valid" + File.separator + "package-info.java"),
                expected);
+    }
+
+    @Test
+    public void testRestrictedTokenSet()
+        throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(JavadocStyleCheck.class);
+        checkConfig.addAttribute("tokens", "METHOD_DEF");
+        checkConfig.addAttribute("scope", "public");
+        checkConfig.addAttribute("checkFirstSentence", "true");
+        checkConfig.addAttribute("checkEmptyJavadoc", "false");
+        checkConfig.addAttribute("checkHtml", "false");
+        final String[] expected = {
+            "88: " + getCheckMessage(NO_PERIOD),
+            "386: " + getCheckMessage(NO_PERIOD),
+        };
+        verify(checkConfig, getPath("InputJavadocStyle.java"), expected);
     }
 }

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -686,6 +686,34 @@ public boolean isSomething()
             <td><a href="property_types.html#boolean">boolean</a></td>
             <td><code>true</code></td>
           </tr>
+          <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+            <td>subset of tokens
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">ANNOTATION_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">ANNOTATION_FIELD_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">PACKAGE_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
+            </td>
+            <td>
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">ANNOTATION_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">ANNOTATION_FIELD_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">PACKAGE_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
+            </td>
+          </tr>
         </table>
       </subsection>
 


### PR DESCRIPTION
This is a fix for a problem introduced with Checkstyle 6.10 with commit [#d56a2a3](https://github.com/checkstyle/checkstyle/commit/d56a2a366c6f9e3e8639d492d548ae562b75dc81#diff-6dbb31589372edafae8e79665300f05a), which prevents the *JavadocStyle* check from correctly evaluating the `tokens` property. Since `getRequiredTokens()` was set to return the result of `getAcceptableTokens()`, the `tokens` property was effectively disabled.

For example, the following configuration, which checks end-of-sentence format exclusively on methods, is no longer possible:

```xml
<module name="JavadocStyle">
  <property name="severity" value="info"/>
  <property name="tokens" value="METHOD_DEF"/>
  <property name="scope" value="public"/>
  <property name="checkFirstSentence" value="true"/>
  <property name="checkEmptyJavadoc" value="false"/>
  <property name="checkHtml" value="false"/>
</module>
```
This PR restores the pre-6.10 behavior of configurable tokens and adds a test case for the above configuration.