### PR TITLE
Issue #2822: Makes FinalClass doesnt recognise as final classes with …

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -21,6 +21,10 @@ package com.puppycrawl.tools.checkstyle.checks.design;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
 
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -50,8 +54,16 @@ public class FinalClassCheck
      */
     public static final String MSG_KEY = "final.class";
 
+    /**
+     * Character separate package names in qualified name of java class.
+     */
+    public static final String PACKAGE_SEPARATOR = ".";
+
     /** Keeps ClassDesc objects for stack of declared classes. */
-    private final Deque<ClassDesc> classes = new ArrayDeque<>();
+    private Deque<ClassDesc> classes;
+
+    /** Full qualified name of the package. */
+    private String packageName;
 
     @Override
     public int[] getDefaultTokens() {
@@ -60,7 +72,7 @@ public class FinalClassCheck
 
     @Override
     public int[] getAcceptableTokens() {
-        return new int[] {TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF};
+        return new int[] {TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF, TokenTypes.PACKAGE_DEF};
     }
 
     @Override
@@ -69,23 +81,45 @@ public class FinalClassCheck
     }
 
     @Override
+    public void beginTree(DetailAST rootAST) {
+        classes = new ArrayDeque<>();
+        packageName = "";
+    }
+
+    @Override
     public void visitToken(DetailAST ast) {
         final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
 
-        if (ast.getType() == TokenTypes.CLASS_DEF) {
-            final boolean isFinal = modifiers.branchContains(TokenTypes.FINAL);
-            final boolean isAbstract = modifiers.branchContains(TokenTypes.ABSTRACT);
-            classes.push(new ClassDesc(isFinal, isAbstract));
-        }
-        // ctors in enums don't matter
-        else if (!ScopeUtils.isInEnumBlock(ast)) {
-            final ClassDesc desc = classes.peek();
-            if (modifiers.branchContains(TokenTypes.LITERAL_PRIVATE)) {
-                desc.reportPrivateCtor();
-            }
-            else {
-                desc.reportNonPrivateCtor();
-            }
+        switch (ast.getType()) {
+
+            case TokenTypes.PACKAGE_DEF:
+                packageName = extractQualifiedName(ast);
+                break;
+
+            case TokenTypes.CLASS_DEF:
+                registerNestedSubclassToOuterSuperClasses(ast);
+
+                final boolean isFinal = modifiers.branchContains(TokenTypes.FINAL);
+                final boolean isAbstract = modifiers.branchContains(TokenTypes.ABSTRACT);
+
+                final String qualifiedClassName = getQualifiedClassName(ast);
+                classes.push(new ClassDesc(qualifiedClassName, isFinal, isAbstract));
+                break;
+
+            case TokenTypes.CTOR_DEF:
+                if (!ScopeUtils.isInEnumBlock(ast)) {
+                    final ClassDesc desc = classes.peek();
+                    if (modifiers.branchContains(TokenTypes.LITERAL_PRIVATE)) {
+                        desc.registerPrivateCtor();
+                    }
+                    else {
+                        desc.registerNonPrivateCtor();
+                    }
+                }
+                break;
+
+            default:
+                throw new IllegalStateException(ast.toString());
         }
     }
 
@@ -96,19 +130,150 @@ public class FinalClassCheck
         }
 
         final ClassDesc desc = classes.pop();
-        if (!desc.isDeclaredAsFinal()
+        if (desc.isWithPrivateCtor()
             && !desc.isDeclaredAsAbstract()
-            && desc.isWithPrivateCtor()
+            && !desc.isDeclaredAsFinal()
             && !desc.isWithNonPrivateCtor()
+            && !desc.isWithNestedSubclass()
             && !ScopeUtils.isInInterfaceOrAnnotationBlock(ast)) {
-            final String className =
-                ast.findFirstToken(TokenTypes.IDENT).getText();
+            final String qualifiedName = desc.getQualifiedName();
+            final String className = getClassNameFromQualifiedName(qualifiedName);
             log(ast.getLineNo(), MSG_KEY, className);
         }
     }
 
+    /**
+     * Get name of class(with qualified package if specified) in extend clause.
+     * @param classExtend extend clause to extract class name
+     * @return super class name
+     */
+    private static String extractQualifiedName(DetailAST classExtend) {
+        final String className;
+
+        if (classExtend.findFirstToken(TokenTypes.IDENT) == null) {
+            // Name specified with packages, have to traverse DOT
+            final DetailAST firstChild = classExtend.findFirstToken(TokenTypes.DOT);
+            final List<String> qualifiedNameParts = new LinkedList<>();
+
+            qualifiedNameParts.add(0, firstChild.findFirstToken(TokenTypes.IDENT).getText());
+            DetailAST traverse = firstChild.findFirstToken(TokenTypes.DOT);
+            while (traverse != null) {
+                qualifiedNameParts.add(0, traverse.findFirstToken(TokenTypes.IDENT).getText());
+                traverse = traverse.findFirstToken(TokenTypes.DOT);
+            }
+            className = StringUtils.join(qualifiedNameParts, PACKAGE_SEPARATOR);
+        }
+        else {
+            className = classExtend.findFirstToken(TokenTypes.IDENT).getText();
+        }
+
+        return className;
+    }
+
+    /**
+     * Register to outer super classes of given classAst that
+     * given classAst is extending them.
+     * @param classAst class which outer super classes will be
+     *                 informed about nesting subclass
+     */
+    private void registerNestedSubclassToOuterSuperClasses(DetailAST classAst) {
+        final String currentAstSuperClassName = getSuperClassName(classAst);
+        if (currentAstSuperClassName != null) {
+            for (ClassDesc classDesc : classes) {
+                final String classDescQualifiedName = classDesc.getQualifiedName();
+                if (doesNameInExtendMatchSuperClassName(classDescQualifiedName,
+                        currentAstSuperClassName)) {
+                    classDesc.registerNestedSubclass();
+                }
+            }
+        }
+    }
+
+    /**
+     * Get qualified class name from given class Ast.
+     * @param classAst class to get qualified class name
+     * @return qualified class name of a class
+     */
+    private String getQualifiedClassName(DetailAST classAst) {
+        final String className = classAst.findFirstToken(TokenTypes.IDENT).getText();
+        String outerClassQualifiedName = null;
+        if (!classes.isEmpty()) {
+            outerClassQualifiedName = classes.peek().getQualifiedName();
+        }
+        return getQualifiedClassName(packageName, outerClassQualifiedName, className);
+    }
+
+    /**
+     * Calculate qualified class name(package + class name) laying inside given
+     * outer class.
+     * @param packageName package name, empty string on default package
+     * @param outerClassQualifiedName qualified name(package + class) of outer class,
+     *                           null if doesnt exist
+     * @param className class name
+     * @return qualified class name(package + class name)
+     */
+    private static String getQualifiedClassName(String packageName, String outerClassQualifiedName,
+                                                String className) {
+        final String qualifiedClassName;
+
+        if (outerClassQualifiedName == null) {
+            if (packageName.isEmpty()) {
+                qualifiedClassName = className;
+            }
+            else {
+                qualifiedClassName = packageName + PACKAGE_SEPARATOR + className;
+            }
+        }
+        else {
+            qualifiedClassName = outerClassQualifiedName + PACKAGE_SEPARATOR + className;
+        }
+        return qualifiedClassName;
+    }
+
+    /**
+     * Get super class name of given class.
+     * @param classAst class
+     * @return super class name or null if super class is not specified
+     */
+    private String getSuperClassName(DetailAST classAst) {
+        String superClassName = null;
+        final DetailAST classExtend = classAst.findFirstToken(TokenTypes.EXTENDS_CLAUSE);
+        if (classExtend != null) {
+            superClassName = extractQualifiedName(classExtend);
+        }
+        return superClassName;
+    }
+
+    /**
+     * Checks if given super class name in extend clause match super class qualified name.
+     * @param superClassQualifiedName super class quaflieid name(with package)
+     * @param superClassInExtendClause name in extend clause
+     * @return true if given super class name in extend clause match super class qualified name,
+     *         false otherwise
+     */
+    private static boolean doesNameInExtendMatchSuperClassName(String superClassQualifiedName,
+                                                               String superClassInExtendClause) {
+        String superClassNormalizedName = superClassQualifiedName;
+        if (!superClassInExtendClause.contains(PACKAGE_SEPARATOR)) {
+            superClassNormalizedName = getClassNameFromQualifiedName(superClassQualifiedName);
+        }
+        return superClassNormalizedName.equals(superClassInExtendClause);
+    }
+
+    /**
+     * Get class name from qualified name.
+     * @param qualifiedName qualified class name
+     * @return class name
+     */
+    private static String getClassNameFromQualifiedName(String qualifiedName) {
+        return qualifiedName.substring(qualifiedName.lastIndexOf(PACKAGE_SEPARATOR) + 1);
+    }
+
     /** Maintains information about class' ctors. */
     private static final class ClassDesc {
+        /** Qualified class name(with package). */
+        private final String qualifiedName;
+
         /** Is class declared as final. */
         private final boolean declaredAsFinal;
 
@@ -121,26 +286,44 @@ public class FinalClassCheck
         /** Does class have private ctors. */
         private boolean withPrivateCtor;
 
+        /** Does class have nested subclass. */
+        private boolean withNestedSubclass;
+
         /**
          *  Create a new ClassDesc instance.
+         *  @param qualifiedName qualified class name(with package)
          *  @param declaredAsFinal indicates if the
          *         class declared as final
          *  @param declaredAsAbstract indicates if the
          *         class declared as abstract
          */
-        ClassDesc(boolean declaredAsFinal, boolean declaredAsAbstract) {
+        ClassDesc(String qualifiedName, boolean declaredAsFinal, boolean declaredAsAbstract) {
+            this.qualifiedName = qualifiedName;
             this.declaredAsFinal = declaredAsFinal;
             this.declaredAsAbstract = declaredAsAbstract;
         }
 
+        /**
+         * Get qualified class name.
+         * @return qualified class name
+         */
+        private String getQualifiedName() {
+            return qualifiedName;
+        }
+
         /** Adds private ctor. */
-        private void reportPrivateCtor() {
+        private void registerPrivateCtor() {
             withPrivateCtor = true;
         }
 
         /** Adds non-private ctor. */
-        private void reportNonPrivateCtor() {
+        private void registerNonPrivateCtor() {
             withNonPrivateCtor = true;
+        }
+
+        /** Adds nested subclass. */
+        private void registerNestedSubclass() {
+            withNestedSubclass = true;
         }
 
         /**
@@ -157,6 +340,14 @@ public class FinalClassCheck
          */
         private boolean isWithNonPrivateCtor() {
             return withNonPrivateCtor;
+        }
+
+        /**
+         * Does class have nested subclass.
+         * @return true if class has nested subclass
+         */
+        private boolean isWithNestedSubclass() {
+            return withNestedSubclass;
         }
 
         /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -25,10 +25,12 @@ import static org.junit.Assert.assertArrayEquals;
 import java.io.File;
 import java.io.IOException;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class FinalClassCheckTest
@@ -39,10 +41,16 @@ public class FinalClassCheckTest
                 + "design" + File.separator + filename);
     }
 
+    @Override
+    protected String getNonCompilablePath(String filename) throws IOException {
+        return super.getNonCompilablePath("checks" + File.separator
+                + "design" + File.separator + filename);
+    }
+
     @Test
     public void testGetRequiredTokens() {
         final FinalClassCheck checkObj = new FinalClassCheck();
-        final int[] expected = {TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF};
+        final int[] expected = {TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF, TokenTypes.PACKAGE_DEF};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }
 
@@ -53,15 +61,56 @@ public class FinalClassCheckTest
         final String[] expected = {
             "7: " + getCheckMessage(MSG_KEY, "InputFinalClass"),
             "15: " + getCheckMessage(MSG_KEY, "test4"),
-            "109: " + getCheckMessage(MSG_KEY, "someinnerClass"),
+            "113: " + getCheckMessage(MSG_KEY, "someinnerClass"),
         };
         verify(checkConfig, getPath("InputFinalClass.java"), expected);
     }
 
     @Test
+    public void testClassWithPrivateCtorAndNestedExtendingSubclass() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(FinalClassCheck.class);
+        final String[] expected = {
+            "15: " + getCheckMessage(MSG_KEY, "C"),
+        };
+        verify(checkConfig,
+                getNonCompilablePath("InputClassWithPrivateCtorWithNestedExtendingClass.java"),
+                expected);
+    }
+
+    @Test
+    public void testClassWithPrivateCtorAndNestedExtendingSubclassWithoutPackage()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(FinalClassCheck.class);
+        final String[] expected = {
+            "7: " + getCheckMessage(MSG_KEY, "C"),
+        };
+        verify(checkConfig,
+                getNonCompilablePath(
+                        "InputClassWithPrivateCtorWithNestedExtendingClassWithoutPackage.java"),
+                expected);
+    }
+
+    @Test
+    public void testImproperToken() throws Exception {
+        final FinalClassCheck finalClassCheck = new FinalClassCheck();
+        final DetailAST badAst = new DetailAST();
+        final int unsupportedTokenByCheck = TokenTypes.EOF;
+        badAst.setType(unsupportedTokenByCheck);
+        try {
+            finalClassCheck.visitToken(badAst);
+            Assert.fail("IllegalStateException is expected");
+        }
+        catch (IllegalStateException ex) {
+            // it is OK
+        }
+    }
+
+    @Test
     public void testGetAcceptableTokens() {
         final FinalClassCheck obj = new FinalClassCheck();
-        final int[] expected = {TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF};
+        final int[] expected = {TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF, TokenTypes.PACKAGE_DEF};
         assertArrayEquals(expected, obj.getAcceptableTokens());
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/InputClassWithPrivateCtorWithNestedExtendingClass.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/InputClassWithPrivateCtorWithNestedExtendingClass.java
@@ -1,0 +1,19 @@
+package com.puppycrawl.tools.checkstyle.checks.design;
+
+public class InputClassWithPrivateCtorWithNestedExtendingClass {
+    class A {
+        private A() {}
+        private class ExtendA extends A {}
+    }
+
+    class B {
+        private B() {}
+        private class ExtendB extends
+                com.puppycrawl.tools.checkstyle.checks.design.InputClassWithPrivateCtorWithNestedExtendingClass.B {}
+    }
+
+    class C {
+        private C() {}
+        private class ExtendC extends com.nonexistent.packages.C {}
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/InputClassWithPrivateCtorWithNestedExtendingClassWithoutPackage.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/InputClassWithPrivateCtorWithNestedExtendingClassWithoutPackage.java
@@ -1,0 +1,11 @@
+public class InputClassWithPrivateCtorWithNestedExtendingClassWithoutPackage {
+    class A {
+        private A() {}
+        private class ExtendA extends A {}
+    }
+
+    class C {
+        private C() {}
+        private class ExtendC extends com.nonexistent.packages.C {}
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputFinalClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputFinalClass.java
@@ -29,6 +29,10 @@ class test6
     public test6() {}
 }
 
+final class test7 {
+    private test7() {}
+}
+
 // Typesafe enum with operation
 // abstract classes cannot be final, see bug #837012
 abstract class Operation


### PR DESCRIPTION
…nested subclasses

In current implementation there is a problem that class with private constructor cannot be made final if there is an inner class that extends it.

Biggest problem with implementation deals with the fact that extends clause can contain class name, or class name with package for example:
```java
private class ExtendA extends A {}
private class ExtendC extends com.nonexistent.packages.C {}
```

To deal with this fact I put full class name(with package information) to ClassDesc, later when it decides if there is an inner class extending outer, we check if in extends clause there is only class name or there is package information and do appropriate comparison with outer classes names.
