### PR TITLE
minor: Update Maven Surefire and Failsafe plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -749,7 +749,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.19</version>
+        <version>2.19.1</version>
         <configuration>
           <includes>
             <include>com/google/**/*.java</include>
@@ -775,7 +775,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19</version>
+        <version>2.19.1</version>
         <configuration>
           <argLine>-Duser.language=en -Duser.country=US -XX:-UseSplitVerifier</argLine>
           <systemPropertyVariables>
@@ -1008,7 +1008,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>2.19</version>
+        <version>2.19.1</version>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
#### Release Notes - Maven Surefire - Version 2.19.1

<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1185'>SUREFIRE-1185</a>]
-         single method test spews status of every single other test
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1187'>SUREFIRE-1187</a>]
-         JUnit4 Provider created unnecessary Runner instance
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1189'>SUREFIRE-1189</a>]
-         Prevent from I/O leakage. Thus close streams in finally block.
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1192'>SUREFIRE-1192</a>]
-         Fixed Sonar and FindBug issues
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1193'>SUREFIRE-1193</a>]
-         Surefire 2.19 hangs in the log4j build
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1194'>SUREFIRE-1194</a>]
-         reporter argument does not work for TestNG
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1197'>SUREFIRE-1197</a>]
-         Surefire 2.19 breaks tests under Windows due to fork problem
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1200'>SUREFIRE-1200</a>]
-         Could not run single test by full name
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1203'>SUREFIRE-1203</a>]
-         Surefire hangs after Test Execution
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1204'>SUREFIRE-1204</a>]
-         -Dtest= option is broken in 2.19
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1208'>SUREFIRE-1208</a>]
-         Start stream capture before loading tests
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1209'>SUREFIRE-1209</a>]
-         rerunFailingTestsCount does not run failed tests if forkCount and
surefire-junit47 is used
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1211'>SUREFIRE-1211</a>]
-         surefire-testng runs JUnit tests
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1215'>SUREFIRE-1215</a>]
-         refs/tags/surefire-2.19.1_vote-1 slows down the Maven build in 20
seconds
</li>
</ul>

<h2>        Improvement
</h2>
<ul>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1135'>SUREFIRE-1135</a>]
-         Improve ignore message for TestNG
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1191'>SUREFIRE-1191</a>]
-         Run Single Test with Package Name Doesn&#39;t work
</li>
<li>[<a href='https://issues.apache.org/jira/browse/SUREFIRE-1202'>SUREFIRE-1202</a>]
-         Allow rerunFailingTestsCount, skipAfterFailureCount together
</li>
</ul>
