### PR TITLE
Issue #2971: VisibilityModifier allowPublicFinalFields

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -72,6 +72,10 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtils;
  * </pre>
  *
  * <p>
+ * <b>allowPublicFinalFields</b> - which allows immutable fields be
+ * declared as public. Default value is <b>true</b>
+ * </p>
+ * <p>
  * <b>allowPublicImmutableFields</b> - which allows immutable fields be
  * declared as public if defined in final class. Default value is <b>true</b>
  * </p>
@@ -328,8 +332,11 @@ public class VisibilityModifierCheck
     /** Whether package visible members are allowed. */
     private boolean packageAllowed;
 
-    /** Allows immutable fields to be declared as public. */
+    /** Allows immutable fields of final classes to be declared as public. */
     private boolean allowPublicImmutableFields = true;
+
+    /** Allows final fields to be declared as public. */
+    private boolean allowPublicFinalFields = true;
 
     /** List of immutable classes canonical names. */
     private List<String> immutableClassCanonicalNames = new ArrayList<>(DEFAULT_IMMUTABLE_TYPES);
@@ -371,11 +378,19 @@ public class VisibilityModifierCheck
     }
 
     /**
-     * Sets whether public immutable are allowed.
+     * Sets whether public immutable fields are allowed.
      * @param allow user's value.
      */
     public void setAllowPublicImmutableFields(boolean allow) {
         allowPublicImmutableFields = allow;
+    }
+
+    /**
+     * Sets whether public final fields are allowed.
+     * @param allow user's value.
+     */
+    public void setAllowPublicFinalFields(boolean allow) {
+        allowPublicFinalFields = allow;
     }
 
     /**
@@ -540,8 +555,7 @@ public class VisibilityModifierCheck
                 || packageAllowed && PACKAGE_ACCESS_MODIFIER.equals(variableScope)
                 || protectedAllowed && PROTECTED_ACCESS_MODIFIER.equals(variableScope)
                 || isIgnoredPublicMember(variableName, variableScope)
-                   || allowPublicImmutableFields
-                      && isImmutableFieldDefinedInFinalClass(variableDef);
+                || isAllowedPublicField(variableDef);
         }
 
         return result;
@@ -567,6 +581,16 @@ public class VisibilityModifierCheck
     private boolean isIgnoredPublicMember(String variableName, String variableScope) {
         return PUBLIC_ACCESS_MODIFIER.equals(variableScope)
             && publicMemberPattern.matcher(variableName).find();
+    }
+
+    /**
+     * Checks whether the variable satisfies the public field check.
+     * @param variableDef Variable definition node.
+     * @return true if allowed
+     */
+    private boolean isAllowedPublicField(DetailAST variableDef) {
+        return allowPublicFinalFields && isImmutableField(variableDef)
+            || allowPublicImmutableFields && isImmutableFieldDefinedInFinalClass(variableDef);
     }
 
     /**
@@ -597,7 +621,6 @@ public class VisibilityModifierCheck
             }
         }
         return modifiersSet;
-
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -117,6 +117,25 @@ public class VisibilityModifierCheckTest
     public void testAllowPublicFinalFieldsInImmutableClass() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicImmutableFields", "true");
+        checkConfig.addAttribute("allowPublicFinalFields", "false");
+        final String[] expected = {
+            "12:39: " + getCheckMessage(MSG_KEY, "includes"),
+            "13:39: " + getCheckMessage(MSG_KEY, "excludes"),
+            "16:23: " + getCheckMessage(MSG_KEY, "list"),
+            "34:20: " + getCheckMessage(MSG_KEY, "value"),
+            "36:24: " + getCheckMessage(MSG_KEY, "bValue"),
+            "37:31: " + getCheckMessage(MSG_KEY, "longValue"),
+        };
+        verify(checkConfig, getPath("InputImmutable.java"), expected);
+    }
+
+    @Test
+    public void testAllowPublicFinalFieldsInNonFinalClass() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicImmutableFields", "false");
+        checkConfig.addAttribute("allowPublicFinalFields", "true");
         final String[] expected = {
             "12:39: " + getCheckMessage(MSG_KEY, "includes"),
             "13:39: " + getCheckMessage(MSG_KEY, "excludes"),
@@ -134,6 +153,8 @@ public class VisibilityModifierCheckTest
                 createCheckConfig(VisibilityModifierCheck.class);
         checkConfig.addAttribute("immutableClassCanonicalNames", "java.util.List,"
                 + "com.google.common.collect.ImmutableSet");
+        checkConfig.addAttribute("allowPublicImmutableFields", "true");
+        checkConfig.addAttribute("allowPublicFinalFields", "false");
         final String[] expected = {
             "14:35: " + getCheckMessage(MSG_KEY, "notes"),
             "15:29: " + getCheckMessage(MSG_KEY, "value"),
@@ -285,6 +306,7 @@ public class VisibilityModifierCheckTest
         final DefaultConfiguration checkConfig =
             createCheckConfig(VisibilityModifierCheck.class);
         checkConfig.addAttribute("allowPublicImmutableFields", "false");
+        checkConfig.addAttribute("allowPublicFinalFields", "false");
         final String[] expected = {
             "10:22: " + getCheckMessage(MSG_KEY, "someIntValue"),
             "11:39: " + getCheckMessage(MSG_KEY, "includes"),
@@ -293,6 +315,50 @@ public class VisibilityModifierCheckTest
             "14:23: " + getCheckMessage(MSG_KEY, "list"),
         };
         verify(checkConfig, getPath("InputPublicImmutable.java"), expected);
+    }
+
+    @Test
+    public void testPublicFinalFieldsNotAllowed() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicImmutableFields", "true");
+        checkConfig.addAttribute("allowPublicFinalFields", "false");
+        final String[] expected = {
+            "10:22: " + getCheckMessage(MSG_KEY, "someIntValue"),
+            "11:39: " + getCheckMessage(MSG_KEY, "includes"),
+            "12:35: " + getCheckMessage(MSG_KEY, "notes"),
+            "13:29: " + getCheckMessage(MSG_KEY, "value"),
+            "14:23: " + getCheckMessage(MSG_KEY, "list"),
+        };
+        verify(checkConfig, getPath("InputPublicImmutable.java"), expected);
+    }
+
+    @Test
+    public void testPublicFinalFieldsAllowed() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("immutableClassCanonicalNames",
+            "com.google.common.collect.ImmutableSet");
+        checkConfig.addAttribute("allowPublicImmutableFields", "false");
+        checkConfig.addAttribute("allowPublicFinalFields", "true");
+        final String[] expected = {
+            "12:35: " + getCheckMessage(MSG_KEY, "notes"),
+            "13:29: " + getCheckMessage(MSG_KEY, "value"),
+            "14:23: " + getCheckMessage(MSG_KEY, "list"),
+        };
+        verify(checkConfig, getPath("InputPublicImmutable.java"), expected);
+    }
+
+    @Test
+    public void testPublicFinalFieldInEnum() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicImmutableFields", "true");
+        checkConfig.addAttribute("allowPublicFinalFields", "false");
+        final String[] expected = {
+            "15:23: " + getCheckMessage(MSG_KEY, "hole"),
+        };
+        verify(checkConfig, getPath("InputEnumIsSealed.java"), expected);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -307,6 +373,7 @@ public class VisibilityModifierCheckTest
     public void testNullModifiers() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicFinalFields", "false");
         final String[] expected = {
             "11:50: " + getCheckMessage(MSG_KEY, "i"),
         };

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputEnumIsSealed.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputEnumIsSealed.java
@@ -1,0 +1,16 @@
+
+package com.puppycrawl.tools.checkstyle.checks.design;
+
+/** Shows that sealed enum is good as final. */
+public enum InputEnumIsSealed {
+    SOME_VALUE;
+
+    static class Hole {
+    }
+
+    /** Normally disallowed if final enclosing class is required. */
+    public final int someField = Integer.MAX_VALUE;
+
+    /** Disallowed because mutable. */
+    public final Hole hole = null;
+}

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -793,6 +793,10 @@ public class Foo{
           named the same type without consideration of package
         </p>
         <p>
+          <b>allowPublicFinalFields</b> - which allows immutable fields be declared as
+          public. Default value is <b>true</b>
+        </p>
+        <p>
           <b>allowPublicImmutableFields</b> - which allows immutable fields be declared as
           public if defined in final class. Default value is <b>true</b>
         </p>
@@ -814,7 +818,8 @@ public class Foo{
         <p>
           <b>Restriction</b>: Check doesn't check if class is immutable, there's no
           checking if accessory methods are missing and all fields are immutable, we only check
-          <b>if current field is immutable and defined in final class</b>
+          <b>if current field is immutable</b>. Under the flag <b>allowPublicImmutableFields</b>,
+          the enclosing class must also be final, to encourage immutability.
         </p>
         <p>
           Star imports are out of scope of this Check. So if one of type imported via
@@ -848,6 +853,12 @@ public class Foo{
             <td>pattern for public members that should be ignored</td>
             <td><a href="property_types.html#regexp">regular expression</a></td>
             <td><code>^serialVersionUID$</code></td>
+          </tr>
+          <tr>
+            <td>allowPublicFinalFields</td>
+            <td>allows immutable fields be declared as public</td>
+            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><code>true</code></td>
           </tr>
           <tr>
             <td>allowPublicImmutableFields</td>


### PR DESCRIPTION
#2971

Loosens the restriction for `allowPublicImmutableFields` that the
enclosing class must be final.

For `allowPublicFinalFields`, the field must be final and immutable.

The new property also defaults to true.