### PR TITLE
Issue #2729: Support of arrays in java8 method references has been added to grammar.

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
@@ -510,8 +510,8 @@ annotationMemberArrayInitializer
 // The two things that can initialize an annotation array element are a conditional expression
 //   and an annotation (nested annotation array initialisers are not valid)
 annotationMemberArrayValueInitializer
-    :    annotationExpression
-    |   annotation
+    :    (annotation) => annotation
+    | annotationExpression
     ;
 
 annotationExpression
@@ -1461,7 +1461,8 @@ postfixExpression
 
 // the basic element of an expression
 primaryExpression
-    :   IDENT ((typeArguments[false] DOUBLE_COLON)=>typeArguments[false])?
+    :    (typeSpec[false] DOUBLE_COLON) => typeSpec[false]
+    |    IDENT
     |    constant
     |    "true"
     |    "false"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/MethodReferencesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/MethodReferencesTest.java
@@ -65,4 +65,13 @@ public class MethodReferencesTest extends BaseCheckTestSupport {
         verify(checkConfig, getNonCompilablePath("InputMethodReferences3.java"), expected);
 
     }
+
+    @Test
+    public void testGenericInArrayBeforeReference()
+            throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(MemberNameCheck.class);
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getNonCompilablePath("InputMethodReferences4.java"), expected);
+
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences4.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences4.java
@@ -1,0 +1,12 @@
+//Compilable with Java8
+//Issue #2729
+package com.puppycrawl.tools.checkstyle.grammars.java8;
+import java.util.Arrays;
+
+public class InputMethodReferences4 {
+    public void doSomething(final Object... arguments) {
+        Arrays.stream(arguments)
+                .map(Object::getClass)
+                .toArray(Class<?>[]::new);
+    }
+}


### PR DESCRIPTION
Reports with line length check (https://github.com/sabaka/contribution/blob/own_config/checkstyle-tester/my_check.xml)
On projects: https://github.com/sabaka/contribution/blob/own_config/checkstyle-tester/projects-to-test-on.properties
origin:
http://sabaka.github.io/issue2729/master/checkstyle.html
after changes:
http://sabaka.github.io/issue2729/checkstyle.html