### PR TITLE
Issue #2944: add EmptyLineSeparator option to check empty lines inside methods

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -399,6 +399,7 @@
     <module name="EmptyForIteratorPad"/>
     <module name="EmptyLineSeparator">
       <property name="allowNoEmptyLineBetweenFields" value="true"/>
+      <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
     </module>
     <module name="GenericWhitespace"/>
     <module name="MethodParamPad"/>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages.properties
@@ -1,6 +1,7 @@
 empty.line.separator=''{0}'' should be separated from previous statement.
 empty.line.separator.multiple.lines=''{0}'' has more than 1 empty lines before.
 empty.line.separator.multiple.lines.after=''{0}'' has more than 1 empty lines after.
+empty.line.separator.multiple.lines.inside=There is more than 1 empty line one after another.
 
 containsTab=Line contains a tab character.
 file.containsTab=File contains tab characters (this is the first instance).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_de.properties
@@ -1,5 +1,6 @@
 empty.line.separator=''{0}'' sollte vom vorangehenden Ausdruck getrennt stehen.
 empty.line.separator.multiple.lines.after=''{0}'' hat mehr als 1 Leerzeilen nach.
+empty.line.separator.multiple.lines.inside=Es gibt mehr als 1 leere Zeile nacheinander.
 
 containsTab=Zeile enthält ein TAB-Zeichen
 file.containsTab=Datei enthält Tabulatorzeichen (diese Stelle ist das erste Vorkommnen).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_es.properties
@@ -14,6 +14,7 @@ ws.typeCast=''conversión de tipos'' no está seguido de espacio en blanco.
 empty.line.separator = ''{0}'' debe ser separado de la declaración anterior.
 empty.line.separator.multiple.lines = ''{0}'' cuenta con más de 1 líneas vacías antes.
 empty.line.separator.multiple.lines.after=''{0}'' cuenta con más de 1 líneas vacías después.
+empty.line.separator.multiple.lines.inside=Hay más de 1 una línea vacía después de otra.
 file.containsTab = Archivo contiene caracteres de tabulación (este es el primer ejemplo).
 no.line.wrap = {0} declaración no debe ser la línea envuelto.
 ws.illegalFollow = ''{0}'' es seguido por un carácter ilegal.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_fi.properties
@@ -15,5 +15,6 @@ ws.illegalFollow=''{0}'' seuraa laiton merkki.
 empty.line.separator = ''{0}'' olisi erotettava edellisen selonteon.
 empty.line.separator.multiple.lines = ''{0}'' on yli 1 tyhjää riviä ennen.
 empty.line.separator.multiple.lines.after=''{0}'' on yli 1 tyhjää riviä jälkeen.
+empty.line.separator.multiple.lines.inside=On enemmän kuin 1 tyhjä rivi yksi toisensa jälkeen.
 file.containsTab = Tiedosto sisältää sarkainmerkeillä (tämä on ensisijaisesti).
 no.line.wrap = {0} lausunto ei pitäisi olla linja-kääritty.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_fr.properties
@@ -15,5 +15,6 @@ ws.illegalFollow=''{0}'' est suivi par un caractère illégal.
 empty.line.separator = ''{0}'' doit être séparé de la déclaration précédente.
 empty.line.separator.multiple.lines = ''{0}'' a plus de 1 lignes vides avant.
 empty.line.separator.multiple.lines.after=''{0}'' compte plus de 1 lignes vides après.
+empty.line.separator.multiple.lines.inside=Il y a plus de 1 ligne vide un après l'autre.
 file.containsTab = Fichier contient des caractères de tabulation (ce qui est le premier exemple).
 no.line.wrap = {0} déclaration ne devrait pas être sur des lignes enveloppé.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_ja.properties
@@ -15,5 +15,6 @@ ws.illegalFollow=が ''{0}'' 不正な文字が続いています。
 empty.line.separator = ''{0}'' 前の文から分離する必要があります。
 empty.line.separator.multiple.lines = ''{0}'' の前に1以上の空行を持っています。
 empty.line.separator.multiple.lines.after=''{0}'' 後の1以上の空行を持っています。
+empty.line.separator.multiple.lines.inside=別の後に1以上の空行の1があります。
 file.containsTab = ファイルが（これが最初のインスタンスである）タブ文字が含まれています。
 no.line.wrap = {0} 文は、行ラップされてはなりません。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_pt.properties
@@ -15,5 +15,6 @@ ws.illegalFollow=''{0}'' é seguido por um carácter ilegal.
 empty.line.separator = ''{0}'' deve ser separada da declaração anterior.
 empty.line.separator.multiple.lines = ''{0}'' tem mais de 1 linhas vazias antes.
 empty.line.separator.multiple.lines.after=''{0}'' tem mais de 1 linhas vazias depois.
+empty.line.separator.multiple.lines.inside=Há mais de um vazio linha um após o outro.
 file.containsTab = Arquivo contém caracteres de tabulação (esta é a primeira instância).
 no.line.wrap = {0} afirmação não deve ser linha-embrulhado.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_tr.properties
@@ -19,4 +19,5 @@ ws.typeCast=''türü dönüştürme'' ifadesinden sonra boşluk kullanılmamış
 empty.line.separator = {0} 'Bir önceki deyimi ayrılmalıdır.
 empty.line.separator.multiple.lines = {0} daha önce en fazla 1 boş hatları vardır.
 empty.line.separator.multiple.lines.after=''{0}'' sonra 1'den fazla boş hatları vardır.
+empty.line.separator.multiple.lines.inside=birbiri ardına 1'den fazla boş satır biri var.
 no.line.wrap = {0} ifadesi hattı sarılı olmamalıdır.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_zh.properties
@@ -1,6 +1,7 @@
 empty.line.separator=''{0}' 前应有空行。
 empty.line.separator.multiple.lines=''{0}'' 前只应有一个空行。
 empty.line.separator.multiple.lines.after=''{0}'' 后只应有一个空行。
+empty.line.separator.multiple.lines.inside=还有陆续超过1空行之一。
 
 containsTab=行内含有制表符 tab 。
 file.containsTab=文件含有制表符 tab （这只是第一例）。

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck.MSG_MULTIPLE_LINES;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck.MSG_MULTIPLE_LINES_AFTER;
+import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck.MSG_MULTIPLE_LINES_INSIDE;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck.MSG_SHOULD_BE_SEPARATED;
 import static org.junit.Assert.assertArrayEquals;
 
@@ -163,5 +164,31 @@ public class EmptyLineSeparatorCheckTest
         checkConfig.addAttribute("allowMultipleEmptyLines", "false");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputPrePreviousLineEmptiness.java"), expected);
+    }
+
+    @Test
+    public void testDisAllowMultipleEmptyLinesInsideClassMembers() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addAttribute("allowMultipleEmptyLinesInsideClassMembers", "false");
+        final String[] expected = {
+            "27: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
+            "39: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
+            "45: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
+            "50: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
+            "55: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
+            "56: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
+        };
+        verify(checkConfig,
+                getPath("InputEmptyLineSeparatorMultipleEmptyLinesInside.java"),
+                expected);
+    }
+
+    @Test
+    public void testAllowMultipleEmptyLinesInsideClassMembers() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+                getPath("InputEmptyLineSeparatorMultipleEmptyLinesInside.java"),
+                expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputEmptyLineSeparatorMultipleEmptyLinesInside.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputEmptyLineSeparatorMultipleEmptyLinesInside.java
@@ -1,0 +1,59 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace;
+
+public abstract class InputEmptyLineSeparatorMultipleEmptyLinesInside
+{
+    public InputEmptyLineSeparatorMultipleEmptyLinesInside() {
+        // empty lines below should cause a violation
+
+
+    }
+
+    private int counter;
+
+    private Object obj = null;
+
+    abstract int generateSrc(String s);
+
+    static {
+        // empty lines below should cause a violation
+
+
+    }
+
+    {
+        // empty lines below should cause a violation
+
+
+    }
+
+    private static void foo() {
+
+
+        // 1 empty line above should cause a violation
+
+        // 1 empty line above should not cause a violation
+
+
+
+        // 2 empty lines above should cause violations
+    }
+}

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -238,6 +238,12 @@ for (Iterator foo = very.long.line.iterator();
              <td><a href="property_types.html#boolean">boolean</a></td>
              <td>true</td>
           </tr>
+            <tr>
+                <td>allowMultipleEmptyLinesInsideClassMembers</td>
+                <td>Allow multiple empty lines inside class members</td>
+                <td><a href="property_types.html#boolean">boolean</a></td>
+                <td>true</td>
+            </tr>
           <tr>
             <td>tokens</td>
             <td>tokens to check</td>
@@ -328,6 +334,45 @@ class Foo
     &lt;property name="allowNoEmptyLineBetweenFields" value="true"/&gt;
 &lt;/module&gt;
       </source>
+      <p>
+          An example how to disallow multiple empty lines inside constructor, initialization block and method:
+      </p>
+      <source>
+          &lt;module name="EmptyLineSeparator"&gt;
+          &lt;property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/&gt;
+          &lt;/module&gt;
+      </source>
+
+      <p>
+          The check is valid only for statements that have body:
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">STATIC_INIT</a>,
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">INSTANCE_INIT</a>,
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
+      </p>
+      <p>
+          Example of declarations with multiple empty lines inside method:
+      </p>
+      <source>
+          ///////////////////////////////////////////////////
+          //HEADER
+          ///////////////////////////////////////////////////
+
+          package com.puppycrawl.tools.checkstyle.whitespace;
+
+          class Foo
+          {
+
+              public void foo() {
+              <br/>
+
+                  System.out.println(1); // violation since method has 2 empty lines subsequently
+              }
+          }
+      </source>
       </subsection>
 
       <subsection name="Example of Usage">
@@ -356,6 +401,10 @@ class Foo
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22empty.line.separator.multiple.lines.after%22">
             empty.line.separator.multiple.lines.after</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22empty.line.separator.multiple.lines.inside%22">
+            empty.line.separator.multiple.lines.inside</a>
           </li>
         </ul>
         <p>


### PR DESCRIPTION
#2944

Diff report over guava, checkstyle, sevntu-checkstyle, pmd, spring-framework, hibernate-orm and Orekit looks OK - http://vladlis.github.io/reports/2944/
