### PR TITLE
Issue #56: fix NPathComplexityCheck

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -75,6 +75,7 @@
 
     <!-- Tone down the checking for test code -->
     <suppress checks="CyclomaticComplexity" files="[\\/]XDocsPagesTest\.java"/>
+    <suppress checks="NPathComplexity" files="[\\/]XDocsPagesTest\.java"/>
     <suppress checks="IllegalCatch" files="[\\/]internal[\\/]\w+Util\.java"/>
     <suppress checks="EmptyBlock" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="ImportControl" files=".*[\\/]src[\\/](test|it)[\\/]"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -29,7 +29,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
-
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -43,6 +42,7 @@ public class NPathComplexityCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
+    //@Ignore
     public void testCalculation() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(NPathComplexityCheck.class);
@@ -51,7 +51,7 @@ public class NPathComplexityCheckTest extends BaseCheckTestSupport {
         final String[] expected = {
             "4:5: " + getCheckMessage(MSG_KEY, 2, 0),
             "7:17: " + getCheckMessage(MSG_KEY, 2, 0),
-            "17:5: " + getCheckMessage(MSG_KEY, 5, 0),
+            "17:5: " + getCheckMessage(MSG_KEY, 10, 0),
             "27:5: " + getCheckMessage(MSG_KEY, 3, 0),
             "34:5: " + getCheckMessage(MSG_KEY, 7, 0),
             "48:5: " + getCheckMessage(MSG_KEY, 3, 0),
@@ -62,6 +62,30 @@ public class NPathComplexityCheckTest extends BaseCheckTestSupport {
         };
 
         verify(checkConfig, getPath("InputComplexity.java"), expected);
+    }
+
+    @Test
+    public void testCalculation2() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(NPathComplexityCheck.class);
+
+        checkConfig.addAttribute("max", "0");
+        final String[] expected = {
+            "5:5: " + getCheckMessage(MSG_KEY, 5, 0),
+            "12:5: " + getCheckMessage(MSG_KEY, 5, 0),
+            "22:5: " + getCheckMessage(MSG_KEY, 4, 0),
+            "34:5: " + getCheckMessage(MSG_KEY, 4, 0),
+            "48:5: " + getCheckMessage(MSG_KEY, 6, 0),
+            "62:5: " + getCheckMessage(MSG_KEY, 15, 0),
+            "86:5: " + getCheckMessage(MSG_KEY, 11, 0),
+            "100:5: " + getCheckMessage(MSG_KEY, 10, 0),
+            "112:5: " + getCheckMessage(MSG_KEY, 120, 0),
+            "124:5: " + getCheckMessage(MSG_KEY, 21, 0),
+            "138:5: " + getCheckMessage(MSG_KEY, 35, 0),
+            "146:5: " + getCheckMessage(MSG_KEY, 25, 0),
+        };
+
+        verify(checkConfig, getPath("InputNPathComplexity.java"), expected);
     }
 
     @Test
@@ -105,10 +129,10 @@ public class NPathComplexityCheckTest extends BaseCheckTestSupport {
             TokenTypes.LITERAL_IF,
             TokenTypes.LITERAL_ELSE,
             TokenTypes.LITERAL_SWITCH,
-            TokenTypes.LITERAL_CASE,
-            TokenTypes.LITERAL_TRY,
-            TokenTypes.LITERAL_CATCH,
+            TokenTypes.CASE_GROUP,
             TokenTypes.QUESTION,
+            TokenTypes.LITERAL_RETURN,
+            TokenTypes.LITERAL_DEFAULT,
         };
         Assert.assertNotNull(actual);
         Assert.assertArrayEquals(expected, actual);
@@ -136,4 +160,51 @@ public class NPathComplexityCheckTest extends BaseCheckTestSupport {
         npathComplexityCheckObj.visitToken(ast);
         npathComplexityCheckObj.leaveToken(ast);
     }
+
+    @Test
+    public void testVisitTokenBeforeExpressionRange() {
+        // Create first ast
+        final DetailAST astIf = mockAST(TokenTypes.LITERAL_IF, "if", "mockfile", 2, 2);
+        final DetailAST astIfLParen = mockAST(TokenTypes.LPAREN, "(", "mockfile", 3, 3);
+        astIf.addChild(astIfLParen);
+        final DetailAST astIfTrue =
+                mockAST(TokenTypes.LITERAL_TRUE, "true", "mockfile", 3, 3);
+        astIf.addChild(astIfTrue);
+        final DetailAST astIfRParen = mockAST(TokenTypes.RPAREN, ")", "mockfile", 4, 4);
+        astIf.addChild(astIfRParen);
+        // Create ternary ast
+        final DetailAST astTernary = mockAST(TokenTypes.QUESTION, "?", "mockfile", 1, 1);
+        final DetailAST astTernaryTrue =
+                mockAST(TokenTypes.LITERAL_TRUE, "true", "mockfile", 1, 2);
+        astTernary.addChild(astTernaryTrue);
+
+        final NPathComplexityCheck mock = new NPathComplexityCheck();
+        // visiting first ast, set expressionSpatialRange to [2,2 - 4,4]
+        mock.visitToken(astIf);
+        //visiting ternary, it lies before expressionSpatialRange
+        mock.visitToken(astTernary);
+    }
+
+    /**
+     * Creates MOCK lexical token and returns AST node for this token.
+     * @param tokenType type of token
+     * @param tokenText text of token
+     * @param tokenFileName file name of token
+     * @param tokenRow token position in a file (row)
+     * @param tokenColumn token position in a file (column)
+     * @return AST node for the token
+     */
+    private static DetailAST mockAST(final int tokenType, final String tokenText,
+            final String tokenFileName, final int tokenRow, final int tokenColumn) {
+        final CommonHiddenStreamToken tokenImportSemi = new CommonHiddenStreamToken();
+        tokenImportSemi.setType(tokenType);
+        tokenImportSemi.setText(tokenText);
+        tokenImportSemi.setLine(tokenRow);
+        tokenImportSemi.setColumn(tokenColumn);
+        tokenImportSemi.setFilename(tokenFileName);
+        final DetailAST astSemi = new DetailAST();
+        astSemi.initialize(tokenImportSemi);
+        return astSemi;
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/InputNPathComplexity.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/InputNPathComplexity.java
@@ -1,0 +1,155 @@
+package com.puppycrawl.tools.checkstyle.checks.metrics;
+// Advise: for lack of ambiguity try to make all factors prime numbers
+public class InputNPathComplexity {
+    //NP = 5
+    void testIfWithExpression() {
+        if (true && true || (true || true)) {
+            
+        }
+    }
+    
+    //NP = 5
+    void testIfElseWithExpression() {
+        if (true && true || (true || true)) {
+            
+        }
+        else {
+            
+        }
+    }
+    
+    //NP = 4
+    void testSimpleSwitch() {
+        int a = 0;
+        switch(a) {
+        case 1:
+            break;
+        case 2:
+        case 3:
+            break;
+        }
+    }
+    
+    //NP = 4
+    void testSimpleSwitchWithDefault() {
+        int a = 0;
+        switch(a) {
+        case 1:
+            break;
+        case 2:
+        case 3:
+            break;
+        default:
+            break;
+        }
+    }
+    
+    //NP = 6
+    void testSwitchWithExpression() {
+        int a = 0;
+        switch(true ? a : a) {
+        case 1:
+            break;
+        case 2:
+        case 3:
+            break;
+        default:
+            break;
+        }
+    }
+    
+    //NP = 15
+    void testComplexSwitch() {
+        int a = 0;
+        switch(a) {
+        case 1:
+            if (true) {
+            }
+            break;
+        case 2:
+            if (true && true || (true || true)) {
+            }
+            else {  
+            }
+            if (true) {
+            }
+        case 3:
+            if (true) {
+            }
+            break;
+        default:
+            break;
+        }
+    }
+    
+    //NP = 11   
+    void testComplexIfElse() {
+        //NP = 2
+        if (true && true) {
+        }
+        //NP += 3
+        else if (true || true || true) {
+        }
+        //NP += 5
+        else if (true && true && true || true || true) {
+        }
+        //NP += 1
+    }
+    
+    //NP = 10
+    boolean testComplexReturn() {
+        if (true && true) {
+            //NP(return) = 4
+            return true && true || (true && true);
+        }
+        else {
+            //NP(return) = 5
+            return true ? true && true : true || true;
+        }
+    }
+    
+    //NP = 120
+    void testForCyclesComplex() {
+        //NP(for) = 2
+        for (int i = 0; i < 10; i++);
+        //NP(for) = 3
+        for (int i = 0; i < 10 && true; i++);
+        //NP(for) = 4
+        for (int i = true ? 0 : 0; i < 10; i++);
+        //NP(for) = 5
+        for (int i = 0; true ? i < 10 : true || true; i++);
+    }
+    
+    //NP = 21
+    void testDoWhileCyclesComplex() {
+        int a = 0;
+        //NP(do-while) = 3
+        do {
+        } while (a < 10 && true);
+        //NP(do-while) = 3 + 3 + 1 = 7
+        do {
+            //NP(do-while) = 3
+            do {
+            } while (a < 10 || true);
+        } while (true ? a > 10 : (a < 10 || true));
+    }
+    
+    //NP = 35
+    void testComplexTernaryOperator() {
+        //NP(t) = 7
+        boolean a = true ? (true ? true : true) : (false ? (true || false) : true);
+        //NP(t) = 5
+        boolean b = true ? (true ? true : true) : true || true;
+    }
+    
+    //NP = 25
+    void testSimpleTernaryBadFormatting() {
+        if(
+           true ? true : true
+                ) { boolean a = true ? true : true;
+        }
+        if(
+                true ? true : true) { boolean b = true ? true : true;
+             }
+    }
+}

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -781,10 +781,10 @@ class SwitchExample {
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">LITERAL_CASE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>.
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CASE_GROUP">CASE_GROUP</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_RETURN">LITERAL_RETURN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DEFAULT">LITERAL_DEFAULT</a>.
             </td>
 
             <td>
@@ -794,10 +794,10 @@ class SwitchExample {
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">LITERAL_CASE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">LITERAL_TRY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>.
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CASE_GROUP">CASE_GROUP</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">QUESTION</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_RETURN">LITERAL_RETURN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DEFAULT">LITERAL_DEFAULT</a>.
             </td>
           </tr>
         </table>


### PR DESCRIPTION
Issue #56 .

This PR is currently incomplete: it lacks single mock test to satisfy cobertura 100% coverage demand.
1. It implements correct calculation of NPath complexity for conditional with complex boolean expression, even for those containing ternary operator.
2. It adds calculation for return operator.
3. It fixes calculation for switch statement.
4. It doesn't implement NPath calculation for try-catch-finally statements yet. It is a question if we need such calculation. Pmd doesn't implement this calculation and there is no formula in original paper.
5. I have no idea of how to perform regressional test for this check.
