### PR TITLE
Add sbt-checkstyle-plugin to list of active tools

### DIFF
--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -273,6 +273,12 @@
                   <td><a href="http://www.jarchitect.com/">JArchitect Home Page</a></td>
                   <td>Imports XML result files from CheckStyle.</td>
               </tr>
+	      <tr>
+                  <td><a href="http://www.scala-sbt.org/">SBT</a></td>
+                  <td>Andrew Johnson</td>
+                  <td><a href="https://github.com/etsy/sbt-checkstyle-plugin">sbt-checkstyle-plugin Project Page</a></td>
+                  <td>SBT plugin for running Checkstyle on Java source files in an SBT project</td>
+              </tr>
           </table>
       </subsection>
 


### PR DESCRIPTION
I'm the author of [sbt-checkstyle-plugin](https://github.com/etsy/sbt-checkstyle-plugin), an SBT plugin from running Checkstyle on Java files in an SBT project.  I'd like to have it added to the list of related tools at http://checkstyle.sourceforge.net/index.html#Related_Tools.

I wasn't sure if this was the best way to go about adding it - let me know if there's something else I should do.