### PR TITLE
Issue #2950: rewrote LineWrappingHandler for nodes not on first line

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1600,6 +1600,16 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
         verify(checkConfig, fileName, expected);
     }
 
+    @Test
+    public void testTwoStatementsPerLine() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+        checkConfig.addAttribute("tabWidth", "4");
+        checkConfig.addAttribute("basicOffset", "4");
+        final String fileName = getPath("InputTwoStatementsPerLine.java");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
     private static final class IndentAudit implements AuditListener {
         private final IndentComment[] comments;
         private int position;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputTwoStatementsPerLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputTwoStatementsPerLine.java
@@ -1,0 +1,13 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation;//indent:0 exp:0
+
+public class InputTwoStatementsPerLine {//indent:0 exp:0
+    int var6 = 5; int var7 = 6, //indent:4 exp:4
+        var8 = 5; //indent:8 exp:8
+
+    public void method() { //indent:4 exp:4
+        long_lined_label: if (true //indent:8 exp:8
+            && true) {} //indent:12 exp:12
+    } //indent:4 exp:4
+    /* package-private */ static final void //indent:4 exp:4
+        method2() {} //indent:8 exp:8
+}//indent:0 exp:0


### PR DESCRIPTION
Issue #2950. This comes before PR #2940.

This fixes indentation for lines with some type of multiple statements on it, and rewrites `LineWrappingHandler` to be more of a utility and not require the first node to be the first on the line. This allows us to use this in places where we don't know where the node is on the line, like `throws`.

Changes to `LineWrappingHandler`:
* It is now more a utility class. It only takes `IndentationCheck` on instance, so it is more connected to `IndentationCheck` and requires us to only make one instance, instead of an instance for every AST.
* Every call to `checkIndentation` now takes the nodes to examine as parameters instead of being stuck to the instance. We never called this method more than once on one instance, so I found the connection to the instance was pointless.
* `getFirstNodeIndent` was replaced with `getLineStart` from `AbstractExpressionHandler`. This does have the side effect of including comments that exist before code on the line, but NetBeans's formatter works this way too.

**Note:** So we stop duplicating methods between this class and `AbstractExpressionHandler`, I may make a unique base like `AbstractHandler` that both classes can use.

I consider `AbstractExpressionHandler.checkLinesIndent` and similar methods a bad emulation of `LineWrappingHandler` and am thinking of replacing them for the other. The reason is because they check all lines inbetween the 2 nodes ignoring the AST structure. This can cause full comments to be picked up in the mix.
It can also be confusing which to use since one uses `basicOffset` and the other uses `lineWrappingIndentation` for indentation, and one uses `forceStrictCondition` while the other doesn't.

All changes to other classes were to make use of the new `LineWrappingHandler`.
Regression to come.