### PR TITLE
Issue #407: Fix cache usage in presence of modules which use external resources for configuration

### DIFF
--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -92,4 +92,15 @@
       </Or>
       <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
     </Match>
+    <Match>
+        <!--
+         False-positive. ExtedrnalResource cannot be null there.
+         FindBugs rise violation due to @Nullable annotation on 'apply' method.
+         See https://stevewall123.wordpress.com/2014/12/18/findbugs-warning-with-guavas-predicate-interface/
+         See http://stackoverflow.com/questions/12422473/nullable-input-in-google-guava-function-interface-triggers-findbugs-warning
+         -->
+        <Class name="com.puppycrawl.tools.checkstyle.PropertyCacheFile$1" />
+        <Method name="apply" />
+        <Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE" />
+    </Match>
 </FindBugsFilter>

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -120,8 +120,9 @@
   </rule>
   <rule ref="rulesets/java/coupling.xml/ExcessiveImports">
     <properties>
-      <!-- TreeWalker integrates Checkstyle and antlr and CheckstyleAntTask integrates Checkstyle with Ant -->
-      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='TreeWalker' or @Image='CheckstyleAntTask']"/>
+      <!-- TreeWalker integrates Checkstyle and antlr and CheckstyleAntTask integrates Checkstyle
+       with Ant. Checker collects external resource locations and setup configuration. -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='TreeWalker' or @Image='CheckstyleAntTask' or @Image='Checker']"/>
     </properties>
   </rule>
   <rule ref="rulesets/java/coupling.xml/CouplingBetweenObjects">

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -52,5 +52,5 @@
     <!-- testing for catch Error is part of 100% coverage -->
     <suppress checks="IllegalCatchExtended"
               files="CheckerTest\.java"
-              lines="569"/>
+              lines="577"/>
 </suppressions>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -13,14 +13,14 @@
          See https://github.com/checkstyle/checkstyle/issues/2285-->
     <suppress checks="IllegalCatch"
               files="Checker.java"
-              lines="247"/>
+              lines="278"/>
     <suppress checks="IllegalCatch"
               files="Checker.java"
-              lines="252"/>
+              lines="388"/>
     <!--Test to reproduce error catching in Checker and satisfy coverage rate. -->
     <suppress checks="IllegalCatch"
               files="CheckerTest.java"
-              lines="569"/>
+              lines="576"/>
 
     <!-- we can not change it as, Check name is part of API (used in configurations) -->
     <suppress checks="AbbreviationAsWordInName"
@@ -132,6 +132,7 @@
     <!-- they are aggregators of logic, usage a several of classes are ok -->
     <suppress checks="ClassDataAbstractionCoupling" files="(Checker|TreeWalker|Main|CheckstyleAntTask|JavadocDetailNodeParser)\.java"/>
     <suppress checks="ClassDataAbstractionCoupling" files="(CheckerTest|TreeWalkerTest|BaseCheckTestSupport|XDocsPagesTest|CheckstyleAntTaskTest)\.java"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="PropertyCacheFile\.java"/>
     <!-- a lot of GUI elements is OK -->
     <suppress checks="ClassDataAbstractionCoupling" files="(JTreeTable|MainFrame)\.java"/>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/ExternalResourceHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/ExternalResourceHolder.java
@@ -1,0 +1,50 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.api;
+
+import java.util.Set;
+
+import com.puppycrawl.tools.checkstyle.Checker;
+
+/**
+ * The following interface should be implemented by each module (inheritor of
+ * {@link AbstractCheck}, implementor of {@link FileSetCheck}, or {@link Filter}) which uses
+ * external resources of any kind for its configuration. Such modules must declare external
+ * resource locations as a set of {@link String} which will be returned from
+ * {@link #getExternalResourceLocations}. This allows Checkstyle to invalidate (clear) cache
+ * when the content of at least one external configuration resource of the module is changed.
+ *
+ * @author Andrei Selkin
+ */
+public interface ExternalResourceHolder {
+
+    /**
+     * Returns a set of external configuration resource locations which are used by the module.
+     * ATTENTION!
+     * If 'getExternalResourceLocations()' return null, there will be
+     * {@link NullPointerException} in {@link Checker#getExternalResourceLocations()}.
+     * Such behaviour will signal that your module (check or filter) is designed incorrectrly.
+     * It make sence to return an empty set from 'getExternalResourceLocations()'
+     * only for composite modules like {@link com.puppycrawl.tools.checkstyle.TreeWalker}.
+     * @return a set of external configuration resource locations which are used by the module.
+     */
+    Set<String> getExternalResourceLocations();
+
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -29,15 +29,18 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.apache.commons.beanutils.ConversionException;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.ExternalResourceHolder;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -45,7 +48,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * Provides support for header and headerFile properties.
  * @author o_sukhosolsky
  */
-public abstract class AbstractHeaderCheck extends AbstractFileSetCheck {
+public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
+    implements ExternalResourceHolder {
     /** Pattern to detect occurrences of '\n' in text. */
     private static final Pattern ESCAPED_LINE_FEED_PATTERN = Pattern.compile("\\\\n");
 
@@ -188,5 +192,10 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck {
         if (readerLines.isEmpty()) {
             setHeader(null);
         }
+    }
+
+    @Override
+    public Set<String> getExternalResourceLocations() {
+        return ImmutableSet.of(headerFile);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -21,12 +21,15 @@ package com.puppycrawl.tools.checkstyle.checks.imports;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Set;
 
 import org.apache.commons.beanutils.ConversionException;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.ExternalResourceHolder;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -44,7 +47,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *
  * @author Oliver Burn
  */
-public class ImportControlCheck extends AbstractCheck {
+public class ImportControlCheck extends AbstractCheck implements ExternalResourceHolder {
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -68,6 +71,9 @@ public class ImportControlCheck extends AbstractCheck {
      * A part of message for exception.
      */
     private static final String UNABLE_TO_LOAD = "Unable to load ";
+
+    /** Location of import control file. */
+    private String fileLocation;
 
     /** The root package controller. */
     private PkgControl root;
@@ -135,6 +141,11 @@ public class ImportControlCheck extends AbstractCheck {
         }
     }
 
+    @Override
+    public Set<String> getExternalResourceLocations() {
+        return ImmutableSet.of(fileLocation);
+    }
+
     /**
      * Set the name for the file containing the import control
      * configuration. It will cause the file to be loaded.
@@ -149,6 +160,7 @@ public class ImportControlCheck extends AbstractCheck {
 
         try {
             root = ImportControlLoader.load(new File(name).toURI());
+            fileLocation = name;
         }
         catch (final CheckstyleException ex) {
             throw new ConversionException(UNABLE_TO_LOAD + name, ex);
@@ -175,6 +187,7 @@ public class ImportControlCheck extends AbstractCheck {
         }
         try {
             root = ImportControlLoader.load(uri);
+            fileLocation = url;
         }
         catch (final CheckstyleException ex) {
             throw new ConversionException(UNABLE_TO_LOAD + url, ex);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
@@ -24,10 +24,13 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.util.Objects;
+import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.ExternalResourceHolder;
 import com.puppycrawl.tools.checkstyle.api.Filter;
 import com.puppycrawl.tools.checkstyle.api.FilterSet;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -40,9 +43,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Rick Giles
  * @author <a href="mailto:piotr.listkiewicz@gmail.com">liscju</a>
  */
-public class SuppressionFilter
-    extends AutomaticBean
-    implements Filter {
+public class SuppressionFilter extends AutomaticBean implements Filter, ExternalResourceHolder {
+
     /** Filename of supression file. */
     private String file;
     /** Tells whether config file existence is optional. */
@@ -103,6 +105,11 @@ public class SuppressionFilter
                 filters = SuppressionsLoader.loadSuppressions(file);
             }
         }
+    }
+
+    @Override
+    public Set<String> getExternalResourceLocations() {
+        return ImmutableSet.of(file);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -209,7 +209,8 @@ public class PropertyCacheFileTest {
 
         final Class<?>[] param = new Class<?>[1];
         param[0] = Serializable.class;
-        final Method method = PropertyCacheFile.class.getDeclaredMethod("getConfigHashCode", param);
+        final Method method =
+            PropertyCacheFile.class.getDeclaredMethod("getHashCodeBasedOnObjectContent", param);
         method.setAccessible(true);
         try {
             method.invoke(cache, config);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -295,5 +295,4 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
             return CommonUtils.EMPTY_INT_ARRAY;
         }
     }
-
 }

--- a/src/xdocs/writingchecks.xml
+++ b/src/xdocs/writingchecks.xml
@@ -608,7 +608,31 @@ public class LimitImplementationFiles extends AbstractFileSetCheck
 
     </section>
 
-    <section name="Huh? I can&#39;t figure it out!">
+      <section name="Declare check's external resource locations">
+       <p>
+         Checkstyle can cache external configuration resources of any kind which are used by your
+         check. If you want to do such a thing, you should implement
+         <a href="http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/api/ExternalResourceHolder.html">ExternalResourceHolder</a>
+         interface. Such module must declare external resource locations as a set of Strings
+         which will be returned from <a href="http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/api/ExternalResourceHolder.html#getExternalResourceLocations--">getExternalResourceLocations</a>
+         method. This will allow Checkstyle to invalidate (clear) cache when the content of at
+         least one external configuration resource of your check is changed.
+       </p>
+       <p>
+         ATTENTION!
+         <li>
+           If <a href="http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/api/ExternalResourceHolder.html#getExternalResourceLocations--">getExternalResourceLocations</a>
+           return null, there will be NullPointerException in <a href="http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/Checker.html#getExternalResourceLocations--">Checker</a>.
+           Such behaviour will signal that your module (check or filter) is designed incorrectrly.
+         </li>
+         <li>
+           It make sence to return an empty set from <a href="http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/api/ExternalResourceHolder.html#getExternalResourceLocations--">getExternalResourceLocations</a>
+           only for composite modules like <a href="http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/TreeWalker.html">TreeWalker</a>.
+         </li>
+       </p>
+      </section>
+
+      <section name="Huh? I can&#39;t figure it out!">
       <p>
         That&#39;s probably our fault, and it means that we have to provide
         better documentation. Please do not hesitate to ask questions on

--- a/src/xdocs/writingfilters.xml
+++ b/src/xdocs/writingfilters.xml
@@ -99,6 +99,12 @@ public class FilesFilter
       </source>
     </section>
 
+    <section name="Declare check's external resource locations">
+      <p>
+        See <a href="http://checkstyle.sourceforge.net/writingchecks.html#Declare_check's_external_resource_locations">Declare check's external resource locations</a>.
+      </p>
+    </section>
+
     <section name="Using Filters">
       <p>
         To incorporate a <code>Filter</code> in the filter set

--- a/src/xdocs/writingjavadocchecks.xml.vm
+++ b/src/xdocs/writingjavadocchecks.xml.vm
@@ -425,6 +425,12 @@ JAVADOC -> <p> First </p>\r\n<p> Second </p><EOF> [0:0]
       Javadoc Checks as well as regular Checks extend <a href="apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html">AbstractCheck</a> class. So integrating new Javadoc Check is similar to <a href="writingchecks.html#Integrate_your_Check">integrating other Checks</a>.
     </section>
 
+    <section name="Declare check's external resource locations">
+      <p>
+        See <a href="http://checkstyle.sourceforge.net/writingchecks.html#Declare_check's_external_resource_locations">Declare check's external resource locations</a>.
+      </p>
+    </section>
+
     <section name="Examples of Javadoc Checks">
       The best source knowledge about how to write Javadoc Checks
       could be taken from


### PR DESCRIPTION
#407 

**Solution to #407 issue. Part 1.**

Questions that should be discussed:

1) Where should we load external resources by their URIs to calculate SHA-1 cache sum? In PropertyCacheFile?
2) Where and how we should treat exceptions if it is not possible to create URI for resource. See failded tests.
3) What default implementation should we use for method 'getExternalResources'?
Suggestions:

```java
public List<URI> getExternalResources() {
    return Collections.EMPTY_LIST;
}
```

or


```java
public Optional<List<URI>>getExternalResources() {
    return Optional.absence();
}
```

Both first and second implementation require null check in Checker, because we do not know whether user will follow the rule and return non null reference.

4) How can we be sure that user will invoke 'super.getExternalResources' , for example, in HeaderCheck and will give information about the header file (from AbstractHeaderCheck) in Checker? 


