### PR TITLE
Issue #2815: improve cache in 'CircleCI'

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,14 @@
+checkout:
+  post:
+    - git clone https://github.com/checkstyle/contribution
+dependencies:
+  post:
+    - (cd contribution/checkstyle-tester && mvn dependency:resolve)
 machine:
   java:
     version: oraclejdk8
   environment:
-    CMD1: "git clone https://github.com/checkstyle/contribution && cd contribution/checkstyle-tester"
+    CMD1: "cd contribution/checkstyle-tester"
     CMD2: " && sed -i.'' 's/^openjdk/#openjdk/' projects-for-circle.properties"
     CMD3: " && sed -i.'' s/projects-to-test-on.properties/projects-for-circle.properties/ launch.sh"
     CMD4: " && cd ../../ && mvn clean install -DskipTests -DskipITs -Dcobertura.skip=true"


### PR DESCRIPTION
Maven dependencies for checkstyle-tester are cached now. For that the tester is being run on no projects in 'dependencies' section.