### PR TITLE
Issue #2661: Enforce AvoidHidingCauseException of sevntu-checkstyle over Checkstyle source code

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -70,5 +70,6 @@
             <property name="checkReadObjectMethod" value="true"/>
             <property name="matchMethodsByArgCount" value="true"/>
         </module>
+        <module name="AvoidHidingCauseException"/>
     </module>
 </module>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
@@ -125,9 +124,7 @@ public final class FileText extends AbstractList<String> {
         }
         catch (final UnsupportedCharsetException ex) {
             final String message = "Unsupported charset: " + charsetName;
-            final UnsupportedEncodingException ex2 = new UnsupportedEncodingException(message);
-            ex2.initCause(ex);
-            throw ex2;
+            throw new IllegalStateException(message, ex);
         }
 
         fullText = readFile(file, decoder);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 
 import org.junit.Test;
 
@@ -37,7 +36,7 @@ public class FileTextTest {
             new FileText(new File("any name"), charsetName);
             fail("UnsupportedEncodingException is expected");
         }
-        catch (UnsupportedEncodingException ex) {
+        catch (IllegalStateException ex) {
             assertEquals("Unsupported charset: " + charsetName, ex.getMessage());
         }
 


### PR DESCRIPTION

Checkstyle violation:
```
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java:[128,13] (extension) AvoidHidingCauseException: Cause exception 'ex' was lost.
```

Cause exception wont be lost because we initiate the cause by invoking ```initCause``` method.
See https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java#L129

Is it a false positive violation?