### PR TITLE
Issue #2291: Fix not raising violation NeedBraces with ForEach loop w…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -354,33 +354,9 @@ public class NeedBracesCheck extends Check {
         }
         else if (literalFor.getParent().getType() == TokenTypes.SLIST
                 && literalFor.getLastChild().getType() != TokenTypes.SLIST) {
-            final DetailAST block = findExpressionBlockInForLoop(literalFor);
-            if (block == null) {
-                result = literalFor.getLineNo() == literalFor.getLastChild().getLineNo();
-            }
-            else {
-                result = literalFor.getLineNo() == block.getLineNo();
-            }
+            result = literalFor.getLineNo() == literalFor.getLastChild().getLineNo();
         }
         return result;
-    }
-
-    /**
-     * Detects and returns expression block in classical and enhanced for loops.
-     *
-     * @param literalFor parent for loop literal
-     * @return expression block
-     */
-    private static DetailAST findExpressionBlockInForLoop(DetailAST literalFor) {
-        final DetailAST forEachClause = literalFor.findFirstToken(TokenTypes.FOR_EACH_CLAUSE);
-        final DetailAST firstToken;
-        if (forEachClause == null) {
-            firstToken = literalFor.findFirstToken(TokenTypes.EXPR);
-        }
-        else {
-            firstToken = forEachClause.findFirstToken(TokenTypes.EXPR);
-        }
-        return firstToken;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheckTest.java
@@ -85,6 +85,7 @@ public class NeedBracesCheckTest extends BaseCheckTestSupport {
             "91: " + getCheckMessage(MSG_KEY_NEED_BRACES, "if"),
             "95: " + getCheckMessage(MSG_KEY_NEED_BRACES, "else"),
             "107: " + getCheckMessage(MSG_KEY_NEED_BRACES, "if"),
+            "114: " + getCheckMessage(MSG_KEY_NEED_BRACES, "for"),
         };
         verify(checkConfig, getPath("InputBracesSingleLineStatements.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputBracesSingleLineStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputBracesSingleLineStatements.java
@@ -108,4 +108,10 @@ public class InputBracesSingleLineStatements
             return true;
         }
     }
+
+    private void forEachLoop() {
+        for (String s: new String[]{""}) break;
+        for (String s: new String[]{""})
+            break;
+    }
 }


### PR DESCRIPTION
…stmt

Problem was strange implementation of checking if FOR_LITERAL ast is in single line. It was comparing start of FOR_LITERAL lineno with first expression found in for, which could be start of iteration expression in FOR_INIT or FOR_ITERATOR. For example such code with allowed single line statement was not raising NeedBraces
```java
for
            (String s: new String[]{""}) break;
```

This PR fix this by comparing line of FOR_LITERAL with the last children( when last child is not SLIST - because when it is it should not raise violation).

