### PR TITLE
spelling: fix typo in word 'Existing' in google_style.xml

### DIFF
--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -41,12 +41,12 @@
                     <img
                         src="images/ok_green.png"
                         alt="" />
-                    - Exiting Check covers all requirements from Google.
+                    - Existing Check covers all requirements from Google.
                     <br />
                     <img
                         src="images/ok_blue.png"
                         alt="" />
-                    - Exiting Check covers some part of requirements from Google.
+                    - Existing Check covers some part of requirements from Google.
                     <br />
                     <img
                         src="images/ban_red.png"


### PR DESCRIPTION
In http://checkstyle.sourceforge.net/google_style.html in legend there are 'Exiting check...' instead of 'Existing check...'