### PR TITLE
Issue #2780: Fix StringIndexOutOfBoundsException in getCheckShortNamemethod of AuditEventDefaultFormatter

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatter.java
@@ -34,6 +34,9 @@ public class AuditEventDefaultFormatter implements AuditEvemtFormatter {
     /** Length of all separators. */
     private static final int LENGTH_OF_ALL_SEPARATORS = 10;
 
+    /** Suffix of module names like XXXXCheck. */
+    private static final String SUFFIX = "Check";
+
     @Override
     public String format(AuditEvent event) {
         final String fileName = event.getFileName();
@@ -87,7 +90,25 @@ public class AuditEventDefaultFormatter implements AuditEvemtFormatter {
      */
     private static String getCheckShortName(AuditEvent event) {
         final String checkFullName = event.getSourceName();
-        return checkFullName.substring(checkFullName.lastIndexOf('.') + 1,
-            checkFullName.lastIndexOf("Check"));
+        final String checkShortName;
+        final int lastDotIndex = checkFullName.lastIndexOf('.');
+        if (lastDotIndex == -1) {
+            if (checkFullName.endsWith(SUFFIX)) {
+                checkShortName = checkFullName.substring(0, checkFullName.lastIndexOf(SUFFIX));
+            }
+            else {
+                checkShortName = checkFullName.substring(0, checkFullName.length());
+            }
+        }
+        else {
+            if (checkFullName.endsWith(SUFFIX)) {
+                checkShortName = checkFullName.substring(lastDotIndex + 1,
+                    checkFullName.lastIndexOf(SUFFIX));
+            }
+            else {
+                checkShortName = checkFullName.substring(lastDotIndex + 1, checkFullName.length());
+            }
+        }
+        return checkShortName;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatterTest.java
@@ -1,0 +1,101 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AuditEvent.class)
+public class AuditEventDefaultFormatterTest {
+
+    @Test
+    public void testFormatFullyQualifiedModuleNameContainsCheckSuffix() {
+        final AuditEvent mock = PowerMockito.mock(AuditEvent.class);
+        when(mock.getSourceName()).thenReturn("com.test.package.TestModuleCheck");
+        when(mock.getSeverityLevel()).thenReturn(SeverityLevel.WARNING);
+        when(mock.getLine()).thenReturn(1);
+        when(mock.getColumn()).thenReturn(1);
+        when(mock.getMessage()).thenReturn("Mocked message.");
+        when(mock.getFileName()).thenReturn("InputMockFile.java");
+        final AuditEvemtFormatter formatter = new AuditEventDefaultFormatter();
+
+        final String expected = "[WARN] InputMockFile.java:1:1: Mocked message. [TestModule]";
+
+        assertEquals(expected, formatter.format(mock));
+    }
+
+    @Test
+    public void testFormatFullyQualifiedModuleNameDoesNotContainCheckSuffix() {
+        final AuditEvent mock = PowerMockito.mock(AuditEvent.class);
+        when(mock.getSourceName()).thenReturn("com.test.package.TestModule");
+        when(mock.getSeverityLevel()).thenReturn(SeverityLevel.WARNING);
+        when(mock.getLine()).thenReturn(1);
+        when(mock.getColumn()).thenReturn(1);
+        when(mock.getMessage()).thenReturn("Mocked message.");
+        when(mock.getFileName()).thenReturn("InputMockFile.java");
+        final AuditEvemtFormatter formatter = new AuditEventDefaultFormatter();
+
+        final String expected = "[WARN] InputMockFile.java:1:1: Mocked message. [TestModule]";
+
+        assertEquals(expected, formatter.format(mock));
+    }
+
+    @Test
+    public void testFormatModuleNameContainsCheckSuffix() {
+        final AuditEvent mock = PowerMockito.mock(AuditEvent.class);
+        when(mock.getSourceName()).thenReturn("TestModuleCheck");
+        when(mock.getSeverityLevel()).thenReturn(SeverityLevel.WARNING);
+        when(mock.getLine()).thenReturn(1);
+        when(mock.getColumn()).thenReturn(1);
+        when(mock.getMessage()).thenReturn("Mocked message.");
+        when(mock.getFileName()).thenReturn("InputMockFile.java");
+        final AuditEvemtFormatter formatter = new AuditEventDefaultFormatter();
+
+        final String expected = "[WARN] InputMockFile.java:1:1: Mocked message. [TestModule]";
+
+        assertEquals(expected, formatter.format(mock));
+    }
+
+    @Test
+    public void testFormatModuleNameDoesNotContainCheckSuffix() {
+        final AuditEvent mock = PowerMockito.mock(AuditEvent.class);
+        when(mock.getSourceName()).thenReturn("TestModule");
+        when(mock.getSeverityLevel()).thenReturn(SeverityLevel.WARNING);
+        when(mock.getLine()).thenReturn(1);
+        when(mock.getColumn()).thenReturn(1);
+        when(mock.getMessage()).thenReturn("Mocked message.");
+        when(mock.getFileName()).thenReturn("InputMockFile.java");
+        final AuditEvemtFormatter formatter = new AuditEventDefaultFormatter();
+
+        final String expected = "[WARN] InputMockFile.java:1:1: Mocked message. [TestModule]";
+
+        assertEquals(expected, formatter.format(mock));
+    }
+}


### PR DESCRIPTION
There are 4 formats of module name:
com.package.TestModuleCheck
com.package.TestModule
TestModuleCheck
TestModule

Now they are treated by getCheckShortName.


P.S.
There is a typo in ```AuditEvemtFormatter```. I'll fix it in separate PR.