### PR TITLE
Pull #2749: Make UT 'testNonAccessibleFile' locale independent 

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -19,7 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.junit.Assert.assertEquals;
@@ -73,8 +73,7 @@ public class PropertyCacheFileTest {
             fail("FileNotFoundException is expected, since access to the file was denied!");
         }
         catch (FileNotFoundException ex) {
-            assertThat(ex.getMessage(), anyOf(endsWith("file.output (Permission denied)"),
-                endsWith("file.output (Access is denied)")));
+            assertThat(ex.getMessage(), containsString("file.output"));
         }
     }
 


### PR DESCRIPTION
The problem was reported by @Vladlis . He uses Russian localse in OS Linux Mint. When he did rebase and ran UTs the 'testNonAccessibleFile' failed.

The exception message should have ended with "file.output (Permission denied)" for OS Linux EN or "file.output (Access is denied)" for OS Windows EN.
But he received ""file.output (Доступ запрещен)" as he uses OS Linux Mint RU.

So, we can assume that contributors who use locale that is differ to EN will have problems with the UT.