### PR TITLE
[Java8] Issue #2821: fixed method parameter type annotation between array

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
@@ -260,7 +260,7 @@ typeSpec[boolean addImagNode]
 // - generic type arguments after
 classTypeSpec[boolean addImagNode]
     :   classOrInterfaceType[addImagNode]
-        (options{greedy=true;}: lb:LBRACK^ {#lb.setType(ARRAY_DECLARATOR);} RBRACK)*
+        (options{greedy=true;}: (annotation)* lb:LBRACK^ {#lb.setType(ARRAY_DECLARATOR);} RBRACK)*
         {
             if ( addImagNode ) {
                 #classTypeSpec = #(#[TYPE,"TYPE"], #classTypeSpec);
@@ -370,7 +370,7 @@ builtInTypeArraySpec[boolean addImagNode]
 // A builtin type specification is a builtin type with possible brackets
 // afterwards (which would make it an array type).
 builtInTypeSpec[boolean addImagNode]
-    :    builtInType (lb:LBRACK^ {#lb.setType(ARRAY_DECLARATOR);} RBRACK)*
+    :    builtInType ((annotation)* lb:LBRACK^ {#lb.setType(ARRAY_DECLARATOR);} RBRACK)*
         {
             if ( addImagNode ) {
                 #builtInTypeSpec = #(#[TYPE,"TYPE"], #builtInTypeSpec);

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations4.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations4.java
@@ -9,6 +9,17 @@ public class InputAnnotations4 {
 	public static void methodName(@NotNull String args) {
 		
 	}
+
+
+    public static <T> T[] checkNotNullContents(T @Nullable [] array) {
+        return null;
+    }
+    public static int checkNotNullContents(int @Nullable [] array) {
+        return 0;
+    }
+    public static int checkNotNullContents(String @Nullable [] array) {
+        return 0;
+    }
 	
 	@Target(ElementType.TYPE_USE)
 	@interface NotNull {


### PR DESCRIPTION
`    public static int checkNotNullContents(int @Nullable [] array) {`

is built into the tree as:

````
		Type "METHOD_DEF" (METHOD_DEF) Line 7 Column 4
			Type "MODIFIERS" (MODIFIERS) Line 7 Column 4
				Type "public" (LITERAL_PUBLIC) Line 7 Column 4
				Type "static" (LITERAL_STATIC) Line 7 Column 11
			Type "TYPE" (TYPE) Line 7 Column 18
				Type "int" (LITERAL_INT) Line 7 Column 18
			Type "checkNotNullContents" (IDENT) Line 7 Column 22
			Type "(" (LPAREN) Line 7 Column 42
			Type "PARAMETERS" (PARAMETERS) Line 7 Column 57
				Type "PARAMETER_DEF" (PARAMETER_DEF) Line 7 Column 57
					Type "MODIFIERS" (MODIFIERS) Line 7 Column 57
					Type "TYPE" (TYPE) Line 7 Column 57
						Type "[" (ARRAY_DECLARATOR) Line 7 Column 57
							Type "int" (LITERAL_INT) Line 7 Column 43
							Type "ANNOTATION" (ANNOTATION) Line 7 Column 47
								Type "@" (AT) Line 7 Column 47
								Type "Nullable" (IDENT) Line 7 Column 48
							Type "]" (RBRACK) Line 7 Column 58
					Type "array" (IDENT) Line 7 Column 60
			Type ")" (RPAREN) Line 7 Column 65
			Type "{" (SLIST) Line 7 Column 67
````