### PR TITLE
Issue #2666: Print name of the Check after printing violation message 

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -41,6 +41,7 @@ import java.util.Properties;
 import java.util.regex.Pattern;
 
 import com.google.common.collect.Lists;
+import com.puppycrawl.tools.checkstyle.BriefUtLogger;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -85,7 +86,7 @@ public class BaseCheckTestSupport {
         checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(dc);
-        checker.addListener(new BriefLogger(stream));
+        checker.addListener(new BriefUtLogger(stream));
         return checker;
     }
 

--- a/src/it/java/com/google/checkstyle/test/base/ConfigValidationTest.java
+++ b/src/it/java/com/google/checkstyle/test/base/ConfigValidationTest.java
@@ -29,6 +29,7 @@ import java.util.Locale;
 
 import org.junit.Test;
 
+import com.puppycrawl.tools.checkstyle.BriefUtLogger;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 
@@ -42,7 +43,7 @@ public class ConfigValidationTest extends BaseCheckTestSupport {
         checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(checkerConfig);
-        checker.addListener(new BriefLogger(stream));
+        checker.addListener(new BriefUtLogger(stream));
 
         final List<File> files = new ArrayList<>();
         listFiles(files, new File("src/it/"), "java");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AuditEvemtFormatter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AuditEvemtFormatter.java
@@ -17,19 +17,19 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ////////////////////////////////////////////////////////////////////////////////
 
-package com.google.checkstyle.test.base;
+package com.puppycrawl.tools.checkstyle;
 
-import java.io.OutputStream;
-
-import com.puppycrawl.tools.checkstyle.DefaultLogger;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 
-/** A brief logger that only display info about errors. */
-class BriefLogger extends DefaultLogger {
-    BriefLogger(OutputStream out) {
-        super(out, true, out, false, false);
-    }
-
-    @Override
-    public void auditStarted(AuditEvent event) { }
+/**
+ * Represents the formatter interface for log message.
+ * @author Andrei Selkin
+ */
+public interface AuditEvemtFormatter {
+    /**
+     * Formats an error message.
+     * @param event audit event.
+     * @return string representation of error message.
+     */
+    String format(AuditEvent event);
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatter.java
@@ -1,0 +1,93 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.util.Locale;
+
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
+
+/**
+ * Represents the default formatter for log message.
+ * Default log message format is: [SEVERITY LEVEL] filePath:lineNo:columnNo: message. [CheckName]
+ * @author Andrei Selkin
+ */
+public class AuditEventDefaultFormatter implements AuditEvemtFormatter {
+
+    /** Length of all separators. */
+    private static final int LENGTH_OF_ALL_SEPARATORS = 10;
+
+    @Override
+    public String format(AuditEvent event) {
+        final String fileName = event.getFileName();
+        final String message = event.getMessage();
+
+        final SeverityLevel severityLevel = event.getSeverityLevel();
+        final String severityLevelName;
+        if (severityLevel == SeverityLevel.WARNING) {
+            // We change the name of severity level intentionally
+            // to shorten the length of the log message.
+            severityLevelName = "WARN";
+        }
+        else {
+            severityLevelName = severityLevel.getName().toUpperCase(Locale.US);
+        }
+
+        // Avoid StringBuffer.expandCapacity
+        final int bufLen = calculateBufferLength(event, severityLevelName.length());
+        final StringBuilder sb = new StringBuilder(bufLen);
+
+        sb.append('[').append(severityLevelName).append("] ")
+            .append(fileName).append(':').append(event.getLine());
+        if (event.getColumn() > 0) {
+            sb.append(':').append(event.getColumn());
+        }
+        sb.append(": ").append(message);
+        final String checkShortName = getCheckShortName(event);
+        sb.append(" [").append(checkShortName).append(']');
+
+        return sb.toString();
+    }
+
+    /**
+     * Returns the length of the buffer for StringBuilder.
+     * bufferLength = fileNameLength + messageLength + lengthOfAllSeparators +
+     * + severityNameLength + checkNameLength.
+     * @param event audit event.
+     * @param severityLevelNameLength length of severity level name.
+     * @return the length of the buffer for StringBuilder.
+     */
+    private static int calculateBufferLength(AuditEvent event, int severityLevelNameLength) {
+        return LENGTH_OF_ALL_SEPARATORS + event.getFileName().length()
+            + event.getMessage().length() + severityLevelNameLength
+            + getCheckShortName(event).length();
+    }
+
+    /**
+     * Returns check name without 'Check' suffix.
+     * @param event audit ivent.
+     * @return check name without 'Check' suffix.
+     */
+    private static String getCheckShortName(AuditEvent event) {
+        final String checkFullName = event.getSourceName();
+        return checkFullName.substring(checkFullName.lastIndexOf('.') + 1,
+            checkFullName.lastIndexOf("Check"));
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -342,7 +342,7 @@ public final class Main {
 
         }
         else if (PLAIN_FORMAT_NAME.equals(format)) {
-            listener = new DefaultLogger(out, closeOutputStream, out, false, true);
+            listener = new DefaultLogger(out, closeOutputStream, out, false);
 
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -473,7 +473,7 @@ public class CheckstyleAntTask extends Task {
             if (formatters.isEmpty()) {
                 final OutputStream debug = new LogOutputStream(this, Project.MSG_DEBUG);
                 final OutputStream err = new LogOutputStream(this, Project.MSG_ERR);
-                listeners[0] = new DefaultLogger(debug, true, err, true, true);
+                listeners[0] = new DefaultLogger(debug, true, err, true);
             }
             else {
                 for (int i = 0; i < formatterCount; i++) {
@@ -603,7 +603,7 @@ public class CheckstyleAntTask extends Task {
                     true, new LogOutputStream(task, Project.MSG_ERR), true);
             }
             final FileOutputStream infoStream = new FileOutputStream(toFile);
-            return new DefaultLogger(infoStream, true, infoStream, false, true);
+            return new DefaultLogger(infoStream, true, infoStream, false);
         }
 
         /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevel.java
@@ -35,13 +35,13 @@ import java.util.Locale;
  * @author Mehmet Can Cömert
  */
 public enum SeverityLevel {
-    /** Security level ignore. */
+    /** Severity level ignore. */
     IGNORE,
-    /** Security level info. */
+    /** Severity level info. */
     INFO,
-    /** Security level warning. */
+    /** Severity level warning. */
     WARNING,
-    /** Security level error. */
+    /** Severity level error. */
     ERROR;
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventUtFormatter.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventUtFormatter.java
@@ -1,0 +1,52 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+
+/**
+ * Represents the formatter for log message which is used in UTs.
+ * Message format is: filePath:lineNo:columnNo: message.
+ * @author Andrei Selkin
+ */
+public class AuditEventUtFormatter implements AuditEvemtFormatter {
+
+    /** Length of all separators. */
+    private static final int LENGTH_OF_ALL_SEPARATORS = 4;
+
+    @Override
+    public String format(AuditEvent event) {
+        final String fileName = event.getFileName();
+        final String message = event.getMessage();
+
+        // avoid StringBuffer.expandCapacity
+        final int bufLen = event.getFileName().length() + event.getMessage().length()
+            + LENGTH_OF_ALL_SEPARATORS;
+        final StringBuilder sb = new StringBuilder(bufLen);
+
+        sb.append(fileName).append(':').append(event.getLine());
+        if (event.getColumn() > 0) {
+            sb.append(':').append(event.getColumn());
+        }
+        sb.append(": ").append(message);
+
+        return sb.toString();
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
-import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -44,7 +43,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.MapDifference.ValueDifference;
 import com.google.common.collect.Maps;
-import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class BaseCheckTestSupport {
@@ -65,23 +63,7 @@ public class BaseCheckTestSupport {
         checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(dc);
-        checker.addListener(new BriefLogger(stream));
-        return checker;
-    }
-
-    protected Checker createChecker(Configuration checkConfig, boolean printSeverity)
-        throws Exception {
-
-        final DefaultConfiguration dc = createCheckerConfig(checkConfig);
-        final Checker checker = new Checker();
-        // make sure the tests always run with english error messages
-        // so the tests don't fail in supported locales like german
-        final Locale locale = Locale.ENGLISH;
-        checker.setLocaleCountry(locale.getCountry());
-        checker.setLocaleLanguage(locale.getLanguage());
-        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
-        checker.configure(dc);
-        checker.addListener(new BriefLogger(stream, printSeverity));
+        checker.addListener(new BriefUtLogger(stream));
         return checker;
     }
 
@@ -119,11 +101,6 @@ public class BaseCheckTestSupport {
     protected void verify(Configuration aConfig, String fileName, String... expected)
             throws Exception {
         verify(createChecker(aConfig), fileName, fileName, expected);
-    }
-
-    protected void verify(Configuration aConfig, boolean printSeverity,
-                          String filename, String... expected) throws Exception {
-        verify(createChecker(aConfig, printSeverity), filename, filename, expected);
     }
 
     protected void verify(Checker checker, String fileName, String... expected)
@@ -275,23 +252,5 @@ public class BaseCheckTestSupport {
         final MessageFormat formatter = new MessageFormat(pr.getProperty(messageKey),
                 Locale.ROOT);
         return formatter.format(arguments);
-    }
-
-    /**
-     * A brief logger that only display info about errors.
-     */
-    protected static class BriefLogger
-            extends DefaultLogger {
-        public BriefLogger(OutputStream out) {
-            super(out, true, out, false, false);
-        }
-
-        public BriefLogger(OutputStream out, boolean printSeverity) {
-            super(out, true, out, false, printSeverity);
-        }
-
-        @Override
-        public void auditStarted(AuditEvent event) {
-        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BriefUtLogger.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BriefUtLogger.java
@@ -1,0 +1,48 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.io.OutputStream;
+
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+
+/**
+ * A brief logger that only display info about errors.
+ * @author Andrei Selkin
+ */
+public class BriefUtLogger extends DefaultLogger {
+
+    /**
+     * Creates BriefLogger object.
+     * @param out output stream for info messages and errors.
+     */
+    public BriefUtLogger(OutputStream out) {
+        super(out, true, out, false, new AuditEventUtFormatter());
+    }
+
+    @Override
+    public void auditStarted(AuditEvent event) {
+    }
+
+    @Override
+    public void auditFinished(AuditEvent event) {
+        super.auditFinished(event);
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -259,12 +259,12 @@ public class MainTest {
             public void checkAssertion() throws IOException {
                 final String expectedPath = getFilePath("InputMain.java");
                 assertEquals(String.format(Locale.ROOT, "Starting audit...%n"
-                                + "%1$s:3:14: "
-                                + "warning: Name 'InputMain' must match pattern"
-                                + " '^[a-z0-9]*$'.%n"
-                                + "%1$s:5:7: "
-                                + "warning: Name 'InputMainInner' must match pattern"
-                                + " '^[a-z0-9]*$'.%n"
+                                + "[WARN] %1$s:3:14: "
+                                + "Name 'InputMain' must match pattern"
+                                + " '^[a-z0-9]*$'. [TypeName]%n"
+                                + "[WARN] %1$s:5:7: "
+                                + "Name 'InputMainInner' must match pattern"
+                                + " '^[a-z0-9]*$'. [TypeName]%n"
                                 + "Audit done.%n", expectedPath),
                         systemOut.getLog());
                 assertEquals("", systemErr.getLog());
@@ -283,10 +283,10 @@ public class MainTest {
             public void checkAssertion() throws IOException {
                 final String expectedPath = getFilePath("InputMain.java");
                 assertEquals(String.format(Locale.ROOT, "Starting audit...%n"
-                        + "%1$s:3:14: error: "
-                        + "Name 'InputMain' must match pattern '^[a-z0-9]*$'.%n"
-                        + "%1$s:5:7: error: "
-                        + "Name 'InputMainInner' must match pattern '^[a-z0-9]*$'.%n"
+                        + "[ERROR] %1$s:3:14: "
+                        + "Name 'InputMain' must match pattern '^[a-z0-9]*$'. [TypeName]%n"
+                        + "[ERROR] %1$s:5:7: "
+                        + "Name 'InputMainInner' must match pattern '^[a-z0-9]*$'. [TypeName]%n"
                         + "Audit done.%n"
                         + "Checkstyle ends with 2 errors.%n", expectedPath), systemOut.getLog());
                 assertEquals("", systemErr.getLog());
@@ -513,8 +513,8 @@ public class MainTest {
                 final String expectedPath = getFilePath("checks/metrics") + File.separator;
                 final StringBuilder sb = new StringBuilder();
                 sb.append("Starting audit...").append(System.getProperty("line.separator"));
-                final String format = "%s.java:%s: warning: File length is %s lines "
-                    + "(max allowed is 170).";
+                final String format = "[WARN] %s.java:%s: File length is %s lines "
+                    + "(max allowed is 170). [FileLength]";
                 for (String[] outputValue : outputValues) {
                     final String line = String.format(Locale.ROOT, format,
                             expectedPath + outputValue[0], outputValue[1],

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -202,7 +202,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(checkerConfig);
-        checker.addListener(new BriefLogger(stream));
+        checker.addListener(new BriefUtLogger(stream));
 
         final String pathToEmptyFile = temporaryFolder.newFile("file.java").getPath();
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
@@ -230,7 +230,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(checkerConfig);
-        checker.addListener(new BriefLogger(stream));
+        checker.addListener(new BriefUtLogger(stream));
 
         final String pathToEmptyFile = temporaryFolder.newFile("file.java").getPath();
         final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
@@ -246,7 +246,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         otherChecker.setLocaleLanguage(locale.getLanguage());
         otherChecker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         otherChecker.configure(checkerConfig);
-        otherChecker.addListener(new BriefLogger(stream));
+        otherChecker.addListener(new BriefUtLogger(stream));
         // here is diff with previous checker
         checkerConfig.addAttribute("fileExtensions", "java,javax");
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/FileSetCheckLifecycleTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/FileSetCheckLifecycleTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.BriefUtLogger;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
@@ -85,7 +86,7 @@ public class FileSetCheckLifecycleTest
         checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(dc);
-        checker.addListener(new BriefLogger(stream));
+        checker.addListener(new BriefUtLogger(stream));
 
         checker.addFileSetCheck(new TestFileSetCheck());
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -87,28 +87,14 @@ public class WriteTagCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testTagPrintSeverityTrue() throws Exception {
+    public void testTagIncomplete() throws Exception {
         checkConfig.addAttribute("tag", "@incomplete");
         checkConfig.addAttribute("tagFormat", "\\S");
-        checkConfig.addAttribute("tagSeverity", "warning");
         final String[] expected = {
-            "11: " + getCheckMessage(WRITE_TAG, "warning: @incomplete",
+            "11: " + getCheckMessage(WRITE_TAG, "@incomplete",
                 "This class needs more code..."),
         };
-        final boolean printSeverity = true;
-        verify(checkConfig, printSeverity, getPath("InputWriteTag.java"), expected);
-    }
-
-    @Test
-    public void testTagPrintSeverityFalse() throws Exception {
-        checkConfig.addAttribute("tag", "@incomplete");
-        checkConfig.addAttribute("tagFormat", "\\S");
-        checkConfig.addAttribute("tagSeverity", "warning");
-        final String[] expected = {
-            "11: " + getCheckMessage(WRITE_TAG, "@incomplete", "This class needs more code..."),
-        };
-        final boolean printSeverity = false;
-        verify(checkConfig, printSeverity, getPath("InputWriteTag.java"), expected);
+        verify(checkConfig, getPath("InputWriteTag.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.BriefUtLogger;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
@@ -141,7 +142,7 @@ public class SuppressWarningsFilterTest
         checker.setModuleClassLoader(Thread.currentThread()
             .getContextClassLoader());
         checker.configure(checkerConfig);
-        checker.addListener(new BriefLogger(stream));
+        checker.addListener(new BriefUtLogger(stream));
         return checker;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 
 import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.BriefUtLogger;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
@@ -229,7 +230,7 @@ public class SuppressWithNearbyCommentFilterTest
         checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(checkerConfig);
-        checker.addListener(new BriefLogger(stream));
+        checker.addListener(new BriefUtLogger(stream));
         return checker;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 
 import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.BriefUtLogger;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
@@ -229,7 +230,7 @@ public class SuppressionCommentFilterTest
         checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(checkerConfig);
-        checker.addListener(new BriefLogger(stream));
+        checker.addListener(new BriefUtLogger(stream));
         return checker;
     }
 


### PR DESCRIPTION
New message looks like:

```
Starting audit...
[WARNING] /media/andreiselkin/TOURO/IDEA_Projects/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/InputMain.java:3:14: Name 'InputMain' must match pattern '^[a-z0-9]*$'. [TypeName]
[WARNING] /media/andreiselkin/TOURO/IDEA_Projects/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/InputMain.java:5:7: Name 'InputMainInner' must match pattern '^[a-z0-9]*$'. [TypeName]
Audit done.
```


