### PR TITLE
doc: Update release notes for 6.14

### DIFF
--- a/src/xdocs/releasenotes.xml
+++ b/src/xdocs/releasenotes.xml
@@ -37,7 +37,7 @@
       <p>Breaking backward compatibility:</p>
         <ul>
           <li>
-            Remove parameters validation from LocalVariableName. Author: Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/2549">#2549</a>
+            Remove catch parameters validation from LocalVariableName. Author: Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/2549">#2549</a>
           </li>
         </ul>
       <p>New:</p>


### PR DESCRIPTION
I think that we removed just catch parameters validation here. By saying 'remove parameters validation' everyone would think 'method parameters'. Correct me if I'm wrong