### PR TITLE
Issue #2678: Fix NPE in ParameterNameCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
+import com.google.common.base.Optional;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
@@ -117,14 +118,16 @@ public class ParameterNameCheck
      */
     private static boolean isOverriddenMethod(DetailAST ast) {
         boolean overridden = false;
+
         final DetailAST parent = ast.getParent().getParent();
-        if (parent.getFirstChild().getFirstChild() != null) {
-            final DetailAST annotation = parent.getFirstChild().getFirstChild();
-            if (annotation.getType() == TokenTypes.ANNOTATION) {
-                final DetailAST overrideToken = annotation.findFirstToken(TokenTypes.IDENT);
-                if ("Override".equals(overrideToken.getText())) {
-                    overridden = true;
-                }
+        final Optional<DetailAST> annotation =
+            Optional.fromNullable(parent.getFirstChild().getFirstChild());
+
+        if (annotation.isPresent() && annotation.get().getType() == TokenTypes.ANNOTATION) {
+            final Optional<DetailAST> overrideToken =
+                Optional.fromNullable(annotation.get().findFirstToken(TokenTypes.IDENT));
+            if (overrideToken.isPresent() && "Override".equals(overrideToken.get().getText())) {
+                overridden = true;
             }
         }
         return overridden;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -46,7 +46,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  * <pre>
  * &lt;module name="ParameterName"&gt;
- *    &lt;property name="format" value="^^[a-z](_?[a-zA-Z0-9]+)*$"/&gt;
+ *    &lt;property name="format" value="^[a-z][_a-zA-Z0-9]+$"/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -137,4 +137,14 @@ public class ParameterNameCheckTest
             };
         verify(checkConfig, getPath("InputOverrideAnnotation.java"), expected);
     }
+
+    @Test
+    public void testIsOverriddenNoNullPointerException()
+        throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ParameterNameCheck.class);
+        checkConfig.addAttribute("format", "^[a-z][a-zA-Z0-9]*$");
+        checkConfig.addAttribute("ignoreOverridden", "true");
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputOverrideAnnotationNoNPE.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputOverrideAnnotationNoNPE.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputOverrideAnnotationNoNPE.java
@@ -1,0 +1,27 @@
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+class InputOverrideAnnotationNoNPE
+{
+    // method with many parameters
+    void myMethod(int a, int b) {
+
+    }
+
+    // method with many parameters
+    void myMethod2(int a, int b) {
+
+    }
+}
+
+class Test extends InputOverrideAnnotationNoNPE
+{
+    @Override
+    void myMethod(int a, int b) {
+
+    }
+
+    @java.lang.Override
+    void myMethod2(int a, int b) {
+
+    }
+}


### PR DESCRIPTION
Configuration:
````xml
<module name = "Checker">
    <property name="charset" value="UTF-8"/>
    <module name="TreeWalker">
         <module name="ParameterNameCheck">
             <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <property name="ignoreOverridden" value="true"/>
         </module>
    </module>
</module>
````

No NPE on the following projects:

[checkstyle](http://mezk.github.io/checkstyle/checkstyle.html)
sevntu checkstyle - 0 violations
guava - 0 violations
[hibernate](http://mezk.github.io/hibernate/checkstyle.html)
[HBase](http://mezk.github.io/HBase/checkstyle.html)
[openjdk](http://mezk.github.io/openjdk/checkstyle.html)
[spring](http://mezk.github.io/spring/checkstyle.html)
[Orekit](http://mezk.github.io/Orekit/checkstyle.html)