### PR TITLE
Issue 2806

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
@@ -113,6 +113,8 @@ public class DefaultLogger extends AutomaticBean implements AuditListener {
     /**
      * Print an Emacs compliant line on the error stream.
      * If the column number is non zero, then also display it.
+     *
+     * @param event the event details
      * @see AuditListener
      **/
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -116,6 +116,8 @@ public class AutomaticBean
      * is called for each {@link Configuration#getChildren child Configuration}
      * of {@code configuration}.
      *
+     * @param config the configuration to use.
+     * @throws CheckstyleException if there is a configuration error.
      * @see Configurable
      */
     @Override
@@ -187,6 +189,9 @@ public class AutomaticBean
 
     /**
      * Implements the Contextualizable interface using bean introspection.
+     *
+     * @param context the context.
+     * @throws CheckstyleException if there is a contextualization error.
      * @see Contextualizable
      */
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -346,11 +346,6 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
 
     @Override
     protected final void processAST(DetailAST ast) {
-        if ((ast.getType() == TokenTypes.METHOD_DEF || ast.getType() == TokenTypes.CTOR_DEF)
-            && getMethodsNumberOfLine(ast) <= minLineCount
-            || hasAllowedAnnotations(ast)) {
-            return;
-        }
         final Scope theScope = calculateScope(ast);
         if (shouldCheck(ast, theScope)) {
             final FileContents contents = getFileContents();
@@ -430,7 +425,20 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
         return allowMissingJavadoc
             || allowMissingPropertyJavadoc
                 && (CheckUtils.isSetterMethod(ast) || CheckUtils.isGetterMethod(ast))
-            || matchesSkipRegex(ast);
+            || matchesSkipRegex(ast)
+            || isContentsAllowMissingJavadoc(ast);
+    }
+
+    /**
+     * Checks if the Javadoc can be missing if the method or constructor is
+     * below the minimum line count or has a special annotation.
+     *
+     * @param ast the tree node for the method or constructor.
+     * @return True if this method or constructor doesn't need Javadoc.
+     */
+    private boolean isContentsAllowMissingJavadoc(DetailAST ast) {
+        return (ast.getType() == TokenTypes.METHOD_DEF || ast.getType() == TokenTypes.CTOR_DEF)
+                && (getMethodsNumberOfLine(ast) <= minLineCount || hasAllowedAnnotations(ast));
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
@@ -211,6 +211,8 @@ public class JTreeTable extends JTable {
 
     /**
      * Overridden to pass the new rowHeight to the tree.
+     *
+     * @param newRowHeight new row height
      */
     @Override
     public final void setRowHeight(int newRowHeight) {
@@ -277,6 +279,9 @@ public class JTreeTable extends JTable {
          * <p>By returning false we are also enforcing the policy that
          * the tree will never be editable (at least by a key sequence).
          *
+         * @param event the event the editor should use to consider
+         *              whether to begin editing or not
+         * @return true if editing can be started
          * @see TableCellEditor
          */
         @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableCellRenderer.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableCellRenderer.java
@@ -81,6 +81,8 @@ class TreeTableCellRenderer extends JTree implements
     /**
      * Sets the row height of the tree, and forwards the row height to
      * the table.
+     *
+     * @param newRowHeight the height of each cell, in pixels
      */
     @Override
     public void setRowHeight(int newRowHeight) {
@@ -95,6 +97,11 @@ class TreeTableCellRenderer extends JTree implements
 
     /**
      * This is overridden to set the height to match that of the JTable.
+     *
+     * @param x the new <i>x</i>-coordinate of this component
+     * @param y the new <i>y</i>-coordinate of this component
+     * @param w the new <code>width</code> of this component
+     * @param h the new <code>height</code> of this component
      */
     @Override
     public void setBounds(int x, int y, int w, int h) {
@@ -104,6 +111,8 @@ class TreeTableCellRenderer extends JTree implements
     /**
      * Subclassed to translate the graphics such that the last visible
      * row will be drawn at 0,0.
+     *
+     * @param graph  the <code>Graphics</code> context in which to paint
      */
     @Override
     public void paint(Graphics graph) {
@@ -113,6 +122,16 @@ class TreeTableCellRenderer extends JTree implements
 
     /**
      * TreeCellRenderer method. Overridden to update the visible row.
+     *
+     * @param   table           the <code>JTable</code> that is asking the
+     *                          renderer to draw; can be <code>null</code>
+     * @param   value           the value of the cell to be rendered.
+     * @param   isSelected      true if the cell is to be rendered with the
+     *                          selection highlighted; otherwise false
+     * @param   hasFocus        if true, render cell appropriately.
+     * @param   row             the row index of the cell being drawn.
+     * @param   column          the column index of the cell being drawn
+     * @return The component used for drawing the cell.
      * @see TableCellRenderer
      */
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -571,4 +571,14 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
         };
         verify(checkConfig, getPath("InputJavadocMethodIgnoreNameRegex.java"), expected);
     }
+
+    @Test
+    public void testMethodsNotSkipWrittenJavadocs() throws Exception {
+        checkConfig.addAttribute("allowedAnnotations", "MyAnnotation");
+        final String[] expected = {
+            "7:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "BAD"),
+            "17:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "BAD"),
+        };
+        verify(checkConfig, getPath("InputJavadocMethodsNotSkipWritten.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputJavadocMethodsNotSkipWritten.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputJavadocMethodsNotSkipWritten.java
@@ -1,0 +1,28 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+public class InputJavadocMethodsNotSkipWritten {
+    /**
+     * Description.
+     * 
+     * @param BAD
+     *            This param doesn't exist.
+     */
+    @MyAnnotation
+    public void InputJavadocMethodsNotSkipWritten() {
+    }
+
+    /**
+     * Description.
+     * 
+     * @param BAD
+     *            This param doesn't exist.
+     */
+    @MyAnnotation
+    public void test() {
+    }
+
+    /** Description. */
+    @MyAnnotation
+    public void test2() {
+    }
+}


### PR DESCRIPTION
Like issue, the number of lines and annotation checks were moved to only if the javadoc is missing. If it is found, then it will always be validated.
Not sure if the method name `isContentsAllowMissingJavadoc` is the best, but it is all that I can think of for right now.
Second commit fixes all violations in CS' source. I just added the missing params/tags and didn't remove any javadocs.