### PR TITLE
Issue #2661: Enforce MultipleStringLiteralsExtended of sevntu-checkstyle over Checkstyle source code

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -5,6 +5,12 @@
         "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 
 <module name="Checker">
+
+    <!-- Filters -->
+    <module name="SuppressionFilter">
+        <property name="file" value="config/sevntu_suppressions.xml"/>
+    </module>
+
     <module name="TreeWalker">
         <module name="StaticMethodCandidate"/>
         <module name="UselessSingleCatchCheck"/>
@@ -93,5 +99,8 @@
             <property name="ignorePattern" value="^ *\* *[^ ]+$"/>
         </module>
         <module name="AvoidHidingCauseException"/>
+        <module name="MultipleStringLiteralsExtended">
+            <property name="highlightAllDuplicates" value="true"/>
+        </module>    
     </module>
 </module>

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+
+    <!-- Fixing these cases will decrease code readability -->
+    <suppress checks="MultipleStringLiteralsExtended"
+              files="JavadocStyleCheck\.java|AbstractTypeAwareCheck\.java|XMLLogger\.java"/>
+    <suppress checks="MultipleStringLiteralsExtended"
+              files=".*[\\/]src[\\/](test|it)[\\/]"/>
+
+</suppressions>


### PR DESCRIPTION
controversial violations

```
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java:[470,40] (extension) MultipleStringLiteralsExtended: The String "]" appears 2 times in the file.
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java:[71,13] (extension) MultipleStringLiteralsExtended: The String "br" appears 2 times in the file.
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java:[71,19] (extension) MultipleStringLiteralsExtended: The String "li" appears 2 times in the file.
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java:[71,25] (extension) MultipleStringLiteralsExtended: The String "dt" appears 2 times in the file.
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java:[71,31] (extension) MultipleStringLiteralsExtended: The String "dd" appears 2 times in the file.
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java:[71,37] (extension) MultipleStringLiteralsExtended: The String "hr" appears 2 times in the file.
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java:[71,43] (extension) MultipleStringLiteralsExtended: The String "img" appears 2 times in the file.
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java:[71,50] (extension) MultipleStringLiteralsExtended: The String "p" appears 2 times in the file.
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java:[71,55] (extension) MultipleStringLiteralsExtended: The String "td" appears 2 times in the file.
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java:[71,61] (extension) MultipleStringLiteralsExtended: The String "tr" appears 2 times in the file.
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java:[71,67] (extension) MultipleStringLiteralsExtended: The String "th" appears 2 times in the file.
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java:[291,43] (extension) MultipleStringLiteralsExtended: The String "/**" appears 2 times in the file.
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java:[91,61] (extension) MultipleStringLiteralsExtended: The String "\">" appears 2 times in the file.
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java:[118,68] (extension) MultipleStringLiteralsExtended: The String "\"" appears 4 times in the file.
```