### PR TITLE
Issue #2729: types changed according to java spec

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/AnnotationsOnArrayTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/AnnotationsOnArrayTest.java
@@ -1,0 +1,50 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.grammars.java8;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
+
+public class AnnotationsOnArrayTest extends BaseCheckTestSupport {
+    @Override
+    protected String getNonCompilablePath(String filename) throws IOException {
+        return super.getNonCompilablePath("grammars" + File.separator
+                + "java8" + File.separator + filename);
+    }
+
+    @Test
+    public void testCanParse()
+        throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(MemberNameCheck.class);
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getNonCompilablePath("InputAnnotationsOnArray.java"),
+                expected);
+
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/TypeUseAnnotationsOnQualifiedTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/TypeUseAnnotationsOnQualifiedTypesTest.java
@@ -1,0 +1,50 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.grammars.java8;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
+
+public class TypeUseAnnotationsOnQualifiedTypesTest extends BaseCheckTestSupport {
+    @Override
+    protected String getNonCompilablePath(String filename) throws IOException {
+        return super.getNonCompilablePath("grammars" + File.separator
+                + "java8" + File.separator + filename);
+    }
+
+    @Test
+    public void testCanParse()
+        throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(MemberNameCheck.class);
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getNonCompilablePath("InputTypeUseAnnotationsOnQualifiedTypes.java"),
+                expected);
+
+    }
+
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotationsOnArray.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotationsOnArray.java
@@ -1,0 +1,35 @@
+//Compilable with Java8
+package com.puppycrawl.tools.checkstyle.grammars.java8;
+
+import static java.lang.annotation.ElementType.TYPE_USE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+public final class InputAnnotationsOnArray {
+
+    private InputAnnotationsOnArray() {
+    }
+
+    public static <T> T[] checkNotNullContents(T @Nullable [] array) {
+        if (array == null) {
+            throw new NullPointerException();
+        }
+
+        return array;
+    }
+
+    public static <T> T[][] checkNotNullContents2(T @Nullable [] @Nullable [] array) {
+        if (array == null) {
+            throw new NullPointerException();
+        }
+
+        return array;
+    }
+}
+
+@Retention(RetentionPolicy.CLASS)
+@Target({ TYPE_USE })
+@interface Nullable {
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/java8/InputTypeUseAnnotationsOnQualifiedTypes.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/java8/InputTypeUseAnnotationsOnQualifiedTypes.java
@@ -1,0 +1,31 @@
+//Compilable with Java8
+package com.puppycrawl.tools.checkstyle.grammars.java8;
+
+import java.awt.geom.Rectangle2D;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+public class InputTypeUseAnnotationsOnQualifiedTypes {
+    /* Causes parse failure */
+    Rectangle2D.@Ann Double rect = null;
+
+    /* Causes parse failure */
+    public final Rectangle2D.@Ann Double getRect1() {
+        return new Rectangle2D.Double();
+    }
+
+    /* Causes parse failure */
+    public final Rectangle2D.Double getRect2() {
+        return new Rectangle2D.@Ann Double();
+    }
+
+    /* Amazingly does not cause parse failure */
+    public final Rectangle2D.Double getRect3() {
+        Rectangle2D.@Ann Double rect = null;
+        return rect;
+    }
+}
+
+@Target({ ElementType.TYPE_USE })
+@interface Ann {
+}


### PR DESCRIPTION
Will help to parse something like  ``A.B.@foo C<bar>.D;``
According to https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-ReferenceType it should be possible