### PR TITLE
Issue #3085: fixed escaping in RegexpOnFilename examples

### DIFF
--- a/src/xdocs/config_regexp.xml
+++ b/src/xdocs/config_regexp.xml
@@ -697,7 +697,7 @@
         </p>
         <source>
 &lt;module name=&quot;RegexpOnFilename&quot;&gt;
-  &lt;property name=&quot;fileNamePattern&quot; value=&quot;\\.gif$&quot;/&gt;
+  &lt;property name=&quot;fileNamePattern&quot; value=&quot;\.gif$&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
@@ -714,7 +714,7 @@
         </p>
         <source>
 &lt;module name=&quot;RegexpOnFilename&quot;&gt;
-  &lt;property name=&quot;folderPattern&quot; value=&quot;[\\/]src[\\/]\\w+[\\/]resources[\\/]&quot;/&gt;
+  &lt;property name=&quot;folderPattern&quot; value=&quot;[\\/]src[\\/]\w+[\\/]resources[\\/]&quot;/&gt;
   &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
   &lt;property name=&quot;fileExtensions&quot; value=&quot;properties, xml&quot;/&gt;
 &lt;/module&gt;
@@ -724,7 +724,7 @@
         </p>
         <source>
 &lt;module name=&quot;RegexpOnFilename&quot;&gt;
-  &lt;property name=&quot;fileNamePattern&quot; value=&quot;\\.(java|xml)$&quot;/&gt;
+  &lt;property name=&quot;fileNamePattern&quot; value=&quot;\.(java|xml)$&quot;/&gt;
   &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
@@ -737,7 +737,7 @@
         <source>
 &lt;module name=&quot;RegexpOnFilename&quot;&gt;
   &lt;property name=&quot;folderPattern&quot; value=&quot;[\\/]src[\\/]&quot;/&gt;
-  &lt;property name=&quot;fileNamePattern&quot; value=&quot;\\.(java|xml)$&quot;/&gt;
+  &lt;property name=&quot;fileNamePattern&quot; value=&quot;\.(java|xml)$&quot;/&gt;
   &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>


### PR DESCRIPTION
Issue #3085 

I accidentally double escaped the examples for the check.