### PR TITLE
Issue #2640: Change abbreviationAsWordInName error message to contain…

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
@@ -43,18 +43,17 @@ public class AbbreviationAsWordInNameTest extends BaseCheckTestSupport {
     public void abbreviationAsWordInNameTest() throws Exception {
 
         final int maxCapitalCount = 1;
-        final String msg = getCheckMessage(clazz, MSG_KEY, maxCapitalCount);
 
         final String[] expected = {
-            "50: " + msg,
-            "52: " + msg,
-            "54: " + msg,
-            "58: " + msg,
-            "60: " + msg,
-            "62: " + msg,
-            "67: " + msg,
-            "69: " + msg,
-            "71: " + msg,
+            "50: " + getWarningMessage("newCustomerID", maxCapitalCount),
+            "52: " + getWarningMessage("supportsIPv6OnIOS", maxCapitalCount),
+            "54: " + getWarningMessage("XMLHTTPRequest", maxCapitalCount),
+            "58: " + getWarningMessage("newCustomerID", maxCapitalCount),
+            "60: " + getWarningMessage("supportsIPv6OnIOS", maxCapitalCount),
+            "62: " + getWarningMessage("XMLHTTPRequest", maxCapitalCount),
+            "67: " + getWarningMessage("newCustomerID", maxCapitalCount),
+            "69: " + getWarningMessage("supportsIPv6OnIOS", maxCapitalCount),
+            "71: " + getWarningMessage("XMLHTTPRequest", maxCapitalCount),
         };
 
         final String filePath = getPath("InputAbbreviationAsWordInTypeNameCheck.java");
@@ -62,5 +61,9 @@ public class AbbreviationAsWordInNameTest extends BaseCheckTestSupport {
         final Configuration checkConfig = getCheckConfig("AbbreviationAsWordInName");
         final Integer[] warnList = getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
+    }
+
+    private String getWarningMessage(String typeName, int expectedCapitalCount) {
+        return getCheckMessage(clazz, MSG_KEY, typeName, expectedCapitalCount);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -208,7 +208,7 @@ public class AbbreviationAsWordInNameCheck extends Check {
 
             final String abbr = getDisallowedAbbreviation(typeName);
             if (abbr != null) {
-                log(nameAst.getLineNo(), MSG_KEY, allowedAbbreviationLength);
+                log(nameAst.getLineNo(), MSG_KEY, typeName, allowedAbbreviationLength);
             }
         }
     }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages.properties
@@ -3,4 +3,4 @@ illegal.abstract.class.name=Name ''{0}'' must match pattern ''{1}''.
 method.name.equals.class.name=Method Name ''{0}'' must not equal the enclosing class name.
 no.abstract.class.modifier=Class ''{0}'' must be declared as ''abstract''.
 
-abbreviation.as.word=Abbreviation in name must contain no more than ''{0}'' capital letters.
+abbreviation.as.word=Abbreviation in name ''{0}'' must contain no more than ''{1}'' capital letters.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages_de.properties
@@ -3,4 +3,4 @@ illegal.abstract.class.name=Klassenname ''{0}'' entspricht nicht dem Muster ''{1
 method.name.equals.class.name=Methodenname ''{0}'' darf nicht der gleiche sein wie der Name der Klasse.
 no.abstract.class.modifier=Die Klasse ''{0}'' muss ''abstract'' deklariert werden.
 
-abbreviation.as.word=Die Abkürzung in diesem Bezeichner darf höchstens aus ''{0}'' Großbuchstaben bestehen.
+abbreviation.as.word=Die Abkürzung in diesem Bezeichner ''{0}'' darf höchstens aus ''{1}'' Großbuchstaben bestehen.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages_es.properties
@@ -2,4 +2,4 @@ name.invalidPattern=El nombre ''{0}'' debe coincidir con el patrón ''{1}''.
 illegal.abstract.class.name=El nombre ''{0}'' debe coincidir con el patrón ''{1}''.
 method.name.equals.class.name = Nombre de método ''{0}'' no debe ser igual al nombre de clase envolvente.
 no.abstract.class.modifier = Clase ''{0}'' se debe declarar como ''abstracta''.
-abbreviation.as.word = Abreviatura en nombre debe contener no más de ''{0}'' mayúsculas.
+abbreviation.as.word = Abreviatura en nombre ''{0}'' debe contener no más de ''{1}'' mayúsculas.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages_fi.properties
@@ -2,4 +2,4 @@ name.invalidPattern=Nimen ''{0}'' pitää olla mallin ''{1}'' mukainen.
 illegal.abstract.class.name=Nimen ''{0}'' pitää olla mallin ''{1}'' mukainen.
 method.name.equals.class.name = Tavan nimi ''{0}'' ei saa yhtä sulkevan luokan nimi.
 no.abstract.class.modifier = Luokka ''{0}'' on ilmoitettu olevan ''abstrakti''.
-abbreviation.as.word = Lyhennys nimi saa olla enintään ''{0}'' isoilla kirjaimilla.
+abbreviation.as.word = Lyhennys nimi saa olla ''{0}'' enintään ''{1}'' isoilla kirjaimilla.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages_fr.properties
@@ -2,4 +2,4 @@ name.invalidPattern=Le nom ''{0}'' n''est pas conforme à l''expression ''{1}''.
 illegal.abstract.class.name=Le nom de la classe abstraite ''{0}'' n''est pas conforme à l''expression ''{1}''.
 method.name.equals.class.name = Nom de la méthode ''{0}'' ne doit pas être égal au nom de la classe englobante.
 no.abstract.class.modifier = Classe ''{0}'' doit être déclarée comme ''abstrait''.
-abbreviation.as.word = Abréviation de nom ne doit pas contenir plus de ''{0}'' lettres majuscules.
+abbreviation.as.word = Abréviation de nom ''{0}'' ne doit pas contenir plus de ''{1}'' lettres majuscules.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages_ja.properties
@@ -2,4 +2,4 @@ name.invalidPattern=名前 ''{0}'' はパターン ''{1}'' に一致しなけれ
 illegal.abstract.class.name=名前 ''{0}'' はパターン ''{1}'' に一致しなければなりません。
 method.name.equals.class.name = メソッド名は ''{0}'' エンクロージングクラス名と同じにはなりません。
 no.abstract.class.modifier = クラス ''{0}'' ''抽象'' として宣言する必要があります。
-abbreviation.as.word = 名前に略語は 以下にする必要があります ''{0}'' 大文字を。
+abbreviation.as.word = 名前に略語は ''{0}'' 以下にする必要があります ''{1}'' 大文字を。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages_pt.properties
@@ -2,4 +2,4 @@ illegal.abstract.class.name=Nome ''{0}'' deve condizer com o padrão ''{1}''.
 name.invalidPattern=Nome ''{0}'' deve condizer com o padrão ''{1}''.
 method.name.equals.class.name = Nome do método ''{0}'' não deve ser igual ao nome da classe delimitador.
 no.abstract.class.modifier = Class ''{0}'' deve ser declarado como ''abstrato''.
-abbreviation.as.word = Sigla em nome deve conter não mais do que ''{0}'' letras maiúsculas.
+abbreviation.as.word = Sigla em nome ''{0}'' deve conter não mais do que ''{1}'' letras maiúsculas.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/naming/messages_tr.properties
@@ -8,4 +8,4 @@ name.invalidPattern = ''{0}'' ismi, şu kalıpta olmalı: ''{1}''.
 
 no.abstract.class.modifier = ''{0}'' sınıfı ''abstract'' olarak tanımlanmalı.
 
-abbreviation.as.word=Adı kısaltması ''{0}'' büyük harflerle fazla içermelidir.
+abbreviation.as.word=''{0}'' Adı kısaltması ''{1}'' büyük harflerle fazla içermelidir.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
@@ -31,8 +31,6 @@ import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
 public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
-    /** Warning message. */
-    private String warningMessage;
 
     @Override
     protected String getPath(String filename) throws IOException {
@@ -46,17 +44,16 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         final DefaultConfiguration checkConfig =
             createCheckConfig(AbbreviationAsWordInNameCheck.class);
         final int expectedCapitalCount = 3;
-        warningMessage = getCheckMessage(MSG_KEY, expectedCapitalCount);
         checkConfig.addAttribute("allowedAbbreviationLength", String.valueOf(expectedCapitalCount));
         checkConfig.addAttribute("allowedAbbreviations", "III");
         checkConfig.addAttribute("tokens", "CLASS_DEF");
         checkConfig.addAttribute("ignoreOverriddenMethods", "true");
 
         final String[] expected = {
-            "9: " + warningMessage,
-            "12: " + warningMessage,
-            "32: " + warningMessage,
-            "37: " + warningMessage,
+            "9: "  + getWarningMessage("FactoryWithBADNAme", expectedCapitalCount),
+            "12: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "32: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "37: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
         };
 
         verify(checkConfig, getPath("InputAbbreviationAsWordInTypeName.java"), expected);
@@ -66,7 +63,6 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     public void testTypeNamesForFourPermittedCapitalLetters() throws Exception {
 
         final int expectedCapitalCount = 4;
-        warningMessage = getCheckMessage(MSG_KEY, expectedCapitalCount);
         final DefaultConfiguration checkConfig =
             createCheckConfig(AbbreviationAsWordInNameCheck.class);
         checkConfig.addAttribute("allowedAbbreviationLength", String.valueOf(expectedCapitalCount));
@@ -75,7 +71,7 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("ignoreOverriddenMethods", "true");
 
         final String[] expected = {
-            "32: " + warningMessage,
+            "32: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
         };
 
         verify(checkConfig, getPath("InputAbbreviationAsWordInTypeName.java"), expected);
@@ -85,7 +81,6 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     public void testTypeNamesForFivePermittedCapitalLetters() throws Exception {
 
         final int expectedCapitalCount = 5;
-        warningMessage = getCheckMessage(MSG_KEY, expectedCapitalCount);
         final DefaultConfiguration checkConfig =
             createCheckConfig(AbbreviationAsWordInNameCheck.class);
         checkConfig.addAttribute("allowedAbbreviationLength", String.valueOf(expectedCapitalCount));
@@ -93,8 +88,8 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("tokens", "CLASS_DEF");
         checkConfig.addAttribute("ignoreOverriddenMethods", "true");
         final String[] expected = {
-            "32: " + warningMessage,
-            "37: " + warningMessage,
+            "32: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "37: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
         };
 
         verify(checkConfig, getPath("InputAbbreviationAsWordInTypeName.java"), expected);
@@ -104,7 +99,6 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     public void testTypeAndVariablesAndMethodNames() throws Exception {
 
         final int expectedCapitalCount = 5;
-        warningMessage = getCheckMessage(MSG_KEY, expectedCapitalCount);
         final DefaultConfiguration checkConfig =
             createCheckConfig(AbbreviationAsWordInNameCheck.class);
         checkConfig.addAttribute("allowedAbbreviationLength", String.valueOf(expectedCapitalCount));
@@ -116,12 +110,12 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("ignoreOverriddenMethods", "true");
 
         final String[] expected = {
-            "32: " + warningMessage,
-            "37: " + warningMessage,
-            "38: " + warningMessage,
-            "39: " + warningMessage,
-            "40: " + warningMessage,
-            "58: " + warningMessage,
+            "32: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "37: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "38: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "39: " + getWarningMessage("marazmaticVARIABLEName", expectedCapitalCount),
+            "40: " + getWarningMessage("MARAZMATICVariableName", expectedCapitalCount),
+            "58: " + getWarningMessage("serialNUMBER", expectedCapitalCount),
         };
 
         verify(checkConfig, getPath("InputAbbreviationAsWordInTypeName.java"), expected);
@@ -131,7 +125,6 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     public void testTypeAndVariablesAndMethodNamesWithNoIgnores() throws Exception {
 
         final int expectedCapitalCount = 5;
-        warningMessage = getCheckMessage(MSG_KEY, expectedCapitalCount);
         final DefaultConfiguration checkConfig =
             createCheckConfig(AbbreviationAsWordInNameCheck.class);
         checkConfig.addAttribute("allowedAbbreviationLength", String.valueOf(expectedCapitalCount));
@@ -145,13 +138,13 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("ignoreOverriddenMethods", "true");
 
         final String[] expected = {
-            "32: " + warningMessage,
-            "37: " + warningMessage,
-            "38: " + warningMessage,
-            "66: " + warningMessage,
-            "72: " + warningMessage,
-            "78: " + warningMessage,
-            "84: " + warningMessage,
+            "32: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "37: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "38: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "66: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "72: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "78: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "84: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
         };
 
         verify(checkConfig, getPath("InputAbbreviationAsWordInTypeName.java"), expected);
@@ -161,7 +154,6 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     public void testTypeAndVariablesAndMethodNamesWithIgnores() throws Exception {
 
         final int expectedCapitalCount = 5;
-        warningMessage = getCheckMessage(MSG_KEY, expectedCapitalCount);
         final DefaultConfiguration checkConfig =
             createCheckConfig(AbbreviationAsWordInNameCheck.class);
         checkConfig.addAttribute("allowedAbbreviationLength", String.valueOf(expectedCapitalCount));
@@ -175,9 +167,9 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("ignoreOverriddenMethods", "true");
 
         final String[] expected = {
-            "32: " + warningMessage,
-            "37: " + warningMessage,
-            "38: " + warningMessage,
+            "32: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "37: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "38: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
         };
 
         verify(checkConfig, getPath("InputAbbreviationAsWordInTypeName.java"), expected);
@@ -187,7 +179,6 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     public void testTypeAndVariablesAndMethodNamesWithIgnoresFinal() throws Exception {
 
         final int expectedCapitalCount = 4;
-        warningMessage = getCheckMessage(MSG_KEY, expectedCapitalCount);
         final DefaultConfiguration checkConfig =
             createCheckConfig(AbbreviationAsWordInNameCheck.class);
         checkConfig.addAttribute("allowedAbbreviationLength", String.valueOf(expectedCapitalCount));
@@ -201,12 +192,13 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("ignoreOverriddenMethods", "true");
 
         final String[] expected = {
-            "12: " + warningMessage,
-            "32: " + warningMessage,
-            "37: " + warningMessage,
-            "38: " + warningMessage,
-            "58: " + warningMessage, // not in ignore list
-            "60: " + warningMessage, // no ignore for static
+            "12: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "32: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "37: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "38: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "58: " + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
+            "60: "
+                + getWarningMessage("s2erialNUMBER", expectedCapitalCount), // no ignore for static
         };
 
         verify(checkConfig, getPath("InputAbbreviationAsWordInTypeName.java"), expected);
@@ -216,7 +208,6 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     public void testTypeAndVariablesAndMethodNamesWithIgnoresStatic() throws Exception {
 
         final int expectedCapitalCount = 5;
-        warningMessage = getCheckMessage(MSG_KEY, expectedCapitalCount);
         final DefaultConfiguration checkConfig =
             createCheckConfig(AbbreviationAsWordInNameCheck.class);
         checkConfig.addAttribute("allowedAbbreviationLength", String.valueOf(expectedCapitalCount));
@@ -230,11 +221,12 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("ignoreOverriddenMethods", "true");
 
         final String[] expected = {
-            "32: " + warningMessage,
-            "37: " + warningMessage,
-            "38: " + warningMessage,
-            "58: " + warningMessage, // not in ignore list
-            "59: " + warningMessage, // no ignore for final
+            "32: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "37: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "38: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "58: " + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
+            "59: "
+                + getWarningMessage("s1erialNUMBER", expectedCapitalCount), // no ignore for final
         };
 
         verify(checkConfig, getPath("InputAbbreviationAsWordInTypeName.java"), expected);
@@ -247,14 +239,13 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         final DefaultConfiguration checkConfig =
             createCheckConfig(AbbreviationAsWordInNameCheck.class);
         final int expectedCapitalCount = 3;
-        warningMessage = getCheckMessage(MSG_KEY, expectedCapitalCount);
         checkConfig.addAttribute("allowedAbbreviationLength", String.valueOf(expectedCapitalCount));
         checkConfig.addAttribute("allowedAbbreviations", "");
         checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF");
         checkConfig.addAttribute("ignoreOverriddenMethods", "true");
 
         final String[] expected = {
-            "22: " + warningMessage,
+            "22: " + getWarningMessage("oveRRRRRrriddenMethod", expectedCapitalCount),
         };
 
         verify(checkConfig,
@@ -266,7 +257,6 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(AbbreviationAsWordInNameCheck.class);
         final int expectedCapitalCount = 0;
-        warningMessage = getCheckMessage(MSG_KEY, expectedCapitalCount);
         checkConfig.addAttribute("allowedAbbreviationLength",
                 String.valueOf(expectedCapitalCount));
         checkConfig.addAttribute("allowedAbbreviations", "");
@@ -277,31 +267,31 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
             + "ANNOTATION_DEF,ANNOTATION_FIELD_DEF,ENUM_CONSTANT_DEF,"
             + "PARAMETER_DEF,VARIABLE_DEF,METHOD_DEF");
         final String[] expected = {
-            "3: " + warningMessage,
-            "6: " + warningMessage,
-            "9: " + warningMessage,
-            "12: " + warningMessage,
-            "32: " + warningMessage,
-            "37: " + warningMessage,
-            "38: " + warningMessage,
-            "39: " + warningMessage,
-            "40: " + warningMessage,
-            "46: " + warningMessage,
-            "47: " + warningMessage,
-            "48: " + warningMessage,
-            "49: " + warningMessage,
-            "57: " + warningMessage,
-            "58: " + warningMessage,
-            "59: " + warningMessage,
-            "60: " + warningMessage,
-            "61: " + warningMessage,
-            "66: " + warningMessage,
-            "72: " + warningMessage,
-            "78: " + warningMessage,
-            "84: " + warningMessage,
-            "88: " + warningMessage,
-            "90: " + warningMessage,
-            "98: " + warningMessage,
+            "3: " + getWarningMessage("IIIInputAbstractClassName", expectedCapitalCount),
+            "6: " + getWarningMessage("NonAAAAbstractClassName", expectedCapitalCount),
+            "9: " + getWarningMessage("FactoryWithBADNAme", expectedCapitalCount),
+            "12: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "32: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "37: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "38: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "39: " + getWarningMessage("marazmaticVARIABLEName", expectedCapitalCount),
+            "40: " + getWarningMessage("MARAZMATICVariableName", expectedCapitalCount),
+            "46: " + getWarningMessage("RIGHT", expectedCapitalCount),
+            "47: " + getWarningMessage("LEFT", expectedCapitalCount),
+            "48: " + getWarningMessage("UP", expectedCapitalCount),
+            "49: " + getWarningMessage("DOWN", expectedCapitalCount),
+            "57: " + getWarningMessage("NonAAAAbstractClassName2", expectedCapitalCount),
+            "58: " + getWarningMessage("serialNUMBER", expectedCapitalCount),
+            "59: " + getWarningMessage("s1erialNUMBER", expectedCapitalCount),
+            "60: " + getWarningMessage("s2erialNUMBER", expectedCapitalCount),
+            "61: " + getWarningMessage("s3erialNUMBER", expectedCapitalCount),
+            "66: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "72: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "78: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "84: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "88: " + getWarningMessage("FIleNameFormatException", expectedCapitalCount),
+            "90: " + getWarningMessage("serialVersionUID", expectedCapitalCount),
+            "98: " + getWarningMessage("userID", expectedCapitalCount),
         };
         verify(checkConfig,
                 getPath("InputAbbreviationAsWordInTypeName.java"), expected);
@@ -313,7 +303,6 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         final DefaultConfiguration checkConfig =
             createCheckConfig(AbbreviationAsWordInNameCheck.class);
         final int expectedCapitalCount = 1;
-        warningMessage = getCheckMessage(MSG_KEY, expectedCapitalCount);
         checkConfig.addAttribute("allowedAbbreviationLength", String.valueOf(expectedCapitalCount));
         checkConfig.addAttribute("ignoreFinal", "false");
         checkConfig.addAttribute("allowedAbbreviations", null);
@@ -321,5 +310,9 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
 
         verify(checkConfig, getPath("InputAbstractMultisetSetCount.java"), expected);
+    }
+
+    private String getWarningMessage(String typeName, int expectedCapitalCount) {
+        return getCheckMessage(MSG_KEY, typeName, expectedCapitalCount);
     }
 }


### PR DESCRIPTION
…s name that violates a format

Change error msg as issue requested. I added in com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheckTest helper method getWarningMessage which is nearly same as introduced getWarningMessage in com.google.checkstyle.test.chapter5naming.rule53camelcase.AbbreviationAsWordInNameCheckTest and they differs by first argument(class). 

Why there are in two different packages test classes which have same purpose? If this is not intended i could merge them in this PR.