### PR TITLE
Issue #2211: OneStatementPerLine has false match with try-with-resources

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
@@ -117,7 +117,10 @@ public final class OneStatementPerLineCheck extends Check {
         switch (ast.getType()) {
             case TokenTypes.SEMI:
                 DetailAST currentStatement = ast;
-                if (isMultilineStatement(currentStatement)) {
+                final boolean hasResourcesPrevSibling =
+                        currentStatement.getPreviousSibling() != null
+                        && currentStatement.getPreviousSibling().getType() == TokenTypes.RESOURCES;
+                if (!hasResourcesPrevSibling && isMultilineStatement(currentStatement)) {
                     currentStatement = ast.getPreviousSibling();
                 }
                 if (isOnTheSameLine(currentStatement, lastStatementEnd,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
@@ -79,6 +79,8 @@ public class OneStatementPerLineCheckTest extends BaseCheckTestSupport {
             "81:10: " + getCheckMessage(MSG_KEY),
             "90:28: " + getCheckMessage(MSG_KEY),
             "135:39: " + getCheckMessage(MSG_KEY),
+            "168:110: " + getCheckMessage(MSG_KEY),
+            "179:107: " + getCheckMessage(MSG_KEY),
         };
 
         verify(checkConfig,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputOneStatementPerLine2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputOneStatementPerLine2.java
@@ -134,4 +134,50 @@ public class InputOneStatementPerLine2 {
             ;
             n++, k--) { var1++; var2++; }
     }
+
+    /**
+     * Multiple statements within try-with-resource on a separate line is legal.
+     * @see <a href="https://github.com/checkstyle/checkstyle/issues/2211">OneStatementPerLine: false match with try-with-resources</a>
+     */
+    private void issue2211pass() {
+        try(
+                AutoCloseable i = new java.io.StringReader("");
+                AutoCloseable k = new java.io.StringReader("");
+        ) {
+        } catch (Exception e1) {
+        }
+    }
+
+    /**
+     * Multiple statements within try-with-resource on a separate line is legal. Added per PR comment:
+     * @see <a href="https://github.com/checkstyle/checkstyle/pull/2750#issuecomment-166032327">Please add UT cases</a>
+     */
+    private void issue2211pass2() {
+        try( AutoCloseable i = new java.io.StringReader("");
+            AutoCloseable k = new java.io.StringReader("");) {
+        } catch (Exception e1) {
+        }
+    }
+
+    /**
+     * Multiple statements within try-with-resource on next line after try is illegal.
+     * @see <a href="https://github.com/checkstyle/checkstyle/issues/2211">OneStatementPerLine: false match with try-with-resources</a>
+     */
+    private void issue2211fail() {
+        try(
+                AutoCloseable i = new java.io.StringReader("");AutoCloseable k = new java.io.StringReader("");
+        ) {
+        } catch (Exception e1) {
+        }
+    }
+
+    /**
+     * Multiple statements within try-with-resource on a same line as try is illegal.  Added per PR comment:
+     * @see <a href="https://github.com/checkstyle/checkstyle/pull/2750#issuecomment-166032327">Please add UT cases</a>
+     */
+    private void issue2211fail2() {
+        try( AutoCloseable i = new java.io.StringReader("");AutoCloseable k = new java.io.StringReader("");) {
+        } catch (Exception e1) {
+        }
+    }
 }


### PR DESCRIPTION
`OneStatementPerLine#isMultilineStatement` was returning true when the `previousSibling` was a RESOURCES token.  The solution was to return false if  `previousSibling` is a RESOURCES token.

Let me know if there are any styling issues.