### PR TITLE
Issue 3103

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,20 @@ matrix:
         - CMD=$CMD1$CMD2$CMD3$CMD4$CMD5$CMD6$CMD7$CS_CMD
         - COVERAGE_CMD=""
 
+    # NoErrorTest - Apache Apex (oraclejdk8)
+    - jdk: oraclejdk8
+      env:
+        - DESC="NoErrorTest - Apache Apex"
+        - CMD1="mvn clean install -DskipTests -DskipITs -Dcobertura.skip=true"
+        - CMD2="              -Dpmd.skip=true -Dfindbugs.skip=true "
+        - CMD3="              -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dxml.skip=true"
+        - CMD4=" && CS_POM_VERSION=$(mvn -q -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)"
+        - CMD5=" && echo CS_version:\$CS_POM_VERSION"
+        - CMD6=" && git clone https://github.com/apache/incubator-apex-core/ && cd incubator-apex-core"
+        - CS_CMD=" && mvn compile checkstyle:check -Dcheckstyle.version=\$CS_POM_VERSION"
+        - CMD=$CMD1$CMD2$CMD3$CMD4$CMD5$CMD6$CMD7$CS_CMD
+        - COVERAGE_CMD=""
+
     # NoExceptiontest - Checkstyle, sevntu-checkstyle (oraclejdk8)
     - jdk: oraclejdk8
       env:

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -90,12 +90,10 @@ public class LineWrappingHandler {
         for (DetailAST node : firstNodesOnLines.values()) {
             final int currentType = node.getType();
 
-            if (currentType == TokenTypes.RCURLY
-                    || currentType == TokenTypes.RPAREN
-                    || currentType == TokenTypes.ARRAY_INIT) {
+            if (currentType == TokenTypes.RPAREN) {
                 logWarningMessage(node, firstNodeIndent);
             }
-            else {
+            else if (currentType != TokenTypes.RCURLY && currentType != TokenTypes.ARRAY_INIT) {
                 logWarningMessage(node, currentIndent);
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -26,6 +26,7 @@ import static com.puppycrawl.tools.checkstyle.checks.indentation.IndentationChec
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -203,6 +204,21 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
         indentationCheck.setThrowsIndent(1);
 
         assertEquals(1, indentationCheck.getThrowsIndent());
+    }
+
+    @Test
+    public void testStrictCondition() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+        checkConfig.addAttribute("arrayInitIndent", "4");
+        checkConfig.addAttribute("basicOffset", "4");
+        checkConfig.addAttribute("braceAdjustment", "4");
+        checkConfig.addAttribute("caseIndent", "4");
+        checkConfig.addAttribute("forceStrictCondition", "true");
+        checkConfig.addAttribute("lineWrappingIndentation", "8");
+        checkConfig.addAttribute("tabWidth", "4");
+        checkConfig.addAttribute("throwsIndent", "8");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, getPath("InputStrictCondition.java"), expected);
     }
 
     @Test
@@ -870,11 +886,11 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
             "127: " + getCheckMessage(MSG_ERROR, "member def type", 10, 12),
             "132: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 10, 8),
             "133: " + getCheckMessage(MSG_ERROR_MULTI, "object def lcurly", 8, "10, 14"),
-            "137: " + getCheckMessage(MSG_ERROR, "}", 8, 10),
+            "137: " + getCheckMessage(MSG_ERROR_MULTI, "object def rcurly", 8, "10, 14"),
             "141: " + getCheckMessage(MSG_ERROR_MULTI, "object def lcurly", 6, "8, 12"),
             "142: " + getCheckMessage(MSG_ERROR, "method def modifier", 12, 10),
             "144: " + getCheckMessage(MSG_ERROR, "method def rcurly", 12, 10),
-            "145: " + getCheckMessage(MSG_ERROR, "}", 6, 8),
+            "145: " + getCheckMessage(MSG_ERROR_MULTI, "object def rcurly", 6, "8, 12"),
             "150: " + getCheckMessage(MSG_ERROR, "method def modifier", 10, 12),
             "152: " + getCheckMessage(MSG_ERROR, "method def rcurly", 10, 12),
             "188: " + getCheckMessage(MSG_ERROR, "class", 0, 4),
@@ -1616,6 +1632,12 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
         public void addError(AuditEvent event) {
             final int line = event.getLine();
             final String message = event.getMessage();
+
+            if (position >= comments.length) {
+                fail("found a warning when none was expected for #" + position + " at line " + line
+                        + " with message " + message);
+            }
+
             final IndentComment comment = comments[position];
             position++;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidClassDefIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidClassDefIndent.java
@@ -134,7 +134,7 @@ final class InputValidClassDefIndent66 extends java.awt.event.MouseAdapter imple
             public void actionPerformed(ActionEvent e) { //indent:12 exp:12
 
             } //indent:12 exp:12
-        }); //indent:8 exp:10 warn
+        }); //indent:8 exp:10,14 warn
 
 
         new JButton().addActionListener(new ActionListener()  //indent:8 exp:8
@@ -142,7 +142,7 @@ final class InputValidClassDefIndent66 extends java.awt.event.MouseAdapter imple
             public void actionPerformed(ActionEvent e) { //indent:12 exp:10 warn
 
             } //indent:12 exp:10 warn
-      }); //indent:6 exp:8 warn
+      }); //indent:6 exp:8,12 warn
 
 
         new JButton().addActionListener(new ActionListener()  //indent:8 exp:8

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputStrictCondition.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputStrictCondition.java
@@ -1,0 +1,14 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation; //indent:0 exp:0
+
+import java.lang.Thread; //indent:0 exp:0
+
+public class InputStrictCondition { //indent:0 exp:0
+    void method(Thread foo) { //indent:4 exp:4
+        method( //indent:8 exp:8
+                new Thread() { //indent:16 exp:16
+                        public void run() { //indent:24 exp:24
+                            } //indent:28 exp:28
+                    } //indent:20 exp:20
+        ); //indent:8 exp:8
+        } //indent:8 exp:8
+    } //indent:4 exp:4


### PR DESCRIPTION
Issue #3103

To fix this issue, I decided to remove validation from RCURLY and ARRAY_INIT for wrapped lines.
These curlies are always validated in other handlers, so there isn't a need to duplicate the same work. This can be seen as in the test, and hopefully regression, as we didn't lose any errors, they just changed around.

I changed one minor thing in the IndentAudit to print an error message instead of an index out of bounds exception.