### PR TITLE
Issue #2645: fixed StringIndexOutOfBoundsException in Indentation check

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -248,7 +248,7 @@ public abstract class AbstractExpressionHandler {
      */
     protected final int getLineStart(String line) {
         int index = 0;
-        while (Character.isWhitespace(line.charAt(index))) {
+        while (index < line.length() && Character.isWhitespace(line.charAt(index))) {
             index++;
         }
         return CommonUtils.lengthExpandedTabs(
@@ -348,9 +348,11 @@ public abstract class AbstractExpressionHandler {
      */
     private void checkLineIndent(int lineNum, IndentLevel indentLevel) {
         final String line = indentCheck.getLine(lineNum - 1);
-        final int start = getLineStart(line);
-        if (indentLevel.isGreaterThan(start)) {
-            logChildError(lineNum, start, indentLevel);
+        if (!line.isEmpty()) {
+            final int start = getLineStart(line);
+            if (indentLevel.isGreaterThan(start)) {
+                logChildError(lineNum, start, indentLevel);
+            }
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -52,12 +52,9 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author  jrichard
  */
 public class IndentationCheckTest extends BaseCheckTestSupport {
-    private static final Pattern NONEMPTY_LINE_REGEX =
-                    Pattern.compile(".*?\\S+.*?");
-
     private static final Pattern LINE_WITH_COMMENT_REGEX =
-                    Pattern.compile(".*?\\S+.*?(//indent:(\\d+)"
-                        + " exp:((>=\\d+)|(\\d+(,\\d+)*?))( warn)?)");
+                    Pattern.compile(".*?(//indent:(\\d+)"
+                        + " exp:((>=\\d+)|(\\d+(,\\d+)*?))( warn)?)$");
 
     private static final Pattern GET_INDENT_FROM_COMMENT_REGEX =
                     Pattern.compile("//indent:(\\d+).*?");
@@ -108,7 +105,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
                                         lineNumber));
                     }
                 }
-                else if (NONEMPTY_LINE_REGEX.matcher(line).matches()) {
+                else if (!line.isEmpty()) {
                     throw new IllegalStateException(String.format(Locale.ROOT,
                                     "File \"%1$s\" has no indentation comment or its format "
                                                     + "malformed. Error on line: %2$d",
@@ -1620,5 +1617,23 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("lineWrappingIndentation", "8");
         final String[] expected = EMPTY_EXPECTED;
         verifyWarns(checkConfig, getNonCompilablePath("InputLambda2.java"), expected, 0);
+    }
+
+    @Test
+    public void testSeparatedStatements() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+        checkConfig.addAttribute("tabWidth", "4");
+        final String fileName = getPath("InputSeparatedStatements.java");
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
+    public void testSeparatedLineWithJustSpaces() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+        checkConfig.addAttribute("tabWidth", "4");
+        final String fileName = getPath("InputSeparatedStatementWithSpaces.java");
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, fileName, expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputFromGuava.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputFromGuava.java
@@ -216,7 +216,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
   {  //indent:2 exp:2
     return null; //indent:4 exp:4
   } //indent:2 exp:2
-  
+
   private static class ValueReference<T1, T2> { //indent:2 exp:2
 
   } //indent:2 exp:2
@@ -239,7 +239,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     } //indent:4 exp:4
 
   } //indent:2 exp:2
-  
+
   private static class StrongValueReference<T1, T2> { //indent:2 exp:2
 
     public StrongValueReference(int value) //indent:4 exp:4
@@ -248,7 +248,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     } //indent:4 exp:4
 
   } //indent:2 exp:2
-  
+
   private static class WeightedStrongValueReference<T1, T2> { //indent:2 exp:2
 
     public WeightedStrongValueReference(int value, int weight) //indent:4 exp:4

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputSeparatedStatementWithSpaces.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputSeparatedStatementWithSpaces.java
@@ -1,0 +1,10 @@
+// test file has no expected comments to test out blank line with just spaces
+package com.puppycrawl.tools.checkstyle.checks.indentation;
+
+import java.util.*
+    // next line should be empty with just spaces, indented correctly
+    
+    ;
+
+public class InputSeparatedStatementWithSpaces {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputSeparatedStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputSeparatedStatements.java
@@ -1,0 +1,12 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation;//indent:0 exp:0
+
+import java.io.*//indent:0 exp:0
+
+    ;//indent:4 exp:4
+
+import java.util.*//indent:0 exp:0
+    //indent:4 exp:4
+    ;//indent:4 exp:4
+
+public class InputSeparatedStatements {//indent:0 exp:0
+}//indent:0 exp:0


### PR DESCRIPTION
This issue has 2 parts connected to it.

1) The main issue was `getLineStart` was trying to go past the end of the line, so I changed that.
2) I also changed `checkLineIndent` to skip empty lines, as the current implementation will require these lines to be indented too., which I believe we don't want.

I could have just done item 2 alone, but item 1 would show up later if someone had a line with just spaces in it, and this would cause the same exception.
I named the test file "separated" because there are other issues with this problem, so they can just be added to this one case.

I changed `LINE_WITH_COMMENT_REGEX`, because it doesn't support blank lines that are just spaces, which the current implementation will require to be in the correct position. This was needed to fully test item 1. See `InputSeparatedStatementWithSpaces`. This also required fixing 1 other input file.
I ended up removing `NONEMPTY_LINE_REGEX` and just doing a basic empty check, since we can have spaced out lines.
Should these be in a separate commit?