### PR TITLE
minor: refactored LineWrappingHandler

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -344,7 +344,6 @@ public abstract class AbstractExpressionHandler {
      * @param indentLevel   the indentation level
      * @param mustMatch     whether or not the indentation level must match
      */
-
     private void checkLineIndent(int lineNum, int colNum,
         IndentLevel indentLevel, boolean mustMatch) {
         final String line = indentCheck.getLine(lineNum - 1);
@@ -357,6 +356,17 @@ public abstract class AbstractExpressionHandler {
                 || !mustMatch && colNum == start && indentLevel.isGreaterThan(start)) {
             logChildError(lineNum, start, indentLevel);
         }
+    }
+
+    /**
+     * Checks indentation on wrapped lines between and including
+     * {@code firstNode} and {@code lastNode}.
+     *
+     * @param firstNode First node to start examining.
+     * @param lastNode Last node to examine inclusively.
+     */
+    protected void checkWrappingIndentation(DetailAST firstNode, DetailAST lastNode) {
+        indentCheck.getLineWrappingHandler().checkIndentation(firstNode, lastNode);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java
@@ -80,9 +80,7 @@ public class ClassDefHandler extends BlockParentHandler {
             checkModifiers();
         }
 
-        final LineWrappingHandler lineWrap =
-            new LineWrappingHandler(getIndentCheck(), getMainAst(), getMainAst().getLastChild());
-        lineWrap.checkIndentation();
+        checkWrappingIndentation(getMainAst(), getMainAst().getLastChild());
         super.checkIndentation();
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ForHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ForHandler.java
@@ -72,10 +72,7 @@ public class ForHandler extends BlockParentHandler {
     public void checkIndentation() {
         checkForParams();
         super.checkIndentation();
-        final LineWrappingHandler lineWrap =
-            new LineWrappingHandler(getIndentCheck(), getMainAst(),
-                getForLoopRightParen(getMainAst()));
-        lineWrap.checkIndentation();
+        checkWrappingIndentation(getMainAst(), getForLoopRightParen(getMainAst()));
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IfHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IfHandler.java
@@ -94,10 +94,7 @@ public class IfHandler extends BlockParentHandler {
     public void checkIndentation() {
         super.checkIndentation();
         checkCondExpr();
-        final LineWrappingHandler lineWrap =
-            new LineWrappingHandler(getIndentCheck(), getMainAst(),
-                    getIfStatementRightParen(getMainAst()));
-        lineWrap.checkIndentation();
+        checkWrappingIndentation(getMainAst(), getIfStatementRightParen(getMainAst()));
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
@@ -112,6 +112,9 @@ public class IndentationCheck extends AbstractCheck {
     /** Handlers currently in use. */
     private final Deque<AbstractExpressionHandler> handlers = new ArrayDeque<>();
 
+    /** Instance of line wrapping handler to use. */
+    private final LineWrappingHandler lineWrappingHandler = new LineWrappingHandler(this);
+
     /** Factory from which handlers are distributed. */
     private final HandlerFactory handlerFactory = new HandlerFactory();
 
@@ -328,6 +331,15 @@ public class IndentationCheck extends AbstractCheck {
     @Override
     public void leaveToken(DetailAST ast) {
         handlers.pop();
+    }
+
+    /**
+     * Accessor for the line wrapping handler.
+     *
+     * @return the line wrapping handler
+     */
+    public LineWrappingHandler getLineWrappingHandler() {
+        return lineWrappingHandler;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
@@ -50,11 +50,11 @@ public class MemberDefHandler extends AbstractExpressionHandler {
         else {
             checkModifiers();
         }
-        final LineWrappingHandler lineWrap =
-            new LineWrappingHandler(getIndentCheck(), getMainAst(),
-                getVarDefStatementSemicolon(getMainAst()));
-        if (lineWrap.getLastNode() != null && !isArrayDeclaration(getMainAst())) {
-            lineWrap.checkIndentation();
+        final DetailAST firstNode = getMainAst();
+        final DetailAST lastNode = getVarDefStatementSemicolon(firstNode);
+
+        if (lastNode != null && !isArrayDeclaration(firstNode)) {
+            checkWrappingIndentation(firstNode, lastNode);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -168,10 +168,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
             false, true);
 
         checkRParen(lparen, rparen);
-        final LineWrappingHandler lineWrap =
-            new LineWrappingHandler(getIndentCheck(), getMainAst(),
-                    getMethodCallLastNode(getMainAst()));
-        lineWrap.checkIndentation();
+        checkWrappingIndentation(getMainAst(), getMethodCallLastNode(getMainAst()));
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
@@ -61,10 +61,7 @@ public class MethodDefHandler extends BlockParentHandler {
     public void checkIndentation() {
         checkModifiers();
 
-        final LineWrappingHandler lineWrap =
-            new LineWrappingHandler(getIndentCheck(), getMainAst(),
-                getMethodDefParamRightParen(getMainAst()));
-        lineWrap.checkIndentation();
+        checkWrappingIndentation(getMainAst(), getMethodDefParamRightParen(getMainAst()));
         if (getLCurly() == null) {
             // abstract method def -- no body
             return;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SynchronizedHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SynchronizedHandler.java
@@ -53,10 +53,8 @@ public class SynchronizedHandler extends BlockParentHandler {
         if (!methodModifier) {
             super.checkIndentation();
             checkSynchronizedExpr();
-            final LineWrappingHandler lineWrap =
-                    new LineWrappingHandler(getIndentCheck(), getMainAst(),
-                            getSynchronizedStatementRightParen(getMainAst()));
-            lineWrap.checkIndentation();
+            checkWrappingIndentation(getMainAst(),
+                    getSynchronizedStatementRightParen(getMainAst()));
         }
     }
 


### PR DESCRIPTION
Split from PR #2951. Lets merge this first and work backwards.

This is set as minor because I am expecting no changes to the user, besides possible speed improvements.
Changes to `LineWrappingHandler`:
* It is now more a utility class. It only takes `IndentationCheck` on instance, so it is more connected to `IndentationCheck` and requires us to only make one instance, instead of an instance for every AST.
* Every call to `checkIndentation` now takes the nodes to examine as parameters instead of being stuck to the instance. We never called this method more than once on one instance, so I found the connection to the instance was pointless.

Regression to come, unless its not needed.