### PR TITLE
Issue #3173: moved SingleSpaceSeparatorCheck from sevntu to checkstyle

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -448,6 +448,9 @@
       <property name="tokens" value="COMMA"/>
       <property name="option" value="EOL"/>
     </module>
+    <module name="SingleSpaceSeparator">
+      <property name="validateComments" value="false"/>
+    </module>
     <module name="TypecastParenPad"/>
     <module name="WhitespaceAfter"/>
     <module name="WhitespaceAround"/>

--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -61,9 +61,6 @@
             <property name="targetConstantTypes" value="LITERAL_NULL,LITERAL_TRUE,LITERAL_FALSE,NUM_INT,NUM_DOUBLE,NUM_LONG,NUM_FLOAT"/>
         </module>
         <module name="EitherLogOrThrowCheck"/>
-        <module name="SingleSpaceSeparator">
-            <metadata name="validateCommentNodes" value="false"/>
-        </module>
         <module name="IllegalCatchExtended">
             <property name="allowRethrow" value="true"/>
         </module>

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -23,6 +23,9 @@
     <suppress checks="SimpleAccessorNameNotation"
               files="ClassFanOutComplexityCheck\.java"
               lines="76"/>
+    <suppress checks="SimpleAccessorNameNotation"
+              files="SingleSpaceSeparatorCheck\.java"
+              lines="110"/>
 
     <!-- These classes are deprecated and will be removed soon. -->
     <suppress checks="ForbidWildcardAsReturnType"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
@@ -1,0 +1,244 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+/**
+ * <p>
+ * Checks that non-whitespace characters are separated by no more than one
+ * whitespace. Separating characters by tabs or multiple spaces will be
+ * reported. Currently the check doesn't permit horizontal alignment. To inspect
+ * whitespaces before and after comments, set the property
+ * {@link #validateComments} to true.
+ * </p>
+ *
+ * <p>
+ * Setting {@link #validateComments} to false will ignore cases like:
+ * </p>
+ *
+ * <pre>
+ * int i;  &#47;&#47; Multiple whitespaces before comment tokens will be ignored.
+ * private void foo(int  &#47;* whitespaces before and after block-comments will be
+ * ignored *&#47;  i) {
+ * </pre>
+ *
+ * <p>
+ * Sometimes, users like to space similar items on different lines to the same
+ * column position for easier reading. This feature isn't supported by this
+ * check, so both braces in the following case will be reported as violations.
+ * </p>
+ *
+ * <pre>
+ * public long toNanos(long d)  { return d;             }  &#47;&#47; 2 violations
+ * public long toMicros(long d) { return d / (C1 / C0); }
+ * </pre>
+ *
+ * <p>
+ * Check have following options:
+ * </p>
+ *
+ * <ul>
+ * <li>validateComments - Boolean when set to {@code true}, whitespaces
+ * surrounding comments will be ignored. Default value is {@code false}.</li>
+ * </ul>
+ *
+ * <p>
+ * To configure the check:
+ * </p>
+ *
+ * <pre>
+ * &lt;module name=&quot;SingleSpaceSeparator&quot;/&gt;
+ * </pre>
+ *
+ * <p>
+ * To configure the check so that it validates comments:
+ * </p>
+ *
+ * <pre>
+ * &lt;module name=&quot;SingleSpaceSeparator&quot;&gt;
+ * &lt;property name=&quot;validateComments&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ *
+ * @author Robert Whitebit
+ * @author Richard Veach
+ */
+public class SingleSpaceSeparatorCheck extends AbstractCheck {
+    /**
+     * A key is pointing to the warning message text in "messages.properties"
+     * file.
+     */
+    public static final String MSG_KEY = "single.space.separator";
+
+    /** Indicates if whitespaces surrounding comments will be ignored. */
+    private boolean validateComments;
+
+    /**
+     * Sets whether or not to validate surrounding whitespaces at comments.
+     *
+     * @param validateComments {@code true} to validate surrounding whitespaces at comments.
+     */
+    public void setValidateComments(boolean validateComments) {
+        this.validateComments = validateComments;
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return CommonUtils.EMPTY_INT_ARRAY;
+    }
+
+    @Override
+    public boolean isCommentNodesRequired() {
+        return validateComments;
+    }
+
+    @Override
+    public void beginTree(DetailAST rootAST) {
+        visitEachToken(rootAST);
+    }
+
+    /**
+     * Examines every sibling and child of {@code node} for violations.
+     *
+     * @param node The node to start examining.
+     */
+    private void visitEachToken(DetailAST node) {
+        DetailAST sibling = node;
+
+        while (sibling != null) {
+            final int columnNo = sibling.getColumnNo() - 1;
+
+            if (columnNo >= 0
+                    && !isTextSeparatedCorrectlyFromPrevious(getLine(sibling.getLineNo() - 1),
+                            columnNo)) {
+                log(sibling.getLineNo(), columnNo, MSG_KEY);
+            }
+            if (sibling.getChildCount() > 0) {
+                visitEachToken(sibling.getFirstChild());
+            }
+
+            sibling = sibling.getNextSibling();
+        }
+    }
+
+    /**
+     * Checks if characters in {@code line} at and around {@code columnNo} has
+     * the correct number of spaces. to return {@code true} the following
+     * conditions must be met:<br />
+     * - the character at {@code columnNo} is the first in the line.<br />
+     * - the character at {@code columnNo} is not separated by whitespaces from
+     * the previous non-whitespace character. <br />
+     * - the character at {@code columnNo} is separated by only one whitespace
+     * from the previous non-whitespace character.<br />
+     * - {@link #validateComments} is disabled and the previous text is the
+     * end of a block comment.
+     *
+     * @param line The line in the file to examine.
+     * @param columnNo The column position in the {@code line} to examine.
+     * @return {@code true} if the text at {@code columnNo} is separated
+     *         correctly from the previous token.
+     */
+    private boolean isTextSeparatedCorrectlyFromPrevious(String line, int columnNo) {
+        return isSingleSpace(line, columnNo)
+                || !isWhitespace(line, columnNo)
+                || isFirstInLine(line, columnNo)
+                || !validateComments && isBlockCommentEnd(line, columnNo);
+    }
+
+    /**
+     * Checks if the {@code line} at {@code columnNo} is a single space, and not
+     * preceded by another space.
+     *
+     * @param line The line in the file to examine.
+     * @param columnNo The column position in the {@code line} to examine.
+     * @return {@code true} if the character at {@code columnNo} is a space, and
+     *         not preceded by another space.
+     */
+    private static boolean isSingleSpace(String line, int columnNo) {
+        return !isPrecededByMultipleWhitespaces(line, columnNo)
+                && isSpace(line, columnNo);
+    }
+
+    /**
+     * Checks if the {@code line} at {@code columnNo} is a space.
+     *
+     * @param line The line in the file to examine.
+     * @param columnNo The column position in the {@code line} to examine.
+     * @return {@code true} if the character at {@code columnNo} is a space.
+     */
+    private static boolean isSpace(String line, int columnNo) {
+        return line.charAt(columnNo) == ' ';
+    }
+
+    /**
+     * Checks if the {@code line} at {@code columnNo} is preceded by at least 2
+     * whitespaces.
+     *
+     * @param line The line in the file to examine.
+     * @param columnNo The column position in the {@code line} to examine.
+     * @return {@code true} if there are at least 2 whitespace characters before
+     *         {@code columnNo}.
+     */
+    private static boolean isPrecededByMultipleWhitespaces(String line, int columnNo) {
+        return columnNo >= 1
+                && Character.isWhitespace(line.charAt(columnNo))
+                && Character.isWhitespace(line.charAt(columnNo - 1));
+    }
+
+    /**
+     * Checks if the {@code line} at {@code columnNo} is a whitespace character.
+     *
+     * @param line The line in the file to examine.
+     * @param columnNo The column position in the {@code line} to examine.
+     * @return {@code true} if the character at {@code columnNo} is a
+     *         whitespace.
+     */
+    private static boolean isWhitespace(String line, int columnNo) {
+        return Character.isWhitespace(line.charAt(columnNo));
+    }
+
+    /**
+     * Checks if the {@code line} up to and including {@code columnNo} is all
+     * non-whitespace text encountered.
+     *
+     * @param line The line in the file to examine.
+     * @param columnNo The column position in the {@code line} to examine.
+     * @return {@code true} if the column position is the first non-whitespace
+     *         text on the {@code line}.
+     */
+    private static boolean isFirstInLine(String line, int columnNo) {
+        return line.substring(0, columnNo + 1).trim().isEmpty();
+    }
+
+    /**
+     * Checks if the {@code line} at {@code columnNo} is the end of a comment,
+     * '*&#47;'.
+     *
+     * @param line The line in the file to examine.
+     * @param columnNo The column position in the {@code line} to examine.
+     * @return {@code true} if the previous text is a end comment block.
+     */
+    private static boolean isBlockCommentEnd(String line, int columnNo) {
+        return line.substring(0, columnNo).trim().endsWith("*/");
+    }
+}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages.properties
@@ -17,3 +17,5 @@ ws.notPreceded=''{0}'' is not preceded with whitespace.
 ws.preceded=''{0}'' is preceded with whitespace.
 ws.illegalFollow=''{0}'' is followed by an illegal character.
 ws.typeCast=''typecast'' is not followed by whitespace.
+
+single.space.separator=Use a single space to separate non-whitespace characters.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_de.properties
@@ -18,3 +18,5 @@ ws.illegalFollow=Nach ''{0}'' folgt ein ungültiges Zeichen.
 ws.typeCast=Nach ''typumwandlung'' folgt kein Leerzeichen.
 
 empty.line.separator.multiple.lines = ''{0}'' verfügt über mehr als 1 Leerzeilen vor.
+
+single.space.separator=Verwenden Sie ein einfaches Leerzeichen um Zeichen zu trennen.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_es.properties
@@ -16,3 +16,5 @@ empty.line.separator.multiple.lines.inside=Hay más de 1 una línea vacía despu
 file.containsTab = Archivo contiene caracteres de tabulación (este es el primer ejemplo).
 no.line.wrap = {0} declaración no debe ser la línea envuelto.
 ws.illegalFollow = ''{0}'' es seguido por un carácter ilegal.
+
+single.space.separator=Utilice un espacio para separar caracteres no est� en blanco.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_fi.properties
@@ -16,3 +16,5 @@ empty.line.separator.multiple.lines.after=''{0}'' on yli 1 tyhjää riviä jälk
 empty.line.separator.multiple.lines.inside=On enemmän kuin 1 tyhjä rivi yksi toisensa jälkeen.
 file.containsTab = Tiedosto sisältää sarkainmerkeillä (tämä on ensisijaisesti).
 no.line.wrap = {0} lausunto ei pitäisi olla linja-kääritty.
+
+single.space.separator=Käytä yksi välilyönti erottaa ei- välilyönnit.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_fr.properties
@@ -16,3 +16,5 @@ empty.line.separator.multiple.lines.after=''{0}'' compte plus de 1 lignes vides 
 empty.line.separator.multiple.lines.inside=Il y a plus de 1 ligne vide un après l'autre.
 file.containsTab = Fichier contient des caractères de tabulation (ce qui est le premier exemple).
 no.line.wrap = {0} déclaration ne devrait pas être sur des lignes enveloppé.
+
+single.space.separator=Utilisez un seul espace pour séparer les caractères non - blancs.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_ja.properties
@@ -16,3 +16,5 @@ empty.line.separator.multiple.lines.after=''{0}'' 後の1以上の空行を持�
 empty.line.separator.multiple.lines.inside=別の後に1以上の空行の1があります。
 file.containsTab = ファイルが（これが最初のインスタンスである）タブ文字が含まれています。
 no.line.wrap = {0} 文は、行ラップされてはなりません。
+
+single.space.separator=非空白文字を分離するために、単一のスペースを使用します。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_pt.properties
@@ -16,3 +16,5 @@ empty.line.separator.multiple.lines.after=''{0}'' tem mais de 1 linhas vazias de
 empty.line.separator.multiple.lines.inside=Há mais de um vazio linha um após o outro.
 file.containsTab = Arquivo contém caracteres de tabulação (esta é a primeira instância).
 no.line.wrap = {0} afirmação não deve ser linha-embrulhado.
+
+single.space.separator=Use um único espaço para separar caracteres não- espaço em branco.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_tr.properties
@@ -19,3 +19,5 @@ empty.line.separator.multiple.lines = {0} daha önce en fazla 1 boş hatları va
 empty.line.separator.multiple.lines.after=''{0}'' sonra 1'den fazla boş hatları vardır.
 empty.line.separator.multiple.lines.inside=birbiri ardına 1'den fazla boş satır biri var.
 no.line.wrap = {0} ifadesi hattı sarılı olmamalıdır.
+
+single.space.separator=boşluk olmayan karakterleri ayırmak için tek bir boşluk kullanın.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages_zh.properties
@@ -17,3 +17,5 @@ ws.notPreceded=''{0}'' 前应有空格。
 ws.preceded=''{0}'' 前不应有空格。
 ws.illegalFollow=''{0}'' 后字符不合法。
 ws.typeCast=类型转换后应有空格。
+
+single.space.separator=用一个空格分隔非空白字符。

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheckTest.java
@@ -1,0 +1,114 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace;
+
+import static com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck.MSG_KEY;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+public class SingleSpaceSeparatorCheckTest extends BaseCheckTestSupport {
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("checks" + File.separator
+                + "whitespace" + File.separator + filename);
+    }
+
+    @Test
+    public void testNoSpaceErrors() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(SingleSpaceSeparatorCheck.class);
+        verify(checkConfig, getPath("InputSingleSpaceNoErrors.java"),
+                CommonUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testSpaceErrors() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(SingleSpaceSeparatorCheck.class);
+        checkConfig.addAttribute("validateComments", String.valueOf(true));
+        final String[] expected = {
+            "1:9: " + getCheckMessage(MSG_KEY),
+            "1:27: " + getCheckMessage(MSG_KEY),
+            "4:8: " + getCheckMessage(MSG_KEY),
+            "6:18: " + getCheckMessage(MSG_KEY),
+            "6:42: " + getCheckMessage(MSG_KEY),
+            "7:20: " + getCheckMessage(MSG_KEY),
+            "8:11: " + getCheckMessage(MSG_KEY),
+            "8:15: " + getCheckMessage(MSG_KEY),
+            "11:3: " + getCheckMessage(MSG_KEY),
+            "12:5: " + getCheckMessage(MSG_KEY),
+            "13:7: " + getCheckMessage(MSG_KEY),
+            "14:8: " + getCheckMessage(MSG_KEY),
+            "17:13: " + getCheckMessage(MSG_KEY),
+            "17:23: " + getCheckMessage(MSG_KEY),
+            "17:32: " + getCheckMessage(MSG_KEY),
+            "18:15: " + getCheckMessage(MSG_KEY),
+            "18:22: " + getCheckMessage(MSG_KEY),
+            "19:16: " + getCheckMessage(MSG_KEY),
+            "19:23: " + getCheckMessage(MSG_KEY),
+            "20:19: " + getCheckMessage(MSG_KEY),
+            "21:21: " + getCheckMessage(MSG_KEY),
+            "26:21: " + getCheckMessage(MSG_KEY),
+            "26:27: " + getCheckMessage(MSG_KEY),
+            "27:14: " + getCheckMessage(MSG_KEY),
+            "27:23: " + getCheckMessage(MSG_KEY),
+            "27:31: " + getCheckMessage(MSG_KEY),
+            "27:46: " + getCheckMessage(MSG_KEY),
+            "28:14: " + getCheckMessage(MSG_KEY),
+            "28:22: " + getCheckMessage(MSG_KEY),
+            "30:16: " + getCheckMessage(MSG_KEY),
+            "30:33: " + getCheckMessage(MSG_KEY),
+            "31:7: " + getCheckMessage(MSG_KEY),
+        };
+
+        verify(checkConfig, getPath("InputSingleSpaceErrors.java"), expected);
+    }
+
+    @Test
+    public void testSpaceErrorsAroundComments() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(SingleSpaceSeparatorCheck.class);
+        checkConfig.addAttribute("validateComments", String.valueOf(true));
+        final String[] expected = {
+            "5:10: " + getCheckMessage(MSG_KEY),
+            "5:42: " + getCheckMessage(MSG_KEY),
+            "6:13: " + getCheckMessage(MSG_KEY),
+            "13:13: " + getCheckMessage(MSG_KEY),
+            "13:20: " + getCheckMessage(MSG_KEY),
+            "14:7: " + getCheckMessage(MSG_KEY),
+        };
+
+        verify(checkConfig, getPath("InputSingleSpaceComments.java"), expected);
+    }
+
+    @Test
+    public void testSpaceErrorsIfCommentsIgnored() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(SingleSpaceSeparatorCheck.class);
+        final String[] expected = {
+            "13:13: " + getCheckMessage(MSG_KEY),
+        };
+
+        verify(checkConfig, getPath("InputSingleSpaceComments.java"), expected);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputSingleSpaceComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputSingleSpaceComments.java
@@ -1,0 +1,15 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace;
+
+public class InputSingleSpaceComments {
+    /* always correct */ int i = 0;
+    int   /* wrong if X is enabled */     j = 0;
+    int k;   // Multiple whitespaces before comment
+
+    /**
+     * Always correct
+     */
+    void foo() {
+        /* Always correct */
+        int  a = 0;	// <- a tab
+    }  // Wrong if X is enabled
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputSingleSpaceErrors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputSingleSpaceErrors.java
@@ -1,0 +1,31 @@
+package  com.puppycrawl.   tools.checkstyle.checks.whitespace;
+
+import java.util.List;
+import  java.util.Vector;
+
+public class      InputSingleSpaceErrors  {
+    int             number; //violation
+int i =    99  ;
+{
+i=1;
+i  =2;
+ i=  3;
+  i =  4;
+    i =	5; // A tab between = and 5.
+}
+
+    private  void foo  (int     i) {
+        if (i  > 10)  {
+            if  (bar(  )) {
+                i  ++;
+                foo  (i);
+            }
+        }
+    }
+
+    private boolean  bar(  ) {
+        List  <Double  > list  = new Vector<  >();
+        int a	= 0;  // Multiple whitespaces before comment
+		int b = 1; // Multiple tabs as indentation are ok.
+        return  Math.random() <  0.5;
+    }  }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputSingleSpaceNoErrors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputSingleSpaceNoErrors.java
@@ -1,0 +1,24 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InputSingleSpaceNoErrors {
+
+    int count; //long indentation - OK
+    String text = "             "; // OK
+
+    private void foo(int i) {
+        if (i > 10) {
+            if (bar()) {
+                i++;
+                foo(i);
+            }
+        }
+    }
+
+    private boolean bar() {
+        List<Double> list = new ArrayList<>();
+        return Math.random() < 0.5;
+    }
+}

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -674,6 +674,11 @@
          Checks that a JavaDoc block which can fit on a single line and doesn't contain at-clauses</td>
       </tr>
       <tr>
+        <td><a href="config_whitespace.html#SingleSpaceSeparator">SingleSpaceSeparator</a></td>
+        <td>
+         Checks that non-whitespace characters are separated by no more than one whitespace.</td>
+      </tr>
+      <tr>
         <td><a href="config_coding.html#SimplifyBooleanExpression">SimplifyBooleanExpression</a></td>
         <td>
         Checks for overly complicated boolean expressions.</td>

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1659,6 +1659,110 @@ foo(i,
       </subsection>
     </section>
 
+    <section name="SingleSpaceSeparator">
+      <subsection name="Description">
+        <p>
+          Checks that non-whitespace characters are separated by no more than one
+          whitespace. Separating characters by tabs or multiple spaces will be
+          reported. Currently the check doesn't permit horizontal alignment. To inspect
+          whitespaces before and after comments, set the property
+          validateComments to true.
+        </p>
+
+        <p>
+          Setting validateComments to false will ignore cases like:
+        </p>
+
+        <source>
+int i;  // Multiple whitespaces before comment tokens will be ignored.
+private void foo(int  /* whitespaces before and after block-comments will be
+ignored */  i) {
+        </source>
+
+        <p>
+          Sometimes, users like to space similar items on different lines to the same
+          column position for easier reading. This feature isn't supported by this
+          check, so both braces in the following case will be reported as violations.
+        </p>
+
+        <source>
+public long toNanos(long d)  { return d;             } // 2 violations
+public long toMicros(long d) { return d / (C1 / C0); }
+        </source>
+      </subsection>
+
+      <subsection name="Properties">
+        <table>
+          <tr>
+            <th>name</th>
+            <th>description</th>
+            <th>type</th>
+            <th>default value</th>
+          </tr>
+          <tr>
+            <td>validateComments</td>
+            <td>If set to true, whitespaces surrounding comments will be ignored.</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>false</code></td>
+          </tr>
+        </table>
+      </subsection>
+
+      <subsection name="Examples">
+        <p>
+          To configure the check:
+        </p>
+
+        <source>
+&lt;module name=&quot;SingleSpaceSeparator&quot;/&gt;
+        </source>
+
+        <p>
+          To configure the check so that it validates comments:
+        </p>
+
+        <source>
+&lt;module name=&quot;SingleSpaceSeparator&quot;&gt;
+  &lt;property name=&quot;validateComments&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SingleSpaceSeparator">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Error Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22single.space.separator%22">
+            single.space.separator</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suite you.
+          Please <a href="config.html#Custom_messages">see the documentation</a> to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.whitespace
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module">
+        <p>
+          <a href="config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+
     <section name="TypecastParenPad">
       <subsection name="Description">
         <p>


### PR DESCRIPTION
Issue #3173

Start of new check from sevntu.

Made some minor modifications from sevntu.
* Removed references of `nodes` and replaced them with `whitespace` characters.
* Changed property `validateCommentNodes` to `validateComments`.
* Changed check's method definitions from `(DetailAST ast, String line)` to `(String line, int columnNo)`.

Questions:
(1)
````
+    public int[] getDefaultTokens() {
+        return CommonUtils.EMPTY_INT_ARRAY;
+    }
....
+    public void beginTree(DetailAST rootAST) {
+        visitEachToken(rootAST);
+    }
````

Can we just change `getDefaultTokens` to all tokens? I dislike parsing the entire tree twice (once by `TreeWalker` and then again by this check).
Should we use reflection to get all tokens, or should I hardcode the list and make a test to verify?

(2)
````
+    private static boolean isSpace(String line, int columnNo) {
+        return line.charAt(columnNo) == ' ';
+    }
````

Is there a specific reason we don't just use `isWhitespace`? is there a reason we don't check tabs and just a space?