### PR TITLE
Issue #2811: Makes JavadocTypeCheck recognise param names without bra…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -340,6 +340,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
             "11: " + getCheckMessage(MSG_MISSING_TAG, "@param <C456>"),
             "44:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<C>"),
             "47: " + getCheckMessage(MSG_MISSING_TAG, "@param <B>"),
+            "60:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<x>"),
         };
         verify(checkConfig, getPath("InputTypeParamsTags.java"), expected);
     }
@@ -352,8 +353,22 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
         final String[] expected = {
             "7:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<D123>"),
             "44:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<C>"),
+            "60:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<x>"),
         };
         verify(checkConfig, getPath("InputTypeParamsTags.java"), expected);
+    }
+
+    @Test
+    public void testDontAllowUnusedParameterTag() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(JavadocTypeCheck.class);
+        final String[] expected = {
+            "6:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<BAD>"),
+            "7:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<BAD>"),
+        };
+        verify(checkConfig,
+                getPath("InputUnusedParamInJavadocForClass.java"),
+                expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputUnusedParamInJavadocForClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputUnusedParamInJavadocForClass.java
@@ -1,0 +1,11 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+/**
+ * InputUnusedParamInJavadocForClass.
+ *
+ * @param BAD This is bad.
+ * @param <BAD> This doesn't exist.
+ * @param
+ */
+public class InputUnusedParamInJavadocForClass {
+}


### PR DESCRIPTION
…ckets

Problem so far was that param name was matched against pattern ("\\s*<([^>]+)>.*") which recognise param names only inside '<', '>'. This patch makes it recognise if it is inside '<'. '>' or is it just name. 