### PR TITLE
minor: renamed suggestedChildLevel to more natural name

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -111,7 +111,7 @@ public abstract class AbstractExpressionHandler {
      * @return the expected indentation amount
      */
     protected IndentLevel getLevelImpl() {
-        return parent.suggestedChildLevel(this);
+        return parent.getSuggestedChildLevel(this);
     }
 
     /**
@@ -123,7 +123,7 @@ public abstract class AbstractExpressionHandler {
      *
      * @return suggested indentation for child
      */
-    public IndentLevel suggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
         return new IndentLevel(getLevel(), getBasicOffset());
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -308,7 +308,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    public IndentLevel suggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
         return getChildrenExpectedLevel();
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CaseHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CaseHandler.java
@@ -63,7 +63,7 @@ public class CaseHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    public IndentLevel suggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
         return getLevel();
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IfHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IfHandler.java
@@ -42,11 +42,11 @@ public class IfHandler extends BlockParentHandler {
     }
 
     @Override
-    public IndentLevel suggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
         if (child instanceof ElseHandler) {
             return getLevel();
         }
-        return super.suggestedChildLevel(child);
+        return super.getSuggestedChildLevel(child);
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
@@ -66,7 +66,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
  *   - suggest child indent level
  *   - allows for some tokens to be on same line (ie inner classes OBJBLOCK)
  *     and not increase indentation level
- *   - looked at using double dispatch for suggestedChildLevel(), but it
+ *   - looked at using double dispatch for getSuggestedChildLevel(), but it
  *     doesn't seem worthwhile, at least now
  *   - both tabs and spaces are considered whitespace in front of the line...
  *     tabs are converted to spaces

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LambdaHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LambdaHandler.java
@@ -41,14 +41,14 @@ public class LambdaHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    public IndentLevel suggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
         return getLevel();
     }
 
     @Override
     protected IndentLevel getLevelImpl() {
         if (getParent() instanceof MethodCallHandler) {
-            return getParent().suggestedChildLevel(this);
+            return getParent().getSuggestedChildLevel(this);
         }
 
         DetailAST parent = getMainAst().getParent();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
@@ -59,7 +59,7 @@ public class MemberDefHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    public IndentLevel suggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
         return getLevel();
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -116,7 +116,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    public IndentLevel suggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
         // for whatever reason a method that crosses lines, like asList
         // here:
         //            System.out.println("methods are: " + Arrays.asList(
@@ -137,7 +137,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
         final DetailAST rparen = getMainAst().findFirstToken(TokenTypes.RPAREN);
         if (getLineStart(rparen) == rparen.getColumnNo()) {
             suggestedLevel.addAcceptedIndent(new IndentLevel(
-                    getParent().suggestedChildLevel(this),
+                    getParent().getSuggestedChildLevel(this),
                     getIndentCheck().getLineWrappingIndentation()
             ));
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/PrimordialHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/PrimordialHandler.java
@@ -40,7 +40,7 @@ public class PrimordialHandler extends AbstractExpressionHandler {
     }
 
     @Override
-    public IndentLevel suggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
         return new IndentLevel(0);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
@@ -68,7 +68,7 @@ public class SlistHandler extends BlockParentHandler {
     }
 
     @Override
-    public IndentLevel suggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
         // this is:
         //  switch (var) {
         //     case 3: {
@@ -83,9 +83,9 @@ public class SlistHandler extends BlockParentHandler {
                 && !(getParent() instanceof SlistHandler)
             || getParent() instanceof CaseHandler
                 && child instanceof SlistHandler) {
-            return getParent().suggestedChildLevel(child);
+            return getParent().getSuggestedChildLevel(child);
         }
-        return super.suggestedChildLevel(child);
+        return super.getSuggestedChildLevel(child);
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler.java
@@ -41,11 +41,11 @@ public class TryHandler extends BlockParentHandler {
     }
 
     @Override
-    public IndentLevel suggestedChildLevel(AbstractExpressionHandler child) {
+    public IndentLevel getSuggestedChildLevel(AbstractExpressionHandler child) {
         if (child instanceof CatchHandler
             || child instanceof FinallyHandler) {
             return getLevel();
         }
-        return super.suggestedChildLevel(child);
+        return super.getSuggestedChildLevel(child);
     }
 }


### PR DESCRIPTION
renamed suggestedChildLevel to getSuggestedChildLevel.
It is a getter and even some methods that call it, like getLevelImpl, are getters.