### PR TITLE
Issue #3022: Moved file-started audit event after file extension check

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -20,7 +20,7 @@
     <!--Test to reproduce error catching in Checker and satisfy coverage rate. -->
     <suppress checks="IllegalCatch"
               files="CheckerTest.java"
-              lines="535"/>
+              lines="569"/>
 
     <!-- we can not change it as, Check name is part of API (used in configurations) -->
     <suppress checks="AbbreviationAsWordInName"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -299,12 +299,12 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
         for (final File file : files) {
             try {
                 final String fileName = file.getAbsolutePath();
-                fireFileStarted(fileName);
                 final long timestamp = file.lastModified();
                 if (cache != null && cache.isInCache(fileName, timestamp)
                         || !CommonUtils.matchesFileExtension(file, fileExtensions)) {
                     continue;
                 }
+                fireFileStarted(fileName);
                 final SortedSet<LocalizedMessage> fileMessages = processFile(file);
                 fireErrors(fileName, fileMessages);
                 fireFileFinished(fileName);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -217,6 +217,9 @@ public class CheckerTest extends BaseCheckTestSupport {
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(checkerConfig);
 
+        final DebugAuditAdapter auditAdapter = new DebugAuditAdapter();
+        checker.addListener(auditAdapter);
+
         final List<File> files = new ArrayList<>();
         final File file = new File("file.pdf");
         files.add(file);
@@ -228,7 +231,38 @@ public class CheckerTest extends BaseCheckTestSupport {
         final int counter = checker.process(files);
 
         // comparing to 1 as there is only one legal file in input
-        assertEquals(1, counter);
+        final int numLegalFiles = 1;
+        assertEquals(numLegalFiles, counter);
+        assertEquals(numLegalFiles, auditAdapter.getNumFilesStarted());
+        assertEquals(numLegalFiles, auditAdapter.getNumFilesFinished());
+    }
+
+    @Test
+    public void testIgnoredFileExtensions() throws Exception {
+        final DefaultConfiguration checkerConfig = new DefaultConfiguration("configuration");
+        checkerConfig.addAttribute("charset", "UTF-8");
+        checkerConfig.addAttribute("cacheFile", temporaryFolder.newFile().getPath());
+
+        final Checker checker = new Checker();
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.configure(checkerConfig);
+
+        final DebugAuditAdapter auditAdapter = new DebugAuditAdapter();
+        checker.addListener(auditAdapter);
+
+        final List<File> allIgnoredFiles = new ArrayList<>();
+        final File ignoredFile = new File("file.pdf");
+        allIgnoredFiles.add(ignoredFile);
+        final String[] fileExtensions = {"java", "xml", "properties"};
+        checker.setFileExtensions(fileExtensions);
+        checker.setCacheFile(temporaryFolder.newFile().getPath());
+        final int counter = checker.process(allIgnoredFiles);
+
+        // comparing to 0 as there is no legal file in input
+        final int numLegalFiles = 0;
+        assertEquals(numLegalFiles, counter);
+        assertEquals(numLegalFiles, auditAdapter.getNumFilesStarted());
+        assertEquals(numLegalFiles, auditAdapter.getNumFilesFinished());
     }
 
     @SuppressWarnings("deprecation")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DebugAuditAdapter.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DebugAuditAdapter.java
@@ -23,8 +23,22 @@ import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 
 class DebugAuditAdapter implements AuditListener {
-    /** Keeps track of the number of errors. */
+    /** Keeps track whether this {@code AuditListener} was called. */
     private boolean called;
+
+    /** Keeps track of the number of files started. */
+    private int numFilesStarted;
+
+    /** Keeps track of the number of files finished. */
+    private int numFilesFinished;
+
+    public int getNumFilesStarted() {
+        return numFilesStarted;
+    }
+
+    public int getNumFilesFinished() {
+        return numFilesFinished;
+    }
 
     public boolean wasCalled() {
         return called;
@@ -52,6 +66,7 @@ class DebugAuditAdapter implements AuditListener {
     @Override
     public void fileStarted(AuditEvent event) {
         called = true;
+        numFilesStarted++;
     }
 
     @Override
@@ -62,5 +77,6 @@ class DebugAuditAdapter implements AuditListener {
     @Override
     public void fileFinished(AuditEvent event) {
         called = true;
+        numFilesFinished++;
     }
 }


### PR DESCRIPTION
#3022 

Added extra unit test to prevent future regression. The test makes sure that file-started & file-finished events are fired only for files that are not filtered out