### PR TITLE
Issue #3106: fixed annotation location check with no modifiers

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -225,7 +225,7 @@ public class AnnotationLocationCheck extends AbstractCheck {
      * @return Some javadoc.
      */
     private static boolean hasAnnotations(DetailAST modifierNode) {
-        return modifierNode.findFirstToken(TokenTypes.ANNOTATION) != null;
+        return modifierNode != null && modifierNode.findFirstToken(TokenTypes.ANNOTATION) != null;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
@@ -148,4 +148,14 @@ public class AnnotationLocationCheckTest extends BaseCheckTestSupport {
         verify(checkConfig, getPath("InputAnnotationLocation2.java"), expected);
     }
 
+    @Test
+    public void testAllTokens() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(AnnotationLocationCheck.class);
+        checkConfig.addAttribute("tokens", "CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, "
+                + "CTOR_DEF, VARIABLE_DEF, PARAMETER_DEF, ANNOTATION_DEF, TYPECAST, "
+                + "LITERAL_THROWS, IMPLEMENTS_CLAUSE, TYPE_ARGUMENT, LITERAL_NEW, DOT, "
+                + "ANNOTATION_FIELD_DEF");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputAnnotationLocation3.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/InputAnnotationLocation3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/InputAnnotationLocation3.java
@@ -1,0 +1,20 @@
+package com.puppycrawl.tools.checkstyle.checks.annotation;
+
+public class InputAnnotationLocation3 {
+    public static void main(String[] args) {
+        final Foo foo = new Foo();
+        foo.bar(new Bar<Foo>() {
+            public void foo() {
+            }
+        });
+    }
+
+    static class Foo {
+        void bar(Bar<Foo> bar) {
+        }
+    }
+
+    static abstract class Bar<T> {
+        abstract void foo();
+    }
+}


### PR DESCRIPTION
Issue #3106

Tokens DOT, LITERAL_NEW, TYPE_ARGUMENT were causing a NPE becuase they could have modifiers for annotations but if they don't, we hide the node in the tree making their find return `null`.