### PR TITLE
Issue #2795: fixed handling of tabs in LineWrapping

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputValidMethodIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputValidMethodIndent.java
@@ -194,4 +194,10 @@ public class InputValidMethodIndent extends java.awt.event.MouseAdapter implemen
         getArray()[0] = 2; //indent:8 exp:8
     } //indent:4 exp:4
 
+    // the following lines have tabs //indent:4 exp:4
+	@SuppressWarnings( //indent:4 exp:4
+		value="" //indent:8 exp:8
+	) //indent:4 exp:4
+	public void testStartOfSequence() { //indent:4 exp:4
+	} //indent:4 exp:4
 } //indent:0 exp:0


### PR DESCRIPTION
changed all `getColumnNo` into calls to `expandedTabsColumnNo`.
`getFirstNodeIndent` had its static removed so it can call `expandedTabsColumnNo`, and slightly changed since the variable used the same name as a field.
Copied `expandedTabsColumnNo` from `AbstractExpressionHandler`. We could make this class extend `AbstractExpressionHandler` if we want, but I'm not sure if it fits since `AbstractExpressionHandler` has a parent, type, and names its firstAst `mainAst`.