### PR TITLE
Issue #2729: arrays brakets after generics in method references left part are supported now.

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/java.g
@@ -493,7 +493,7 @@ annotationMemberValuePair!
 
 annotationMemberValueInitializer
     :
-        annotationExpression | annotation | annotationMemberArrayInitializer
+        (annotationExpression)=>annotationExpression | annotation | annotationMemberArrayInitializer
     ;
 
 // This is an initializer used to set up an annotation member array.
@@ -519,7 +519,7 @@ annotationMemberArrayInitializer
 // The two things that can initialize an annotation array element are a conditional expression
 //   and an annotation (nested annotation array initialisers are not valid)
 annotationMemberArrayValueInitializer
-    :    annotationExpression
+    :    (annotationExpression)=>annotationExpression
     |   annotation
     ;
 
@@ -1039,7 +1039,7 @@ traditionalStatement
         // An expression statement.  This could be a method call,
         // assignment statement, or any other expression evaluated for
         // side-effects.
-        |    {LA(2) != COLON}? expression (SEMI)?
+        |    ({LA(2) != COLON}? expression (SEMI)?)=> {LA(2) != COLON}? expression (SEMI)?
 
         // class definition
         |    m:modifiers! classDefinition[#m]
@@ -1426,7 +1426,7 @@ postfixExpression
         (options{warnWhenFollowAmbig=false;} :    // qualified id (id.id.id.id...) -- build the name
             DOT^
             ( (typeArguments[false])?
-              ( IDENT ((typeArguments[false] DOUBLE_COLON)=>typeArguments[false])?
+              ( IDENT
               | "this"
               | "super" // ClassName.super.field
               )
@@ -1480,7 +1480,8 @@ postfixExpression
 
 // the basic element of an expression
 primaryExpression
-    :   IDENT ((typeArguments[false] DOUBLE_COLON)=>typeArguments[false])?
+    :   (typeSpec[false] DOUBLE_COLON) => typeSpec[false]
+    |    IDENT
     |    constant
     |    "true"
     |    "false"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/MethodReferencesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/MethodReferencesTest.java
@@ -65,4 +65,31 @@ public class MethodReferencesTest extends BaseCheckTestSupport {
         verify(checkConfig, getNonCompilablePath("InputMethodReferences3.java"), expected);
 
     }
+
+    @Test
+    public void testArrayAfterGeneric()
+            throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(MemberNameCheck.class);
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getNonCompilablePath("InputMethodReferences4.java"), expected);
+
+    }
+
+    @Test
+    public void testFromHiernate()
+            throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(MemberNameCheck.class);
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getNonCompilablePath("InputMethodReferences5.java"), expected);
+
+    }
+
+    @Test
+    public void testFromSpring()
+            throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(MemberNameCheck.class);
+        final String[] expected = ArrayUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getNonCompilablePath("InputMethodReferences6.java"), expected);
+
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences4.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences4.java
@@ -1,0 +1,12 @@
+//Compilable with Java8
+//Issue #2729
+package com.puppycrawl.tools.checkstyle.grammars.java8;
+import java.util.Arrays;
+
+public class InputMethodReferences4 {
+    public void doSomething(final Object... arguments) {
+        Arrays.stream(arguments)
+                .map(Object::getClass)
+                .toArray(Class<?>[]::new);
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences5.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences5.java
@@ -1,0 +1,27 @@
+//Compilable with Java8
+package com.puppycrawl.tools.checkstyle.grammars.java8;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ METHOD, FIELD })
+@Retention(RUNTIME)
+public @interface InputMethodReferences5 {
+    JoinFormula formula() default @JoinFormula(value = "", referencedColumnName = "");
+
+    JoinColumn column() default @JoinColumn();
+}
+
+@interface JoinFormula {
+    String value();
+
+    String referencedColumnName();
+}
+
+@interface JoinColumn {
+
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences6.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences6.java
@@ -1,0 +1,17 @@
+//Compilable with Java8
+package com.puppycrawl.tools.checkstyle.grammars.java8;
+
+public final class InputMethodReferences6 {
+
+    public void testMethod() {
+
+        @SuppressWarnings("unused")
+        class MyClass {
+            public int doSomething() {
+                return 0;
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
#2729

Not the prettiest solution with semantic predicates, but it works.