### PR TITLE
Issue #1487: Improve code coverage of CheckstyleAntTask

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -130,7 +130,7 @@
     <suppress checks="ClassDataAbstractionCoupling" files="AutomaticBean\.java"/>
     <!-- they are aggregators of logic, usage a several of classes are ok -->
     <suppress checks="ClassDataAbstractionCoupling" files="(Checker|TreeWalker|Main|CheckstyleAntTask|AbstractJavadocCheck)\.java"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="(CheckerTest|TreeWalkerTest|BaseCheckTestSupport|XDocsPagesTest)\.java"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="(CheckerTest|TreeWalkerTest|BaseCheckTestSupport|XDocsPagesTest|CheckstyleAntTaskTest)\.java"/>
     <!-- a lot of GUI elements is OK -->
     <suppress checks="ClassDataAbstractionCoupling" files="(JTreeTable|MainFrame)\.java"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1807,11 +1807,15 @@
                     <branchRate>75</branchRate>
                     <lineRate>92</lineRate>
                   </regex>
+                  <regex>
+                    <pattern>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</pattern>
+                    <branchRate>97</branchRate>
+                    <lineRate>100</lineRate>
+                  </regex>
                 </regexes>
               </check>
               <instrumentation>
                 <excludes>
-                  <exclude>com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask*.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/grammars/javadoc/*.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/gui/*.class</exclude>
                   <!-- deprecated classes -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -115,7 +115,7 @@ public class CheckstyleAntTask extends Task {
     ////////////////////////////////////////////////////////////////////////////
 
     /**
-     * Tells this task to set the named property to "true" when there
+     * Tells this task to write failure message to the named property when there
      * is a violation.
      * @param propertyName the name of the property to set
      *                      in the event of an failure.
@@ -540,7 +540,7 @@ public class CheckstyleAntTask extends Task {
      */
     public static class Formatter {
         /** The formatter type. */
-        private FormatterType formatterType;
+        private FormatterType type;
         /** The file to output to. */
         private File toFile;
         /** Whether or not the write to the named file. */
@@ -551,12 +551,7 @@ public class CheckstyleAntTask extends Task {
          * @param type the type
          */
         public void setType(FormatterType type) {
-            final String val = type.getValue();
-            if (!E_XML.equals(val) && !E_PLAIN.equals(val)) {
-                throw new BuildException("Invalid formatter type: " + val);
-            }
-
-            formatterType = type;
+            this.type = type;
         }
 
         /**
@@ -582,8 +577,8 @@ public class CheckstyleAntTask extends Task {
          * @throws IOException if an error occurs
          */
         public AuditListener createListener(Task task) throws IOException {
-            if (formatterType != null
-                    && E_XML.equals(formatterType.getValue())) {
+            if (type != null
+                    && E_XML.equals(type.getValue())) {
                 return createXmlLogger(task);
             }
             return createDefaultLogger(task);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -1,0 +1,432 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.ant;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.types.FileSet;
+import org.apache.tools.ant.types.Path;
+import org.apache.tools.ant.types.Reference;
+import org.junit.Test;
+import org.powermock.api.mockito.PowerMockito;
+
+import com.google.common.collect.Lists;
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultLogger;
+import com.puppycrawl.tools.checkstyle.XMLLogger;
+
+public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
+
+    private static final String FLAWLESS_INPUT = "ant/InputCheckstyleAntTaskFlawless.java";
+    private static final String VIOLATED_INPUT = "ant/InputCheckstyleAntTaskError.java";
+    private static final String CONFIG_FILE = "ant/ant_task_test_checks.xml";
+    private static final String NOT_EXISTING_FILE = "target/not_existing.xml";
+    private static final String FAILURE_PROPERTY_VALUE = "myValue";
+
+    private CheckstyleAntTask getCheckstyleAntTask() throws IOException {
+        final CheckstyleAntTask antTask = new CheckstyleAntTask();
+        antTask.setConfig(new File(getPath(CONFIG_FILE)));
+        antTask.setProject(new Project());
+        return antTask;
+    }
+
+    @Test
+    public final void testDefaultFlawless() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
+        antTask.execute();
+    }
+
+    @Test
+    public final void testFileSet() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        final FileSet examinationFileSet = new FileSet();
+        examinationFileSet.setFile(new File(getPath(FLAWLESS_INPUT)));
+        antTask.addFileset(examinationFileSet);
+        antTask.execute();
+    }
+
+    @Test
+    public final void testNoConfigFile() throws IOException {
+        final CheckstyleAntTask antTask = new CheckstyleAntTask();
+        antTask.setProject(new Project());
+        antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
+        try {
+            antTask.execute();
+            fail("Exception is expected");
+        }
+        catch (BuildException ex) {
+            assertEquals("Must specify 'config'.", ex.getMessage());
+        }
+    }
+
+    @Test
+    public final void testNonExistingConfig() throws IOException {
+        final CheckstyleAntTask antTask = new CheckstyleAntTask();
+        antTask.setConfig(new File(getPath(NOT_EXISTING_FILE)));
+        antTask.setProject(new Project());
+        antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
+        try {
+            antTask.execute();
+            fail("Exception is expected");
+        }
+        catch (BuildException ex) {
+            assertTrue(ex.getMessage().startsWith("Unable to create a Checker: configLocation"));
+        }
+    }
+
+    @Test
+    public final void testEmptyConfigFile() throws IOException {
+        final CheckstyleAntTask antTask = new CheckstyleAntTask();
+        antTask.setConfig(new File(getPath("ant/empty_config.xml")));
+        antTask.setProject(new Project());
+        antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
+        try {
+            antTask.execute();
+            fail("Exception is expected");
+        }
+        catch (BuildException ex) {
+            assertTrue(ex.getMessage().startsWith("Unable to create a Checker: configLocation"));
+        }
+    }
+
+    @Test
+    public final void testNoFile() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        try {
+            antTask.execute();
+            fail("Exception is expected");
+        }
+        catch (BuildException ex) {
+            assertEquals("Must specify at least one of 'file' or nested 'fileset'.",
+                ex.getMessage());
+        }
+    }
+
+    @Test
+    public final void testMaxWarningExeeded() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        antTask.setFile(new File(getPath("ant/InputCheckstyleAntTaskWarning.java")));
+        antTask.setMaxWarnings(0);
+        try {
+            antTask.execute();
+            fail("Exception is expected");
+        }
+        catch (BuildException ex) {
+            assertEquals("Got 0 errors and 1 warnings.", ex.getMessage());
+        }
+    }
+
+    @Test
+    public final void testMaxErrors() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        antTask.setFile(new File(getPath(VIOLATED_INPUT)));
+        antTask.setMaxErrors(2);
+        antTask.execute();
+    }
+
+    @Test
+    public final void testFailureProperty() throws IOException {
+        final CheckstyleAntTask antTask = new CheckstyleAntTask();
+        antTask.setConfig(new File(getPath(CONFIG_FILE)));
+        antTask.setFile(new File(getPath(VIOLATED_INPUT)));
+
+        final Project project = new Project();
+        final String failurePropertyName = "myProperty";
+        project.setProperty(failurePropertyName, FAILURE_PROPERTY_VALUE);
+
+        antTask.setProject(project);
+        antTask.setFailureProperty(failurePropertyName);
+        try {
+            antTask.execute();
+            fail("Exception is expected");
+        }
+        catch (BuildException ex) {
+            final Map<String, Object> hashtable = project.getProperties();
+            final Object propertyValue = hashtable.get(failurePropertyName);
+            assertEquals("Got 2 errors and 0 warnings.", propertyValue);
+        }
+    }
+
+    @Test
+    public final void testOverrideProperty() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        antTask.setFile(new File(getPath(VIOLATED_INPUT)));
+        final CheckstyleAntTask.Property property = new CheckstyleAntTask.Property();
+        property.setKey("lineLength.severity");
+        property.setValue("ignore");
+        antTask.addProperty(property);
+        antTask.execute();
+    }
+
+    @Test
+    public final void testOmitIgnoredModules() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        antTask.setFile(new File(getPath(VIOLATED_INPUT)));
+        antTask.setFailOnViolation(false);
+        antTask.setOmitIgnoredModules(false);
+
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        final File outputFile = new File("target/ant_task_plain_output.txt");
+        formatter.setTofile(outputFile);
+        final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
+        formatterType.setValue("plain");
+        formatter.setType(formatterType);
+        formatter.createListener(null);
+
+        antTask.addFormatter(formatter);
+        antTask.execute();
+
+        final List<String> output = FileUtils.readLines(outputFile);
+        assertEquals("Starting audit...", output.get(0));
+        assertTrue(output.get(1).startsWith("[WARN]"));
+        assertTrue(output.get(1).endsWith("InputCheckstyleAntTaskError.java:4: "
+                + "@incomplete=Some javadoc [WriteTag]"));
+        assertTrue(output.get(2).startsWith("[ERROR]"));
+        assertTrue(output.get(2).endsWith("InputCheckstyleAntTaskError.java:7: "
+                + "Line is longer than 70 characters (found 80). [LineLength]"));
+        assertTrue(output.get(3).startsWith("[ERROR]"));
+        assertTrue(output.get(3).endsWith("InputCheckstyleAntTaskError.java:9: "
+                + "Line is longer than 70 characters (found 81). [LineLength]"));
+        assertEquals("Audit done.", output.get(4));
+    }
+
+    @Test
+    public final void testConfigurationByUrl() throws IOException {
+        final CheckstyleAntTask antTask = new CheckstyleAntTask();
+        antTask.setProject(new Project());
+        final URL url = new File(getPath(CONFIG_FILE)).toURI().toURL();
+        antTask.setConfigURL(url);
+        antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
+        antTask.execute();
+    }
+
+    @Test
+    public final void testSimultaneousConfiguration() throws IOException {
+        CheckstyleAntTask antTask;
+        final File file = new File(getPath(CONFIG_FILE));
+        final URL url = file.toURI().toURL();
+        final String expected =
+                "Attributes 'config' and 'configURL' must not be set at the same time";
+        try {
+            antTask = new CheckstyleAntTask();
+            antTask.setConfigUrl(url);
+            antTask.setConfig(file);
+            fail("Exception is expected");
+        }
+        catch (BuildException ex) {
+            assertEquals(expected, ex.getMessage());
+        }
+        try {
+            antTask = new CheckstyleAntTask();
+            antTask.setConfig(file);
+            antTask.setConfigUrl(url);
+            fail("Exception is expected");
+        }
+        catch (BuildException ex) {
+            assertEquals(expected, ex.getMessage());
+        }
+    }
+
+    @Test
+    public final void testSetPropertiesFile() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        antTask.setFile(new File(getPath(VIOLATED_INPUT)));
+        antTask.setProperties(new File(getPath("ant/checkstyleAntTest.properties")));
+        antTask.execute();
+    }
+
+    @Test
+    public final void testSetPropertiesNonExistingFile() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
+        antTask.setProperties(new File(getPath(NOT_EXISTING_FILE)));
+        try {
+            antTask.execute();
+            fail("Exception is expected");
+        }
+        catch (BuildException ex) {
+            assertTrue(ex.getMessage().startsWith("Error loading Properties file"));
+        }
+    }
+
+    @Test
+    public final void testXmlOutput() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        antTask.setFile(new File(getPath(VIOLATED_INPUT)));
+        antTask.setFailOnViolation(false);
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        final File outputFile = new File("target/log.xml");
+        formatter.setTofile(outputFile);
+        final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
+        formatterType.setValue("xml");
+        formatter.setType(formatterType);
+        antTask.addFormatter(formatter);
+        antTask.execute();
+
+        final List<String> expected = FileUtils.readLines(
+                new File(getPath("ant/ant_task_xml_output.xml")));
+        final List<String> actual = FileUtils.readLines(outputFile);
+        for (int i = 0; i < expected.size(); i++) {
+            final String line = expected.get(i);
+            if (!line.startsWith("<checkstyle version") && !line.startsWith("<file")) {
+                assertEquals(line, actual.get(i));
+            }
+        }
+    }
+
+    @Test
+    public final void testCreateListenerException() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        final File outputFile = new File("target/");
+        formatter.setTofile(outputFile);
+        antTask.addFormatter(formatter);
+        try {
+            antTask.execute();
+            fail("Exception is expected");
+        }
+        catch (BuildException ex) {
+            assertTrue(ex.getMessage().startsWith("Unable to create listeners: formatters"));
+        }
+    }
+
+    @Test
+    public void testSetInvalidType() {
+        final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
+        try {
+            formatterType.setValue("foo");
+            fail("Exception is expected");
+        }
+        catch (BuildException ex) {
+            assertEquals("foo is not a legal value for this attribute", ex.getMessage());
+        }
+    }
+
+    @Test
+    public final void testSetClassName() {
+        final String customName = "customName";
+        final CheckstyleAntTask.Listener listener = new CheckstyleAntTask.Listener();
+        listener.setClassname(customName);
+        assertEquals(customName, listener.getClassname());
+    }
+
+    @Test
+    public void testSetFileValueByFile() throws IOException {
+        final String filename = getPath("ant/checkstyleAntTest.properties");
+        final CheckstyleAntTask.Property property = new CheckstyleAntTask.Property();
+        property.setFile(new File(filename));
+        assertEquals(property.getValue(), new File(filename).getAbsolutePath());
+    }
+
+    @Test
+    public void testDefaultLoggerListener() throws IOException {
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        formatter.setUseFile(false);
+        assertTrue(formatter.createListener(null) instanceof DefaultLogger);
+    }
+
+    @Test
+    public void testDefaultLoggerListenerWithToFile() throws IOException {
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        formatter.setUseFile(false);
+        formatter.setTofile(new File("target/"));
+        assertTrue(formatter.createListener(null) instanceof DefaultLogger);
+    }
+
+    @Test
+    public void testXmlLoggerListener() throws IOException {
+        final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
+        formatterType.setValue("xml");
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        formatter.setType(formatterType);
+        formatter.setUseFile(false);
+        assertTrue(formatter.createListener(null) instanceof XMLLogger);
+    }
+
+    @Test
+    public void testXmlLoggerListenerWithToFile() throws IOException {
+        final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
+        formatterType.setValue("xml");
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        formatter.setType(formatterType);
+        formatter.setUseFile(false);
+        formatter.setTofile(new File("target/"));
+        assertTrue(formatter.createListener(null) instanceof XMLLogger);
+    }
+
+    @Test
+    public void testSetClasspath() {
+        // temporary fake test
+        final CheckstyleAntTask antTask = new CheckstyleAntTask();
+        final Project project = new Project();
+        antTask.setClasspath(new Path(project, "/"));
+        antTask.setClasspath(new Path(project, "/checkstyle"));
+        antTask.setClasspathRef(new Reference());
+    }
+
+    @Test
+    public void testSetClasspathRef() {
+        // temporary fake test
+        final CheckstyleAntTask antTask = new CheckstyleAntTask();
+        antTask.setClasspathRef(new Reference());
+    }
+
+    @Test
+    public void testCheckerException() throws IOException {
+        final CheckstyleAntTask antTask = new CheckstyleAntTaskStub();
+        antTask.setConfig(new File(getPath(CONFIG_FILE)));
+        antTask.setProject(new Project());
+        antTask.setFile(new File(""));
+        try {
+            antTask.execute();
+            fail("Exception is expected");
+        }
+        catch (BuildException ex) {
+            assertTrue(ex.getMessage().startsWith("Unable to process files:"));
+        }
+    }
+
+    private static class CheckstyleAntTaskStub extends CheckstyleAntTask {
+        @Override
+        protected List<File> scanFileSets() {
+            final File mock = PowerMockito.mock(File.class);
+            // Assume that I/O error is happened when we try to invoke 'lastModified()' method.
+            final Exception expectedError = new RuntimeException("");
+            when(mock.lastModified()).thenThrow(expectedError);
+            final List<File> list = Lists.newArrayList();
+            list.add(mock);
+            return list;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/ant/InputCheckstyleAntTaskError.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/ant/InputCheckstyleAntTaskError.java
@@ -1,0 +1,10 @@
+package com.puppycrawl.tools.checkstyle.ant;
+
+/**
+ * @incomplete Some javadoc
+ */
+public final class InputCheckstyleAntTaskError {
+    private static final String FOO = "This line is longer then 70 characters.";
+
+    private static final String FOOO = "This line is longer then 70 characters.";
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/ant/InputCheckstyleAntTaskFlawless.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/ant/InputCheckstyleAntTaskFlawless.java
@@ -1,0 +1,5 @@
+package com.puppycrawl.tools.checkstyle.ant;
+
+public final class InputCheckstyleAntTaskFlawless {
+    private String foo = "A short line";
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/ant/InputCheckstyleAntTaskWarning.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/ant/InputCheckstyleAntTaskWarning.java
@@ -1,0 +1,6 @@
+package com.puppycrawl.tools.checkstyle.ant;
+
+public final class InputCheckstyleAntTaskWarning {
+    int foo;
+    int foo1;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/ant/ant_task_test_checks.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/ant/ant_task_test_checks.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="LineLength">
+      <property name="max" value="70"/>
+      <property name="severity"
+                value="${lineLength.severity}"
+                default="error"/>
+    </module>
+    <module name="EmptyLineSeparator">
+      <property name="severity" value="warning"/>
+    </module>
+    <module name="WriteTag">
+      <property name="tag" value="@incomplete"/>
+      <property name="tagFormat" value="\S"/>
+      <property name="severity" value="ignore"/>
+      <property name="tagSeverity" value="warning"/>
+    </module>
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/ant/ant_task_xml_output.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/ant/ant_task_xml_output.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="6.16-SNAPSHOT">
+<file name="/home/vlad/projects/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/ant/InputCheckstyleAntTaskError.java">
+<error line="7" severity="error" message="Line is longer than 70 characters (found 80)." source="com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck"/>
+<error line="9" severity="error" message="Line is longer than 70 characters (found 81)." source="com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck"/>
+</file>
+</checkstyle>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/ant/checkstyleAntTest.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/ant/checkstyleAntTest.properties
@@ -1,0 +1,1 @@
+lineLength.severity=ignore


### PR DESCRIPTION
Issue #1487

Current coverage is [here](http://vladlis.github.io/reports/cobertura/com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask.html).

Strange thing is that in `testEmptyConfig()` here `checker` is null: https://github.com/Vladlis/checkstyle/blob/cb9979644b598156ca1155a76cb61ae1aac6c2e0/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java#L334

but it still goes inside `if`
![-checkstyle - -projects-checkstyle - checkstyle - -projects-checkstyle-src-main-java-com-puppycrawl-tools-checkstyle-ant-checkstyleanttask java - intellij idea 15 0 1](https://cloud.githubusercontent.com/assets/9678372/13618454/3a72d976-e595-11e5-8c2f-463397805d6e.png)

