### PR TITLE
Issue #3005: Fix allowByTailComment option in AvoidEscapedUnicodeCharacters

### DIFF
--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -77,6 +77,7 @@
       <!-- false positive, beginTree is a kind of constructor for Checks -->
       <Or>
         <Class name="com.puppycrawl.tools.checkstyle.checks.AbstractDeclarationCollector" />
+        <Class name="com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck" />
         <Class name="com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck" />
         <Class name="com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck" />
         <Class name="com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck" />

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -79,6 +79,14 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
             "77: " + getCheckMessage(MSG_KEY),
             "79: " + getCheckMessage(MSG_KEY),
             "82: " + getCheckMessage(MSG_KEY),
+            "86: " + getCheckMessage(MSG_KEY),
+            "87: " + getCheckMessage(MSG_KEY),
+            "88: " + getCheckMessage(MSG_KEY),
+            "89: " + getCheckMessage(MSG_KEY),
+            "92: " + getCheckMessage(MSG_KEY),
+            "93: " + getCheckMessage(MSG_KEY),
+            "94: " + getCheckMessage(MSG_KEY),
+            "98: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }
@@ -112,6 +120,13 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
             "77: " + getCheckMessage(MSG_KEY),
             "79: " + getCheckMessage(MSG_KEY),
             "82: " + getCheckMessage(MSG_KEY),
+            "86: " + getCheckMessage(MSG_KEY),
+            "87: " + getCheckMessage(MSG_KEY),
+            "88: " + getCheckMessage(MSG_KEY),
+            "89: " + getCheckMessage(MSG_KEY),
+            "92: " + getCheckMessage(MSG_KEY),
+            "94: " + getCheckMessage(MSG_KEY),
+            "98: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }
@@ -132,7 +147,6 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
             "60: " + getCheckMessage(MSG_KEY),
             "61: " + getCheckMessage(MSG_KEY),
             "62: " + getCheckMessage(MSG_KEY),
-            "72: " + getCheckMessage(MSG_KEY),
             "73: " + getCheckMessage(MSG_KEY),
             "74: " + getCheckMessage(MSG_KEY),
             "75: " + getCheckMessage(MSG_KEY),
@@ -140,6 +154,8 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
             "77: " + getCheckMessage(MSG_KEY),
             "79: " + getCheckMessage(MSG_KEY),
             "82: " + getCheckMessage(MSG_KEY),
+            "92: " + getCheckMessage(MSG_KEY),
+            "98: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }
@@ -159,6 +175,11 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
             "32: " + getCheckMessage(MSG_KEY),
             "33: " + getCheckMessage(MSG_KEY),
             "42: " + getCheckMessage(MSG_KEY),
+            "86: " + getCheckMessage(MSG_KEY),
+            "87: " + getCheckMessage(MSG_KEY),
+            "88: " + getCheckMessage(MSG_KEY),
+            "89: " + getCheckMessage(MSG_KEY),
+            "98: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }
@@ -181,6 +202,13 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends BaseCheckTestSupport
             "33: " + getCheckMessage(MSG_KEY),
             "34: " + getCheckMessage(MSG_KEY),
             "42: " + getCheckMessage(MSG_KEY),
+            "86: " + getCheckMessage(MSG_KEY),
+            "87: " + getCheckMessage(MSG_KEY),
+            "88: " + getCheckMessage(MSG_KEY),
+            "89: " + getCheckMessage(MSG_KEY),
+            "93: " + getCheckMessage(MSG_KEY),
+            "94: " + getCheckMessage(MSG_KEY),
+            "98: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/InputAvoidEscapedUnicodeCharacters.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/InputAvoidEscapedUnicodeCharacters.java
@@ -69,7 +69,7 @@ public class InputAvoidEscapedUnicodeCharacters {
 	          case '\f':
 	          case '\r':
 	          case ' ':
-	          case '\u0085':
+	          case '\u0085': // some comment
 	          case '\u1680':
 	          case '\u2028':
 	          case '\u2029':
@@ -82,4 +82,18 @@ public class InputAvoidEscapedUnicodeCharacters {
 	          return c >= '\u2000' && c <= '\u200a';
 	      }
 	 }
+
+	private String unitAbbrev5 = "\u03bcs"; 	// comment is separated by space + tab
+	private String unitAbbrev6 = "\u03bcs";	// comment is separated by tab
+	private String unitAbbrev7 = "\u03bcs";	/* comment is separated by tab */
+	private String unitAbbrev8 = "\u03bcs"; /* comment
+	                                           has 2 lines */
+	void foo() {
+		for (char c = '\u0000'; c < '\uffff'; c++) {
+			if (c == '\u001b' ||     // ESC
+					c == '\u2014')   // Em-Dash?
+				continue;
+		}
+	}
+	private String unitAbbrev9 = "\u03bcs"; /* comment */ int i;
 }


### PR DESCRIPTION
#3005 
Method `hasTrailComment()` had a strange logic which relied on the presence of a `SEMI` in the end of line, thus had a lot of false-positives and even an NPE. So it needed to be reimplemented.

Case, which caused NPE - https://github.com/checkstyle/checkstyle/compare/master...Vladlis:i3005-unicode?expand=1#diff-6312dd3750155aba02013bf7d3de75feR92