### PR TITLE
Issue #2989: SummaryJavadocCheck period fix

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -13,6 +13,7 @@
   <allow pkg="java.io"/>
   <allow pkg="java.net"/>
   <allow pkg="java.nio"/>
+  <allow pkg="java.text"/>
   <allow pkg="java.util"/>
   <allow pkg="javax.xml.parsers"/>
   <allow pkg="org.apache.commons.beanutils"/>

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/SummaryJavadocTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/SummaryJavadocTest.java
@@ -58,12 +58,17 @@ public class SummaryJavadocTest extends BaseCheckTestSupport {
             "summary.javaDoc");
 
         final String[] expected = {
+            "9: " + msgFirstSentence,
             "14: " + msgFirstSentence,
+            "32: " + msgFirstSentence,
             "37: " + msgFirstSentence,
             "47: " + msgForbiddenFragment,
+            "53: " + msgFirstSentence,
             "58: " + msgForbiddenFragment,
+            "64: " + msgFirstSentence,
             "69: " + msgFirstSentence,
             "83: " + msgForbiddenFragment,
+            "98: " + msgFirstSentence,
             "103: " + msgFirstSentence,
         };
 

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/InputCorrectSummaryJavaDocCheck.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/InputCorrectSummaryJavaDocCheck.java
@@ -9,17 +9,17 @@ class InputCorrectSummaryJavaDocCheck {
      * Some Javadoc This method returns.
      */
     public static final byte NUL = 0;
-    
+
     /**
      * As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}.
      */
     void foo3() {}
-    
+
     /**
      * @throws Exception if an error occurs.
      */
     void foo4() throws Exception {}
-    
+
     /** An especially This method returns short bit of Javadoc. */
     void foo5() {}
 
@@ -29,17 +29,14 @@ class InputCorrectSummaryJavaDocCheck {
      */
     void foo6() {}
 
-    /** 
-     * <a href="mailto:vlad@htmlbook.ru"/> 
-     */
      class InnerInputCorrectJavaDocParagraphCheck {
 
          /**
           * foooo@foooo.
           */
         public static final byte NUL = 0;
-        
-        /** 
+
+        /**
          * Some java@doc.
          * This method returns.
          */
@@ -49,24 +46,24 @@ class InputCorrectSummaryJavaDocCheck {
          * Returns the customer ID. This method returns
          */
         int getId() {return 666;}
-        
+
         /**
          * <a href="mailto:vlad@htmlbook.ru"/>.
          */
         void foo2() {}
-        
+
         /**
          * As of JDK 1.1,
          * replaced by {@link #setBounds(int,int,int,int)}. This method returns.
          */
         void foo3() {}
-        
+
         /**
          * @throws Exception if an error occurs.
          */
         void foo4() throws Exception {}
-        
-        /** 
+
+        /**
          * JAXB Provider Use Only: Provides partial default
          * implementations for some of the javax.xml.bind interfaces.
          */
@@ -82,7 +79,7 @@ class InputCorrectSummaryJavaDocCheck {
      /**
       * Some
       * javadoc. A {@code Foo} is a simple Javadoc.
-      * 
+      *
       * Some Javadoc. A {@code Foo}
       * is a simple Javadoc.
       */
@@ -98,17 +95,17 @@ class InputCorrectSummaryJavaDocCheck {
          * This method returns.
          */
         boolean emulated(String s) {return false;}
-        
+
         /**
          * As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}.
          */
         void foo3() {}
-        
+
         /**
          * @throws Exception if an error occurs.
          */
         void foo4() throws Exception {}
-        
+
         /** An especially short bit of Javadoc. */
         void foo5() {}
 
@@ -116,20 +113,20 @@ class InputCorrectSummaryJavaDocCheck {
          * An especially short bit of Javadoc.
          */
         void foo6() {}
-        
+
         /**
          * Some Javadoc. This method returns some javadoc.
          */
         boolean emulated() {return false;}
-        
+
         /**
          * Some Javadoc. This method returns some javadoc. Some Javadoc.
          */
         boolean emulated1() {return false;}
-        
+
         /**
          * @return Some Javadoc the customer ID.
          */
-        int geId() {return 666;} 
+        int geId() {return 666;}
     };
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/InputIncorrectSummaryJavaDocCheck.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/InputIncorrectSummaryJavaDocCheck.java
@@ -5,17 +5,17 @@ package com.google.checkstyle.test.chapter7javadoc.rule72thesummaryfragment;
  * is a simple Javadoc. Some javadoc.
  */
 class InputIncorrectSummaryJavaDocCheck {
-    
-    /**
+
+/*warn*//**
      * As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}
      */
     void foo3() {}
-    
+
 /*warn*//**
      * @throws Exception if an error occurs
      */
     void foo4() throws Exception {}
-    
+
     /** An especially short bit of Javadoc. */
     void foo5() {}
 
@@ -29,8 +29,8 @@ class InputIncorrectSummaryJavaDocCheck {
      */
     public static final byte NUL = 0;
 
-    /** 
-     * <a href="mailto:vlad@htmlbook.ru"/> 
+/*warn*//**
+     * <a href="mailto:vlad@htmlbook.ru"/>
      */
      class InnerInputCorrectJavaDocParagraphCheck {
 
@@ -39,7 +39,7 @@ class InputIncorrectSummaryJavaDocCheck {
           */
         public static final byte NUL = 0;
 
-        /** 
+        /**
          * Some java@doc.
          */
         public static final byte NUL_2 = 0;
@@ -49,8 +49,8 @@ class InputIncorrectSummaryJavaDocCheck {
          * returns some javadoc. Some javadoc.
          */
         boolean emulated() {return false;}
-        
-        /**
+
+/*warn*//**
          * <a href="mailto:vlad@htmlbook.ru"/>
          */
         void foo2() {}
@@ -59,18 +59,18 @@ class InputIncorrectSummaryJavaDocCheck {
          * @return the
          * customer ID some javadoc.
          */
-        int geId() {return 666;} 
+        int geId() {return 666;}
 
-        /**
+/*warn*//**
          * As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}
          */
         void foo3() {}
-        
+
 /*warn*//**
          * @throws Exception if an error occurs
          */
         void foo4() throws Exception {}
-        
+
         /** An especially short bit of Javadoc. */
         void foo5() {}
 
@@ -94,17 +94,17 @@ class InputIncorrectSummaryJavaDocCheck {
          * Some Javadoc.
          */
         void emulated(String s) {}
-        
-        /**
+
+/*warn*//**
          * As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}
          */
         void foo3() {}
-        
+
 /*warn*//**
          * @throws Exception if an error occurs
          */
         void foo4() throws Exception {}
-        
+
         /** An especially short bit of Javadoc. */
         void foo5() {}
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -88,7 +88,7 @@ public final class TreeWalker
     /** Context of child components. */
     private Context childContext;
 
-    /** A factory for creating submodules (i.e. the Checks) */
+    /** A factory for creating submodules (i.e. the Checks). */
     private ModuleFactory moduleFactory;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -387,7 +387,7 @@ public final class LocalizedMessage
     /**
      * <p>
      * Custom ResourceBundle.Control implementation which allows explicitly read
-     * the properties files as UTF-8
+     * the properties files as UTF-8.
      * </p>
      *
      * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -58,7 +58,7 @@ public class SuppressWarningsHolder
      */
     public static final String CHECKSTYLE_PREFIX = "checkstyle:";
 
-    /** Java.lang namespace prefix, which is stripped from SuppressWarnings */
+    /** Java.lang namespace prefix, which is stripped from SuppressWarnings. */
     private static final String JAVA_LANG_PREFIX = "java.lang.";
 
     /** Suffix to be removed from subclasses of Check. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -126,7 +126,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
         COMPACT,
 
         /**
-         * Compact example.]
+         * Compact example
          *
          * <pre>@SuppressWarnings("unchecked")</pre>.
          */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -223,7 +223,8 @@ public class NeedBracesCheck extends AbstractCheck {
     }
 
     /**
-     * Checks if current loop statement does not have body, e.g.:
+     * Checks if current loop statement does not have body.
+     * e.g.:
      * <p>
      * {@code
      *   while (value.incrementValue() < 5);
@@ -317,7 +318,8 @@ public class NeedBracesCheck extends AbstractCheck {
     }
 
     /**
-     * Checks if current do-while statement is single-line statement, e.g.:
+     * Checks if current do-while statement is single-line statement.
+     * e.g.:
      * <p>
      * {@code
      * do this.notify(); while (o != null);
@@ -337,7 +339,7 @@ public class NeedBracesCheck extends AbstractCheck {
     }
 
     /**
-     * Checks if current for statement is single-line statement, e.g.:
+     * Checks if current for statement is single-line statement. e.g.:
      * <p>
      * {@code
      * for (int i = 0; ; ) this.notify();
@@ -359,7 +361,8 @@ public class NeedBracesCheck extends AbstractCheck {
     }
 
     /**
-     * Checks if current if statement is single-line statement, e.g.:
+     * Checks if current if statement is single-line statement.
+     * e.g.:
      * <p>
      * {@code
      * if (obj.isValid()) return true;
@@ -386,7 +389,8 @@ public class NeedBracesCheck extends AbstractCheck {
     }
 
     /**
-     * Checks if current lambda statement is single-line statement, e.g.:
+     * Checks if current lambda statement is single-line statement.
+     * e.g.:
      * <p>
      * {@code
      * Runnable r = () -> System.out.println("Hello, world!");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -70,7 +70,7 @@ public class IllegalInstantiationCheck
      */
     public static final String MSG_KEY = "instantiation.avoid";
 
-    /** {@link java.lang} package as string */
+    /** {@link java.lang} package as string. */
     private static final String JAVA_LANG = "java.lang.";
 
     /** Set of fully qualified class names. E.g. "java.lang.Boolean" */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -389,7 +389,7 @@ public final class ModifiedControlVariableCheck extends AbstractCheck {
     }
 
     /**
-     * Find all child of given AST of type TokenType.EXPR
+     * Find all child of given AST of type TokenType.EXPR.
      * @param ast parent of expressions to find
      * @return all child of given ast
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -121,7 +121,8 @@ public class CommentsIndentationCheck extends AbstractCheck {
     }
 
     /**
-     * Checks single line comment indentations over surrounding code, e.g.:
+     * Checks single line comment indentations over surrounding code.
+     * e.g.:
      * <p>
      * {@code
      * // some comment - this is ok
@@ -702,7 +703,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
 
     /**
      * Checks if comment and next code statement
-     * (or previous code stmt like <b>case</b> in switch block) are indented at the same level,
+     * (or previous code stmt like <b>case</b> in switch block) are indented at the same level.
      * e.g.:
      * <p>
      * <pre>
@@ -737,7 +738,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
     }
 
     /**
-     * Checks if current single line comment is trailing comment, e.g.:
+     * Checks if current single line comment is trailing comment. e.g.:
      * <p>
      * {@code
      * double d = 3.14; // some comment
@@ -753,7 +754,8 @@ public class CommentsIndentationCheck extends AbstractCheck {
     }
 
     /**
-     * Checks comment block indentations over surrounding code, e.g.:
+     * Checks comment block indentations over surrounding code.
+     * e.g.:
      * <p>
      * {@code
      * /* some comment *&#47; - this is ok
@@ -778,7 +780,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
     }
 
     /**
-     * Checks if current comment block is trailing comment, e.g.:
+     * Checks if current comment block is trailing comment. e.g.:
      * <p>
      * {@code
      * double d = 3.14; /* some comment *&#47;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SynchronizedHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SynchronizedHandler.java
@@ -70,7 +70,7 @@ public class SynchronizedHandler extends BlockParentHandler {
     }
 
     /**
-     * Checks if given synchronized is modifier of method*
+     * Checks if given synchronized is modifier of method.
      * @param ast synchronized(TokenTypes.LITERAL_SYNCHRONIZED) to check
      * @return true if synchronized only modifies method
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
@@ -185,12 +185,12 @@ public final class NPathComplexityCheck extends AbstractCheck {
         currentValue = currentValue.subtract(BigInteger.ONE).add(popValue());
     }
 
-    /** Visits while, do, for, if, try, ? (in ?::) or switch. */
+    /** Visits while, do, for, if, try, &#063; (in &#063;::) or switch. */
     private void visitMultiplyingConditional() {
         pushValue();
     }
 
-    /** Leaves while, do, for, if, try, ? (in ?::) or switch. */
+    /** Leaves while, do, for, if, try, &#063; (in &#063;::) or switch. */
     private void leaveMultiplyingConditional() {
         currentValue = currentValue.add(BigInteger.ONE).multiply(popValue());
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
@@ -372,7 +372,7 @@ public class RedundantModifierCheck
     /**
      * Checks if method definition is annotated with
      * <a href="https://docs.oracle.com/javase/8/docs/api/java/lang/SafeVarargs.html">
-     * SafeVarargs</a> annotation
+     * SafeVarargs</a> annotation.
      * @param methodDef method definition node
      * @return true or false
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
@@ -318,6 +318,7 @@ public final class CommonUtils {
     }
 
     /**
+     * Invoke a constructor.
      * @param constructor
      *            to invoke
      * @param parameters

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -69,12 +69,17 @@ public class SummaryJavadocCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("forbiddenSummaryFragments",
                 "^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )");
         final String[] expected = {
+            "9: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
             "14: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+            "32: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
             "37: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
             "47: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+            "53: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
             "58: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+            "64: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
             "69: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
             "83: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+            "98: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
             "103: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
         };
         verify(checkConfig, getPath("InputIncorrectSummaryJavaDoc.java"), expected);
@@ -92,9 +97,22 @@ public class SummaryJavadocCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
+    public void testChinesePeriod() throws Exception {
+        //Chinese period.
+        checkConfig.addAttribute("period", "\u3002");
+        final String[] expected = {
+            "5: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+        };
+
+        verify(checkConfig, getPath("InputSummaryJavadocChinesePeriod.java"), expected);
+    }
+
+    @Test
     public void testNoPeriod() throws Exception {
         checkConfig.addAttribute("period", "");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "3: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+        };
 
         verify(checkConfig, getPath("InputSummaryJavadocNoPeriod.java"), expected);
     }
@@ -102,9 +120,14 @@ public class SummaryJavadocCheckTest extends BaseCheckTestSupport {
     @Test
     public void testDefaultConfiguration() throws Exception {
         final String[] expected = {
+            "9: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
             "14: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+            "32: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
             "37: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+            "53: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+            "64: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
             "69: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+            "98: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
             "103: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
         };
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputCorrectSummaryJavaDoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputCorrectSummaryJavaDoc.java
@@ -1,7 +1,19 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
 /**
- * Some Javadoc A {@code Foo} is a simple Javadoc.
+ * Checks comment block indentations over surrounding code.
+ * e.g.:
+ * <p>
+ * {@code
+ * /* some comment *&#47; - this is ok
+ * double d = 3.14;
+ *     /* some comment *&#47; - this is <b>not</b> ok.
+ * double d1 = 5.0;
+ * }
+ * </p>
+ * @param blockComment {@link TokenTypes#BLOCK_COMMENT_BEGIN block comment begin}.
  */
 class InputCorrectSummaryJavaDoc {
 
@@ -10,15 +22,21 @@ class InputCorrectSummaryJavaDoc {
      */
     public static final byte NUL = 0;
     
+    /** Single line Javadoc with 2 tail astrisks. **/
+    void foo1() {}
     /**
-     * As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}.
-     */
+     * Multiple line Javadoc with 2 tail astrisks. *
+     **/
+    void foo2() {}
+    /**
+     * Multiple line Javadoc with 2 tail astrisks.
+     **/
     void foo3() {}
     
     /**
-     * @throws Exception if an error occurs.
+     * As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}.
      */
-    void foo4() throws Exception {}
+    void foo4() {}
     
     /** An especially This method returns short bit of Javadoc. */
     void foo5() {}
@@ -33,7 +51,7 @@ class InputCorrectSummaryJavaDoc {
     void foo7() {}
 
     /** 
-     * <a href="mailto:vlad@htmlbook.ru"/> 
+     * <a href="mailto:vlad@htmlbook.ru"/>.
      */
      class InnerInputCorrectJavaDocParagraphCheck {
 
@@ -63,11 +81,6 @@ class InputCorrectSummaryJavaDoc {
          * replaced by {@link #setBounds(int,int,int,int)}. This method returns.
          */
         void foo3() {}
-        
-        /**
-         * @throws Exception if an error occurs.
-         */
-        void foo4() throws Exception {}
         
         /** 
          * JAXB Provider Use Only: Provides partial default
@@ -107,11 +120,6 @@ class InputCorrectSummaryJavaDoc {
          */
         void foo3() {}
         
-        /**
-         * @throws Exception if an error occurs.
-         */
-        void foo4() throws Exception {}
-        
         /** An especially short bit of Javadoc. */
         void foo5() {}
 
@@ -130,14 +138,5 @@ class InputCorrectSummaryJavaDoc {
          */
         boolean emulated1() {return false;}
         
-        /**
-         * @return Some Javadoc the customer ID.
-         */
-        int geId() {return 666;} 
-        
-        /**
-         * @return Sentence one. Sentence two.
-         */
-        String twoSentences() {return "Sentence one. Sentence two.";} 
     };
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputIncorrectSummaryJavaDoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputIncorrectSummaryJavaDoc.java
@@ -5,17 +5,17 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
  * is a simple Javadoc. Some javadoc.
  */
 class InputIncorrectSummaryJavaDoc {
-    
+
     /**
      * As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}
      */
     void foo3() {}
-    
+
     /**
      * @throws Exception if an error occurs
      */
     void foo4() throws Exception {}
-    
+
     /** An especially short bit of Javadoc. */
     void foo5() {}
 
@@ -29,8 +29,8 @@ class InputIncorrectSummaryJavaDoc {
      */
     public static final byte NUL = 0;
 
-    /** 
-     * <a href="mailto:vlad@htmlbook.ru"/> 
+    /**
+     * <a href="mailto:vlad@htmlbook.ru"/>
      */
      class InnerInputCorrectJavaDocParagraphCheck {
 
@@ -39,7 +39,7 @@ class InputIncorrectSummaryJavaDoc {
           */
         public static final byte NUL = 0;
 
-        /** 
+        /**
          * Some java@doc.
          */
         public static final byte NUL_2 = 0;
@@ -49,7 +49,7 @@ class InputIncorrectSummaryJavaDoc {
          * returns some javadoc. Some javadoc.
          */
         boolean emulated() {return false;}
-        
+
         /**
          * <a href="mailto:vlad@htmlbook.ru"/>
          */
@@ -59,18 +59,18 @@ class InputIncorrectSummaryJavaDoc {
          * @return the
          * customer ID some javadoc.
          */
-        int geId() {return 666;} 
+        int geId() {return 666;}
 
         /**
          * As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}
          */
         void foo3() {}
-        
+
         /**
          * @throws Exception if an error occurs
          */
         void foo4() throws Exception {}
-        
+
         /** An especially short bit of Javadoc. */
         void foo5() {}
 
@@ -94,17 +94,17 @@ class InputIncorrectSummaryJavaDoc {
          * Some Javadoc.
          */
         void emulated(String s) {}
-        
+
         /**
          * As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}
          */
         void foo3() {}
-        
+
         /**
          * @throws Exception if an error occurs
          */
         void foo4() throws Exception {}
-        
+
         /** An especially short bit of Javadoc. */
         void foo5() {}
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputSummaryJavadocChinesePeriod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputSummaryJavadocChinesePeriod.java
@@ -1,0 +1,33 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+public class InputSummaryJavadocChinesePeriod
+{
+    /**
+      * <a href="mailto:vlad@htmlbook.ru"></a>
+      */
+    public void foo2() {
+
+    }
+
+    /**
+     * @return 1。
+     */
+    public int foo3() {
+        return 1;
+    }
+
+    /**
+     * A sentence。For Chinese Period Test
+     */
+    void foo4() throws Exception {}
+
+    /** A sentence
+     * 。For Chinese Period Test */
+    void foo5() {}
+
+    /**
+     * A
+     * sentence。For Chinese Period Test
+     */
+    void foo6() {}
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputSummaryJavadocNoPeriod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputSummaryJavadocNoPeriod.java
@@ -1,5 +1,8 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+/**
+ * 
+ */
 public class InputSummaryJavadocNoPeriod
 {
     /**

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1559,7 +1559,7 @@ public boolean isSomething()
       <subsection name="Description">
         <p>
           Checks that <a href="http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html#firstsentence">
-          Javadoc summary sentence</a> does not contain phrases that are not recommended to use.
+          Javadoc summary sentence</a> do exist, end with proper period, and does not contain phrases that are not recommended to use.
         </p>
       </subsection>
 
@@ -1579,7 +1579,7 @@ public boolean isSomething()
           </tr>
           <tr>
             <td>period</td>
-            <td>period symbol at the end of first javadoc sentence</td>
+            <td>period symbol at the end of first javadoc sentence, should be a punctuation</td>
             <td><a href="property_types.html#string">String literal</a></td>
             <td><code>.</code></td>
           </tr>
@@ -1588,7 +1588,7 @@ public boolean isSomething()
 
       <subsection name="Examples">
         <p>
-          By default Check validate that first sentence is not empty:
+          By default Check validate that first sentence is not empty, and end with period:
         </p>
         <source>
 &lt;module name=&quot;SummaryJavadocCheck&quot;/&gt;
@@ -1602,11 +1602,11 @@ public boolean isSomething()
 &lt;/module&gt;
         </source>
         <p>
-          To specify period symbol at the end of first javadoc sentence:
+          To specify period symbol at the end of first javadoc sentence, say chinese period('。', Unicode \u3002):
         </p>
         <source>
 &lt;module name=&quot;SummaryJavadocCheck&quot;&gt;
-    &lt;property name=&quot;period&quot; value=&quot;STRING_LITERAL&quot;/&gt;
+    &lt;property name=&quot;period&quot; value=&quot;。&quot;/&gt;
 &lt;/module&gt;
         </source>
       </subsection>


### PR DESCRIPTION
[2989](https://github.com/checkstyle/checkstyle/issues/2989)
Fix the issue, and fix other bugs:
- Some false negative. ~~fixed~~

```
E:\test>type config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="SummaryJavadoc">
        </module>
    </module>
</module>

E:\test>type TestSummaryJavadocFalseNegative.java
public class TestSummaryJavadocFalseNegative extends Exception {

    /**
     * JAXB 1.0 only default validation event handler
     */
    public static final byte NUL = 0;

    /**
     * @throws Exception if an error occurs.
     */
    public void foo1() throws Exception {

    }

    /**
      * @return 1.
      */
    public int foo2(){
        return 1;
    }

    /**
      * <a href="mailto:vlad@htmlbook.ru"></a>
      */
    public void foo3() {

    }
}

E:\test>java -jar checkstyle-6.16.1-all.jar -c config.xml TestSummaryJavadocFalseNegative.java
Starting audit...
Audit done.
```

![qq 20160308003237](https://cloud.githubusercontent.com/assets/16668296/13575805/aa293c2c-e4c5-11e5-8d98-556ed93c520c.png)
- One false positive. ~~fixed~~

```
E:\test>type config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="SummaryJavadoc">
        </module>
    </module>
</module>

E:\test>type TestSummaryJavadocFalsePositive.java
public class TestSummaryJavadocFalsePositive {

    /** 
      * {@inheritDoc} */
    public String toString(){
        return "";
    }
}

E:\test>java -jar checkstyle-6.16.1-all.jar -c config.xml TestSummaryJavadocFalsePositive.java
Starting audit...
[ERROR] E:\test\TestSummaryJavadocFalsePositive.java:3: First sentence of Javadoc is incomplete (period is missing) or not present. [SummaryJavadoc]
Audit done.
Checkstyle ends with 1 errors.
```
- One weird behavior. **Keep the same way with JDK**

```
E:\test>type config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="SummaryJavadoc">
        </module>
    </module>
</module>

E:\test>type TestSummaryJavadocWeird.java
public class TestSummaryJavadocWeird {
    /** 
     *  A {@code Foo.  Foo}
     */
    public void foo(){

    }

}

E:\test>java -jar checkstyle-6.16.1-all.jar -c config.xml TestSummaryJavadocWeird.java
Starting audit...
Audit done.
```

![qq 20160308004408](https://cloud.githubusercontent.com/assets/16668296/13576102/ea0812b8-e4c6-11e5-9f99-0701001f37f0.png)
