### PR TITLE
Issue #2973: removed unused VOCAB from java.g

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
@@ -1867,14 +1867,6 @@ BINARY_DIGIT
     :    ('0'|'1')
     ;
 
-
-// a dummy rule to force vocabulary to be all characters (except special
-//   ones that ANTLR uses internally (0 to 2)
-protected
-VOCAB
-    :    '\3'..'\377'
-    ;
-
 protected ID_START:
         '_' | '$' |
         (


### PR DESCRIPTION
Issue #2973

This one is for VOCAB.
It looks like it was unused since the creation of the grammar in 2001. https://github.com/checkstyle/checkstyle/blob/0fd69594a4c3e82f92f93f0371791da66938f8c3/src/checkstyle/com/puppycrawl/tools/checkstyle/java.g#L1101-L1106
I saw the comment above it, but there is no case to prove why it is needed and regression showed no errors with it gone.