### PR TITLE
Issue 2763: restoration of throwsIndent

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -322,6 +322,7 @@
       <property name="basicOffset" value="4"/>
       <property name="braceAdjustment" value="0"/>
       <property name="caseIndent" value="4"/>
+      <property name="throwsIndent" value="8"/>
     </module>
     <module name="OuterTypeFilename"/>
     <module name="TodoComment">

--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -118,7 +118,7 @@ public class BaseCheckTestSupport {
             String messageFileName,
             String[] expected,
             Integer... warnsExpected)
-        throws Exception {
+            throws Exception {
         stream.flush();
         final List<File> theFiles = Lists.newArrayList();
         Collections.addAll(theFiles, processedFiles);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -521,7 +521,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
      * @throws UnsupportedEncodingException if charset is unsupported.
      */
     public void setCharset(String charset)
-        throws UnsupportedEncodingException {
+            throws UnsupportedEncodingException {
         if (!Charset.isSupported(charset)) {
             final String message = "unsupported charset: '" + charset + "'";
             throw new UnsupportedEncodingException(message);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -118,7 +118,7 @@ public final class ConfigurationLoader {
      */
     private ConfigurationLoader(final PropertyResolver overrideProps,
                                 final boolean omitIgnoredModules)
-        throws ParserConfigurationException, SAXException {
+            throws ParserConfigurationException, SAXException {
         saxHandler = new InternalLoader();
         overridePropsResolver = overrideProps;
         this.omitIgnoredModules = omitIgnoredModules;
@@ -148,7 +148,7 @@ public final class ConfigurationLoader {
      * @throws SAXException if an error occurs
      */
     private void parseInputSource(InputSource source)
-        throws IOException, SAXException {
+            throws IOException, SAXException {
         saxHandler.parseInputSource(source);
     }
 
@@ -176,7 +176,7 @@ public final class ConfigurationLoader {
      */
     public static Configuration loadConfiguration(String config,
         PropertyResolver overridePropsResolver, boolean omitIgnoredModules)
-        throws CheckstyleException {
+            throws CheckstyleException {
         // figure out if this is a File or a URL
         final URI uri = CommonUtils.getUriByFilename(config);
         final InputSource source = new InputSource(uri.toString());
@@ -204,7 +204,7 @@ public final class ConfigurationLoader {
     @Deprecated
     public static Configuration loadConfiguration(InputStream configStream,
         PropertyResolver overridePropsResolver, boolean omitIgnoredModules)
-        throws CheckstyleException {
+            throws CheckstyleException {
         return loadConfiguration(new InputSource(configStream),
                                  overridePropsResolver, omitIgnoredModules);
     }
@@ -223,7 +223,7 @@ public final class ConfigurationLoader {
      */
     public static Configuration loadConfiguration(InputSource configSource,
             PropertyResolver overridePropsResolver, boolean omitIgnoredModules)
-        throws CheckstyleException {
+            throws CheckstyleException {
         try {
             final ConfigurationLoader loader =
                 new ConfigurationLoader(overridePropsResolver,
@@ -265,7 +265,7 @@ public final class ConfigurationLoader {
      */
     private static String replaceProperties(
             String value, PropertyResolver props, String defaultValue)
-        throws CheckstyleException {
+            throws CheckstyleException {
         if (value == null) {
             return null;
         }
@@ -319,7 +319,7 @@ public final class ConfigurationLoader {
     private static void parsePropertyString(String value,
                                            List<String> fragments,
                                            List<String> propertyRefs)
-        throws CheckstyleException {
+            throws CheckstyleException {
         int prev = 0;
         //search for the next instance of $ from the 'prev' position
         int pos = value.indexOf(DOLLAR_SIGN, prev);
@@ -401,7 +401,7 @@ public final class ConfigurationLoader {
          * @throws ParserConfigurationException if an error occurs
          */
         InternalLoader()
-            throws SAXException, ParserConfigurationException {
+                throws SAXException, ParserConfigurationException {
             super(createIdToResourceNameMap());
         }
 
@@ -410,7 +410,7 @@ public final class ConfigurationLoader {
                                  String localName,
                                  String qName,
                                  Attributes attributes)
-            throws SAXException {
+                throws SAXException {
             if (qName.equals(MODULE)) {
                 //create configuration
                 final String name = attributes.getValue(NAME);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -76,7 +76,7 @@ public final class PackageNamesLoader
      * @throws SAXException if an error occurs
      */
     private PackageNamesLoader()
-        throws ParserConfigurationException, SAXException {
+            throws ParserConfigurationException, SAXException {
         super(DTD_PUBLIC_ID, DTD_RESOURCE_NAME);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -147,7 +147,7 @@ public final class TreeWalker
 
     @Override
     public void setupChild(Configuration childConf)
-        throws CheckstyleException {
+            throws CheckstyleException {
         final String name = childConf.getName();
         final Object module = moduleFactory.createModule(name);
         if (!(module instanceof AbstractCheck)) {
@@ -202,7 +202,7 @@ public final class TreeWalker
      * @throws CheckstyleException if an error occurs
      */
     private void registerCheck(AbstractCheck check)
-        throws CheckstyleException {
+            throws CheckstyleException {
         validateDefaultTokens(check);
         final int[] tokens;
         final Set<String> checkTokens = check.getTokenNames();
@@ -419,7 +419,7 @@ public final class TreeWalker
      *                 if parsing failed
      */
     public static DetailAST parse(FileContents contents)
-        throws RecognitionException, TokenStreamException {
+            throws RecognitionException, TokenStreamException {
         final String fullText = contents.getText().getFullText().toString();
         final Reader reader = new StringReader(fullText);
         final GeneratedJavaLexer lexer = new GeneratedJavaLexer(reader);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -600,7 +600,7 @@ public class CheckstyleAntTask extends Task {
          * @throws IOException if an error occurs
          */
         private AuditListener createDefaultLogger(Task task)
-            throws IOException {
+                throws IOException {
             if (toFile == null || !useFile) {
                 return new DefaultLogger(
                     new LogOutputStream(task, Project.MSG_DEBUG),

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractLoader.java
@@ -64,7 +64,7 @@ public abstract class AbstractLoader
      * @throws ParserConfigurationException if an error occurs
      */
     protected AbstractLoader(String publicId, String dtdResourceName)
-        throws SAXException, ParserConfigurationException {
+            throws SAXException, ParserConfigurationException {
         this(new HashMap<String, String>(1));
         publicIdToResourceNameMap.put(publicId, dtdResourceName);
     }
@@ -76,7 +76,7 @@ public abstract class AbstractLoader
      * @throws ParserConfigurationException if an error occurs
      */
     protected AbstractLoader(Map<String, String> publicIdToResourceNameMap)
-        throws SAXException, ParserConfigurationException {
+            throws SAXException, ParserConfigurationException {
         this.publicIdToResourceNameMap =
             Maps.newHashMap(publicIdToResourceNameMap);
         final SAXParserFactory factory = SAXParserFactory.newInstance();
@@ -95,13 +95,13 @@ public abstract class AbstractLoader
      * @throws SAXException in an error occurs
      */
     public void parseInputSource(InputSource inputSource)
-        throws IOException, SAXException {
+            throws IOException, SAXException {
         parser.parse(inputSource);
     }
 
     @Override
     public InputSource resolveEntity(String publicId, String systemId)
-        throws SAXException, IOException {
+            throws SAXException, IOException {
         if (publicIdToResourceNameMap.keySet().contains(publicId)) {
             final String dtdResourceName =
                     publicIdToResourceNameMap.get(publicId);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -120,7 +120,7 @@ public class AutomaticBean
      */
     @Override
     public final void configure(Configuration config)
-        throws CheckstyleException {
+            throws CheckstyleException {
         configuration = config;
 
         final String[] attributes = config.getAttributeNames();
@@ -191,7 +191,7 @@ public class AutomaticBean
      */
     @Override
     public final void contextualize(Context context)
-        throws CheckstyleException {
+            throws CheckstyleException {
 
         final Collection<String> attributes = context.getAttributeNames();
 
@@ -235,7 +235,7 @@ public class AutomaticBean
      * @see Configuration#getChildren
      */
     protected void setupChild(Configuration childConf)
-        throws CheckstyleException {
+            throws CheckstyleException {
         if (childConf != null) {
             throw new CheckstyleException(childConf.getName() + " is not allowed as a child in "
                     + getConfiguration().getName());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
@@ -70,7 +70,7 @@ public class ClassResolver {
      * @throws ClassNotFoundException if unable to resolve the class
      */
     public Class<?> resolve(String name, String currentClass)
-        throws ClassNotFoundException {
+            throws ClassNotFoundException {
         // See if the class is full qualified
         Class<?> clazz = resolveQualifiedName(name);
         if (clazz != null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
@@ -125,7 +125,7 @@ public class NewlineAtEndOfFileCheck
      *         provided reader
      */
     private boolean endsWithNewline(RandomAccessFile randomAccessFile)
-        throws IOException {
+            throws IOException {
         final int len = lineSeparator.length();
         if (randomAccessFile.length() < len) {
             return false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -93,7 +93,7 @@ final class ImportControlLoader extends AbstractLoader {
                              final String localName,
                              final String qName,
                              final Attributes attributes)
-        throws SAXException {
+            throws SAXException {
         if ("import-control".equals(qName)) {
             final String pkg = safeGet(attributes, PKG_ATTRIBUTE_NAME);
             stack.push(new PkgControl(pkg));
@@ -196,7 +196,7 @@ final class ImportControlLoader extends AbstractLoader {
      * @throws SAXException if the attribute does not exist.
      */
     private static String safeGet(final Attributes attributes, final String name)
-        throws SAXException {
+            throws SAXException {
         final String returnValue = attributes.getValue(name);
         if (returnValue == null) {
             throw new SAXException("missing attribute " + name);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -215,8 +215,18 @@ public abstract class AbstractExpressionHandler {
      * @return the start of the line for the given expression
      */
     protected final int getLineStart(DetailAST ast) {
-        final String line = indentCheck.getLine(ast.getLineNo() - 1);
-        return getLineStart(line);
+        return getLineStart(ast.getLineNo());
+    }
+
+    /**
+     * Get the start of the line for the given line number.
+     *
+     * @param lineNo   the line number to find the start for
+     *
+     * @return the start of the line for the given expression
+     */
+    protected final int getLineStart(int lineNo) {
+        return getLineStart(indentCheck.getLine(lineNo - 1));
     }
 
     /**
@@ -367,6 +377,22 @@ public abstract class AbstractExpressionHandler {
      */
     protected void checkWrappingIndentation(DetailAST firstNode, DetailAST lastNode) {
         indentCheck.getLineWrappingHandler().checkIndentation(firstNode, lastNode);
+    }
+
+    /**
+     * Checks indentation on wrapped lines between and including
+     * {@code firstNode} and {@code lastNode}.
+     *
+     * @param firstNode First node to start examining.
+     * @param lastNode Last node to examine inclusively.
+     * @param wrappedIndentLevel Indentation all wrapped lines should use.
+     * @param startIndent Indentation first line before wrapped lines used.
+     * @param ignoreFirstLine Test if first line's indentation should be checked or not.
+     */
+    protected void checkWrappingIndentation(DetailAST firstNode, DetailAST lastNode,
+            int wrappedIndentLevel, int startIndent, boolean ignoreFirstLine) {
+        indentCheck.getLineWrappingHandler().checkIndentation(firstNode, lastNode,
+                wrappedIndentLevel, startIndent, ignoreFirstLine);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -74,6 +74,20 @@ public class LineWrappingHandler {
      * @param indentLevel Indentation all wrapped lines should use.
      */
     public void checkIndentation(DetailAST firstNode, DetailAST lastNode, int indentLevel) {
+        checkIndentation(firstNode, lastNode, indentLevel, -1, true);
+    }
+
+    /**
+     * Checks line wrapping into expressions and definitions.
+     *
+     * @param firstNode First node to start examining.
+     * @param lastNode Last node to examine inclusively.
+     * @param indentLevel Indentation all wrapped lines should use.
+     * @param startIndent Indentation first line before wrapped lines used.
+     * @param ignoreFirstLine Test if first line's indentation should be checked or not.
+     */
+    public void checkIndentation(DetailAST firstNode, DetailAST lastNode, int indentLevel,
+            int startIndent, boolean ignoreFirstLine) {
         final NavigableMap<Integer, DetailAST> firstNodesOnLines = collectFirstNodes(firstNode,
                 lastNode);
 
@@ -82,9 +96,18 @@ public class LineWrappingHandler {
             checkAnnotationIndentation(firstLineNode, firstNodesOnLines, indentLevel);
         }
 
-        // First node should be removed because it was already checked before.
-        firstNodesOnLines.remove(firstNodesOnLines.firstKey());
-        final int firstNodeIndent = getLineStart(firstLineNode);
+        if (ignoreFirstLine) {
+            // First node should be removed because it was already checked before.
+            firstNodesOnLines.remove(firstNodesOnLines.firstKey());
+        }
+
+        final int firstNodeIndent;
+        if (startIndent == -1) {
+            firstNodeIndent = getLineStart(firstLineNode);
+        }
+        else {
+            firstNodeIndent = startIndent;
+        }
         final int currentIndent = firstNodeIndent + indentLevel;
 
         for (DetailAST node : firstNodesOnLines.values()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
@@ -57,9 +57,59 @@ public class MethodDefHandler extends BlockParentHandler {
         }
     }
 
+    /**
+     * Check the indentation level of the throws clause.
+     */
+    private void checkThrows() {
+        final DetailAST throwsAst = getMainAst().findFirstToken(TokenTypes.LITERAL_THROWS);
+
+        if (throwsAst != null) {
+            checkWrappingIndentation(throwsAst, throwsAst.getNextSibling(), getIndentCheck()
+                    .getThrowsIndent(), getLineStart(getMethodDefLineStart(getMainAst())),
+                    !isOnStartOfLine(throwsAst));
+        }
+    }
+
+    /**
+     * Gets the start line of the method, excluding any annotations. This is required because the
+     * current {@link TokenTypes#METHOD_DEF} may not always be the start as seen in
+     * https://github.com/checkstyle/checkstyle/issues/3145.
+     *
+     * @param mainAst
+     *            The method definition ast.
+     * @return The start column position of the method.
+     */
+    private int getMethodDefLineStart(DetailAST mainAst) {
+        // get first type position
+        int lineStart = mainAst.findFirstToken(TokenTypes.IDENT).getLineNo();
+
+        // check if there is a type before the indent
+        final DetailAST typeNode = mainAst.findFirstToken(TokenTypes.TYPE);
+        if (typeNode != null) {
+            lineStart = getFirstLine(lineStart, typeNode);
+        }
+
+        // check if there is a modifier before the type
+        for (DetailAST node = mainAst.findFirstToken(TokenTypes.MODIFIERS).getFirstChild();
+                node != null;
+                node = node.getNextSibling()) {
+            // skip annotations as we check them else where as outside the method
+            if (node.getType() == TokenTypes.ANNOTATION) {
+                continue;
+            }
+
+            if (node.getLineNo() < lineStart) {
+                lineStart = node.getLineNo();
+            }
+        }
+
+        return lineStart;
+    }
+
     @Override
     public void checkIndentation() {
         checkModifiers();
+        checkThrows();
 
         checkWrappingIndentation(getMainAst(), getMethodDefParamRightParen(getMainAst()));
         if (getLCurly() == null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -71,7 +71,7 @@ public final class SuppressionsLoader
      * @throws SAXException if an error occurs
      */
     private SuppressionsLoader()
-        throws ParserConfigurationException, SAXException {
+            throws ParserConfigurationException, SAXException {
         super(createIdToResourceNameMap());
     }
 
@@ -80,7 +80,7 @@ public final class SuppressionsLoader
                              String localName,
                              String qName,
                              Attributes attributes)
-        throws SAXException {
+            throws SAXException {
         if ("suppress".equals(qName)) {
             //add SuppressElement filter to the filter chain
             final String checks = attributes.getValue("checks");
@@ -121,7 +121,7 @@ public final class SuppressionsLoader
      * @throws CheckstyleException if an error occurs.
      */
     public static FilterSet loadSuppressions(String filename)
-        throws CheckstyleException {
+            throws CheckstyleException {
         // figure out if this is a File or a URL
         final URI uri = CommonUtils.getUriByFilename(filename);
         final InputSource source = new InputSource(uri.toString());
@@ -137,7 +137,7 @@ public final class SuppressionsLoader
      */
     private static FilterSet loadSuppressions(
             InputSource source, String sourceName)
-        throws CheckstyleException {
+            throws CheckstyleException {
         try {
             final SuppressionsLoader suppressionsLoader =
                 new SuppressionsLoader();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -49,7 +49,7 @@ public class ConfigurationLoaderTest {
     }
 
     private static Configuration loadConfiguration(String name)
-        throws CheckstyleException {
+            throws CheckstyleException {
         return loadConfiguration(name, new Properties());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -54,7 +54,7 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 public class PackageNamesLoaderTest {
     @Test
     public void testDefault()
-        throws CheckstyleException {
+            throws CheckstyleException {
         final Set<String> packageNames = PackageNamesLoader
                 .getPackageNames(Thread.currentThread()
                         .getContextClassLoader());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -44,7 +44,7 @@ public class PackageObjectFactoryTest {
 
     @Test
     public void testMakeObjectFromName()
-        throws CheckstyleException {
+            throws CheckstyleException {
         final Checker checker =
             (Checker) factory.createModule(
                         "com.puppycrawl.tools.checkstyle.Checker");
@@ -53,7 +53,7 @@ public class PackageObjectFactoryTest {
 
     @Test
     public void testMakeCheckFromName()
-        throws CheckstyleException {
+            throws CheckstyleException {
         final ConstantNameCheck check =
                 (ConstantNameCheck) factory.createModule(
                         "com.puppycrawl.tools.checkstyle.checks.naming.ConstantName");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -81,7 +81,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
 
     @Test
     public void testAcceptableTokens()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(HiddenFieldCheck.class);
         checkConfig.addAttribute("tokens", "VARIABLE_DEF, ENUM_DEF, CLASS_DEF, METHOD_DEF,"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -50,7 +50,7 @@ public class XMLLoggerTest {
 
     @Test
     public void testEncode()
-        throws IOException {
+            throws IOException {
         new XMLLogger(outStream, false);
         final String[][] encodings = {
             {"<", "&lt;"},
@@ -73,7 +73,7 @@ public class XMLLoggerTest {
 
     @Test
     public void testIsReference()
-        throws IOException {
+            throws IOException {
         new XMLLogger(outStream, false);
         final String[] references = {
             "&#0;",
@@ -103,7 +103,7 @@ public class XMLLoggerTest {
 
     @Test
     public void testCloseStream()
-        throws IOException {
+            throws IOException {
         final XMLLogger logger = new XMLLogger(outStream, true);
         logger.auditStarted(null);
         logger.auditFinished(null);
@@ -113,7 +113,7 @@ public class XMLLoggerTest {
 
     @Test
     public void testNoCloseStream()
-        throws IOException {
+            throws IOException {
         final XMLLogger logger = new XMLLogger(outStream, false);
         logger.auditStarted(null);
         logger.auditFinished(null);
@@ -124,7 +124,7 @@ public class XMLLoggerTest {
 
     @Test
     public void testFileStarted()
-        throws IOException {
+            throws IOException {
         final XMLLogger logger = new XMLLogger(outStream, true);
         logger.auditStarted(null);
         final AuditEvent ev = new AuditEvent(this, "Test.java");
@@ -136,7 +136,7 @@ public class XMLLoggerTest {
 
     @Test
     public void testFileFinished()
-        throws IOException {
+            throws IOException {
         final XMLLogger logger = new XMLLogger(outStream, true);
         logger.auditStarted(null);
         final AuditEvent ev = new AuditEvent(this, "Test.java");
@@ -199,7 +199,7 @@ public class XMLLoggerTest {
 
     @Test
     public void testAddException()
-        throws IOException {
+            throws IOException {
         final XMLLogger logger = new XMLLogger(outStream, true);
         logger.auditStarted(null);
         final LocalizedMessage message =
@@ -219,7 +219,7 @@ public class XMLLoggerTest {
     }
 
     private String[] getOutStreamLines()
-        throws IOException {
+            throws IOException {
         final byte[] bytes = outStream.toByteArray();
         final ByteArrayInputStream inStream =
             new ByteArrayInputStream(bytes);
@@ -243,7 +243,7 @@ public class XMLLoggerTest {
      * @param expectedLines expected error report lines
      */
     private void verifyLines(String... expectedLines)
-        throws IOException {
+            throws IOException {
         final String[] lines = getOutStreamLines();
         assertEquals("length.", expectedLines.length + 3, lines.length);
         assertEquals("first line.",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheckTest.java
@@ -48,7 +48,7 @@ public class ArrayTypeStyleCheckTest
 
     @Test
     public void testJavaStyle()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ArrayTypeStyleCheck.class);
         final String[] expected = {
@@ -60,7 +60,7 @@ public class ArrayTypeStyleCheckTest
 
     @Test
     public void testCStyle()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ArrayTypeStyleCheck.class);
         checkConfig.addAttribute("javaStyle", "false");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheckTest.java
@@ -41,7 +41,7 @@ public class DescendantTokenCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(DescendantTokenCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -50,7 +50,7 @@ public class DescendantTokenCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testMaximumNumber()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_NATIVE");
@@ -64,7 +64,7 @@ public class DescendantTokenCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testMessage()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_NATIVE");
@@ -79,7 +79,7 @@ public class DescendantTokenCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testMinimumNumber()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_SWITCH");
@@ -93,7 +93,7 @@ public class DescendantTokenCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testMinimumDepth()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_SWITCH");
@@ -106,7 +106,7 @@ public class DescendantTokenCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testMaximumDepth()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_SWITCH");
@@ -119,7 +119,7 @@ public class DescendantTokenCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testEmptyStatements()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "EMPTY_STAT");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -145,7 +145,7 @@ public class NewlineAtEndOfFileCheckTest
 
     @Test(expected = CheckstyleException.class)
     public void testSetLineSeparatorFailure()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(NewlineAtEndOfFileCheck.class);
         checkConfig.addAttribute("lineSeparator", "ct");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
@@ -45,7 +45,7 @@ public class UncommentedMainCheckTest
 
     @Test
     public void testDefaults()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(UncommentedMainCheck.class);
         final String[] expected = {
@@ -59,7 +59,7 @@ public class UncommentedMainCheckTest
 
     @Test
     public void testExcludedClasses()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(UncommentedMainCheck.class);
         checkConfig.addAttribute("excludedClasses", "\\.Main.*$");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UpperEllCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UpperEllCheckTest.java
@@ -48,7 +48,7 @@ public class UpperEllCheckTest
 
     @Test
     public void testWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(UpperEllCheck.class);
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckTest.java
@@ -48,7 +48,7 @@ public class AvoidNestedBlocksCheckTest
 
     @Test
     public void testStrictSettings()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(AvoidNestedBlocksCheck.class);
         final String[] expected = {
@@ -62,7 +62,7 @@ public class AvoidNestedBlocksCheckTest
 
     @Test
     public void testAllowSwitchInCase()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(AvoidNestedBlocksCheck.class);
         checkConfig.addAttribute("allowInSwitchCase", "true");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
@@ -53,7 +53,7 @@ public class EmptyBlockCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(EmptyBlockCheck.class);
         final String[] expected = {
@@ -71,7 +71,7 @@ public class EmptyBlockCheckTest
 
     @Test
     public void testText()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(EmptyBlockCheck.class);
         checkConfig.addAttribute("option", BlockOption.TEXT.toString());
@@ -87,7 +87,7 @@ public class EmptyBlockCheckTest
 
     @Test
     public void testStatement()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(EmptyBlockCheck.class);
         checkConfig.addAttribute("option", BlockOption.STMT.toString());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheckTest.java
@@ -40,7 +40,7 @@ public class ArrayTrailingCommaCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ArrayTrailingCommaCheck.class);
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidInlineConditionalsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidInlineConditionalsCheckTest.java
@@ -40,7 +40,7 @@ public class AvoidInlineConditionalsCheckTest
 
     @Test
     public void testIt()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(AvoidInlineConditionalsCheck.class);
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheckTest.java
@@ -40,7 +40,7 @@ public class CovariantEqualsCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(CovariantEqualsCheck.class);
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheckTest.java
@@ -59,7 +59,7 @@ public class DefaultComesLastCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testDefaultMethodsInJava8()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(DefaultComesLastCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EmptyStatementCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EmptyStatementCheckTest.java
@@ -40,7 +40,7 @@ public class EmptyStatementCheckTest
 
     @Test
     public void testEmptyStatements()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(EmptyStatementCheck.class);
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -156,7 +156,7 @@ public class FinalLocalVariableCheckTest
 
     @Test
     public void testLambda()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(FinalLocalVariableCheck.class);
         checkConfig.addAttribute("tokens", "PARAMETER_DEF,VARIABLE_DEF");
@@ -169,7 +169,7 @@ public class FinalLocalVariableCheckTest
 
     @Test
     public void testVariableNameShadowing()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(FinalLocalVariableCheck.class);
         checkConfig.addAttribute("tokens", "PARAMETER_DEF,VARIABLE_DEF");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
@@ -85,7 +85,7 @@ public class HiddenFieldCheckTest
 
     @Test
     public void testNoParameters()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(HiddenFieldCheck.class);
         checkConfig.addAttribute("tokens", "VARIABLE_DEF");
@@ -114,7 +114,7 @@ public class HiddenFieldCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(HiddenFieldCheck.class);
         final String[] expected = {
@@ -160,7 +160,7 @@ public class HiddenFieldCheckTest
     /** Tests ignoreFormat property. */
     @Test
     public void testIgnoreFormat()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(HiddenFieldCheck.class);
         checkConfig.addAttribute("ignoreFormat", "^i.*$");
@@ -201,7 +201,7 @@ public class HiddenFieldCheckTest
     /** Tests ignoreSetter property. */
     @Test
     public void testIgnoreSetter()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(HiddenFieldCheck.class);
         checkConfig.addAttribute("ignoreSetter", "true");
@@ -244,7 +244,7 @@ public class HiddenFieldCheckTest
     /** Tests ignoreSetter and setterCanReturnItsClass properties. */
     @Test
     public void testIgnoreChainSetter()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(HiddenFieldCheck.class);
         checkConfig.addAttribute("ignoreSetter", "true");
@@ -286,7 +286,7 @@ public class HiddenFieldCheckTest
     /** Tests ignoreConstructorParameter property. */
     @Test
     public void testIgnoreConstructorParameter()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(HiddenFieldCheck.class);
         checkConfig.addAttribute("ignoreConstructorParameter", "true");
@@ -330,7 +330,7 @@ public class HiddenFieldCheckTest
     /** Test against a class with field declarations in different order. */
     @Test
     public void testReordered()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(HiddenFieldCheck.class);
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckTest.java
@@ -39,7 +39,7 @@ public class IllegalTokenCheckTest
 
     @Test
     public void testCheckWithDefaultSettings()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(IllegalTokenCheck.class);
         final String[] expected = {
@@ -51,7 +51,7 @@ public class IllegalTokenCheckTest
 
     @Test
     public void testPreviouslyIllegalTokens()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(IllegalTokenCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_SWITCH,POST_INC,POST_DEC");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
@@ -40,7 +40,7 @@ public class IllegalTokenTextCheckTest
 
     @Test
     public void testCaseSensitive()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(IllegalTokenTextCheck.class);
         checkConfig.addAttribute("tokens", "STRING_LITERAL");
@@ -54,7 +54,7 @@ public class IllegalTokenTextCheckTest
 
     @Test
     public void testCaseInSensitive()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(IllegalTokenTextCheck.class);
         checkConfig.addAttribute("tokens", "STRING_LITERAL");
@@ -69,7 +69,7 @@ public class IllegalTokenTextCheckTest
 
     @Test
     public void testCustomMessage()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(IllegalTokenTextCheck.class);
         checkConfig.addAttribute("tokens", "STRING_LITERAL");
@@ -85,7 +85,7 @@ public class IllegalTokenTextCheckTest
 
     @Test
     public void testNullCustomMessage()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(IllegalTokenTextCheck.class);
         checkConfig.addAttribute("tokens", "STRING_LITERAL");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckTest.java
@@ -39,7 +39,7 @@ public class MagicNumberCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MagicNumberCheck.class);
         final String[] expected = {
@@ -90,7 +90,7 @@ public class MagicNumberCheckTest
 
     @Test
     public void testIgnoreSome()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MagicNumberCheck.class);
         checkConfig.addAttribute("ignoreNumbers", "0, 1, 3.0, 8, 16, 3000");
@@ -136,7 +136,7 @@ public class MagicNumberCheckTest
 
     @Test
     public void testIgnoreNone()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MagicNumberCheck.class);
         checkConfig.addAttribute("ignoreNumbers", "");
@@ -210,7 +210,7 @@ public class MagicNumberCheckTest
 
     @Test
     public void testIntegersOnly()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MagicNumberCheck.class);
         checkConfig.addAttribute("tokens", "NUM_INT, NUM_LONG");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheckTest.java
@@ -43,7 +43,7 @@ public class NoCloneCheckTest
 
     @Test
     public void testHasClone()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(NoCloneCheck.class);
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoFinalizerCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoFinalizerCheckTest.java
@@ -45,7 +45,7 @@ public class NoFinalizerCheckTest
 
     @Test
     public void testHasFinalizer()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(NoFinalizerCheck.class);
         final String[] expected = {
@@ -56,7 +56,7 @@ public class NoFinalizerCheckTest
 
     @Test
     public void testHasNoFinalizer()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(NoFinalizerCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
@@ -41,7 +41,7 @@ public class ParameterAssignmentCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ParameterAssignmentCheck.class);
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheckTest.java
@@ -41,7 +41,7 @@ public class InterfaceIsTypeCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(InterfaceIsTypeCheck.class);
         final String[] expected = {
@@ -52,7 +52,7 @@ public class InterfaceIsTypeCheckTest
 
     @Test
     public void testAllowMarker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(InterfaceIsTypeCheck.class);
         checkConfig.addAttribute("allowMarkerInterfaces", "false");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -63,7 +63,7 @@ public class VisibilityModifierCheckTest
 
     @Test
     public void testInner()
-        throws Exception {
+            throws Exception {
         final String[] expected = {
             "30:24: " + getCheckMessage(MSG_KEY, "rData"),
             "33:27: " + getCheckMessage(MSG_KEY, "protectedVariable"),
@@ -77,7 +77,7 @@ public class VisibilityModifierCheckTest
 
     @Test
     public void testIgnoreAccess()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(VisibilityModifierCheck.class);
         checkConfig.addAttribute("publicMemberPattern", "^r[A-Z]");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheckTest.java
@@ -41,7 +41,7 @@ public class AvoidStarImportCheckTest
 
     @Test
     public void testDefaultOperation()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(AvoidStarImportCheck.class);
         final String[] expected = {
@@ -59,7 +59,7 @@ public class AvoidStarImportCheckTest
 
     @Test
     public void testExcludes()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(AvoidStarImportCheck.class);
         checkConfig.addAttribute("excludes",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheckTest.java
@@ -48,7 +48,7 @@ public class AvoidStaticImportCheckTest
 
     @Test
     public void testDefaultOperation()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(AvoidStaticImportCheck.class);
         final String[] expected = {
@@ -70,7 +70,7 @@ public class AvoidStaticImportCheckTest
 
     @Test
     public void testStarExcludes()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(AvoidStaticImportCheck.class);
         checkConfig.addAttribute("excludes", "java.io.File.*,sun.net.ftpclient.FtpClient.*");
@@ -90,7 +90,7 @@ public class AvoidStaticImportCheckTest
 
     @Test
     public void testMemberExcludes()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(AvoidStaticImportCheck.class);
         checkConfig.addAttribute("excludes", "java.io.File.listRoots");
@@ -112,7 +112,7 @@ public class AvoidStaticImportCheckTest
 
     @Test
     public void testBogusMemberExcludes()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(AvoidStaticImportCheck.class);
 
@@ -140,7 +140,7 @@ public class AvoidStaticImportCheckTest
 
     @Test
     public void testInnerClassMemberExcludesStar()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(AvoidStaticImportCheck.class);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
@@ -47,7 +47,7 @@ public class IllegalImportCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithSupplied()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(IllegalImportCheck.class);
         checkConfig.addAttribute("illegalPkgs", "java.io");
@@ -61,7 +61,7 @@ public class IllegalImportCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(IllegalImportCheck.class);
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckTest.java
@@ -60,7 +60,7 @@ public class RedundantImportCheckTest
 
     @Test
     public void testWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(RedundantImportCheck.class);
         final String[] expected = {
@@ -77,7 +77,7 @@ public class RedundantImportCheckTest
 
     @Test
     public void testUnnamedPackage()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(RedundantImportCheck.class);
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1378,6 +1378,33 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
+    public void testThrowsIndentationLevel2() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+
+        checkConfig.addAttribute("basicOffset", "1");
+        checkConfig.addAttribute("forceStrictCondition", "true");
+        checkConfig.addAttribute("lineWrappingIndentation", "3");
+        checkConfig.addAttribute("tabWidth", "4");
+        checkConfig.addAttribute("throwsIndent", "5");
+        final String[] expected = {
+            "7: " + getCheckMessage(MSG_ERROR, "Exception", 0, 6),
+            "10: " + getCheckMessage(MSG_ERROR, "NullPointerException", 0, 6),
+            "13: " + getCheckMessage(MSG_ERROR, "throws", 0, 6),
+            "16: " + getCheckMessage(MSG_ERROR, "throws", 0, 6),
+            "18: " + getCheckMessage(MSG_ERROR, "throws", 0, 6),
+            "19: " + getCheckMessage(MSG_ERROR, "Exception", 0, 6),
+            "22: " + getCheckMessage(MSG_ERROR, "throws", 0, 6),
+            "23: " + getCheckMessage(MSG_ERROR, "Exception", 0, 6),
+            "24: " + getCheckMessage(MSG_ERROR, "NullPointerException", 0, 6),
+            "27: " + getCheckMessage(MSG_ERROR, "throws", 0, 6),
+            "28: " + getCheckMessage(MSG_ERROR, "Exception", 0, 6),
+            "31: " + getCheckMessage(MSG_ERROR, "throws", 0, 6),
+            "37: " + getCheckMessage(MSG_ERROR, "throws", 0, 6),
+        };
+        verifyWarns(checkConfig, getPath("InputInvalidThrowsIndent2.java"), expected);
+    }
+
+    @Test
     public void testCaseLevel() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -541,7 +541,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testValidDotWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -559,7 +559,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testValidMethodWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -580,7 +580,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testInvalidMethodWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -632,7 +632,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testInvalidSwitchWithChecker()
-        throws Exception {
+            throws Exception {
 
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
@@ -675,7 +675,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testValidSwitchWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -693,7 +693,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testValidArrayInitDefaultIndentWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -711,7 +711,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testValidArrayInitWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "8");
@@ -729,7 +729,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testInvalidArrayInitWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -781,7 +781,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testValidTryWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -799,7 +799,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testInvalidTryWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -838,7 +838,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testInvalidClassDefWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -893,7 +893,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testInvalidBlockWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -958,7 +958,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testInvalidIfWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -1050,7 +1050,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testInvalidWhileWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -1120,7 +1120,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testInvalidForWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -1161,7 +1161,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testValidForWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -1179,7 +1179,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testValidDoWhileWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -1197,7 +1197,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testInvalidDoWhileWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -1233,7 +1233,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testValidBlockWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -1251,7 +1251,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testValidWhileWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -1269,7 +1269,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testValidClassDefWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -1290,7 +1290,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testValidInterfaceDefWithChecker()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -1308,7 +1308,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testValidCommaWithChecker()
-        throws Exception {
+            throws Exception {
 
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -122,7 +122,7 @@ public class AbstractJavadocCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testCheckReuseAfterParseErrorWithFollowingAntlrErrorInSingleFile()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(TempCheck.class);
         final String[] expected = {
             "4: " + getCheckMessage(MSG_JAVADOC_MISSED_HTML_CLOSE, 4, "unclosedTag"),
@@ -133,7 +133,7 @@ public class AbstractJavadocCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testPosition()
-        throws Exception {
+            throws Exception {
         JavadocCatchCheck.clearCounter();
         final DefaultConfiguration checkConfig = createCheckConfig(JavadocCatchCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -143,7 +143,7 @@ public class AbstractJavadocCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testPositionWithSinglelineComments()
-        throws Exception {
+            throws Exception {
         JavadocCatchCheck.clearCounter();
         final DefaultConfiguration checkConfig = createCheckConfig(JavadocCatchCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -153,7 +153,7 @@ public class AbstractJavadocCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testPositionOnlyComments()
-        throws Exception {
+            throws Exception {
         JavadocCatchCheck.clearCounter();
         final DefaultConfiguration checkConfig = createCheckConfig(JavadocCatchCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -68,7 +68,7 @@ public class JavadocStyleCheckTest
 
     @Test
     public void testDefaultSettings()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocStyleCheck.class);
         final String[] expected = {
@@ -203,7 +203,7 @@ public class JavadocStyleCheckTest
 
     @Test
     public void testScopePublic()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocStyleCheck.class);
         checkConfig.addAttribute("checkFirstSentence", "true");
@@ -228,7 +228,7 @@ public class JavadocStyleCheckTest
 
     @Test
     public void testScopeProtected()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocStyleCheck.class);
         checkConfig.addAttribute("checkFirstSentence", "true");
@@ -256,7 +256,7 @@ public class JavadocStyleCheckTest
 
     @Test
     public void testScopePackage()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocStyleCheck.class);
         checkConfig.addAttribute("checkFirstSentence", "true");
@@ -306,7 +306,7 @@ public class JavadocStyleCheckTest
 
     @Test
     public void testExcludeScope()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocStyleCheck.class);
         checkConfig.addAttribute("scope", "private");
@@ -400,7 +400,7 @@ public class JavadocStyleCheckTest
 
     @Test
     public void testRestrictedTokenSet()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(JavadocStyleCheck.class);
         checkConfig.addAttribute("tokens", "METHOD_DEF");
         checkConfig.addAttribute("scope", "public");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -183,7 +183,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testAuthorRegularEx()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocTypeCheck.class);
         checkConfig.addAttribute("authorFormat", "0*");
@@ -197,7 +197,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testAuthorRegularExError()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocTypeCheck.class);
         checkConfig.addAttribute("authorFormat", "ABC");
@@ -217,7 +217,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testVersionRequired()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocTypeCheck.class);
         checkConfig.addAttribute("versionFormat", "\\S");
@@ -229,7 +229,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testVersionRegularEx()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocTypeCheck.class);
         checkConfig.addAttribute("versionFormat", "^\\p{Digit}+\\.\\p{Digit}+$");
@@ -243,7 +243,7 @@ public class JavadocTypeCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testVersionRegularExError()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocTypeCheck.class);
         checkConfig.addAttribute("versionFormat", "\\$Revision.*\\$");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
@@ -66,7 +66,7 @@ public class JavadocVariableCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocVariableCheck.class);
         final String[] expected = {
@@ -80,7 +80,7 @@ public class JavadocVariableCheckTest
 
     @Test
     public void testAnother()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocVariableCheck.class);
         final String[] expected = {
@@ -93,7 +93,7 @@ public class JavadocVariableCheckTest
 
     @Test
     public void testAnother2()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocVariableCheck.class);
         checkConfig.addAttribute("scope", Scope.PUBLIC.getName());
@@ -103,7 +103,7 @@ public class JavadocVariableCheckTest
 
     @Test
     public void testAnother3()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocVariableCheck.class);
         final String[] expected = {
@@ -120,7 +120,7 @@ public class JavadocVariableCheckTest
 
     @Test
     public void testAnother4()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(JavadocVariableCheck.class);
         checkConfig.addAttribute("scope", Scope.PUBLIC.getName());
@@ -242,7 +242,7 @@ public class JavadocVariableCheckTest
 
     @Test
     public void testIgnoredVariableNames()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(JavadocVariableCheck.class);
         checkConfig.addAttribute("ignoreNamePattern", "log|logger");
@@ -291,7 +291,7 @@ public class JavadocVariableCheckTest
 
     @Test
     public void testDoNotIgnoreAnythingWhenIgnoreNamePatternIsEmpty()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(JavadocVariableCheck.class);
         checkConfig.addAttribute("ignoreNamePattern", "");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -163,7 +163,7 @@ public class WriteTagCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testRegularEx()
-        throws Exception {
+            throws Exception {
         checkConfig.addAttribute("tag", "@author");
         checkConfig.addAttribute("tagFormat", "0*");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -172,7 +172,7 @@ public class WriteTagCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testRegularExError()
-        throws Exception {
+            throws Exception {
         checkConfig.addAttribute("tag", "@author");
         checkConfig.addAttribute("tagFormat", "ABC");
         final String[] expected = {
@@ -206,7 +206,7 @@ public class WriteTagCheckTest extends BaseCheckTestSupport {
                           File[] processedFiles,
                           String messageFileName,
                           String... expected)
-        throws Exception {
+            throws Exception {
         stream.flush();
         final List<File> theFiles = Lists.newArrayList();
         Collections.addAll(theFiles, processedFiles);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
@@ -72,7 +72,7 @@ public class ModifierOrderCheckTest
 
     @Test
     public void testDefaultMethods()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(ModifierOrderCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
@@ -84,7 +84,7 @@ public class RedundantModifierCheckTest
 
     @Test
     public void testStaticMethodInInterface()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(RedundantModifierCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -93,7 +93,7 @@ public class RedundantModifierCheckTest
 
     @Test
     public void testFinalInInterface()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(RedundantModifierCheck.class);
         final String[] expected = {
@@ -190,7 +190,7 @@ public class RedundantModifierCheckTest
 
     @Test
     public void testFinalInAnonymousClass()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(RedundantModifierCheck.class);
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
@@ -234,7 +234,7 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testTypeNamesForThreePermittedCapitalLettersWithOverriddenMethod()
-        throws Exception {
+            throws Exception {
 
         final DefaultConfiguration checkConfig =
             createCheckConfig(AbbreviationAsWordInNameCheck.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ClassTypeParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ClassTypeParameterNameCheckTest.java
@@ -49,7 +49,7 @@ public class ClassTypeParameterNameCheckTest
 
     @Test
     public void testClassDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ClassTypeParameterNameCheck.class);
 
@@ -65,7 +65,7 @@ public class ClassTypeParameterNameCheckTest
 
     @Test
     public void testClassFooName()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ClassTypeParameterNameCheck.class);
         checkConfig.addAttribute("format", "^foo$");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
@@ -59,7 +59,7 @@ public class ConstantNameCheckTest
 
     @Test
     public void testIllegalRegexp()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ConstantNameCheck.class);
         checkConfig.addAttribute("format", "\\");
@@ -78,7 +78,7 @@ public class ConstantNameCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ConstantNameCheck.class);
 
@@ -93,7 +93,7 @@ public class ConstantNameCheckTest
 
     @Test
     public void testAccessControlTuning()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ConstantNameCheck.class);
         checkConfig.addAttribute("applyToPublic", "false");
@@ -110,7 +110,7 @@ public class ConstantNameCheckTest
 
     @Test
     public void testInterfaceAndAnnotation()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ConstantNameCheck.class);
 
@@ -125,7 +125,7 @@ public class ConstantNameCheckTest
 
     @Test
     public void testDefault1()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ConstantNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -154,7 +154,7 @@ public class ConstantNameCheckTest
 
     @Test
     public void testStaticMethodInInterface()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(ConstantNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/InterfaceTypeParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/InterfaceTypeParameterNameCheckTest.java
@@ -49,7 +49,7 @@ public class InterfaceTypeParameterNameCheckTest
 
     @Test
     public void testInterfaceDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(InterfaceTypeParameterNameCheck.class);
 
@@ -63,7 +63,7 @@ public class InterfaceTypeParameterNameCheckTest
 
     @Test
     public void testInterfaceFooName()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(InterfaceTypeParameterNameCheck.class);
         checkConfig.addAttribute("format", "^foo$");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckTest.java
@@ -49,7 +49,7 @@ public class LocalFinalVariableNameCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(LocalFinalVariableNameCheck.class);
 
@@ -63,7 +63,7 @@ public class LocalFinalVariableNameCheckTest
 
     @Test
     public void testSet()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(LocalFinalVariableNameCheck.class);
         checkConfig.addAttribute("format", "[A-Z]+");
@@ -78,7 +78,7 @@ public class LocalFinalVariableNameCheckTest
 
     @Test
     public void testInnerClass()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(LocalFinalVariableNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheckTest.java
@@ -40,7 +40,7 @@ public class LocalVariableNameCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(LocalVariableNameCheck.class);
 
@@ -57,7 +57,7 @@ public class LocalVariableNameCheckTest
 
     @Test
     public void testInnerClass()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(LocalVariableNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -66,7 +66,7 @@ public class LocalVariableNameCheckTest
 
     @Test
     public void testLoopVariables()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(LocalVariableNameCheck.class);
         checkConfig.addAttribute("format", "^[a-z]{2,}[a-zA-Z0-9]*$");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheckTest.java
@@ -48,7 +48,7 @@ public class MemberNameCheckTest
 
     @Test
     public void testSpecified()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
         checkConfig.addAttribute("format", "^m[A-Z][a-zA-Z0-9]*$");
@@ -64,7 +64,7 @@ public class MemberNameCheckTest
 
     @Test
     public void testInnerClass()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
@@ -50,7 +50,7 @@ public class MethodNameCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MethodNameCheck.class);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodTypeParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodTypeParameterNameCheckTest.java
@@ -49,7 +49,7 @@ public class MethodTypeParameterNameCheckTest
 
     @Test
     public void testMethodDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MethodTypeParameterNameCheck.class);
 
@@ -67,7 +67,7 @@ public class MethodTypeParameterNameCheckTest
 
     @Test
     public void testMethodFooName()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MethodTypeParameterNameCheck.class);
         checkConfig.addAttribute("format", "^foo$");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheckTest.java
@@ -49,7 +49,7 @@ public class PackageNameCheckTest
 
     @Test
     public void testSpecified()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(PackageNameCheck.class);
         checkConfig.addAttribute("format", "[A-Z]+");
@@ -65,7 +65,7 @@ public class PackageNameCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(PackageNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -49,7 +49,7 @@ public class ParameterNameCheckTest
 
     @Test
     public void testCatch()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ParameterNameCheck.class);
         checkConfig.addAttribute("format", "^NO_WAY_MATEY$");
@@ -59,7 +59,7 @@ public class ParameterNameCheckTest
 
     @Test
     public void testSpecified()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ParameterNameCheck.class);
         checkConfig.addAttribute("format", "^a[A-Z][a-zA-Z0-9]*$");
@@ -76,7 +76,7 @@ public class ParameterNameCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ParameterNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -95,7 +95,7 @@ public class ParameterNameCheckTest
 
     @Test
     public void testSkipMethodsWithOverrideAnnotationTrue()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ParameterNameCheck.class);
         checkConfig.addAttribute("format", "^h$");
@@ -117,7 +117,7 @@ public class ParameterNameCheckTest
 
     @Test
     public void testSkipMethodsWithOverrideAnnotationFalse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ParameterNameCheck.class);
         checkConfig.addAttribute("format", "^h$");
@@ -140,7 +140,7 @@ public class ParameterNameCheckTest
 
     @Test
     public void testIsOverriddenNoNullPointerException()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(ParameterNameCheck.class);
         checkConfig.addAttribute("format", "^[a-z][a-zA-Z0-9]*$");
         checkConfig.addAttribute("ignoreOverridden", "true");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheckTest.java
@@ -49,7 +49,7 @@ public class StaticVariableNameCheckTest
 
     @Test
     public void testSpecified()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(StaticVariableNameCheck.class);
         checkConfig.addAttribute("format", "^s[A-Z][a-zA-Z0-9]*$");
@@ -64,7 +64,7 @@ public class StaticVariableNameCheckTest
 
     @Test
     public void testAccessTuning()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(StaticVariableNameCheck.class);
         checkConfig.addAttribute("format", "^s[A-Z][a-zA-Z0-9]*$");
@@ -78,7 +78,7 @@ public class StaticVariableNameCheckTest
 
     @Test
     public void testInterfaceOrAnnotationBlock()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(StaticVariableNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheckTest.java
@@ -43,7 +43,7 @@ public class TypeNameCheckTest
 
     @Test
     public void testSpecified()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(TypeNameCheck.class);
         checkConfig.addAttribute("format", "^inputHe");
@@ -53,7 +53,7 @@ public class TypeNameCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(TypeNameCheck.class);
         final String[] expected = {
@@ -71,7 +71,7 @@ public class TypeNameCheckTest
 
     @Test
     public void testClassSpecific()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(TypeNameCheck.class);
         checkConfig.addAttribute("tokens", TokenUtils.getTokenName(TokenTypes.CLASS_DEF));
@@ -84,7 +84,7 @@ public class TypeNameCheckTest
 
     @Test
     public void testInterfaceSpecific()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(TypeNameCheck.class);
         checkConfig.addAttribute("tokens", TokenUtils.getTokenName(TokenTypes.INTERFACE_DEF));
@@ -97,7 +97,7 @@ public class TypeNameCheckTest
 
     @Test
     public void testEnumSpecific()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(TypeNameCheck.class);
         checkConfig.addAttribute("tokens", TokenUtils.getTokenName(TokenTypes.ENUM_DEF));
@@ -110,7 +110,7 @@ public class TypeNameCheckTest
 
     @Test
     public void testAnnotationSpecific()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(TypeNameCheck.class);
         checkConfig.addAttribute("tokens", TokenUtils.getTokenName(TokenTypes.ANNOTATION_DEF));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheckTest.java
@@ -149,7 +149,7 @@ public class RegexpCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testMessagePropertyGood()
-        throws Exception {
+            throws Exception {
         final String illegal = "System\\.(out)|(err)\\.print(ln)?\\(";
         final DefaultConfiguration checkConfig =
             createCheckConfig(RegexpCheck.class);
@@ -165,7 +165,7 @@ public class RegexpCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testMessagePropertyBad()
-        throws Exception {
+            throws Exception {
         final String illegal = "System\\.(out)|(err)\\.print(ln)?\\(";
         final DefaultConfiguration checkConfig =
             createCheckConfig(RegexpCheck.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
@@ -67,7 +67,7 @@ public class RegexpMultilineCheckTest extends BaseFileSetCheckTestSupport {
 
     @Test
     public void testMessageProperty()
-        throws Exception {
+            throws Exception {
         final String illegal = "System\\.(out)|(err)\\.print(ln)?\\(";
         checkConfig.addAttribute("format", illegal);
         final String message = "Bad line :(";

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheckTest.java
@@ -58,7 +58,7 @@ public class RegexpSinglelineCheckTest extends BaseFileSetCheckTestSupport {
 
     @Test
     public void testMessageProperty()
-        throws Exception {
+            throws Exception {
         final String illegal = "System\\.(out)|(err)\\.print(ln)?\\(";
         checkConfig.addAttribute("format", illegal);
         final String message = "Bad line :(";

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheckTest.java
@@ -65,7 +65,7 @@ public class RegexpSinglelineJavaCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testMessageProperty()
-        throws Exception {
+            throws Exception {
         final String illegal = "System\\.(out)|(err)\\.print(ln)?\\(";
         checkConfig.addAttribute("format", illegal);
         final String message = "Bad line :(";

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
@@ -58,7 +58,7 @@ public class LineLengthCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testSimple()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(LineLengthCheck.class);
         checkConfig.addAttribute("max", "80");
@@ -72,7 +72,7 @@ public class LineLengthCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void shouldLogActualLineLength()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(LineLengthCheck.class);
         checkConfig.addAttribute("max", "80");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
@@ -61,7 +61,7 @@ public class ParameterNumberCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ParameterNumberCheck.class);
         final String[] expected = {
@@ -72,7 +72,7 @@ public class ParameterNumberCheckTest
 
     @Test
     public void testNum()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ParameterNumberCheck.class);
         checkConfig.addAttribute("max", "2");
@@ -85,7 +85,7 @@ public class ParameterNumberCheckTest
 
     @Test
     public void shouldLogActualParameterNumber()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ParameterNumberCheck.class);
         checkConfig.addMessage("maxParam", "{0},{1}");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheckTest.java
@@ -57,7 +57,7 @@ public class NoLineWrapCheckTest
 
     @Test
     public void testCustomTokensLineWrapping()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(NoLineWrapCheck.class);
         checkConfig.addAttribute("tokens", "IMPORT, CLASS_DEF, METHOD_DEF, ENUM_DEF");
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheckTest.java
@@ -50,7 +50,7 @@ public class OperatorWrapCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final String[] expected = {
             "15:19: " + getCheckMessage(MSG_LINE_NEW, "+"),
             "16:15: " + getCheckMessage(MSG_LINE_NEW, "-"),
@@ -63,7 +63,7 @@ public class OperatorWrapCheckTest
 
     @Test
     public void testOpWrapEol()
-        throws Exception {
+            throws Exception {
         checkConfig.addAttribute("option", WrapOption.EOL.toString());
         final String[] expected = {
             "18:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "-"),
@@ -75,7 +75,7 @@ public class OperatorWrapCheckTest
 
     @Test
     public void testAssignEol()
-        throws Exception {
+            throws Exception {
         checkConfig.addAttribute("tokens", "ASSIGN");
         checkConfig.addAttribute("option", WrapOption.EOL.toString());
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
@@ -44,7 +44,7 @@ public class ParenPadCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ParenPadCheck.class);
         final String[] expected = {
@@ -63,7 +63,7 @@ public class ParenPadCheckTest
 
     @Test
     public void testSpace()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ParenPadCheck.class);
         checkConfig.addAttribute("option", PadOption.SPACE.toString());
@@ -107,7 +107,7 @@ public class ParenPadCheckTest
 
     @Test
     public void testDefaultForIterator()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ParenPadCheck.class);
         final String[] expected = {
@@ -124,7 +124,7 @@ public class ParenPadCheckTest
 
     @Test
     public void testSpaceEmptyForIterator()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ParenPadCheck.class);
         checkConfig.addAttribute("option", PadOption.SPACE.toString());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
@@ -52,7 +52,7 @@ public class SeparatorWrapCheckTest
 
     @Test
     public void testDot()
-        throws Exception {
+            throws Exception {
         checkConfig.addAttribute("option", "NL");
         checkConfig.addAttribute("tokens", "DOT");
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheckTest.java
@@ -45,7 +45,7 @@ public class TypecastParenPadCheckTest
 
     @Test
     public void testDefault()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(TypecastParenPadCheck.class);
         final String[] expected = {
@@ -57,7 +57,7 @@ public class TypecastParenPadCheckTest
 
     @Test
     public void testSpace()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(TypecastParenPadCheck.class);
         checkConfig.addAttribute("option", PadOption.SPACE.toString());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java
@@ -63,7 +63,7 @@ public class WhitespaceAroundCheckTest
 
     @Test
     public void testIt()
-        throws Exception {
+            throws Exception {
         final String[] expected = {
             "16:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
             "16:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
@@ -107,7 +107,7 @@ public class WhitespaceAroundCheckTest
 
     @Test
     public void testIt2()
-        throws Exception {
+            throws Exception {
         final String[] expected = {
             "153:27: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
             "154:27: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
@@ -121,7 +121,7 @@ public class WhitespaceAroundCheckTest
 
     @Test
     public void testIt3()
-        throws Exception {
+            throws Exception {
         final String[] expected = {
             "37:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "while"),
             "54:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "for"),
@@ -137,7 +137,7 @@ public class WhitespaceAroundCheckTest
 
     @Test
     public void testIt4()
-        throws Exception {
+            throws Exception {
         checkConfig.addAttribute("allowEmptyMethods", "true");
         checkConfig.addAttribute("allowEmptyConstructors", "true");
         final String[] expected = {
@@ -149,7 +149,7 @@ public class WhitespaceAroundCheckTest
 
     @Test
     public void testGenericsTokensAreFlagged()
-        throws Exception {
+            throws Exception {
         final String[] expected = {
             "6:67: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "&"),
             "6:68: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "&"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -114,7 +114,7 @@ public class SuppressWarningsFilterTest
 
     @Override
     public Checker createChecker(Configuration checkConfig)
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkerConfig =
             new DefaultConfiguration("configuration");
         final DefaultConfiguration checksConfig =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -204,7 +204,7 @@ public class SuppressWithNearbyCommentFilterTest
 
     private void verifySuppressed(Configuration filterConfig,
             String... suppressed)
-        throws Exception {
+            throws Exception {
         verify(createChecker(filterConfig),
                getPath("InputSuppressWithNearbyCommentFilter.java"),
                removeSuppressed(ALL_MESSAGES, suppressed));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -204,7 +204,7 @@ public class SuppressionCommentFilterTest
 
     private void verifySuppressed(Configuration aFilterConfig,
             String... aSuppressed)
-        throws Exception {
+            throws Exception {
         verify(createChecker(aFilterConfig),
                getPath("InputSuppressionCommentFilter.java"),
                removeSuppressed(ALL_MESSAGES, aSuppressed));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
@@ -171,7 +171,7 @@ public class SuppressionFilterTest {
     }
 
     private static SuppressionFilter createSupressionFilter(String fileName, boolean optional)
-        throws CheckstyleException {
+            throws CheckstyleException {
         final SuppressionFilter suppressionFilter = new SuppressionFilter();
         suppressionFilter.setFile(fileName);
         suppressionFilter.setOptional(optional);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -57,7 +57,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
 
     @Test
     public void testNoSuppressions()
-        throws CheckstyleException {
+            throws CheckstyleException {
         final FilterSet fc =
             SuppressionsLoader.loadSuppressions(getPath("suppressions_none.xml"));
         final FilterSet fc2 = new FilterSet();
@@ -100,7 +100,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
 
     @Test
     public void testMultipleSuppression()
-        throws CheckstyleException {
+            throws CheckstyleException {
         final FilterSet fc =
             SuppressionsLoader.loadSuppressions(getPath("suppressions_multiple.xml"));
         final FilterSet fc2 = new FilterSet();
@@ -268,7 +268,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
 
     @Test
     public void testLoadFromClasspath()
-        throws CheckstyleException {
+            throws CheckstyleException {
         final FilterSet fc =
             SuppressionsLoader.loadSuppressions(getPath("suppressions_none.xml"));
         final FilterSet fc2 = new FilterSet();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/EmbeddedNullCharTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/EmbeddedNullCharTest.java
@@ -42,7 +42,7 @@ public class EmbeddedNullCharTest
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/HexFloatsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/HexFloatsTest.java
@@ -42,7 +42,7 @@ public class HexFloatsTest
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7DiamondTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7DiamondTest.java
@@ -42,7 +42,7 @@ public class Java7DiamondTest
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7MultiCatchTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7MultiCatchTest.java
@@ -42,7 +42,7 @@ public class Java7MultiCatchTest
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7NumericalLiteralsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7NumericalLiteralsTest.java
@@ -42,7 +42,7 @@ public class Java7NumericalLiteralsTest
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7StringSwitchTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7StringSwitchTest.java
@@ -42,7 +42,7 @@ public class Java7StringSwitchTest
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7TryWithResourcesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7TryWithResourcesTest.java
@@ -42,7 +42,7 @@ public class Java7TryWithResourcesTest
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/LineCommentAtTheEndOfFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/LineCommentAtTheEndOfFileTest.java
@@ -44,7 +44,7 @@ public class LineCommentAtTheEndOfFileTest
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/MultiDimensionalArraysInGenericsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/MultiDimensionalArraysInGenericsTest.java
@@ -38,7 +38,7 @@ public class MultiDimensionalArraysInGenericsTest
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/UnicodeEscapeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/UnicodeEscapeTest.java
@@ -42,7 +42,7 @@ public class UnicodeEscapeTest
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/VarargTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/VarargTest.java
@@ -42,7 +42,7 @@ public class VarargTest
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/AnnotationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/AnnotationTest.java
@@ -44,7 +44,7 @@ public class AnnotationTest extends BaseCheckTestSupport {
 
     @Test
     public void testSimpleTypeAnnotation()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -54,7 +54,7 @@ public class AnnotationTest extends BaseCheckTestSupport {
 
     @Test
     public void testAnnotationOnClass()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -64,7 +64,7 @@ public class AnnotationTest extends BaseCheckTestSupport {
 
     @Test
     public void testClassCastTypeAnnotation()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -74,7 +74,7 @@ public class AnnotationTest extends BaseCheckTestSupport {
 
     @Test
     public void testMethodParametersTypeAnnotation()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -84,7 +84,7 @@ public class AnnotationTest extends BaseCheckTestSupport {
 
     @Test
     public void testAnnotationInThrows()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -94,7 +94,7 @@ public class AnnotationTest extends BaseCheckTestSupport {
 
     @Test
     public void testAnnotationInGeneric()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -104,7 +104,7 @@ public class AnnotationTest extends BaseCheckTestSupport {
 
     @Test
     public void testAnnotationOnConstructorCall()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -114,7 +114,7 @@ public class AnnotationTest extends BaseCheckTestSupport {
 
     @Test
     public void testAnnotationNestedCall()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -124,7 +124,7 @@ public class AnnotationTest extends BaseCheckTestSupport {
 
     @Test
     public void testAnnotationOnWildcards()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -134,7 +134,7 @@ public class AnnotationTest extends BaseCheckTestSupport {
 
     @Test
     public void testAnnotationInCatchParameters()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/AnnotationsOnArrayTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/AnnotationsOnArrayTest.java
@@ -38,7 +38,7 @@ public class AnnotationsOnArrayTest extends BaseCheckTestSupport {
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/DefaultMethodsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/DefaultMethodsTest.java
@@ -44,7 +44,7 @@ public class DefaultMethodsTest extends BaseCheckTestSupport {
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -54,7 +54,7 @@ public class DefaultMethodsTest extends BaseCheckTestSupport {
 
     @Test
     public void testSwitch()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/LambdaTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/LambdaTest.java
@@ -38,7 +38,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testLambdaInVariableInitialization()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -48,7 +48,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithoutArgsOneLineLambdaBody()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -58,7 +58,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithoutArgsFullLambdaBody()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -68,7 +68,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithOneArgWithOneLineBody()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -78,7 +78,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithOneArgWithFullBody()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -88,7 +88,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithOneArgWithoutTypeOneLineBody()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -98,7 +98,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithOneArgWithoutTypeFullBody()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -108,7 +108,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithFewArgsWithoutTypeOneLineBody()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -118,7 +118,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithFewArgsWithoutTypeFullBody()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -128,7 +128,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithOneArgWithoutParenthesesWithoutTypeOneLineBody()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -138,7 +138,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithOneArgWithoutParenthesesWithoutTypeFullBody()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -148,7 +148,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithFewArgWIthTypeOneLine()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -158,7 +158,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithFewArgWithTypeFullBody()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -168,7 +168,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testWIthMultilineBody()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -178,7 +178,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testCasesFromSpec()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -188,7 +188,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testWithTypecast()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -198,7 +198,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testInAssignment()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -208,7 +208,7 @@ public class LambdaTest extends BaseCheckTestSupport {
 
     @Test
     public void testInTernary()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/MethodReferencesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/MethodReferencesTest.java
@@ -38,7 +38,7 @@ public class MethodReferencesTest extends BaseCheckTestSupport {
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -48,7 +48,7 @@ public class MethodReferencesTest extends BaseCheckTestSupport {
 
     @Test
     public void testFromSpec()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -58,7 +58,7 @@ public class MethodReferencesTest extends BaseCheckTestSupport {
 
     @Test
     public void testGenericInPostfixExpressionBeforeReference()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -94,7 +94,7 @@ public class MethodReferencesTest extends BaseCheckTestSupport {
 
     @Test
     public void testMethodReferences7()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/TypeUseAnnotationsOnQualifiedTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/TypeUseAnnotationsOnQualifiedTypesTest.java
@@ -38,7 +38,7 @@ public class TypeUseAnnotationsOnQualifiedTypesTest extends BaseCheckTestSupport
 
     @Test
     public void testCanParse()
-        throws Exception {
+            throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(MemberNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParseTreeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParseTreeTest.java
@@ -42,7 +42,7 @@ public class JavadocParseTreeTest {
     private final BaseErrorListener errorListener = new FailOnErrorListener();
 
     private ParseTree parseJavadoc(String aBlockComment)
-        throws IOException {
+            throws IOException {
         final Charset utf8Charset = Charset.forName("UTF-8");
         final InputStream in = new ByteArrayInputStream(aBlockComment.getBytes(utf8Charset));
 
@@ -61,7 +61,7 @@ public class JavadocParseTreeTest {
     }
 
     private static String getFileContent(File filename)
-        throws IOException {
+            throws IOException {
         return Files.toString(filename, Charsets.UTF_8);
     }
 
@@ -81,7 +81,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void oneSimpleHtmlTag()
-        throws IOException {
+            throws IOException {
         final String filename = getHtmlPath("InputOneSimpleHtmlTag.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeOneSimpleHtmlTag();
@@ -90,7 +90,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void textBeforeJavadocTags()
-        throws IOException {
+            throws IOException {
         final String filename = getDocPath("InputTextBeforeJavadocTags.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeTextBeforeJavadocTags();
@@ -99,7 +99,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void customJavadocTags()
-        throws IOException {
+            throws IOException {
         final String filename = getDocPath("InputCustomJavadocTags.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeCustomJavadocTags();
@@ -108,7 +108,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void javadocTagDescriptionWithInlineTags()
-        throws IOException {
+            throws IOException {
         final String filename = getDocPath("InputJavadocTagDescriptionWithInlineTags.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeJavadocTagDescriptionWithInlineTags();
@@ -117,7 +117,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void leadingAsterisks()
-        throws IOException {
+            throws IOException {
         final String filename = getPath("InputLeadingAsterisks.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeLeadingAsterisks();
@@ -126,7 +126,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void authorWithMailto()
-        throws IOException {
+            throws IOException {
         final String filename = getDocPath("InputAuthorWithMailto.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeAuthorWithMailto();
@@ -135,7 +135,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void htmlTagsInParagraph()
-        throws IOException {
+            throws IOException {
         final String filename = getHtmlPath("InputHtmlTagsInParagraph.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeHtmlTagsInParagraph();
@@ -144,7 +144,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void linkInlineTags()
-        throws IOException {
+            throws IOException {
         final String filename = getDocPath("InputLinkInlineTags.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeLinkInlineTags();
@@ -153,7 +153,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void seeReferenceWithFewNestedClasses()
-        throws IOException {
+            throws IOException {
         final String filename = getDocPath("InputSeeReferenceWithFewNestedClasses.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeSeeReferenceWithFewNestedClasses();
@@ -162,7 +162,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void paramWithGeneric()
-        throws IOException {
+            throws IOException {
         final String filename = getDocPath("InputParamWithGeneric.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeParamWithGeneric();
@@ -171,7 +171,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void serial()
-        throws IOException {
+            throws IOException {
         final String filename = getDocPath("InputSerial.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeSerial();
@@ -180,7 +180,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void since()
-        throws IOException {
+            throws IOException {
         final String filename = getDocPath("InputSince.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeSince();
@@ -189,7 +189,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void unclosedAndClosedParagraphs()
-        throws IOException {
+            throws IOException {
         final String filename = getHtmlPath("InputUnclosedAndClosedParagraphs.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeUnclosedAndClosedParagraphs();
@@ -198,7 +198,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void listWithUnclosedItemInUnclosedParagraph()
-        throws IOException {
+            throws IOException {
         final String filename = getHtmlPath("InputListWithUnclosedItemInUnclosedParagraph.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder
@@ -208,7 +208,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void unclosedParagraphFollowedByJavadocTag()
-        throws IOException {
+            throws IOException {
         final String filename = getHtmlPath("InputUnclosedParagraphFollowedByJavadocTag.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeUnclosedParagraphFollowedByJavadocTag();
@@ -217,7 +217,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void allJavadocInlineTags()
-        throws IOException {
+            throws IOException {
         final String filename = getDocPath("InputAllJavadocInlineTags.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeAllJavadocInlineTags();
@@ -226,7 +226,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void docRootInheritDoc()
-        throws IOException {
+            throws IOException {
         final String filename = getDocPath("InputDocRootInheritDoc.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeDocRootInheritDoc();
@@ -235,7 +235,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void fewWhiteSpacesAsSeparator()
-        throws IOException {
+            throws IOException {
         final String filename = getDocPath("InputFewWhiteSpacesAsSeparator.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeFewWhiteSpacesAsSeparator();
@@ -244,7 +244,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void mixedCaseOfHtmlTags()
-        throws IOException {
+            throws IOException {
         final String filename = getHtmlPath("InputMixedCaseOfHtmlTags.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeMixedCaseOfHtmlTags();
@@ -253,7 +253,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void htmlComments()
-        throws IOException {
+            throws IOException {
         final String filename = getHtmlPath("InputComments.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeComments();
@@ -262,7 +262,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void negativeNumberInAttribute()
-        throws IOException {
+            throws IOException {
         final String filename = getHtmlPath("InputNegativeNumberInAttribute.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeNegativeNumberInAttribute();
@@ -271,7 +271,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void dollarInLink()
-        throws IOException {
+            throws IOException {
         final String filename = getDocPath("InputDollarInLink.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeDollarInLink();
@@ -280,7 +280,7 @@ public class JavadocParseTreeTest {
 
     @Test
     public void dotCharacterInCustomTags()
-        throws IOException {
+            throws IOException {
         final String filename = getDocPath("InputCustomTagWithDot.txt");
         final ParseTree generatedTree = parseJavadoc(getFileContent(new File(filename)));
         final ParseTree expectedTree = ParseTreeBuilder.treeCustomTagWithDot();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidMethodIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidMethodIndent.java
@@ -161,7 +161,7 @@ public class InputInvalidMethodIndent { //indent:0 exp:0
     } //indent:4 exp:4
 
     private void myFunc() //indent:4 exp:4
-      throws Exception //indent:6 exp:6
+        throws Exception //indent:8 exp:8
     { //indent:4 exp:4
     } //indent:4 exp:4
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidThrowsIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidThrowsIndent.java
@@ -22,14 +22,25 @@ public class InputInvalidThrowsIndent { //indent:0 exp:0
 
     // This should pass for our reconfigured throwsIndent test. //indent:4 exp:4
     private void myFunc() //indent:4 exp:4
-            throws Exception //indent:12 exp:12
+            throws Exception //indent:12 exp:>=12
     { //indent:4 exp:4
     } //indent:4 exp:4
 
     // This is the out of the box default configuration, but should fail //indent:4 exp:4
     // for our reconfigured test. //indent:4 exp:4
     private void myFunc2() //indent:4 exp:4
-        throws Exception //indent:8 exp:8
+            throws Exception //indent:12 exp:>=12
+    { //indent:4 exp:4
+    } //indent:4 exp:4
+
+    private void myFunc3() //indent:4 exp:4
+            throws //indent:12 exp:>=12
+            Exception //indent:12 exp:>=12
+    { //indent:4 exp:4
+    } //indent:4 exp:4
+
+    private void myFunc4() throws //indent:4 exp:4
+                Exception //indent:16 exp:>=12
     { //indent:4 exp:4
     } //indent:4 exp:4
 } //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidThrowsIndent2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidThrowsIndent2.java
@@ -1,0 +1,40 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation; //indent:0 exp:0
+
+public abstract class InputInvalidThrowsIndent2 { //indent:0 exp:0
+ public void m1() throws Exception { //indent:1 exp:1
+ } //indent:1 exp:1
+ public void m2() throws //indent:1 exp:1
+Exception { //indent:0 exp:6 warn
+ } //indent:1 exp:1
+ public void m3() throws Exception, //indent:1 exp:1
+NullPointerException { //indent:0 exp:6 warn
+ } //indent:1 exp:1
+ public void m4() //indent:1 exp:1
+throws Exception { //indent:0 exp:6 warn
+ } //indent:1 exp:1
+ public abstract void m5() //indent:1 exp:1
+throws Exception; //indent:0 exp:6 warn
+ public void m6() //indent:1 exp:1
+throws //indent:0 exp:6 warn
+Exception { //indent:0 exp:6 warn
+ } //indent:1 exp:1
+ public void m7() //indent:1 exp:1
+throws //indent:0 exp:6 warn
+Exception, //indent:0 exp:6 warn
+NullPointerException { //indent:0 exp:6 warn
+ } //indent:1 exp:1
+ double[] m8() //indent:1 exp:1
+throws //indent:0 exp:6 warn
+Exception { return null; //indent:0 exp:6 warn
+ } //indent:1 exp:1
+ public InputInvalidThrowsIndent2() //indent:1 exp:1
+throws Exception {//indent:0 exp:6 warn
+ } //indent:1 exp:1
+ @TestAnnotation //indent:1 exp:1
+ public //indent:1 exp:1
+    static //indent:4 exp:4
+    void m9() //indent:4 exp:4
+throws Exception {} //indent:0 exp:6 warn
+} //indent:0 exp:0
+
+@interface TestAnnotation {} //indent:0 exp:0


### PR DESCRIPTION
Issue #2763 

This restores `throwsIndent`s code from https://github.com/checkstyle/checkstyle/commit/1ff166e1b64ddf40bd9f9cbd9834b8905f77fd94 with 1 addition.

https://github.com/rnveach/checkstyle/blob/404c1ced913286319251ee5f86549f13891c1940/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java#L78-L88
These lines are new. They allow exceptions that appear on separate lines to be indented based on line wrapping. Without it, those lines would be skipped, just like throws was before this fix.

**Gray area**:
https://github.com/rnveach/checkstyle/blob/404c1ced913286319251ee5f86549f13891c1940/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java#L80-L87
This section is ugly and I may look into fixing it.
The issue is `LineWrappingHandler`s first node must be the first node on the line (source https://github.com/checkstyle/checkstyle/blob/7572ba1f8e392bd0a57e87c48f4d3abefb83fe6a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java#L107-L108). If you don't give it the first node on the line, it thinks the node is still the first on the line and produces invalid indentation recommendations. I feel this is a tough requirement to meet unless we design another routine to search for the first node.
I don't know how this will affect the other areas that call the class or filed issues.