### PR TITLE
Issue #2773: added exception for invalid AutomaticBean children

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -225,15 +225,21 @@ public class AutomaticBean
     /**
      * Called by configure() for every child of this component's Configuration.
      * <p>
-     * The default implementation does nothing.
+     * The default implementation throws {@link CheckstyleException} if
+     * {@code childConf} is {@code null} because it doesn't support children. It
+     * must be overridden to validate and support children that are wanted.
      * </p>
+     *
      * @param childConf a child of this component's Configuration
      * @throws CheckstyleException if there is a configuration error.
      * @see Configuration#getChildren
      */
     protected void setupChild(Configuration childConf)
         throws CheckstyleException {
-        // No code by default, should be overridden only by demand at subclasses
+        if (childConf != null) {
+            throw new CheckstyleException(childConf.getName() + " is not allowed as a child in "
+                    + getConfiguration().getName());
+        }
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -433,6 +433,46 @@ public class MainTest {
     }
 
     @Test
+    public void testExistingIncorrectChildrenInConfigFile()
+            throws Exception {
+        exit.expectSystemExitWithStatus(-2);
+        exit.checkAssertionAfterwards(new Assertion() {
+            @Override
+            public void checkAssertion() {
+                final String output = String.format(Locale.ROOT,
+                        "Checkstyle ends with 1 errors.%n");
+                assertEquals(output, systemOut.getLog());
+                final String errorOuput = "com.puppycrawl.tools.checkstyle.api."
+                        + "CheckstyleException: cannot initialize module RegexpSingleline"
+                        + " - RegexpSingleline is not allowed as a child in RegexpSingleline";
+                assertTrue(systemErr.getLog().startsWith(errorOuput));
+            }
+        });
+        Main.main("-c", getPath("config-incorrectChildren.xml"),
+            getPath("InputMain.java"));
+    }
+
+    @Test
+    public void testExistingIncorrectChildrenInConfigFile2()
+            throws Exception {
+        exit.expectSystemExitWithStatus(-2);
+        exit.checkAssertionAfterwards(new Assertion() {
+            @Override
+            public void checkAssertion() {
+                final String output = String.format(Locale.ROOT,
+                        "Checkstyle ends with 1 errors.%n");
+                assertEquals(output, systemOut.getLog());
+                final String errorOuput = "com.puppycrawl.tools.checkstyle.api."
+                        + "CheckstyleException: cannot initialize module TreeWalker"
+                        + " - JavadocVariable is not allowed as a child in JavadocMethod";
+                assertTrue(systemErr.getLog().startsWith(errorOuput));
+            }
+        });
+        Main.main("-c", getPath("config-incorrectChildren2.xml"),
+            getPath("InputMain.java"));
+    }
+
+    @Test
     public void testLoadPropertiesIoException() throws Exception {
         final Class<?>[] param = new Class<?>[1];
         param[0] = File.class;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -19,10 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 
 import org.apache.commons.beanutils.ConversionException;
@@ -65,6 +67,25 @@ public class AutomaticBeanTest {
     public void testSetupChildFromBaseClass() throws CheckstyleException {
         final TestBean testBean = new TestBean();
         testBean.setupChild(null);
+    }
+
+    @Test
+    public void testSetupInvalidChildFromBaseClass() throws Exception {
+        final TestBean testBean = new TestBean();
+        final DefaultConfiguration parentConf = new DefaultConfiguration("parentConf");
+        final DefaultConfiguration childConf = new DefaultConfiguration("childConf");
+        final Field field = AutomaticBean.class.getDeclaredField("configuration");
+        field.setAccessible(true);
+        field.set(testBean, parentConf);
+
+        try {
+            testBean.setupChild(childConf);
+            fail("expecting checkstyle exception");
+        }
+        catch (CheckstyleException ex) {
+            assertEquals("expected exception", "childConf is not allowed as a child in parentConf",
+                    ex.getMessage());
+        }
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/config-incorrectChildren.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/config-incorrectChildren.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+  <module name="RegexpSingleline">
+    <property name="format" value="\s+$"/>
+    <property name="minimum" value="0"/>
+    <property name="maximum" value="0"/>
+
+    <module name="RegexpSingleline">
+      <property name="format" value="\s+$"/>
+      <property name="minimum" value="0"/>
+      <property name="maximum" value="0"/>
+    </module>
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/config-incorrectChildren2.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/config-incorrectChildren2.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocMethod">
+      <module name="JavadocVariable">
+      </module>
+    </module>
+  </module>
+</module>


### PR DESCRIPTION
AutomaticBean will now throw an exception on setupChild if the config isn't null for the default behavior.
I added 3 test cases to verify the exception in different scenarios I found.