### PR TITLE
Issue #2661: Enforce ForbidWildcardAsReturnType of sevntu-checkstyle over Checkstyle source code

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -103,5 +103,6 @@
             <property name="highlightAllDuplicates" value="true"/>
         </module>
         <module name="SimpleAccessorNameNotation"/>
+        <module name="ForbidWildcardAsReturnType"/>
     </module>
 </module>

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -20,4 +20,17 @@
     <suppress checks="SimpleAccessorNameNotation"
               files="ClassFanOutComplexityCheck\.java"
               lines="76"/>
+
+    <!-- These classes are deprecated and will be removed soon. -->
+    <suppress checks="ForbidWildcardAsReturnType"
+              files="AbstractTypeAwareCheck\.java"
+              lines="223,239,419"/>
+    <suppress checks="ForbidWildcardAsReturnType"
+              files="ClassResolver\.java"
+              lines="72,184"/>
+    <!-- We need to satisfy javax.swing.table.AbstractTableModel
+    public Class<?> getColumnClass(int columnIndex) { -->
+    <suppress checks="ForbidWildcardAsReturnType"
+              files="ParseTreeTableModel\.java"
+              lines="106"/>
 </suppressions>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
@@ -85,9 +85,10 @@ public class HandlerFactory {
      *                type from TokenTypes
      * @param handlerClass
      *                the handler to register
+     * @param <T> type of the handler class object.
      */
-    private void register(int type, Class<?> handlerClass) {
-        final Constructor<?> ctor = CommonUtils.getConstructor(handlerClass,
+    private <T> void register(int type, Class<T> handlerClass) {
+        final Constructor<T> ctor = CommonUtils.getConstructor(handlerClass,
                 IndentationCheck.class,
                 // current AST
                 DetailAST.class,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
@@ -289,10 +289,12 @@ public final class CommonUtils {
      *            from which constructor is returned
      * @param parameterTypes
      *            of constructor
+     * @param <T> type of the target class object.
      * @return constructor of targetClass or {@link IllegalStateException} if any exception occurs
      * @see Class#getConstructor(Class[])
      */
-    public static Constructor<?> getConstructor(Class<?> targetClass, Class<?>... parameterTypes) {
+    public static <T> Constructor<T> getConstructor(Class<T> targetClass,
+                                                    Class<?>... parameterTypes) {
         try {
             return targetClass.getConstructor(parameterTypes);
         }


### PR DESCRIPTION
It is impossible to avoid wildcard as return type, because we don't know the actual type of the
returning object when we invoke the methods. That is why I suppressed some violations.