### PR TITLE
Issue #3157: Javadoc value tag can reference import

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java
@@ -142,6 +142,7 @@ public class JavadocTag {
     public boolean canReferenceImports() {
         return tagInfo == JavadocTagInfo.SEE
                 || tagInfo == JavadocTagInfo.LINK
+                || tagInfo == JavadocTagInfo.VALUE
                 || tagInfo == JavadocTagInfo.LINKPLAIN
                 || tagInfo == JavadocTagInfo.THROWS
                 || tagInfo == JavadocTagInfo.EXCEPTION;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -105,6 +105,13 @@ public class UnusedImportsCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
+    public void testProcessJavadocWithLinkTag() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(UnusedImportsCheck.class);
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputUnusedImportWithValueTag.java"), expected);
+    }
+
+    @Test
     public void testAnnotations() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(UnusedImportsCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/InputUnusedImportWithValueTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/InputUnusedImportWithValueTag.java
@@ -1,0 +1,15 @@
+package com.puppycrawl.tools.checkstyle.checks.imports;
+
+import java.util.Calendar;
+
+public class InputUnusedImportWithValueTag {
+
+    /**
+     * Method determines current month as for {@value Calendar#MONTH}.
+     *
+     * @return index of the current month.
+     */
+    public int currentMonth() {
+        return 1;
+    }
+}


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/3157

Javadoc `{@value}` tag references static constant and makes its value appear in the generated javadoc. Constant can be referenced either by fully qualified name `{@value java.util.Calendar#MONTH}` or by relative name `{@value Calendar#MONTH}` when corresponding import is present
`import java.util.Calendar;`.

This PR fixes an issue with `UnusedImports` check which considered imports used in `{@value}` to be unused.