### PR TITLE
Issue #2973: removed unused inferredParameterList from java.g

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
@@ -1606,15 +1606,11 @@ lambdaExpression
 lambdaParameters
     :    IDENT
     |    LPAREN (parameterDeclarationList)? RPAREN
-    |    LPAREN inferredParameterList RPAREN
     ;
 
 lambdaBody
     :    (options{generateAmbigWarnings=false;}: expression
     |    statement)
-    ;
-inferredParameterList
-    :    IDENT (COMMA IDENT)*
     ;
 
 


### PR DESCRIPTION
Issue #2973

This one is for `inferredParameterList`.
Though this was probably added to be more like the JLS, it is never used because `parameterDeclarationList` gets all the attention.
This can be seen from all our regression cases:
https://github.com/checkstyle/checkstyle/blob/4820a458f0abb13c1b014800eff1aaaac9f8cd5c/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/InputRegressionJava8Class1Ast.txt#L473-L485
https://github.com/checkstyle/checkstyle/blob/4820a458f0abb13c1b014800eff1aaaac9f8cd5c/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/InputRegressionJava8Class1Ast.txt#L561-L572
