### PR TITLE
minor: renaming indentation methods to more natural name

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -228,7 +228,7 @@ public class RightCurlyCheck extends Check {
         else if (shouldBeAloneOnLine(bracePolicy, details)) {
             violation = MSG_KEY_LINE_ALONE;
         }
-        else if (shouldStartLine && !startsLine(details, targetSourceLine)) {
+        else if (shouldStartLine && !isOnStartOfLine(details, targetSourceLine)) {
             violation = MSG_KEY_LINE_NEW;
         }
         return violation;
@@ -268,7 +268,7 @@ public class RightCurlyCheck extends Check {
      * @param targetSourceLine source line to check
      * @return true if right curly brace starts target source line.
      */
-    private static boolean startsLine(Details details, String targetSourceLine) {
+    private static boolean isOnStartOfLine(Details details, String targetSourceLine) {
         return CommonUtils.hasWhitespaceBefore(details.rcurly.getColumnNo(), targetSourceLine)
                 || details.lcurly.getLineNo() == details.rcurly.getLineNo();
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -190,7 +190,7 @@ public abstract class AbstractExpressionHandler {
      *
      * @return true if it is, false otherwise
      */
-    protected final boolean startsLine(DetailAST ast) {
+    protected final boolean isOnStartOfLine(DetailAST ast) {
         return getLineStart(ast) == expandedTabsColumnNo(ast);
     }
 
@@ -507,7 +507,7 @@ public abstract class AbstractExpressionHandler {
         for (DetailAST modifier = modifiers.getFirstChild();
              modifier != null;
              modifier = modifier.getNextSibling()) {
-            if (startsLine(modifier)
+            if (isOnStartOfLine(modifier)
                 && !getLevel().isAcceptable(expandedTabsColumnNo(modifier))) {
                 logError(modifier, "modifier",
                     expandedTabsColumnNo(modifier));
@@ -577,7 +577,7 @@ public abstract class AbstractExpressionHandler {
             // or has <lparen level> + 1 indentation
             final int lparenLevel = expandedTabsColumnNo(lparen);
 
-            if (!getLevel().isAcceptable(rparenLevel) && startsLine(rparen)
+            if (!getLevel().isAcceptable(rparenLevel) && isOnStartOfLine(rparen)
                     && rparenLevel != lparenLevel + 1) {
                 logError(rparen, "rparen", rparenLevel);
             }
@@ -593,7 +593,7 @@ public abstract class AbstractExpressionHandler {
         // same line as the lcurly
         if (lparen == null
             || getLevel().isAcceptable(expandedTabsColumnNo(lparen))
-            || !startsLine(lparen)) {
+            || !isOnStartOfLine(lparen)) {
             return;
         }
         logError(lparen, "lparen", expandedTabsColumnNo(lparen));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -96,7 +96,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
             || getLevel().isAcceptable(expandedTabsColumnNo(topLevel)) || hasLabelBefore()) {
             return;
         }
-        if (!shouldTopLevelStartLine() && !startsLine(topLevel)) {
+        if (!shouldTopLevelStartLine() && !isOnStartOfLine(topLevel)) {
             return;
         }
         logError(topLevel, "", expandedTabsColumnNo(topLevel));
@@ -158,7 +158,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
         final DetailAST lcurly = getLCurly();
         final int lcurlyPos = expandedTabsColumnNo(lcurly);
 
-        if (curlyLevel().isAcceptable(lcurlyPos) || !startsLine(lcurly)) {
+        if (curlyLevel().isAcceptable(lcurlyPos) || !isOnStartOfLine(lcurly)) {
             return;
         }
 
@@ -203,7 +203,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
         final int rcurlyPos = expandedTabsColumnNo(rcurly);
 
         if (curlyLevel().isAcceptable(rcurlyPos)
-            || !shouldStartWithRCurly() && !startsLine(rcurly)
+            || !shouldStartWithRCurly() && !isOnStartOfLine(rcurly)
             || areOnSameLine(rcurly, lcurly)) {
             return;
         }
@@ -295,10 +295,10 @@ public class BlockParentHandler extends AbstractExpressionHandler {
         // try to suggest single level to children using curlies'
         // levels.
         if (getLevel().isMultiLevel() && hasCurlies()) {
-            if (startsLine(getLCurly())) {
+            if (isOnStartOfLine(getLCurly())) {
                 indentLevel = new IndentLevel(expandedTabsColumnNo(getLCurly()) + getBasicOffset());
             }
-            else if (startsLine(getRCurly())) {
+            else if (isOnStartOfLine(getRCurly())) {
                 final IndentLevel level = new IndentLevel(curlyLevel(), getBasicOffset());
                 level.addAcceptedIndent(level.getFirstIndentLevel() + getLineWrappingIndent());
                 indentLevel = level;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
@@ -66,7 +66,7 @@ public class MemberDefHandler extends AbstractExpressionHandler {
     @Override
     protected void checkModifiers() {
         final DetailAST modifier = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
-        if (startsLine(modifier)
+        if (isOnStartOfLine(modifier)
             && !getLevel().isAcceptable(expandedTabsColumnNo(modifier))) {
             logError(modifier, "modifier", expandedTabsColumnNo(modifier));
         }
@@ -79,7 +79,7 @@ public class MemberDefHandler extends AbstractExpressionHandler {
         final DetailAST type = getMainAst().findFirstToken(TokenTypes.TYPE);
         final DetailAST ident = AbstractExpressionHandler.getFirstToken(type);
         final int columnNo = expandedTabsColumnNo(ident);
-        if (startsLine(ident) && !getLevel().isAcceptable(columnNo)) {
+        if (isOnStartOfLine(ident) && !getLevel().isAcceptable(columnNo)) {
             logError(ident, "type", columnNo);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
@@ -51,7 +51,7 @@ public class MethodDefHandler extends BlockParentHandler {
     @Override
     protected void checkModifiers() {
         final DetailAST modifier = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
-        if (startsLine(modifier)
+        if (isOnStartOfLine(modifier)
             && !getLevel().isAcceptable(expandedTabsColumnNo(modifier))) {
             logError(modifier, "modifier", expandedTabsColumnNo(modifier));
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
@@ -95,7 +95,7 @@ public class ObjectBlockHandler extends BlockParentHandler {
         final IndentLevel level = curlyLevel();
         level.addAcceptedIndent(level.getFirstIndentLevel() + getLineWrappingIndentation());
 
-        if (!level.isAcceptable(rcurlyPos) && startsLine(rcurly)) {
+        if (!level.isAcceptable(rcurlyPos) && isOnStartOfLine(rcurly)) {
             logError(rcurly, "rcurly", rcurlyPos, curlyLevel());
         }
     }


### PR DESCRIPTION
renamed startsLine to isOnStartOfLine.
boolean methods should start with 'is'. Even the javadoc for the method says 'is at the start of a line'.