### PR TITLE
Issue #3144: fixed NPE in FinalLocalVariable for lambda in field

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -562,7 +562,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
     }
 
     /**
-     * Find the Class, Constructor, Enum or Method in which it is defined.
+     * Find the Class, Constructor, Enum, Method, or Field in which it is defined.
      * @param ast Variable for which we want to find the scope in which it is defined
      * @return ast The Class or Constructor or Method in which it is defined.
      */
@@ -571,7 +571,9 @@ public class FinalLocalVariableCheck extends AbstractCheck {
         while (astTraverse.getType() != TokenTypes.METHOD_DEF
                 && astTraverse.getType() != TokenTypes.CLASS_DEF
                 && astTraverse.getType() != TokenTypes.ENUM_DEF
-                && astTraverse.getType() != TokenTypes.CTOR_DEF) {
+                && astTraverse.getType() != TokenTypes.CTOR_DEF
+                && (astTraverse.getType() != TokenTypes.VARIABLE_DEF
+                        || !ScopeUtils.isClassFieldDef(astTraverse))) {
             astTraverse = astTraverse.getParent();
         }
         return astTraverse;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -160,7 +160,9 @@ public class FinalLocalVariableCheckTest
         final DefaultConfiguration checkConfig =
             createCheckConfig(FinalLocalVariableCheck.class);
         checkConfig.addAttribute("tokens", "PARAMETER_DEF,VARIABLE_DEF");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "32:16: " + "Variable 'result' should be declared final.",
+        };
         verify(checkConfig, getNonCompilablePath("InputFinalLocalVariableNameLambda.java"),
             expected);
     }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/InputFinalLocalVariableNameLambda.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/InputFinalLocalVariableNameLambda.java
@@ -25,3 +25,12 @@ public class InputFinalLocalVariableNameLambda {
                     (t, u) -> t.add(u.getAmount()));
  }
 }
+interface Operation {
+    public Object apply();
+
+    public static final Operation OPERATION = () -> {
+        Object result;
+        result = null;
+        return result;
+    };
+}


### PR DESCRIPTION
Issue #3144 

Exception is because we are in an interface and `findFirstUpperNamedBlock` wasn't stopping at the interface definition.
Code fix has it now stopping at the field definition. This is because the code was original stopping at methods, and fields are on the same hierarchy, so I thought it was better to stop here.