### PR TITLE
Issue 3175

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -99,7 +99,7 @@
             <property name="ignoreConstructor" value="true"/>
             <property name="ignoreField" value="true"/>
             <property name="ignoreMethod" value="true"/>
-            <property name="ignorePattern" value="^ *\* *[^ ]+$"/>
+            <property name="ignorePattern" value="^( *\* *[^ ]+)|((package|import) .*)$"/>
         </module>
         <module name="AvoidHidingCauseException"/>
         <module name="MultipleStringLiteralsExtended">

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -11,6 +11,8 @@
               files="JavadocStyleCheck\.java|AbstractTypeAwareCheck\.java|XMLLogger\.java"/>
     <suppress checks="MultipleStringLiteralsExtended"
               files=".*[\\/]src[\\/](test|it)[\\/]"/>
+    <suppress checks="LineLengthExtended"
+              files="ParseTreeBuilder\.java"/>
 
     <!-- Override methods from base class.
     Issue: https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/166-->
@@ -45,4 +47,8 @@
     <suppress checks="CustomDeclarationOrder"
               files="AbstractViolationReporter.java"
               lines="152,164"/>
+
+    <!-- Tone down the checking for test code -->
+    <suppress checks="CauseParameterInException|ForbidCCommentsInMethods|IllegalCatchExtended"
+              files=".*[\\/]src[\\/](test|it)[\\/]"/>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,8 @@
           <maxAllowedViolations>0</maxAllowedViolations>
           <violationSeverity>error</violationSeverity>
           <propertyExpansion>project.basedir=${project.basedir}</propertyExpansion>
-          <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+          <sourceDirectory>${project.basedir}/src</sourceDirectory>
+          <excludes>**/it/resources/**/*,**/test/resources/**/*,**/test/resources-noncompilable/**/*</excludes>
         </configuration>
         <executions>
           <execution>

--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -143,8 +143,8 @@ public class BaseCheckTestSupport {
                 parseInt = parseInt.substring(0, parseInt.indexOf(':'));
                 final int lineNumber = Integer.parseInt(parseInt);
                 assertTrue("input file is expected to have a warning comment on line number "
-                        + lineNumber, theWarnings.remove((Integer) lineNumber)
-                            || previousLineNumber == lineNumber);
+                        + lineNumber, previousLineNumber == lineNumber
+                            || theWarnings.remove((Integer) lineNumber));
                 previousLineNumber = lineNumber;
             }
 

--- a/src/it/java/com/google/checkstyle/test/base/BaseIndentationCheckSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseIndentationCheckSupport.java
@@ -59,10 +59,6 @@ public class BaseIndentationCheckSupport extends BaseCheckTestSupport {
         return getLinesWithWarnAndCheckComments(fileName, TAB_WIDTH);
     }
 
-    private enum CommentType {
-        MULTILEVEL, SINGLE_LEVEL, NON_STRICT_LEVEL, UNKNOWN
-    }
-
     private static Integer[] getLinesWithWarnAndCheckComments(String aFileName,
             final int tabWidth)
                     throws IOException {
@@ -212,5 +208,9 @@ public class BaseIndentationCheckSupport extends BaseCheckTestSupport {
             }
         }
         return 0;
+    }
+
+    private enum CommentType {
+        MULTILEVEL, SINGLE_LEVEL, NON_STRICT_LEVEL, UNKNOWN
     }
 }

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineTest.java
@@ -80,7 +80,7 @@ public class OneStatementPerLineTest extends BaseCheckTestSupport {
             "multiple.statements.line");
 
         final String[] expected = {
-            "32:6: "  + msg,
+            "32:6: " + msg,
             "37:58: " + msg,
             "38:58: " + msg,
             "38:74: " + msg,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -132,7 +132,7 @@ public class BaseCheckTestSupport {
                           String... expected)
             throws Exception {
         verify(checker,
-                new File[]{new File(processedFilename)},
+                new File[] {new File(processedFilename)},
                 messageFileName, expected);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -631,7 +631,7 @@ public class MainTest {
                                 + "Checkstyle ends with 1 errors.%n");
                 assertEquals(expectedExceptionMessage, systemOut.getLog());
 
-                final String exceptionFirstLine =  String.format(Locale.ROOT,
+                final String exceptionFirstLine = String.format(Locale.ROOT,
                         "com.puppycrawl.tools.checkstyle.api."
                         + "CheckstyleException: Exception was thrown while processing "
                         + new File(getNonCompilablePath("InputIncorrectClass.java")).getPath()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -253,7 +253,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
 
         @Override
         public int[] getAcceptableTokens() {
-            return new int[]{TokenTypes.SINGLE_LINE_COMMENT};
+            return new int[] {TokenTypes.SINGLE_LINE_COMMENT};
         }
 
         @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
@@ -57,17 +57,17 @@ public class AbstractCheckTest {
         final AbstractCheck check = new AbstractCheck() {
             @Override
             public int[] getDefaultTokens() {
-                return  CommonUtils.EMPTY_INT_ARRAY;
+                return CommonUtils.EMPTY_INT_ARRAY;
             }
 
             @Override
             public int[] getAcceptableTokens() {
-                return  CommonUtils.EMPTY_INT_ARRAY;
+                return CommonUtils.EMPTY_INT_ARRAY;
             }
 
             @Override
             public int[] getRequiredTokens() {
-                return  CommonUtils.EMPTY_INT_ARRAY;
+                return CommonUtils.EMPTY_INT_ARRAY;
             }
         };
         // Eventually it will become clear abstract method

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/CheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/CheckTest.java
@@ -22,6 +22,8 @@ package com.puppycrawl.tools.checkstyle.api;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
 public class CheckTest {
     @SuppressWarnings("deprecation")
     @Test
@@ -29,7 +31,7 @@ public class CheckTest {
         final Object module = new Check() {
             @Override
             public int[] getDefaultTokens() {
-                return null;
+                return CommonUtils.EMPTY_INT_ARRAY;
             }
         };
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -189,7 +189,7 @@ public class NewlineAtEndOfFileCheckTest
                 .getDeclaredMethod("endsWithNewline", RandomAccessFile.class);
         method.setAccessible(true);
         final RandomAccessFile file = mock(RandomAccessFile.class);
-        when(file.length()).thenReturn(2000000L);
+        when(file.length()).thenReturn(2_000_000L);
         try {
             method.invoke(new NewlineAtEndOfFileCheck(), file);
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckTest.java
@@ -43,7 +43,7 @@ public class MissingDeprecatedCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testGetRequiredTokens() {
-        final MissingDeprecatedCheck checkObj = new  MissingDeprecatedCheck();
+        final MissingDeprecatedCheck checkObj = new MissingDeprecatedCheck();
         final int[] expected = {
             TokenTypes.INTERFACE_DEF,
             TokenTypes.CLASS_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckTest.java
@@ -53,7 +53,7 @@ public class OneTopLevelClassCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testAcceptableTokens() {
-        final OneTopLevelClassCheck check =  new OneTopLevelClassCheck();
+        final OneTopLevelClassCheck check = new OneTopLevelClassCheck();
         check.getAcceptableTokens();
         // ZERO tokens as Check do Traverse of Tree himself, he does not need to subscribed to
         // Tokens

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
@@ -40,7 +40,7 @@ public class IllegalImportCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testGetRequiredTokens() {
-        final IllegalImportCheck checkObj = new  IllegalImportCheck();
+        final IllegalImportCheck checkObj = new IllegalImportCheck();
         final int[] expected = {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
         assertArrayEquals(expected, checkObj.getRequiredTokens());
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -321,7 +321,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
         final String[] expected = {
             "19: " + getCheckMessage(MSG_ERROR, ")", 16, 0),
-            "22: " + getCheckMessage(MSG_ERROR, ")",  8, 4),
+            "22: " + getCheckMessage(MSG_ERROR, ")", 8, 4),
         };
 
         verifyWarns(checkConfig,
@@ -1583,7 +1583,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
             "20: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 16, 4),
             "21: " + getCheckMessage(MSG_ERROR_MULTI, "method def modifier", 24, "18, 20, 22"),
             "23: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "method def", 32, "20, 22, 24"),
-            "24: " + getCheckMessage(MSG_ERROR_MULTI, "method def rcurly",  24, "18, 20, 22"),
+            "24: " + getCheckMessage(MSG_ERROR_MULTI, "method def rcurly", 24, "18, 20, 22"),
             "26: " + getCheckMessage(MSG_ERROR, "method def rcurly", 8, 2),
         };
         verifyWarns(checkConfig, getPath("InputAnonymousClassInMethod.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -198,7 +198,7 @@ public class AbstractJavadocCheckTest extends BaseCheckTestSupport {
 
         @Override
         public int[] getDefaultJavadocTokens() {
-            return new int[]{JavadocTokenTypes.JAVADOC};
+            return new int[] {JavadocTokenTypes.JAVADOC};
         }
 
         @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -71,7 +71,7 @@ public class NPathComplexityCheckTest extends BaseCheckTestSupport {
 
         checkConfig.addAttribute("max", "0");
 
-        final long largerThanMaxInt = 3486784401L;
+        final long largerThanMaxInt = 3_486_784_401L;
 
         final String[] expected = {
             "9:5: " + getCheckMessage(MSG_KEY, largerThanMaxInt, 0),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
@@ -130,7 +130,7 @@ public class RedundantModifierCheckTest
                 createCheckConfig(RedundantModifierCheck.class);
 
         final String[] expected = {
-            "18:5: "  + getCheckMessage(MSG_KEY, "public"),
+            "18:5: " + getCheckMessage(MSG_KEY, "public"),
         };
         verify(checkConfig, getPath("InputRedundantPublicModifierInNotPublicClass.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
@@ -50,7 +50,7 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("ignoreOverriddenMethods", "true");
 
         final String[] expected = {
-            "9: "  + getWarningMessage("FactoryWithBADNAme", expectedCapitalCount),
+            "9: " + getWarningMessage("FactoryWithBADNAme", expectedCapitalCount),
             "12: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
             "32: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
             "37: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
@@ -62,7 +62,7 @@ public class LineLengthCheckTest extends BaseCheckTestSupport {
         final DefaultConfiguration checkConfig =
             createCheckConfig(LineLengthCheck.class);
         checkConfig.addAttribute("max", "80");
-        checkConfig.addAttribute("ignorePattern",  "^.*is OK.*regexp.*$");
+        checkConfig.addAttribute("ignorePattern", "^.*is OK.*regexp.*$");
         final String[] expected = {
             "18: " + getCheckMessage(MSG_KEY, 80, 81),
             "145: " + getCheckMessage(MSG_KEY, 80, 83),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDocletTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDocletTest.java
@@ -92,8 +92,8 @@ public class TokenTypesDocletTest {
         // a lot of different places, must not be changed and an int value is used to encrypt
         // a token type.
         final ListBuffer<String[]> options = new ListBuffer<>();
-        options.add(new String[]{"-doclet", "TokenTypesDoclet"});
-        options.add(new String[]{"-destfile", "target/tokentypes.properties"});
+        options.add(new String[] {"-doclet", "TokenTypesDoclet"});
+        options.add(new String[] {"-destfile", "target/tokentypes.properties"});
 
         final ListBuffer<String> names = new ListBuffer<>();
         names.add(getPath("InputTokenTypesDocletNotConstants.java"));
@@ -109,7 +109,7 @@ public class TokenTypesDocletTest {
     @Test
     public void testEmptyJavadoc() throws Exception {
         final ListBuffer<String[]> options = new ListBuffer<>();
-        options.add(new String[]{"-destfile", "target/tokentypes.properties"});
+        options.add(new String[] {"-destfile", "target/tokentypes.properties"});
 
         final ListBuffer<String> names = new ListBuffer<>();
         names.add(getPath("InputTokenTypesDocletEmptyJavadoc.java"));
@@ -133,7 +133,7 @@ public class TokenTypesDocletTest {
     @Test
     public void testCorrect() throws Exception {
         final ListBuffer<String[]> options = new ListBuffer<>();
-        options.add(new String[]{"-destfile", "target/tokentypes.properties"});
+        options.add(new String[] {"-destfile", "target/tokentypes.properties"});
 
         final ListBuffer<String> names = new ListBuffer<>();
         names.add(getPath("InputTokenTypesDocletCorrect.java"));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
@@ -47,7 +47,7 @@ public class CommentsTest extends BaseCheckTestSupport {
 
     @Test
     public void testToString() {
-        final Comment comment = new Comment(new String[]{"value"}, 1, 2, 3);
+        final Comment comment = new Comment(new String[] {"value"}, 1, 2, 3);
         Assert.assertEquals("Comment[2:1-2:3]", comment.toString());
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParseTreeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParseTreeTest.java
@@ -38,8 +38,8 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class JavadocParseTreeTest {
-    private JavadocParser parser;
     private final BaseErrorListener errorListener = new FailOnErrorListener();
+    private JavadocParser parser;
 
     private ParseTree parseJavadoc(String aBlockComment)
             throws IOException {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/ParseTreeBuilder.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/ParseTreeBuilder.java
@@ -58,7 +58,7 @@ import com.puppycrawl.tools.checkstyle.grammars.javadoc.JavadocParser.TrTagOpenC
  * It is located in 'contribution' repository:
  * <a href="https://github.com/checkstyle/contribution/blob/master/javadoc-expected-tree-generator/ExpectedParseTreeGenerator.java">Link</a>
  */
-@Generated("ExpectedParseTreeGenerator")
+@Generated(value="ExpectedParseTreeGenerator")
 //@formatter:off
 final class ParseTreeBuilder {
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CheckUtil.java
@@ -278,7 +278,7 @@ public final class CheckUtil {
     }
 
     public static String getTokenText(int[] tokens, int... subtractions) {
-        if (Arrays.equals(tokens, TokenUtils.getAllTokenIds()) && subtractions.length == 0) {
+        if (subtractions.length == 0 && Arrays.equals(tokens, TokenUtils.getAllTokenIds())) {
             return "TokenTypes.";
         }
         else {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
@@ -92,10 +92,6 @@ public class CommitValidationTest {
 
     private static final int PREVIOUS_COMMITS_TO_CHECK_COUNT = 10;
 
-    private enum CommitsResolutionMode {
-        BY_COUNTER, BY_LAST_COMMIT_AUTHOR
-    }
-
     private static final CommitsResolutionMode COMMITS_RESOLUTION_MODE =
             CommitsResolutionMode.BY_LAST_COMMIT_AUTHOR;
 
@@ -220,8 +216,8 @@ public class CommitValidationTest {
             commits.add(lastCommit);
 
             boolean wasLastCheckedCommitAuthorSameAsLastCommit = true;
-            while (previousCommitsIterator.hasNext()
-                    && wasLastCheckedCommitAuthorSameAsLastCommit) {
+            while (wasLastCheckedCommitAuthorSameAsLastCommit
+                    && previousCommitsIterator.hasNext()) {
                 final RevCommit currentCommit = previousCommitsIterator.next();
                 final String currentCommitAuthor = currentCommit.getAuthorIdent().getName();
                 if (currentCommitAuthor.equals(lastCommitAuthor)) {
@@ -249,6 +245,10 @@ public class CommitValidationTest {
             String commitMessage) {
         return "Commit " + commitId + " message: \"" + commitMessage + "\" is invalid\n"
                 + getRulesForCommitMessageFormatting();
+    }
+
+    private enum CommitsResolutionMode {
+        BY_COUNTER, BY_LAST_COMMIT_AUTHOR
     }
 
     private static class RevCommitsPair {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
@@ -159,12 +159,9 @@ public class XDocsPagesTest {
                         .replace("...", "").trim();
 
                 if (unserializedSource.charAt(0) != '<'
-                        || unserializedSource.charAt(unserializedSource.length() - 1) != '>') {
-                    continue;
-                }
-
-                // no dtd testing yet
-                if (unserializedSource.contains("<!")) {
+                        || unserializedSource.charAt(unserializedSource.length() - 1) != '>'
+                        // no dtd testing yet
+                        || unserializedSource.contains("<!")) {
                     continue;
                 }
 


### PR DESCRIPTION
Issue #3175 

expanded sevntu testing to all folders.

LineLengthExtended needed same ignore to package/import that we added to LineLength.
I was unsure about CauseParameterInException, ForbidCCommentsInMethods, IllegalCatchExtended violations so I just suppressed them for now.
Underscores added to numbers were placed in positions were commas would be separating thousands, etc.