### PR TITLE
Issue #2376: Fixed typo in BASEFONT javadoc tag

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1508,10 +1508,10 @@ public final class JavadocTokenTypes {
     /** Base tag name. */
     public static final int BASE_HTML_TAG_NAME = JavadocParser.BASE_HTML_TAG_NAME;
 
-    /** Basefront html tag. */
-    public static final int BASEFRONT_TAG = JavadocParser.RULE_basefrontTag + RULE_TYPES_OFFSET;
-    /** Basefront tag name. */
-    public static final int BASEFRONT_HTML_TAG_NAME = JavadocParser.BASEFRONT_HTML_TAG_NAME;
+    /** Basefont html tag. */
+    public static final int BASEFONT_TAG = JavadocParser.RULE_basefontTag + RULE_TYPES_OFFSET;
+    /** Basefont tag name. */
+    public static final int BASEFONT_HTML_TAG_NAME = JavadocParser.BASEFONT_HTML_TAG_NAME;
 
     /** Br html tag. */
     public static final int BR_TAG = JavadocParser.RULE_brTag + RULE_TYPES_OFFSET;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocLexer.g4
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocLexer.g4
@@ -294,7 +294,7 @@ THEAD_HTML_TAG_NAME: T H E A D {!htmlTagNameCatched}? {htmlTagNameCatched=true;}
 // singleton tags
 AREA_HTML_TAG_NAME: A R E A {!htmlTagNameCatched}? {htmlTagNameCatched=true;};
 BASE_HTML_TAG_NAME: B A S E {!htmlTagNameCatched}? {htmlTagNameCatched=true;};
-BASEFRONT_HTML_TAG_NAME: B A S E F R O N T {!htmlTagNameCatched}? {htmlTagNameCatched=true;};
+BASEFONT_HTML_TAG_NAME: B A S E F O N T {!htmlTagNameCatched}? {htmlTagNameCatched=true;};
 BR_HTML_TAG_NAME: B R {!htmlTagNameCatched}? {htmlTagNameCatched=true;};
 COL_HTML_TAG_NAME: C O L {!htmlTagNameCatched}? {htmlTagNameCatched=true;};
 FRAME_HTML_TAG_NAME: F R A M E {!htmlTagNameCatched}? {htmlTagNameCatched=true;};

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParser.g4
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParser.g4
@@ -763,7 +763,7 @@ thead: theadTagOpen
 singletonElement: singletonTag
             | areaTag
             | baseTag
-            | basefrontTag
+            | basefontTag
             | brTag
             | colTag
             | frameTag
@@ -801,7 +801,7 @@ singletonTag: OPEN
 
 areaTag: OPEN AREA_HTML_TAG_NAME (attribute | NEWLINE | LEADING_ASTERISK | WS)* (SLASH_CLOSE | CLOSE);
 baseTag: OPEN BASE_HTML_TAG_NAME (attribute | NEWLINE | LEADING_ASTERISK | WS)* (SLASH_CLOSE | CLOSE);
-basefrontTag: OPEN BASEFRONT_HTML_TAG_NAME (attribute | NEWLINE | LEADING_ASTERISK | WS)* (SLASH_CLOSE | CLOSE);
+basefontTag: OPEN BASEFONT_HTML_TAG_NAME (attribute | NEWLINE | LEADING_ASTERISK | WS)* (SLASH_CLOSE | CLOSE);
 brTag: OPEN BR_HTML_TAG_NAME (attribute | NEWLINE | LEADING_ASTERISK | WS)* (SLASH_CLOSE | CLOSE);
 colTag: OPEN COL_HTML_TAG_NAME (attribute | NEWLINE | LEADING_ASTERISK | WS)* (SLASH_CLOSE | CLOSE);
 frameTag: OPEN FRAME_HTML_TAG_NAME (attribute | NEWLINE | LEADING_ASTERISK | WS)* (SLASH_CLOSE | CLOSE);
@@ -817,7 +817,7 @@ wrongSinletonTag: OPEN SLASH singletonTagName CLOSE {notifyErrorListeners($singl
                   ;
 singletonTagName: (AREA_HTML_TAG_NAME
                   | BASE_HTML_TAG_NAME
-                  | BASEFRONT_HTML_TAG_NAME
+                  | BASEFONT_HTML_TAG_NAME
                   | BR_HTML_TAG_NAME
                   | COL_HTML_TAG_NAME
                   | FRAME_HTML_TAG_NAME


### PR DESCRIPTION
No exceptions detected while generating Checkstyle report on OpenJDK:
```
bizmailov@vdu-bizmailov:~/git/contribution/checkstyle-tester$ ./launch.sh -Dcheckstyle.config.location=my_check.xml
Testing Checkstyle started
openjdk is synchronized

Running 'mvn clean' on src/main/java ...
..................
Done. Result report is locates at: target/site/index.html
bizmailov@vdu-bizmailov:~/git/contribution/checkstyle-tester$ grep "Got an exception" target/site/checkstyle.html 
bizmailov@vdu-bizmailov:~/git/contribution/checkstyle-tester$ 
```
Only javadoc check is included in config file:
```
<module name="JavadocParagraph"/>
```