### PR TITLE
Issue #2973: removed unused FLOAT_SUFFIX from java.g

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
@@ -2058,11 +2058,6 @@ SIGNED_INTEGER
     ;
 
 protected
-FLOAT_SUFFIX
-    :    'f'|'F'|'d'|'D'
-    ;
-
-protected
 BINARY_EXPONENT
     :   ('p'|'P') SIGNED_INTEGER
     ;


### PR DESCRIPTION
Rework of PR #2977. Issue #2973.
Removed rule, left in token.