### PR TITLE
minor: Change expanding node method to double-click

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
@@ -106,7 +106,7 @@ public class JTreeTable extends JTable {
 
             @Override
             public void actionPerformed(ActionEvent event) {
-                doExpandByEnter();
+                expandSelectedNode();
             }
         };
         final KeyStroke stroke = KeyStroke.getKeyStroke("ENTER");
@@ -118,16 +118,16 @@ public class JTreeTable extends JTable {
             @Override
             public void mouseClicked(MouseEvent event) {
                 if (event.getClickCount() == 2) {
-                    makeCodeSelection();
+                    expandSelectedNode();
                 }
             }
         });
     }
 
     /**
-     * Do expansion of a tree node after pressing ENTER.
+     * Do expansion of a tree node.
      */
-    private void doExpandByEnter() {
+    private void expandSelectedNode() {
         final TreePath selected = makeCodeSelection();
 
         if (tree.isExpanded(selected)) {


### PR DESCRIPTION
Expanding node in node tree by clicking enter does not seem intuitive to me, in my opinion nodes in tree should expand just by double-click and in the same time selecting code that is associated with given node.