### PR TITLE
Pull #3162: Update version of commons-collections to 3.2.2(from 3.2.1) to fix security vulnerability CVE-2015-6420

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,20 @@
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
       <version>1.9.2</version>
+      <!--Upgrading to commons-collections 3.2.2 to fix security vulnerability CVE-2015-6420.
+       This change can be reverted when upgrading to commons-beanutils 1.9.3
+       https://issues.apache.org/jira/browse/BEANUTILS-482-->
+      <exclusions>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>


### PR DESCRIPTION
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-6420