### PR TITLE
Issue #2904: fixed bad code in InputInnerAssignmentLambdaExpressions

### DIFF
--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/InputInnerAssignmentLambdaExpressions.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/InputInnerAssignmentLambdaExpressions.java
@@ -1,10 +1,11 @@
+//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.function.Supplier;
 
 public class InputInnerAssignmentLambdaExpressions {
     interface MyLambda {
-        boolean e(Object e);
+        void e(Object e);
     }
     private static class MyButton {
         public void setOnAction(MyLambda my) {
@@ -12,8 +13,6 @@ public class InputInnerAssignmentLambdaExpressions {
     }
     private void setAction() {
         MyButton button = new MyButton();
-        boolean pressed = false;
-        button.setOnAction(e -> pressed = true);  //No violation here
-        button.setOnAction(e -> { pressed = true; });  //No violation here
+        button.setOnAction(e -> { boolean pressed = true; });  //No violation here
     }
 }


### PR DESCRIPTION
I couldn't fix both lambdas.
If left as is, Eclipse gave the error `Local variable pressed defined in an enclosing scope must be final or effectively final`.
I was able to fix the second one, but the first one couldn't be fixed the same way as Eclipse gave the error `Syntax error on token(s), misplaced construct(s)`.
I couldn't leave the original `boolean pressed = ...` outside the lambda because Eclipse gae the error `Lambda expression's local variable pressed cannot redeclare another local variable defined in an enclosing scope.`.
Code coverage was not required for the first lambda.