### PR TITLE
Issue #2973: removed unused annotations from java.g

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
@@ -1432,7 +1432,6 @@ postfixExpression
               )
             | "class"
             | newExpression
-            | annotations
             )
 
             //Java 8 method references.


### PR DESCRIPTION
Issue #2973

This is the last of the removes.
It is for annotations inside postfixExpression. 

This was the main one i wasn't sure about.
We have no tests hitting it. Regression didn't turn up anything, but that may not mean much since this is Java 8.

This was added a year and a half ago, here: https://github.com/checkstyle/checkstyle/blob/5891815628e56f0eefe91b9de61cba7a67591381/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g#L1405