### PR TITLE
Pull #2859: Disallow usage of java.util.Stack and java.util.Vector in code

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -28,7 +28,9 @@
         <module name="InterfaceTypeParameterNameCheck"/>
         <module name="ForbidThrowAnonymousExceptionsCheck"/>
         <module name="ForbidReturnInFinallyBlock"/>
-        <module name="ForbidInstantiation"/>
+        <module name="ForbidInstantiation">
+            <property name="forbiddenClasses" value="java.lang.NullPointerException,java.util.Vector,java.util.Stack"/>
+        </module>
         <module name="ForbidCCommentsInMethods"/>
         <module name="FinalizeImplementationCheck"/>
         <module name="RequiredParameterForAnnotation"/>
@@ -89,7 +91,7 @@
         </module>
         <module name="ForbidCertainImports">
             <property name="packageNameRegexp" value="^.*(api|utils).*$"/>
-            <property name="forbiddenImportsRegexp" value="^.*checks.*$"/>
+            <property name="forbiddenImportsRegexp" value="^.*checks.*|java\.util\.Vector|java\.util\.Stack$"/>
         </module>
         <module name="LineLengthExtended">
             <property name="max" value="100"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -19,8 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.checks.indentation;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Locale;
-import java.util.Stack;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -497,11 +498,11 @@ public class CommentsIndentationCheck extends Check {
      */
     private static DetailAST getOneLinePreviousStatementOfSingleLineComment(DetailAST comment) {
         DetailAST previousStatement = null;
-        final Stack<DetailAST> stack = new Stack<>();
+        final Deque<DetailAST> stack = new ArrayDeque<>();
         DetailAST root = comment.getParent();
 
-        while (root != null || !stack.empty()) {
-            if (!stack.empty()) {
+        while (root != null || !stack.isEmpty()) {
+            if (!stack.isEmpty()) {
                 root = stack.pop();
             }
             while (root != null) {


### PR DESCRIPTION
According to     
https://docs.oracle.com/javase/7/docs/api/java/util/Stack.html
https://docs.oracle.com/javase/7/docs/api/java/util/Vector.html
http://stackoverflow.com/a/1386288/1015848

>A more complete and consistent set of LIFO stack operations is provided by the Deque interface and its implementations, which should be used in preference to Stack class. 

>As of the Java 2 platform v1.2, Vector class was retrofitted to implement the List interface, making it a member of the Java Collections Framework. Unlike the new collection implementations, Vector is synchronized. If a thread-safe implementation is not needed, it is recommended to use ArrayList in place of Vector.

So, java.util.Vector and java.util.Stack should be prohibited in our code.

@romani 
I used ForbidInstantiation and ForbidCertainImports from SevNTU Checkstyle. I did not use IllegalImport and/or ImportControl from the main project as them disallow usage of the whole package but not a certain classes from the package.

