### PR TITLE
Issue #903: Skip type annotations from validation of ModifierOrderCheck (part 2)

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
@@ -204,10 +204,19 @@ public class ModifierOrderCheck
     private static boolean isAnnotationOnType(DetailAST modifier) {
         boolean annotationOnType = false;
         final DetailAST modifiers = modifier.getParent();
-        final int definitionTokenType = modifiers.getParent().getType();
-        if (definitionTokenType == TokenTypes.VARIABLE_DEF
-                || definitionTokenType == TokenTypes.PARAMETER_DEF) {
+        final DetailAST definition = modifiers.getParent();
+        final int definitionType = definition.getType();
+        if (definitionType == TokenTypes.VARIABLE_DEF
+                || definitionType == TokenTypes.PARAMETER_DEF
+                || definitionType == TokenTypes.CTOR_DEF) {
             annotationOnType = true;
+        }
+        else if (definitionType == TokenTypes.METHOD_DEF) {
+            final DetailAST typeToken = definition.findFirstToken(TokenTypes.TYPE);
+            final int methodReturnType = typeToken.getLastChild().getType();
+            if (methodReturnType != TokenTypes.LITERAL_VOID) {
+                annotationOnType = true;
+            }
         }
         return annotationOnType;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
@@ -116,9 +116,19 @@ public class ModifierOrderCheckTest
         // Type Annotations are avaliable only in Java 8
         // We skip type annotations from validation
         // See https://github.com/checkstyle/checkstyle/issues/903#issuecomment-172228013
-        final DefaultConfiguration checkConfig =
-            createCheckConfig(ModifierOrderCheck.class);
-        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+        final DefaultConfiguration checkConfig = createCheckConfig(ModifierOrderCheck.class);
+        final String[] expected = {
+            "103:13: " + getCheckMessage(MSG_ANNOTATION_ORDER, "@MethodAnnotation"),
+        };
         verify(checkConfig, getNonCompilablePath("InputTypeAnnotations.java"), expected);
+    }
+
+    @Test
+    public void testAnnotationOnAnnotationDeclaration() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ModifierOrderCheck.class);
+        final String[] expected = {
+            "3:8: " + getCheckMessage(MSG_ANNOTATION_ORDER, "@InterfaceAnnotation"),
+        };
+        verify(checkConfig, getPath("InputModifierOrderAnnotationDeclaration.java"), expected);
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/InputTypeAnnotations.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/InputTypeAnnotations.java
@@ -1,4 +1,3 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.modifier;
 
 import java.io.File;
@@ -6,13 +5,12 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
-public class InputTypeAnnotations {
+public class InputTypeAnnotations extends MyClass {
 
     // Simple type definitions with type annotations
     private @TypeAnnotation String hello = "Hello, World!";
@@ -78,9 +76,52 @@ public class InputTypeAnnotations {
     class Nested { }
 
     class T { }
+
+    // Type annotation on method return type
+    @Override
+    public @TypeAnnotation String toString() { return ""; }
+
+    @Override
+    @TypeAnnotation public int hashCode() { return 1; }
+
+    public @TypeAnnotation int foo8() { return 1; }
+
+    public @TypeAnnotation boolean equals(Object obj) { return super.equals(obj); }
+
+//    @TypeAnnotation void foo9() { } <-- Compiletime error: void type cannot be annotated with type annotation
+
+    @Override
+    void foo10() {
+        super.foo10();
+    }
 }
 
-@Target({ElementType.FIELD, ElementType.LOCAL_VARIABLE, ElementType.PARAMETER,
-         ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+class MyClass {
+
+    // It is annotation on method, but not on type!
+    @MethodAnnotation void foo10() {}
+    private @MethodAnnotation void foo11() {}
+
+    public @TypeAnnotation MyClass() {}
+    @ConstructorAnnotation public MyClass(String name) {}
+}
+
+enum MyEnum {
+    @TypeAnnotation A;
+}
+
+interface IInterfacable {
+    default @TypeAnnotation String foo() {
+        return null;
+    }
+}
+
+@Target({
+    ElementType.FIELD, ElementType.LOCAL_VARIABLE, ElementType.PARAMETER,
+    ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
 @interface TypeAnnotation {
 }
+
+@interface MethodAnnotation {}
+
+@interface ConstructorAnnotation {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/InputModifierOrderAnnotationDeclaration.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/InputModifierOrderAnnotationDeclaration.java
@@ -1,0 +1,7 @@
+package com.puppycrawl.tools.checkstyle.checks.modifier;
+
+public @InterfaceAnnotation @interface InputModifierOrderAnnotationDeclaration {
+    int getValue();
+}
+
+@interface InterfaceAnnotation {}


### PR DESCRIPTION
@romani 

#903

In accordance with [jsr308](http://types.cs.washington.edu/jsr308/specification/java-annotation-design.html) source locations for annotations on types that follow modifiers are:

1) [Method return types](https://github.com/MEZk/checkstyle/blob/8e77474df0d76db7049ff60700856f485c3b1f2f/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/InputTypeAnnotations.java#L87).
2) [Method and constructor parameter definitions](https://github.com/MEZk/checkstyle/blob/8e77474df0d76db7049ff60700856f485c3b1f2f/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/InputTypeAnnotations.java#L51).
3) [Fields definitions] (https://github.com/MEZk/checkstyle/blob/8e77474df0d76db7049ff60700856f485c3b1f2f/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/InputTypeAnnotations.java#L16).
4) [Constructor declarations](https://github.com/MEZk/checkstyle/blob/8e77474df0d76db7049ff60700856f485c3b1f2f/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/InputTypeAnnotations.java#L105).


Nevertheless, there are a few nuances:

* Type annotations cannot be applied to void, for example:

````java
public class MyClass {

// public @TypeAnnotation void foo() {} <-- compile time error

    @Target({
        ElementType.FIELD, ElementType.LOCAL_VARIABLE, ElementType.PARAMETER,
        ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
    @interface TypeAnnotation {
    }
}
````

* Annotation can precede 'void' if it is an annotation on method, for example:

````java
public class MyClass2 {
    public @MethodAnnotation void foo() {} // violation!!!
    @MethodAnnotation public void foo() {} // correct order.
    @interface MethodAnnotation { }
}
````

That is why if it is annotation on void type, we rely on javac, if it is annotation on method which precedes 'void' and it breaks modifier order, the check will rise violation, as it is shown in the example.

@pniederw
Please, take a look.