### PR TITLE
Issue 3105

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -91,6 +91,7 @@
     <suppress checks="AvoidStaticImport" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="MethodCount" files="[\\/]ImportOrderCheckTest.java$"/>
     <suppress checks="MethodCount" files="[\\/]IndentationCheckTest.java$"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="[\\/]IndentationCheckTest.java$"/>
     <suppress checks="MethodCount" files="[\\/]JavadocMethodCheckTest.java$"/>
     <suppress checks="MethodCount" files="[\\/]MainTest.java$"/>
     <suppress checks="EqualsAvoidNull" files="[\\/]Int.*FilterTest.java$"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputAnonymousClassInMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputAnonymousClassInMethod.java
@@ -18,10 +18,10 @@ import java.io.FileFilter; //indent:0 exp:0
 public class InputAnonymousClassInMethod { //indent:0 exp:0
 	private void walkDir(File dir, FileFilter fileFilter) { //indent:8 exp:2 warn
 		walkDir( dir, new FileFilter() { //indent:16 exp:4 warn
-			@Override //indent:24 exp:8 warn
+			@Override //indent:24 exp:18,20,22 warn
 			public boolean accept(File path) { //indent:24 exp:24
-				return ( path.isDirectory() ); //indent:32 exp:12 warn
-			} //indent:24 exp:8 warn
+				return ( path.isDirectory() ); //indent:32 exp:20,22,24 warn
+			} //indent:24 exp:18,20,22 warn
 		} ); //indent:16 exp:16
 	} //indent:8 exp:2 warn
 } //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidAnonymousClassIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidAnonymousClassIndent.java
@@ -25,7 +25,7 @@ public class InputInvalidAnonymousClassIndent { //indent:0 exp:0
                     return new Thread(); //indent:20 exp:20
                 } else { //indent:16 exp:16
                     return new Thread(); //indent:20 exp:20
-                }}}); //indent:16 exp:17 warn
+                }}}); //indent:16 ioffset:1 exp:12,16 warn
         return; //indent:8 exp:8
     } //indent:4 exp:4
 } //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidClassDefIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidClassDefIndent.java
@@ -134,7 +134,7 @@ final class InputValidClassDefIndent66 extends java.awt.event.MouseAdapter imple
             public void actionPerformed(ActionEvent e) { //indent:12 exp:12
 
             } //indent:12 exp:12
-        }); //indent:8 exp:10,14 warn
+        }); //indent:8 exp:10 warn
 
 
         new JButton().addActionListener(new ActionListener()  //indent:8 exp:8
@@ -142,7 +142,7 @@ final class InputValidClassDefIndent66 extends java.awt.event.MouseAdapter imple
             public void actionPerformed(ActionEvent e) { //indent:12 exp:10 warn
 
             } //indent:12 exp:10 warn
-      }); //indent:6 exp:8,12 warn
+      }); //indent:6 exp:8 warn
 
 
         new JButton().addActionListener(new ActionListener()  //indent:8 exp:8

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidForIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidForIndent.java
@@ -74,7 +74,7 @@ public class InputInvalidForIndent { //indent:0 exp:0
         } //indent:8 exp:8
 
         for (int i=0; i<10; i++) { //indent:8 exp:8
-            System.getProperty("foo"); } //indent:12 exp:8 warn
+            System.getProperty("foo"); } //indent:12 ioffset:27 exp:8 warn
 
         for (int i=0;  //indent:8 exp:8
             i<10; i++ //indent:12 exp:>=12

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidIfIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidIfIndent.java
@@ -90,7 +90,7 @@ public class InputInvalidIfIndent { //indent:0 exp:0
          if (test)  //indent:9 exp:8 warn
          { //indent:9 exp:8 warn
          } else  //indent:9 exp:8 warn
-       { //indent:7 exp:9 warn
+       { //indent:7 exp:8 warn
           } //indent:10 exp:8 warn
 
         // lcurly for if and else on same line -- mixed braces //indent:8 exp:8
@@ -230,7 +230,7 @@ System.getProperty("blah"); //indent:0 exp:12 warn
                 } //indent:16 exp:16
 
         if (test) { //indent:8 exp:8
-            System.getProperty("blah"); } //indent:12 exp:8 warn
+            System.getProperty("blah"); } //indent:12 ioffset:28 exp:8 warn
     } //indent:4 exp:4
 
     public void parenIfTest() { //indent:4 exp:4
@@ -248,7 +248,7 @@ System.getProperty("blah"); //indent:0 exp:12 warn
         } //indent:8 exp:8
 
         if  //indent:8 exp:8
-      ( //indent:6 exp:8,12 warn
+      ( //indent:6 exp:8 warn
             test //indent:12 exp:12
       ) { //indent:6 exp:8 warn
             System.getProperty("blah");  //indent:12 exp:12

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidLabelWithWhileLoopIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidLabelWithWhileLoopIndent.java
@@ -15,8 +15,8 @@ package com.puppycrawl.tools.checkstyle.checks.indentation; //indent:0 exp:0
 public class InputInvalidLabelWithWhileLoopIndent { //indent:0 exp:0
 
     public InputInvalidLabelWithWhileLoopIndent() { //indent:4 exp:4
-         LOOP://indent:9 exp:8 warn
-         while (true) { //indent:9 exp:8 warn
+         LOOP://indent:9 exp:4,8 warn
+         while (true) { //indent:9 exp:8,12 warn
             break LOOP; //indent:12 exp:13 warn
         } //indent:8 exp:8
     } //indent:4 exp:4


### PR DESCRIPTION
Issue #3105

First part of the changes to the test.
We now verify that the input file has the same indentation as the CS violation and has the same expected indentations as the CS violation. **The test still can't fully verify non-CS violation comments.**

Comments now have a new attribute, `ioffset` (short for indent offset). This is used when the CS violation's current indentation is different than the indentation of the first character found in the line. It's default value is 0. [Reasoning why needed.](https://github.com/checkstyle/checkstyle/issues/3105#issuecomment-210875289)
CS reported violation indent = `indent` + `ioffset`.
**Note:** Some places where we use this with a large value may have to be inspected as possible issues.

Other changes include streamlining test code by removing excess regular expressions, new audit listener to grab the violations, and having a single class hold all the data on the comment's attributes. All the original check and balances still remain.