### PR TITLE
Issue #2939: Add UT checking if checks clear their state in beginTree…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/UserDefinedOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/UserDefinedOption.java
@@ -1,0 +1,16 @@
+package com.puppycrawl.tools.checkstyle;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used on Checks field to mark it
+ * as user defined option.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface UserDefinedOption {
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/ChecksShouldCleanTheirPrivateFieldTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/ChecksShouldCleanTheirPrivateFieldTest.java
@@ -1,0 +1,133 @@
+package com.puppycrawl.tools.checkstyle.internal;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.ClassPath;
+
+import com.puppycrawl.tools.checkstyle.UserDefinedOption;
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+
+import org.junit.Test;
+
+public class ChecksShouldCleanTheirPrivateFieldTest {
+    public static final String CHECKSTYLE_PACKAGE = "com.puppycrawl.tools.checkstyle";
+    private static final String CHECK_FILE_NAME = ".+Check$";
+
+    private static final List<String> CHECKS_ON_PAGE_IGNORE_LIST = Arrays.asList(
+            "AbstractAccessControlNameCheck",
+            "AbstractCheck",
+            "AbstractClassCouplingCheck",
+            "AbstractComplexityCheck",
+            "AbstractFileSetCheck",
+            "AbstractFormatCheck",
+            "AbstractHeaderCheck",
+            "AbstractIllegalCheck",
+            "AbstractIllegalMethodCheck",
+            "AbstractJavadocCheck",
+            "AbstractNameCheck",
+            "AbstractNestedDepthCheck",
+            "AbstractOptionCheck",
+            "AbstractParenPadCheck",
+            "AbstractSuperCheck",
+            "AbstractTypeAwareCheck",
+            "AbstractTypeParameterNameCheck",
+            "FileSetCheck"
+    );
+
+    @Test
+    public void testAllChecksCleanTheyPrivateFields() throws Exception {
+        ImmutableSet<ClassPath.ClassInfo> topLevelClassesRecursive =
+                ClassPath.from(getClass().getClassLoader())
+                        .getTopLevelClassesRecursive(CHECKSTYLE_PACKAGE);
+
+        for (ClassPath.ClassInfo classInfo : topLevelClassesRecursive) {
+            final Class cl = classInfo.load();
+            final String className = classInfo.getSimpleName();
+            if (className.matches(CHECK_FILE_NAME)
+                    && classExtendsAbstractCheck(cl)
+                    && !CHECKS_ON_PAGE_IGNORE_LIST.contains(className)) {
+                List<String> classInstancePrivateFieldsName =
+                        getClassInstanceFieldNames(cl);
+                checkIfBeginTreeClearsFields(cl, classInstancePrivateFieldsName);
+            }
+        }
+    }
+
+    private boolean classExtendsAbstractCheck(Class cl) {
+        boolean extendsAbstractCheck = false;
+        if (cl != AbstractCheck.class && AbstractCheck.class.isAssignableFrom(cl)) {
+            extendsAbstractCheck = true;
+        }
+        return extendsAbstractCheck;
+    }
+
+    private static List<String> getClassInstanceFieldNames(Class cl) {
+        List<String> privateFieldNames = new LinkedList<>();
+        for (Field field : cl.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers())
+                    && !field.isAnnotationPresent(UserDefinedOption.class)) {
+                privateFieldNames.add(field.getName());
+            }
+        }
+        return privateFieldNames;
+    }
+
+    private static void checkIfBeginTreeClearsFields(Class cl, List<String> fieldNames)
+            throws IllegalAccessException, InvocationTargetException, InstantiationException,
+            NoSuchFieldException, NoSuchMethodException {
+        Object classInstance = cl.getConstructors()[0].newInstance();
+        Map<String, Object> beforeBeginTreeFieldValues =
+                getObjectFieldValues(classInstance, fieldNames);
+        invokeBeginTreeOnObject(classInstance);
+        Map<String, Object> afterBeginTreeFieldValues =
+                getObjectFieldValues(classInstance, fieldNames);
+        compareFieldValues(cl.getName(), beforeBeginTreeFieldValues, afterBeginTreeFieldValues);
+    }
+
+    private static Map<String, Object> getObjectFieldValues(Object object, List<String> fieldNames)
+            throws NoSuchFieldException, IllegalAccessException {
+        Map<String, Object> fieldValues = new HashMap<>();
+        for (String fieldName : fieldNames) {
+            Object fieldValue = getFieldValueFromObject(object, fieldName);
+            fieldValues.put(fieldName, fieldValue);
+        }
+        return fieldValues;
+    }
+
+    private static void invokeBeginTreeOnObject(Object object)
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method beginTree = object.getClass().getMethod("beginTree", DetailAST.class);
+        DetailAST emptyDetailAst = new DetailAST();
+        beginTree.invoke(object, emptyDetailAst);
+    }
+
+    private static void compareFieldValues(String className,
+                                           Map<String, Object> beforeFieldValues,
+                                           Map<String, Object> afterFieldValues) {
+        for (String fieldName : beforeFieldValues.keySet()) {
+            Object beforeValue = beforeFieldValues.get(fieldName);
+            Object afterValue = afterFieldValues.get(fieldName);
+            if ((beforeValue == null && afterValue == null)
+                    || (beforeValue != null && beforeValue.equals(afterValue))) {
+                System.err.println(className + " check doesnt clear " + fieldName + " on beginTree() method");
+            }
+        }
+    }
+
+    private static Object getFieldValueFromObject(Object classInstance, String fieldName)
+            throws NoSuchFieldException, IllegalAccessException {
+        Field declaredField = classInstance.getClass().getDeclaredField(fieldName);
+        declaredField.setAccessible(true);
+        return declaredField.get(classInstance);
+    }
+}


### PR DESCRIPTION
… method

For now its just sketch of the solution to discuss. It doesn't comform style and failing on style checks, but i think we should discuss the algorithm and idea first, and later discuss style issues.

It declares UserDefinedOption annotation which all fields declared by users in Checks will be annotated with. This patch also contains proposal of UT test of checking if checks clear their fields in beginTree.

UT at first filters all classes which are declared in com.puppycrawl.tools.checkstyle package, then it filters all classes that extends AbstractCheck and are not at the excluded list - i took this list essentialy by copy pasting from XDocsPagesTest. 

UT having filtered list of classes, it gets all non static fields that are not annotated by UserDefinedOption. 

First assumption of the solution is checking "clearance" of fields is not possible(because there are many different ways of how this can be done, it can clear field by invoking clear() method on it, it can assign it to null etc), we can only check if values of those fields are changed by invocation of beginTree.

So to check clearance we first create object from class, we get field values, later invoke beginTree on this object and get field values again, and compare them. If they are same then beginTree doesn't do any clearance and it prints it as error on error output.

Problem with this solution appears when beginTree uses information from fields that are annotated with UserDefinedFields. Because we construct object from classes by running no parameter constructor, and later we dont assign values to fields annotated with UserDefinedFields, then if beginTree tries to manipulate on fields annotated with UserDefinedFields it leads to errors. 

For example running this patch raise NullPointerException on OuterTypeFilenameCheck which tries to invoke getFileContents from super class AbstractCheck which returns null - because we didn't assign anything to this value.

Another thing that probably should be done, is to move all functionality of checking if given Class is clearing its field to another class to be able to unit test it with locally defined classes.

I am looking forward to any suggestions how to resolve this, or any other ideas how to construct this check.