### PR TITLE
Issue #325: Check placement of Javadoc comments in AbstractJavadocCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -43,6 +43,7 @@ import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.grammars.javadoc.JavadocLexer;
 import com.puppycrawl.tools.checkstyle.grammars.javadoc.JavadocParser;
+import com.puppycrawl.tools.checkstyle.utils.BlockCommentPosition;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtils;
 
 /**
@@ -173,7 +174,8 @@ public abstract class AbstractJavadocCheck extends Check {
 
     @Override
     public final void visitToken(DetailAST blockCommentNode) {
-        if (JavadocUtils.isJavadocComment(blockCommentNode)) {
+        if (JavadocUtils.isJavadocComment(blockCommentNode)
+              && isCorrectJavadocPosition(blockCommentNode)) {
             // store as field, to share with child Checks
             blockCommentAst = blockCommentNode;
 
@@ -209,6 +211,29 @@ public abstract class AbstractJavadocCheck extends Check {
      */
     protected DetailAST getBlockCommentAst() {
         return blockCommentAst;
+    }
+
+    /**
+     * Checks Javadoc comment it's in right place.
+     * From Javadoc util documentation:
+     * "Placement of comments - Documentation comments are recognized only when placed
+     * immediately before class, interface, constructor, method, or field
+     * declarations -- see the class example, method example, and field example.
+     * Documentation comments placed in the body of a method are ignored. Only one
+     * documentation comment per declaration statement is recognized by the Javadoc tool."
+     *
+     * @param blockComment Block comment AST
+     * @return true if Javadoc is in right place
+     */
+    private static boolean isCorrectJavadocPosition(DetailAST blockComment) {
+        return BlockCommentPosition.isOnClass(blockComment)
+                || BlockCommentPosition.isOnInterface(blockComment)
+                || BlockCommentPosition.isOnEnum(blockComment)
+                || BlockCommentPosition.isOnMethod(blockComment)
+                || BlockCommentPosition.isOnField(blockComment)
+                || BlockCommentPosition.isOnConstructor(blockComment)
+                || BlockCommentPosition.isOnEnumConstant(blockComment)
+                || BlockCommentPosition.isOnAnnotationDef(blockComment);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -183,13 +183,10 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
      * @return parent type.
      */
     private static int getParentType(DetailAST commentBlock) {
-        int type = 0;
         final DetailAST parentNode = commentBlock.getParent();
-        if (parentNode != null) {
-            type = parentNode.getType();
-            if (type == TokenTypes.TYPE || type == TokenTypes.MODIFIERS) {
-                type = parentNode.getParent().getType();
-            }
+        int type = parentNode.getType();
+        if (type == TokenTypes.TYPE || type == TokenTypes.MODIFIERS) {
+            type = parentNode.getParent().getType();
         }
         return type;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPosition.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPosition.java
@@ -1,0 +1,217 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.utils;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * Utility class that has methods to check javadoc comment position in java file.
+ * @author bizmailov
+ *
+ */
+public final class BlockCommentPosition {
+
+    /**
+     * Forbid new instances.
+     */
+    private BlockCommentPosition() {
+    }
+
+    /**
+     * Node is on class definition.
+     * @param blockComment DetailAST
+     * @return true if node is before class
+     */
+    public static boolean isOnClass(DetailAST blockComment) {
+        return isOnPlainToken(blockComment, TokenTypes.CLASS_DEF, TokenTypes.LITERAL_CLASS)
+                || isOnTokenWithModifiers(blockComment, TokenTypes.CLASS_DEF)
+                || isOnTokenWithAnnotation(blockComment, TokenTypes.CLASS_DEF);
+    }
+
+    /**
+     * Node is on interface definition.
+     * @param blockComment DetailAST
+     * @return true if node is before interface
+     */
+    public static boolean isOnInterface(DetailAST blockComment) {
+        return isOnPlainToken(blockComment, TokenTypes.INTERFACE_DEF, TokenTypes.LITERAL_INTERFACE)
+                || isOnTokenWithModifiers(blockComment, TokenTypes.INTERFACE_DEF)
+                || isOnTokenWithAnnotation(blockComment, TokenTypes.INTERFACE_DEF);
+    }
+
+    /**
+     * Node is on enum definition.
+     * @param blockComment DetailAST
+     * @return true if node is before enum
+     */
+    public static boolean isOnEnum(DetailAST blockComment) {
+        return isOnPlainToken(blockComment, TokenTypes.ENUM_DEF, TokenTypes.ENUM)
+                || isOnTokenWithModifiers(blockComment, TokenTypes.ENUM_DEF)
+                || isOnTokenWithAnnotation(blockComment, TokenTypes.ENUM_DEF);
+    }
+
+    /**
+     * Node is on annotation definition.
+     * @param blockComment DetailAST
+     * @return true if node is before annotation
+     */
+    public static boolean isOnAnnotationDef(DetailAST blockComment) {
+        return isOnPlainToken(blockComment, TokenTypes.ANNOTATION_DEF, TokenTypes.AT)
+                || isOnTokenWithModifiers(blockComment, TokenTypes.ANNOTATION_DEF)
+                || isOnTokenWithAnnotation(blockComment, TokenTypes.ANNOTATION_DEF);
+    }
+
+    /**
+     * Node is on method declaration.
+     * @param blockComment DetailAST
+     * @return true if node is before method
+     */
+    public static boolean isOnMethod(DetailAST blockComment) {
+        return isOnPlainClassMember(blockComment, TokenTypes.METHOD_DEF)
+                || isOnTokenWithModifiers(blockComment, TokenTypes.METHOD_DEF)
+                || isOnTokenWithAnnotation(blockComment, TokenTypes.METHOD_DEF);
+    }
+
+    /**
+     * Node is on field declaration.
+     * @param blockComment DetailAST
+     * @return true if node is before field
+     */
+    public static boolean isOnField(DetailAST blockComment) {
+        return isOnPlainClassMember(blockComment, TokenTypes.VARIABLE_DEF)
+                || isOnTokenWithModifiers(blockComment, TokenTypes.VARIABLE_DEF)
+                || isOnTokenWithAnnotation(blockComment, TokenTypes.VARIABLE_DEF);
+    }
+
+    /**
+     * Node is on constructor.
+     * @param blockComment DetailAST
+     * @return true if node is before constructor
+     */
+    public static boolean isOnConstructor(DetailAST blockComment) {
+        return isOnPlainToken(blockComment, TokenTypes.CTOR_DEF, TokenTypes.IDENT)
+                || isOnTokenWithModifiers(blockComment, TokenTypes.CTOR_DEF)
+                || isOnTokenWithAnnotation(blockComment, TokenTypes.CTOR_DEF);
+    }
+
+    /**
+     * Node is on enum constant.
+     * @param blockComment DetailAST
+     * @return true if node is before enum constant
+     */
+    public static boolean isOnEnumConstant(DetailAST blockComment) {
+        final boolean isOnPlainConst = blockComment.getParent() != null
+                && blockComment.getParent().getType() == TokenTypes.ENUM_CONSTANT_DEF
+                && getPrevSiblingSkipComments(blockComment).getType() == TokenTypes.ANNOTATIONS
+                && getPrevSiblingSkipComments(blockComment).getChildCount() == 0;
+        final boolean isOnConstWithAnnotation = !isOnPlainConst && blockComment.getParent() != null
+                && blockComment.getParent().getType() == TokenTypes.ANNOTATION
+                && blockComment.getParent().getParent().getParent().getType()
+                    == TokenTypes.ENUM_CONSTANT_DEF;
+        return isOnPlainConst || isOnConstWithAnnotation;
+    }
+
+    /**
+     * Checks that block comment is on specified token without any modifiers.
+     * @param blockComment block comment start DetailAST
+     * @param parentTokenType parent token type
+     * @param nextTokenType next token type
+     * @return true if block comment is on specified token without modifiers
+     */
+    private static boolean isOnPlainToken(DetailAST blockComment,
+            int parentTokenType, int nextTokenType) {
+        return blockComment.getParent() != null
+                && blockComment.getParent().getType() == parentTokenType
+                && getPrevSiblingSkipComments(blockComment).getChildCount() == 0
+                && getNextSiblingSkipComments(blockComment).getType() == nextTokenType;
+    }
+
+    /**
+     * Checks that block comment is on specified token with modifiers.
+     * @param blockComment block comment start DetailAST
+     * @param tokenType parent token type
+     * @return true if block comment is on specified token with modifiers
+     */
+    private static boolean isOnTokenWithModifiers(DetailAST blockComment, int tokenType) {
+        return blockComment.getParent() != null
+                && blockComment.getParent().getType() == TokenTypes.MODIFIERS
+                && blockComment.getParent().getParent().getType() == tokenType
+                && getPrevSiblingSkipComments(blockComment) == null;
+    }
+
+    /**
+     * Checks that block comment is on specified token with annotation.
+     * @param blockComment block comment start DetailAST
+     * @param tokenType parent token type
+     * @return true if block comment is on specified token with annotation
+     */
+    private static boolean isOnTokenWithAnnotation(DetailAST blockComment, int tokenType) {
+        return blockComment.getParent() != null
+                && blockComment.getParent().getType() == TokenTypes.ANNOTATION
+                && getPrevSiblingSkipComments(blockComment.getParent()) == null
+                && blockComment.getParent().getParent().getType() == TokenTypes.MODIFIERS
+                && blockComment.getParent().getParent().getParent().getType() == tokenType
+                && getPrevSiblingSkipComments(blockComment) == null;
+    }
+
+    /**
+     * Checks that block comment is on specified class member without any modifiers.
+     * @param blockComment block comment start DetailAST
+     * @param memberType parent token type
+     * @return true if block comment is on specified token without modifiers
+     */
+    private static boolean isOnPlainClassMember(DetailAST blockComment, int memberType) {
+        return blockComment.getParent() != null
+                && blockComment.getParent().getType() == TokenTypes.TYPE
+                && blockComment.getParent().getParent().getType() == memberType
+                // previous parent sibling is always TokenTypes.MODIFIERS
+                && blockComment.getParent().getPreviousSibling().getChildCount() == 0;
+    }
+
+    /**
+     * Get next sibling node skipping any comment nodes.
+     * @param node current node
+     * @return next sibling
+     */
+    private static DetailAST getNextSiblingSkipComments(DetailAST node) {
+        DetailAST result = node.getNextSibling();
+        while (result.getType() == TokenTypes.SINGLE_LINE_COMMENT
+                || result.getType() == TokenTypes.BLOCK_COMMENT_BEGIN) {
+            result = result.getNextSibling();
+        }
+        return result;
+    }
+
+    /**
+     * Get previous sibling node skipping any comments.
+     * @param node current node
+     * @return previous sibling
+     */
+    private static DetailAST getPrevSiblingSkipComments(DetailAST node) {
+        DetailAST result = node.getPreviousSibling();
+        while (result != null
+                && (result.getType() == TokenTypes.SINGLE_LINE_COMMENT
+                || result.getType() == TokenTypes.BLOCK_COMMENT_BEGIN)) {
+            result = result.getPreviousSibling();
+        }
+        return result;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputJavadocPosition.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputJavadocPosition.java
@@ -1,0 +1,241 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/////////////
+// CLASSES //
+/////////////
+
+/**Javadoc*/
+class/**nope*/ A/**nope*/{
+	/**Javadoc*/
+	protected/**nope*/ class/**nope*/ B/**nope*/{/**nope*/}
+	
+	/**Javadoc*/
+	private/**nope*/ static/**nope*/ class/**nope*/ C/**nope*/{/**nope*/}
+	
+	/**Javadoc*/
+	@Component/**nope*/ class/**nope*/ D/**nope*/{/**nope*/}
+	
+	/**Javadoc*/
+	@Component/**nope*/ private/**nope*/ class/**nope*/ E/**nope*/{/**nope*/}
+	
+	/**Javadoc*/
+	private/**nope*/ @Component/**nope*/ class/**nope*/ F/**nope*/{/**nope*/}
+}
+
+//////////////////
+// CONSTRUCTORS //
+//////////////////
+
+/**Javadoc*/
+class/**nope*/ AA/**nope*/{
+	/**Javadoc*/
+	AA/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+/**Javadoc*/
+class/**nope*/ BB/**nope*/{
+	/**Javadoc*/
+	private/**nope1*/ BB/**nope2*/(/**nope3*/)/**nope4*/{/**nope5*/}/**nope6*/
+}
+
+class/**nope*/ DD/**nope*/{
+	/**Javadoc*/
+	@Component/**nope*/ DD/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class/**nope*/ EE/**nope*/{
+	/**Javadoc*/
+	@Component/**nope*/ private/**nope*/ EE/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class/**nope*/ FF/**nope*/{
+	/**Javadoc*/
+	private/**nope*/ @Component/**nope*/ FF/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+/////////////
+// METHODS //
+/////////////
+
+class AAA {
+	/**Javadoc*/
+	void/**nope*/ a/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class BBB {
+	/**Javadoc*/
+	private/**nope*/ void/**nope*/ a/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class CCC {
+	/**Javadoc*/
+	static/**nope*/ private/**nope*/ void/**nope*/ a/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class DDD {
+	/**Javadoc*/
+	@Component/**nope*/ void/**nope*/ a/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class EEE {
+	/**Javadoc*/
+	@Component/**nope*/ private/**nope*/ void/**nope*/ a/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class FFF {
+	/**Javadoc*/
+	static/**nope*/ @Component/**nope*/ private/**nope*/ void/**nope*/ a/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class GGG {
+	/**Javadoc*/
+	void/**nope*/ a/**nope*/(@Component/**nope*/int/**nope*/ a/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+////////////////
+// INTERFACES //
+////////////////
+
+/**Javadoc*/
+interface/**nope*/ AAAA/**nope*/ {}
+
+/**Javadoc*/
+abstract/**nope*/ interface/**nope*/ BBBB/**nope*/ {/**nope*/}
+
+/**Javadoc*/
+@Component/**nope*/ interface/**nope*/ CCCC/**nope*/ {/**nope*/}
+
+/**Javadoc*/
+@Component/**nope*/ abstract/**nope*/ interface/**nope*/ DDDD/**nope*/ {/**nope*/}
+
+/**Javadoc*/
+abstract/**nope*/ @Component/**nope*/ interface/**nope*/ EEEE/**nope*/ {/**nope*/}
+
+///////////
+// ENUMS //
+///////////
+
+/**Javadoc*/
+enum/**nope*/ AAAAA/**nope*/ {}
+
+class ASD {
+	/**Javadoc*/
+	private/**nope*/ enum/**nope*/ BBBBB/**nope*/ {/**nope*/}
+	
+	/**Javadoc*/
+	@Component/**nope*/ enum/**nope*/ CCCCC/**nope*/ {/**nope*/}
+	
+	/**Javadoc*/
+	@Component/**nope*/ private/**nope*/ enum/**nope*/ DDDDD/**nope*/ {/**nope*/}
+	
+	/**Javadoc*/
+	private/**nope*/ @Component/**nope*/ enum/**nope*/ EEEEE/**nope*/ {/**nope*/}
+}
+
+////////////
+// FIELDS //
+////////////
+
+class AAAAAA {
+	/**Javadoc*/
+	int/**nope*/ a/**nope*/;
+	/**Javadoc*/
+	private/**nope*/ int/**nope*/ b/**nope*/;
+	/**Javadoc*/
+	private/**nope*/ final/**nope*/ int/**nope*/ c/**nope*/=1;
+	/**Javadoc*/
+	private/**nope*/ static/**nope*/ final/**nope*/ int/**nope*/ d/**nope*/=1;
+}
+
+class BBBBBB {
+	/**Javadoc*/
+	int/**nope*/ a/**nope*/=/**nope*/1/**nope*/;
+	/**Javadoc*/
+	private/**nope*/ int/**nope*/ b/**nope*/=/**nope*/1/**nope*/;
+	/**Javadoc*/
+	private/**nope*/ final/**nope*/ int/**nope*/ c/**nope*/=/**nope*/1/**nope*/;
+	/**Javadoc*/
+	private/**nope*/ static/**nope*/ final/**nope*/ int/**nope*/ d/**nope*/=/**nope*/1/**nope*/;
+}
+
+
+class CCCCCC {
+	/**Javadoc*/
+	Object/**nope*/ a/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/
+	private/**nope*/ Object/**nope*/ b/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/
+	private/**nope*/ final/**nope*/ Object/**nope*/ c/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/
+	private/**nope*/ static/**nope*/ final/**nope*/ Object/**nope*/ d/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+}
+
+class DDDDDD {
+	/**Javadoc*/
+	@Component/**nope*/ Object/**nope*/ a/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/
+	@Component/**nope*/ private/**nope*/ Object/**nope*/ b/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/
+	@Component/**nope*/ private/**nope*/ final/**nope*/ Object/**nope*/ c/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/
+	@Component/**nope*/ private/**nope*/ static/**nope*/ final/**nope*/ Object/**nope*/ d/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+}
+
+class EEEEEE {
+	/**Javadoc*/
+	private/**nope*/ @Component/**nope*/ Object/**nope*/ b/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/
+	private/**nope*/ @Component/**nope*/ final/**nope*/ Object/**nope*/ c/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/
+	private/**nope*/ @Component/**nope*/ static/**nope*/ final/**nope*/ Object/**nope*/ d/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+}
+
+/////////////////
+// ENUM CONSTS //
+/////////////////
+
+enum AAAAAAA {
+	/**Javadoc*/
+	ONE/**nope*/, 
+	/**Javadoc*/
+	TWO/**nope*/
+}
+
+enum BBBBBBB {
+	/**Javadoc*/
+	ONE/**nope*/(/**nope*/1/**nope*/)/**nope*/, 
+	/**Javadoc*/
+	TWO/**nope*/(/**nope*/2/**nope*/)/**nope*/;
+	BBBBBBB(int i){}
+}
+
+enum CCCCCCC {
+	/**Javadoc*/
+	@Component/**nope*/ ONE/**nope*/(/**nope*/1/**nope*/)/**nope*/, 
+	/**Javadoc*/
+	@Component/**nope*/ TWO/**nope*/(/**nope*/2/**nope*/)/**nope*/;
+	CCCCCCC(int i){}
+}
+
+/**Javadoc*/
+@Retention(/**nope*/RetentionPolicy/**nope*/./**nope*/RUNTIME/**nope4*/)/**nope*/
+@Target(/**nope*/{/**nope*/ElementType/**nope*/./**nope*/CONSTRUCTOR/**nope*/, /**nope*/ElementType/**nope*/./**nope*/FIELD/**nope*/
+	, /**nope*/ElementType/**nope*/./**nope*/LOCAL_VARIABLE/**nope*/, /**nope*/ElementType/**nope*/./**nope*/METHOD
+	, /**nope*/ElementType/**nope*/./**nope*/PARAMETER/**nope*/, /**nope*/ElementType/**nope*/./**nope*/TYPE/**nope*/}/**nope*/)/**nope*/
+@interface/**nope*/ Component/**nope*/ {/**nope*/
+}
+
+/**Javadoc*/
+@interface/**nope*/ MyAnnotation/**nope*/ {/**nope*/
+}
+
+class MyTemp1 {
+	/**Javadoc*/ //noise
+	private @interface/**nope*/ MyAnnotation3/**nope*/ {/**nope*/
+	}
+}
+
+/**nope*/

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputJavadocPositionOnlyComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputJavadocPositionOnlyComments.java
@@ -1,0 +1,3 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+/** Javadoc for import */
+import java.io.Serializable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputJavadocPositionWithSinglelineComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputJavadocPositionWithSinglelineComments.java
@@ -1,0 +1,242 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/////////////
+// CLASSES //
+/////////////
+
+/**Javadoc*/ /*noise*/ //noise
+class/**nope*/ V/**nope*/{
+	/**Javadoc*/ //noise
+	protected/**nope*/ class/**nope*/ N/**nope*/{/**nope*/}
+	
+	/**Javadoc*/ //noise
+	private/**nope*/ static/**nope*/ class/**nope*/ X/**nope*/{/**nope*/}
+	
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ class/**nope*/ Z/**nope*/{/**nope*/}
+	
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ private/**nope*/ class/**nope*/ Y/**nope*/{/**nope*/}
+	
+	/**Javadoc*/ //noise
+	private/**nope*/ @Component2/**nope*/ class/**nope*/ M/**nope*/{/**nope*/}
+}
+
+//////////////////
+// CONSTRUCTORS //
+//////////////////
+
+/**Javadoc*/ //noise
+class/**nope*/ VV/**nope*/{
+	/**Javadoc*/ //noise
+	VV/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+/**Javadoc*/ //noise
+class/**nope*/ NN/**nope*/{
+	/**Javadoc*/ //noise
+	private/**nope1*/ NN/**nope2*/(/**nope3*/)/**nope4*/{/**nope5*/}/**nope6*/
+}
+
+class/**nope*/ ZZ/**nope*/{
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ ZZ/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class/**nope*/ YY/**nope*/{
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ private/**nope*/ YY/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class/**nope*/ MM/**nope*/{
+	/**Javadoc*/ //noise
+	private/**nope*/ @Component2/**nope*/ MM/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+/////////////
+// METHODS //
+/////////////
+
+class VVV {
+	/**Javadoc*/ //noise
+	void/**nope*/ a/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class NNN {
+	/**Javadoc*/ //noise
+	private/**nope*/ void/**nope*/ a/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class XXX {
+	/**Javadoc*/ //noise
+	static/**nope*/ private/**nope*/ void/**nope*/ a/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class ZZZ {
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ void/**nope*/ a/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class YYY {
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ private/**nope*/ void/**nope*/ a/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class MMM {
+	/**Javadoc*/ //noise
+	static/**nope*/ @Component2/**nope*/ private/**nope*/ void/**nope*/ a/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+class LKJ {
+	/**Javadoc*/ //noise
+	void/**nope*/ a/**nope*/(@Component2/**nope*/int/**nope*/ a/**nope*/)/**nope*/{/**nope*/}/**nope*/
+}
+
+////////////////
+// INTERFACES //
+////////////////
+
+/**Javadoc*/ //noise
+interface/**nope*/ VVVV/**nope*/ {}
+
+/**Javadoc*/ //noise
+abstract/**nope*/ interface/**nope*/ NNNN/**nope*/ {/**nope*/}
+
+/**Javadoc*/ //noise
+@Component2/**nope*/ interface/**nope*/ XXXX/**nope*/ {/**nope*/}
+
+/**Javadoc*/ //noise
+@Component2/**nope*/ abstract/**nope*/ interface/**nope*/ ZZZZ/**nope*/ {/**nope*/}
+
+/**Javadoc*/ //noise
+abstract/**nope*/ @Component2/**nope*/ interface/**nope*/ YYYY/**nope*/ {/**nope*/}
+
+///////////
+// ENUMS //
+///////////
+
+/**Javadoc*/ //noise
+enum/**nope*/ VVVVV/**nope*/ {}
+
+class VSZ {
+	/**Javadoc*/ //noise
+	private/**nope*/ enum/**nope*/ NNNNN/**nope*/ {/**nope*/}
+	
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ enum/**nope*/ XXXXX/**nope*/ {/**nope*/}
+	
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ private/**nope*/ enum/**nope*/ ZZZZZ/**nope*/ {/**nope*/}
+	
+	/**Javadoc*/ //noise
+	private/**nope*/ @Component2/**nope*/ enum/**nope*/ YYYYY/**nope*/ {/**nope*/}
+}
+
+////////////
+// FIELDS //
+////////////
+
+class VVVVVV {
+	/**Javadoc*/ //noise
+	int/**nope*/ a/**nope*/;
+	/**Javadoc*/ //noise
+	private/**nope*/ int/**nope*/ b/**nope*/;
+	/**Javadoc*/ //noise
+	private/**nope*/ final/**nope*/ int/**nope*/ c/**nope*/=1;
+	/**Javadoc*/ //noise
+	private/**nope*/ static/**nope*/ final/**nope*/ int/**nope*/ d/**nope*/=1;
+}
+
+class NNNNNN {
+	/**Javadoc*/ //noise
+	int/**nope*/ a/**nope*/=/**nope*/1/**nope*/;
+	/**Javadoc*/ //noise
+	private/**nope*/ int/**nope*/ b/**nope*/=/**nope*/1/**nope*/;
+	/**Javadoc*/ //noise
+	private/**nope*/ final/**nope*/ int/**nope*/ c/**nope*/=/**nope*/1/**nope*/;
+	/**Javadoc*/ //noise
+	private/**nope*/ static/**nope*/ final/**nope*/ int/**nope*/ d/**nope*/=/**nope*/1/**nope*/;
+}
+
+
+class XXXXXX {
+	/**Javadoc*/ //noise
+	Object/**nope*/ a/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/ //noise
+	private/**nope*/ Object/**nope*/ b/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/ //noise
+	private/**nope*/ final/**nope*/ Object/**nope*/ c/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/ //noise
+	private/**nope*/ static/**nope*/ final/**nope*/ Object/**nope*/ d/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+}
+
+class ZZZZZZ {
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ Object/**nope*/ a/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ private/**nope*/ Object/**nope*/ b/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ private/**nope*/ final/**nope*/ Object/**nope*/ c/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ private/**nope*/ static/**nope*/ final/**nope*/ Object/**nope*/ d/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+}
+
+class YYYYYY {
+	/*noise*/ /**Javadoc*/ //noise
+	private/**nope*/ @Component2/**nope*/ Object/**nope*/ b/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/ //noise
+	private/**nope*/ @Component2/**nope*/ final/**nope*/ Object/**nope*/ c/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+	/**Javadoc*/ //noise
+	private/**nope*/ @Component2/**nope*/ static/**nope*/ final/**nope*/ Object/**nope*/ d/**nope*/ =/**nope*/ new/**nope*/ Object/**nope*/(/**nope*/)/**nope*/{/**nope*/}/**nope*/;
+}
+
+/////////////////
+// ENUM CONSTS //
+/////////////////
+
+enum VVVVVVV {
+	/**Javadoc*/ //noise
+	ONY/**nope*/, 
+	/**Javadoc*/ //noise
+	TWO/**nope*/
+}
+
+enum NNNNNNN {
+	/**Javadoc*/ /*noise*/ //noise
+	ONY/**nope*/(/**nope*/1/**nope*/)/**nope*/, 
+	/**Javadoc*/ //noise
+	TWO/**nope*/(/**nope*/2/**nope*/)/**nope*/;
+	NNNNNNN(int i){}
+}
+
+enum XXXXXXX {
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ ONY/**nope*/(/**nope*/1/**nope*/)/**nope*/, 
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ TWO/**nope*/(/**nope*/2/**nope*/)/**nope*/;
+	XXXXXXX(int i){}
+}
+
+
+/**Javadoc*/ //noise
+@Retention(/**nope*/RetentionPolicy/**nope*/./**nope*/RUNTIME/**nope4*/)/**nope*/
+@Target(/**nope*/{/**nope*/ElementType/**nope*/./**nope*/CONSTRUCTOR/**nope*/, /**nope*/ElementType/**nope*/./**nope*/FIELD/**nope*/
+	, /**nope*/ElementType/**nope*/./**nope*/LOCAL_VARIABLE/**nope*/, /**nope*/ElementType/**nope*/./**nope*/METHOD
+	, /**nope*/ElementType/**nope*/./**nope*/PARAMETER/**nope*/, /**nope*/ElementType/**nope*/./**nope*/TYPE/**nope*/}/**nope*/)/**nope*/
+@interface/**nope*/ Component2/**nope*/ {/**nope*/
+}
+
+/**Javadoc*/ //noise
+@interface/**nope*/ MyAnnotation2/**nope*/ {/**nope*/
+}
+
+class MyTemp2 {
+	/**Javadoc*/ //noise
+	private @interface/**nope*/ MyAnnotation3/**nope*/ {/**nope*/
+	}
+}
+
+/**nope*/


### PR DESCRIPTION
I generated checkstyle reports on all projects in project-to-test-on.txt by checkstyle-tester (there was only one Javadoc check, AtclauseOrderCheck, in config file). There is no any exceptions in reports.