### PR TITLE
Issue #2973: added java lexer cases for coverage

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -1982,6 +1982,8 @@
                      See https://github.com/checkstyle/checkstyle/issues/2285-->
                 <option value="ProhibitedExceptionThrown" />
                 <option value="MismatchedQueryAndUpdateOfCollection" />
+                <!-- Till https://github.com/checkstyle/checkstyle/issues/3066 -->
+                <option value="ProhibitedExceptionCaught" />
             </list>
         </option>
     </inspection_tool>

--- a/pom.xml
+++ b/pom.xml
@@ -1811,18 +1811,18 @@
                 <haltOnFailure>true</haltOnFailure>
                 <branchRate>100</branchRate>
                 <lineRate>100</lineRate>
-                <totalBranchRate>90</totalBranchRate>
-                <totalLineRate>90</totalLineRate>
+                <totalBranchRate>92</totalBranchRate>
+                <totalLineRate>98</totalLineRate>
                 <regexes>
                   <regex>
                     <pattern>com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaRecognizer</pattern>
-                    <branchRate>71</branchRate>
-                    <lineRate>95</lineRate>
+                    <branchRate>72</branchRate>
+                    <lineRate>96</lineRate>
                   </regex>
                   <regex>
                     <pattern>com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaLexer</pattern>
-                    <branchRate>75</branchRate>
-                    <lineRate>92</lineRate>
+                    <branchRate>79</branchRate>
+                    <lineRate>97</lineRate>
                   </regex>
                 </regexes>
               </check>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java
@@ -67,6 +67,17 @@ public final class AstTreeStringPrinter {
     }
 
     /**
+     * Parse a file and print the parse tree.
+     * @param text the text to parse.
+     * @param withComments true to include comments to AST
+     * @return the AST of the file in String form.
+     * @throws CheckstyleException if the file is not a Java source.
+     */
+    public static String printAst(FileText text, boolean withComments) throws CheckstyleException {
+        return printTree(parseFileText(text, withComments));
+    }
+
+    /**
      * Print AST.
      * @param ast the root AST node.
      * @return string AST.
@@ -142,6 +153,18 @@ public final class AstTreeStringPrinter {
             throws IOException, CheckstyleException {
         final FileText text = new FileText(file.getAbsoluteFile(),
             System.getProperty("file.encoding", "UTF-8"));
+        return parseFileText(text, withComments);
+    }
+
+    /**
+     * Parse a text and return the parse tree.
+     * @param text the text to parse.
+     * @param withComments true to include comment nodes to the tree
+     * @return the root node of the parse tree.
+     * @throws CheckstyleException if the file is not a Java source.
+     */
+    private static DetailAST parseFileText(FileText text, boolean withComments)
+            throws CheckstyleException {
         final FileContents contents = new FileContents(text);
         final DetailAST result;
         try {
@@ -155,7 +178,7 @@ public final class AstTreeStringPrinter {
         catch (RecognitionException | TokenStreamException ex) {
             final String exceptionMsg = String.format(Locale.ROOT,
                 "%s occurred during the analysis of file %s.",
-                ex.getClass().getSimpleName(), file.getPath());
+                ex.getClass().getSimpleName(), text.getFile().getPath());
             throw new CheckstyleException(exceptionMsg, ex);
         }
 


### PR DESCRIPTION
Issue #2973

The first for the hard to reach code coverages.
This doesn't reach 100% line coverage because the remaining 59 lines are actually unreachable code by normal means. For now, I am submitting these and increasing the coverage rate.
My plan to reach the other areas is to have the `LA` method return delayed values instead of static positioning, but for now I will work on the recognizer.

So I don't have to keep creating files for every small test, I split `parseFile` apart with the addition of `parseFileText`. I also added the method `verifyAstRaw` and the class `AssertGeneratedJavaLexer `.
Suppressions are needed because the ANTLR checks are very specific.