### PR TITLE
Issue #1064: fixed slow javadoc antlr parsing

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParser.g4
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParser.g4
@@ -917,4 +917,10 @@ javadocInlineTag:
 
 htmlComment: HTML_COMMENT_START (text | NEWLINE | LEADING_ASTERISK)* HTML_COMMENT_END;
 
-text : (CHAR | WS)+ ;
+text : ((CHAR | WS)
+ {
+  _la = _input.LA(1);
+  if ((_la != WS) && (_la != CHAR)) return _localctx;
+  else if (_alt == 1) continue;
+ }
+       )+;


### PR DESCRIPTION
Issue #1064
Description of fix is at: https://groups.google.com/d/msg/checkstyle-devel/Uyu-vO50eAQ/CdKYGSX-CAAJ

Basically, we are injecting code into the ANTLR to skip calling `adaptivePredict` which is causing the slowdown.

I implemented this change in my project's CS and saw no negative effects as is and when removing or changing javadocs to report violations.
I did see a drop in runtime from 70 seconds to 20 seconds.
I will run regression.

Issue is still waiting approval.