### PR TITLE
Issue #2904: fixed bad code in InputIllegalInstantiation2

### DIFF
--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/InputIllegalInstantiation2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/InputIllegalInstantiation2.java
@@ -1,3 +1,4 @@
+//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.function.Function;
@@ -10,7 +11,6 @@ public class InputIllegalInstantiation2
     {
 
         Supplier<InputMethodReferencesTest2> supplier = InputMethodReferencesTest2::new;
-        Supplier<InputMethodReferencesTest2> suppl = InputMethodReferencesTest2::<Integer> new;
         Function<Integer, String[]> messageArrayFactory = String[]::new;
 
     }


### PR DESCRIPTION
> Supplier<InputMethodReferencesTest2> suppl = InputMethodReferencesTest2::&lt;Integer&gt; new;

Eclipse error highlighting `Integer`: `Explicit type arguments cannot be specified in raw constructor reference`
No code coverage attached, so if no one has any alternatives, I just removed it.