### PR TITLE
Issue #281: fixed line wrap handling of slist/objblock

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -162,22 +162,20 @@ public class LineWrappingHandler {
         result.put(firstNode.getLineNo(), firstNode);
         DetailAST curNode = firstNode.getFirstChild();
 
-        while (curNode != null && curNode != lastNode) {
+        while (curNode != lastNode) {
 
             if (curNode.getType() == TokenTypes.OBJBLOCK
                     || curNode.getType() == TokenTypes.SLIST) {
-                curNode = curNode.getNextSibling();
+                curNode = curNode.getLastChild();
             }
 
-            if (curNode != null) {
-                final DetailAST firstTokenOnLine = result.get(curNode.getLineNo());
+            final DetailAST firstTokenOnLine = result.get(curNode.getLineNo());
 
-                if (firstTokenOnLine == null
-                    || expandedTabsColumnNo(firstTokenOnLine) >= expandedTabsColumnNo(curNode)) {
-                    result.put(curNode.getLineNo(), curNode);
-                }
-                curNode = getNextCurNode(curNode);
+            if (firstTokenOnLine == null
+                || expandedTabsColumnNo(firstTokenOnLine) >= expandedTabsColumnNo(curNode)) {
+                result.put(curNode.getLineNo(), curNode);
             }
+            curNode = getNextCurNode(curNode);
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -914,15 +914,17 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
             "132: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 10, 8),
             "133: " + getCheckMessage(MSG_ERROR_MULTI, "object def lcurly", 8, "10, 14"),
             "137: " + getCheckMessage(MSG_ERROR_MULTI, "object def rcurly", 8, "10, 14"),
+            "137: " + getCheckMessage(MSG_ERROR, "}", 8, 10),
             "141: " + getCheckMessage(MSG_ERROR_MULTI, "object def lcurly", 6, "8, 12"),
             "142: " + getCheckMessage(MSG_ERROR, "method def modifier", 12, 10),
             "144: " + getCheckMessage(MSG_ERROR, "method def rcurly", 12, 10),
             "145: " + getCheckMessage(MSG_ERROR_MULTI, "object def rcurly", 6, "8, 12"),
+            "145: " + getCheckMessage(MSG_ERROR, "}", 6, 8),
             "150: " + getCheckMessage(MSG_ERROR, "method def modifier", 10, 12),
             "152: " + getCheckMessage(MSG_ERROR, "method def rcurly", 10, 12),
             "188: " + getCheckMessage(MSG_ERROR, "class", 0, 4),
         };
-        verifyWarns(checkConfig, fileName, expected);
+        verifyWarns(checkConfig, fileName, expected, 2);
     }
 
     @Test
@@ -1619,10 +1621,10 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
             "52: " + getCheckMessage(MSG_ERROR, "block lcurly", 9, 8),
             "64: " + getCheckMessage(MSG_CHILD_ERROR, "block", 7, 6),
             "65: " + getCheckMessage(MSG_ERROR, "block rcurly", 5, 4),
-            "175: " + getCheckMessage(MSG_CHILD_ERROR, "block", 9, 10),
-            "175: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 9, 10),
-            "176: " + getCheckMessage(MSG_CHILD_ERROR, "block", 11, 10),
-            "181: " + getCheckMessage(MSG_ERROR, "block rcurly", 7, 8),
+            "179: " + getCheckMessage(MSG_CHILD_ERROR, "block", 9, 10),
+            "179: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 9, 10),
+            "180: " + getCheckMessage(MSG_CHILD_ERROR, "block", 11, 10),
+            "185: " + getCheckMessage(MSG_ERROR, "block rcurly", 7, 8),
         };
         verifyWarns(checkConfig, getNonCompilablePath("InputLambda1.java"), expected, 1);
     }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/InputLambda1.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/InputLambda1.java
@@ -91,6 +91,10 @@ public class InputLambda1 { //indent:0 exp:0
           x.run(); //indent:10 exp:10
         }); //indent:8 exp:8
 
+    Object o2 = new Thread(() -> { //indent:4 exp:4
+      x.run(); //indent:6 exp:6
+    }).toString(); //indent:4 exp:4
+
     SomeInterface i1 = (LongTypeName //indent:4 exp:4
         arg) -> { //indent:8 exp:8
       System.out.print(arg.toString()); //indent:6 exp:6


### PR DESCRIPTION
Fix for latest in issue.
````
String result = IntStream.range(0, 10).mapToObj(i -> {
    int j = i * i;
    return Integer.toString(j);
}).filter(x -> x.equals("36")).findFirst().orElse(null);
````
Error: `'.' have incorrect indentation level 10, expected level should be 12. [Indentation]`

The issue is not with lambdas, but with `LineWrappingHandler.collectFirstNodes`. Originally it was set to skip SLIST/OBJBLOCK, so this caused it to incorrectly pick `.` (PERIOD) as the first node of the line, instead of `}`. The issue can be seen with other, non-lambda code like:
````
    String t = this.run(new Test() {
    }).run().now();
````

Because of the change to the method, null nodes can't be found anymore, so the null protections had to be removed to appease code coverage.
I added the code from the issue to the input file.