### PR TITLE
Issue #3143 : maxForVoid for ReturnCount Check

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -231,7 +231,9 @@
     <module name="PackageDeclaration"/>
     <module name="ParameterAssignment"/>
     <module name="RequireThis"/>
-    <module name="ReturnCount"/>
+    <module name="ReturnCount">
+      <property name="maxForVoid" value="0"/>
+    </module>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
     <module name="StringLiteralEquality"/>

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -27,7 +27,7 @@
     <!-- These classes are deprecated and will be removed soon. -->
     <suppress checks="ForbidWildcardAsReturnType"
               files="AbstractTypeAwareCheck\.java"
-              lines="230,246,411"/>
+              lines="230,246,409"/>
     <suppress checks="ForbidWildcardAsReturnType"
               files="ClassResolver\.java"
               lines="72,184"/>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -123,9 +123,9 @@
     <suppress checks="MethodCount" files="[\\/]JavadocMethodCheck.java$"/>
 
     <!-- getDetails() method - huge Switch, it has to be monolithic -->
-    <suppress checks="ExecutableStatementCount" files="RightCurlyCheck\.java" lines="316"/>
-    <suppress checks="JavaNCSS" files="RightCurlyCheck\.java" lines="316"/>
-    <suppress checks="CyclomaticComplexity" files="RightCurlyCheck\.java" lines="316"/>
+    <suppress checks="ExecutableStatementCount" files="RightCurlyCheck\.java" lines="313"/>
+    <suppress checks="JavaNCSS" files="RightCurlyCheck\.java" lines="313"/>
+    <suppress checks="CyclomaticComplexity" files="RightCurlyCheck\.java" lines="313"/>
 
     <!-- we need that set of converters -->
     <suppress checks="ClassDataAbstractionCoupling" files="AutomaticBean\.java"/>
@@ -168,4 +168,8 @@
     <!-- Not reasonable to split as encapsulation of logic will be damaged. -->
     <suppress checks="ExecutableStatementCount" files="Main\.java" lines="128"/>
     <suppress checks="JavaNCSS" files="Main\.java"  lines="128"/>
+
+    <!-- too complex to break apart -->
+    <suppress checks="CyclomaticComplexity" files="MissingOverrideCheck\.java"  lines="144"/>
+    <suppress checks="ReturnCount" files="JavadocStyleCheck\.java"  lines="342"/>
 </suppressions>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -460,17 +460,17 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
     public final void setFileExtensions(String... extensions) {
         if (extensions == null) {
             fileExtensions = null;
-            return;
         }
-
-        fileExtensions = new String[extensions.length];
-        for (int i = 0; i < extensions.length; i++) {
-            final String extension = extensions[i];
-            if (CommonUtils.startsWithChar(extension, '.')) {
-                fileExtensions[i] = extension;
-            }
-            else {
-                fileExtensions[i] = "." + extension;
+        else {
+            fileExtensions = new String[extensions.length];
+            for (int i = 0; i < extensions.length; i++) {
+                final String extension = extensions[i];
+                if (CommonUtils.startsWithChar(extension, '.')) {
+                    fileExtensions[i] = extension;
+                }
+                else {
+                    fileExtensions[i] = "." + extension;
+                }
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
@@ -107,18 +107,16 @@ public final class FullIdent {
      * @param ast the node to recurse from
      */
     private static void extractFullIdent(FullIdent full, DetailAST ast) {
-        if (ast == null) {
-            return;
-        }
-
-        if (ast.getType() == TokenTypes.DOT) {
-            extractFullIdent(full, ast.getFirstChild());
-            full.append(".");
-            extractFullIdent(
-                full, ast.getFirstChild().getNextSibling());
-        }
-        else {
-            full.append(ast);
+        if (ast != null) {
+            if (ast.getType() == TokenTypes.DOT) {
+                extractFullIdent(full, ast.getFirstChild());
+                full.append(".");
+                extractFullIdent(
+                    full, ast.getFirstChild().getNextSibling());
+            }
+            else {
+                full.append(ast);
+            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -307,24 +307,22 @@ public abstract class AbstractTypeAwareCheck extends AbstractCheck {
         final Map<String, AbstractClassInfo> paramsMap = Maps.newHashMap();
         typeParams.push(paramsMap);
 
-        if (params == null) {
-            return;
-        }
-
-        for (DetailAST child = params.getFirstChild();
-             child != null;
-             child = child.getNextSibling()) {
-            if (child.getType() == TokenTypes.TYPE_PARAMETER) {
-                final String alias =
-                    child.findFirstToken(TokenTypes.IDENT).getText();
-                final DetailAST bounds =
-                    child.findFirstToken(TokenTypes.TYPE_UPPER_BOUNDS);
-                if (bounds != null) {
-                    final FullIdent name =
-                        FullIdent.createFullIdentBelow(bounds);
-                    final AbstractClassInfo classInfo =
-                        createClassInfo(new Token(name), currentClassName);
-                    paramsMap.put(alias, classInfo);
+        if (params != null) {
+            for (DetailAST child = params.getFirstChild();
+                 child != null;
+                 child = child.getNextSibling()) {
+                if (child.getType() == TokenTypes.TYPE_PARAMETER) {
+                    final String alias =
+                        child.findFirstToken(TokenTypes.IDENT).getText();
+                    final DetailAST bounds =
+                        child.findFirstToken(TokenTypes.TYPE_UPPER_BOUNDS);
+                    if (bounds != null) {
+                        final FullIdent name =
+                            FullIdent.createFullIdentBelow(bounds);
+                        final AbstractClassInfo classInfo =
+                            createClassInfo(new Token(name), currentClassName);
+                        paramsMap.put(alias, classInfo);
+                    }
                 }
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheck.java
@@ -59,24 +59,19 @@ public class ArrayTypeStyleCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         final DetailAST typeAST = ast.getParent();
-        if (typeAST.getType() != TokenTypes.TYPE) {
-            return;
-        }
-        final DetailAST parentAst = typeAST.getParent();
-        if (parentAst.getType() == TokenTypes.METHOD_DEF) {
-            // Do not check method's return type.
-            // We have no alternatives here.
-            return;
-        }
+        if (typeAST.getType() == TokenTypes.TYPE
+                // Do not check method's return type.
+                // We have no alternatives here.
+                && typeAST.getParent().getType() != TokenTypes.METHOD_DEF) {
+            final DetailAST variableAST = typeAST.getNextSibling();
+            if (variableAST != null) {
+                final boolean isJavaStyle =
+                    variableAST.getLineNo() > ast.getLineNo()
+                    || variableAST.getColumnNo() > ast.getColumnNo();
 
-        final DetailAST variableAST = typeAST.getNextSibling();
-        if (variableAST != null) {
-            final boolean isJavaStyle =
-                variableAST.getLineNo() > ast.getLineNo()
-                || variableAST.getColumnNo() > ast.getColumnNo();
-
-            if (isJavaStyle != javaStyle) {
-                log(ast.getLineNo(), ast.getColumnNo(), MSG_KEY);
+                if (isJavaStyle != javaStyle) {
+                    log(ast.getLineNo(), ast.getColumnNo(), MSG_KEY);
+                }
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
@@ -115,18 +115,16 @@ public class FinalParametersCheck extends AbstractCheck {
     public void visitToken(DetailAST ast) {
         // don't flag interfaces
         final DetailAST container = ast.getParent().getParent();
-        if (container.getType() == TokenTypes.INTERFACE_DEF) {
-            return;
-        }
-
-        if (ast.getType() == TokenTypes.LITERAL_CATCH) {
-            visitCatch(ast);
-        }
-        else if (ast.getType() == TokenTypes.FOR_EACH_CLAUSE) {
-            visitForEachClause(ast);
-        }
-        else {
-            visitMethod(ast);
+        if (container.getType() != TokenTypes.INTERFACE_DEF) {
+            if (ast.getType() == TokenTypes.LITERAL_CATCH) {
+                visitCatch(ast);
+            }
+            else if (ast.getType() == TokenTypes.FOR_EACH_CLAUSE) {
+                visitForEachClause(ast);
+            }
+            else {
+                visitMethod(ast);
+            }
         }
     }
 
@@ -135,29 +133,25 @@ public class FinalParametersCheck extends AbstractCheck {
      * @param method method or ctor to check.
      */
     private void visitMethod(final DetailAST method) {
-        // exit on fast lane if there is nothing to check here
-        if (!method.branchContains(TokenTypes.PARAMETER_DEF)) {
-            return;
-        }
-
-        // ignore abstract and native methods
         final DetailAST modifiers =
             method.findFirstToken(TokenTypes.MODIFIERS);
-        if (modifiers.branchContains(TokenTypes.ABSTRACT)
-                || modifiers.branchContains(TokenTypes.LITERAL_NATIVE)) {
-            return;
-        }
+        // exit on fast lane if there is nothing to check here
 
-        // we can now be sure that there is at least one parameter
-        final DetailAST parameters =
-            method.findFirstToken(TokenTypes.PARAMETERS);
-        DetailAST child = parameters.getFirstChild();
-        while (child != null) {
-            // children are PARAMETER_DEF and COMMA
-            if (child.getType() == TokenTypes.PARAMETER_DEF) {
-                checkParam(child);
+        if (method.branchContains(TokenTypes.PARAMETER_DEF)
+                // ignore abstract and native methods
+                && !modifiers.branchContains(TokenTypes.ABSTRACT)
+                && !modifiers.branchContains(TokenTypes.LITERAL_NATIVE)) {
+            // we can now be sure that there is at least one parameter
+            final DetailAST parameters =
+                method.findFirstToken(TokenTypes.PARAMETERS);
+            DetailAST child = parameters.getFirstChild();
+            while (child != null) {
+                // children are PARAMETER_DEF and COMMA
+                if (child.getType() == TokenTypes.PARAMETER_DEF) {
+                    checkParam(child);
+                }
+                child = child.getNextSibling();
             }
-            child = child.getNextSibling();
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -211,40 +211,38 @@ public class SuppressWarningsHolder
         if ("SuppressWarnings".equals(identifier)) {
 
             final List<String> values = getAllAnnotationValues(ast);
-            if (isAnnotationEmpty(values)) {
-                return;
-            }
+            if (!isAnnotationEmpty(values)) {
+                final DetailAST targetAST = getAnnotationTarget(ast);
 
-            final DetailAST targetAST = getAnnotationTarget(ast);
+                if (targetAST == null) {
+                    log(ast.getLineNo(), MSG_KEY);
+                }
+                else {
+                    // get text range of target
+                    final int firstLine = targetAST.getLineNo();
+                    final int firstColumn = targetAST.getColumnNo();
+                    final DetailAST nextAST = targetAST.getNextSibling();
+                    final int lastLine;
+                    final int lastColumn;
+                    if (nextAST == null) {
+                        lastLine = Integer.MAX_VALUE;
+                        lastColumn = Integer.MAX_VALUE;
+                    }
+                    else {
+                        lastLine = nextAST.getLineNo();
+                        lastColumn = nextAST.getColumnNo() - 1;
+                    }
 
-            if (targetAST == null) {
-                log(ast.getLineNo(), MSG_KEY);
-                return;
-            }
-
-            // get text range of target
-            final int firstLine = targetAST.getLineNo();
-            final int firstColumn = targetAST.getColumnNo();
-            final DetailAST nextAST = targetAST.getNextSibling();
-            final int lastLine;
-            final int lastColumn;
-            if (nextAST == null) {
-                lastLine = Integer.MAX_VALUE;
-                lastColumn = Integer.MAX_VALUE;
-            }
-            else {
-                lastLine = nextAST.getLineNo();
-                lastColumn = nextAST.getColumnNo() - 1;
-            }
-
-            // add suppression entries for listed checks
-            final List<Entry> entries = ENTRIES.get();
-            for (String value : values) {
-                String checkName = value;
-                // strip off the checkstyle-only prefix if present
-                checkName = removeCheckstylePrefixIfExists(checkName);
-                entries.add(new Entry(checkName, firstLine, firstColumn,
-                        lastLine, lastColumn));
+                    // add suppression entries for listed checks
+                    final List<Entry> entries = ENTRIES.get();
+                    for (String value : values) {
+                        String checkName = value;
+                        // strip off the checkstyle-only prefix if present
+                        checkName = removeCheckstylePrefixIfExists(checkName);
+                        entries.add(new Entry(checkName, firstLine, firstColumn,
+                                lastLine, lastColumn));
+                    }
+                }
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -153,16 +153,13 @@ public class UncommentedMainCheck
      * @param method method definition node
      */
     private void visitMethodDef(DetailAST method) {
-        if (classDepth != 1) {
-            // method in inner class or in interface definition
-            return;
-        }
-
-        if (checkClassName()
-            && checkName(method)
-            && checkModifiers(method)
-            && checkType(method)
-            && checkParams(method)) {
+        if (classDepth == 1
+                // method not in inner class or in interface definition
+                && checkClassName()
+                && checkName(method)
+                && checkModifiers(method)
+                && checkType(method)
+                && checkParams(method)) {
             log(method.getLineNo(), MSG_KEY);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -435,26 +435,24 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
      * @param annotation the annotation token
      */
     private void checkTrailingComma(final DetailAST annotation) {
-        if (trailingArrayComma == TrailingArrayComma.IGNORE) {
-            return;
-        }
+        if (trailingArrayComma != TrailingArrayComma.IGNORE) {
+            DetailAST child = annotation.getFirstChild();
 
-        DetailAST child = annotation.getFirstChild();
+            while (child != null) {
+                DetailAST arrayInit = null;
 
-        while (child != null) {
-            DetailAST arrayInit = null;
+                if (child.getType() == TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {
+                    arrayInit = child.findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
+                }
+                else if (child.getType() == TokenTypes.ANNOTATION_ARRAY_INIT) {
+                    arrayInit = child;
+                }
 
-            if (child.getType() == TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {
-                arrayInit = child.findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
+                if (arrayInit != null) {
+                    logCommaViolation(arrayInit);
+                }
+                child = child.getNextSibling();
             }
-            else if (child.getType() == TokenTypes.ANNOTATION_ARRAY_INIT) {
-                arrayInit = child;
-            }
-
-            if (arrayInit != null) {
-                logCommaViolation(arrayInit);
-            }
-            child = child.getNextSibling();
         }
     }
 
@@ -489,23 +487,21 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
      * @param ast the annotation token
      */
     private void checkCheckClosingParens(final DetailAST ast) {
-        if (closingParens == ClosingParens.IGNORE) {
-            return;
-        }
+        if (closingParens != ClosingParens.IGNORE) {
+            final DetailAST paren = ast.getLastChild();
+            final boolean parenExists = paren.getType() == TokenTypes.RPAREN;
 
-        final DetailAST paren = ast.getLastChild();
-        final boolean parenExists = paren.getType() == TokenTypes.RPAREN;
-
-        if (closingParens == ClosingParens.ALWAYS
-            && !parenExists) {
-            log(ast.getLineNo(), MSG_KEY_ANNOTATION_PARENS_MISSING);
-        }
-        else if (closingParens == ClosingParens.NEVER
-                 && parenExists
-                 && !ast.branchContains(TokenTypes.EXPR)
-                 && !ast.branchContains(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR)
-                 && !ast.branchContains(TokenTypes.ANNOTATION_ARRAY_INIT)) {
-            log(ast.getLineNo(), MSG_KEY_ANNOTATION_PARENS_PRESENT);
+            if (closingParens == ClosingParens.ALWAYS
+                && !parenExists) {
+                log(ast.getLineNo(), MSG_KEY_ANNOTATION_PARENS_MISSING);
+            }
+            else if (closingParens == ClosingParens.NEVER
+                     && parenExists
+                     && !ast.branchContains(TokenTypes.EXPR)
+                     && !ast.branchContains(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR)
+                     && !ast.branchContains(TokenTypes.ANNOTATION_ARRAY_INIT)) {
+                log(ast.getLineNo(), MSG_KEY_ANNOTATION_PARENS_PRESENT);
+            }
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
@@ -150,23 +150,26 @@ public final class MissingOverrideCheck extends AbstractCheck {
         if (containsTag && !JavadocTagInfo.INHERIT_DOC.isValidOn(ast)) {
             log(ast.getLineNo(), MSG_KEY_TAG_NOT_VALID_ON,
                 JavadocTagInfo.INHERIT_DOC.getText());
-            return;
         }
+        else {
+            boolean check = true;
 
-        if (javaFiveCompatibility) {
-            final DetailAST defOrNew = ast.getParent().getParent();
+            if (javaFiveCompatibility) {
+                final DetailAST defOrNew = ast.getParent().getParent();
 
-            if (defOrNew.branchContains(TokenTypes.EXTENDS_CLAUSE)
-                || defOrNew.branchContains(TokenTypes.IMPLEMENTS_CLAUSE)
-                || defOrNew.getType() == TokenTypes.LITERAL_NEW) {
-                return;
+                if (defOrNew.branchContains(TokenTypes.EXTENDS_CLAUSE)
+                    || defOrNew.branchContains(TokenTypes.IMPLEMENTS_CLAUSE)
+                    || defOrNew.getType() == TokenTypes.LITERAL_NEW) {
+                    check = false;
+                }
             }
-        }
 
-        if (containsTag
-            && !AnnotationUtility.containsAnnotation(ast, OVERRIDE)
-            && !AnnotationUtility.containsAnnotation(ast, FQ_OVERRIDE)) {
-            log(ast.getLineNo(), MSG_KEY_ANNOTATION_MISSING_OVERRIDE);
+            if (check
+                && containsTag
+                && !AnnotationUtility.containsAnnotation(ast, OVERRIDE)
+                && !AnnotationUtility.containsAnnotation(ast, FQ_OVERRIDE)) {
+                log(ast.getLineNo(), MSG_KEY_ANNOTATION_MISSING_OVERRIDE);
+            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -153,62 +153,63 @@ public class SuppressWarningsCheck extends AbstractCheck {
     public void visitToken(final DetailAST ast) {
         final DetailAST annotation = getSuppressWarnings(ast);
 
-        if (annotation == null) {
-            return;
-        }
+        if (annotation != null) {
+            final DetailAST warningHolder =
+                findWarningsHolder(annotation);
 
-        final DetailAST warningHolder =
-            findWarningsHolder(annotation);
+            final DetailAST token =
+                    warningHolder.findFirstToken(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
+            DetailAST warning;
 
-        final DetailAST token =
-                warningHolder.findFirstToken(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
-        DetailAST warning;
+            if (token == null) {
+                warning = warningHolder.findFirstToken(TokenTypes.EXPR);
+            }
+            else {
+                // case like '@SuppressWarnings(value = UNUSED)'
+                warning = token.findFirstToken(TokenTypes.EXPR);
+            }
 
-        if (token == null) {
-            warning = warningHolder.findFirstToken(TokenTypes.EXPR);
-        }
-        else {
-            // case like '@SuppressWarnings(value = UNUSED)'
-            warning = token.findFirstToken(TokenTypes.EXPR);
-        }
-
-        //rare case with empty array ex: @SuppressWarnings({})
-        if (warning == null) {
-            //check to see if empty warnings are forbidden -- are by default
-            logMatch(warningHolder.getLineNo(),
-                warningHolder.getColumnNo(), "");
-            return;
-        }
-
-        while (warning != null) {
-            if (warning.getType() == TokenTypes.EXPR) {
-                final DetailAST fChild = warning.getFirstChild();
-                switch (fChild.getType()) {
-                    //typical case
-                    case TokenTypes.STRING_LITERAL:
-                        final String warningText =
-                            removeQuotes(warning.getFirstChild().getText());
-                        logMatch(warning.getLineNo(),
-                                warning.getColumnNo(), warningText);
-                        break;
-                    // conditional case
-                    // ex: @SuppressWarnings((false) ? (true) ? "unchecked" : "foo" : "unused")
-                    case TokenTypes.QUESTION:
-                        walkConditional(fChild);
-                        break;
-                    // param in constant case
-                    // ex: public static final String UNCHECKED = "unchecked";
-                    // @SuppressWarnings(UNCHECKED) or @SuppressWarnings(SomeClass.UNCHECKED)
-                    case TokenTypes.IDENT:
-                    case TokenTypes.DOT:
-                        break;
-                    default:
-                        // Known limitation: cases like @SuppressWarnings("un" + "used") or
-                        // @SuppressWarnings((String) "unused") are not properly supported,
-                        // but they should not cause exceptions.
+            //rare case with empty array ex: @SuppressWarnings({})
+            if (warning == null) {
+                //check to see if empty warnings are forbidden -- are by default
+                logMatch(warningHolder.getLineNo(),
+                    warningHolder.getColumnNo(), "");
+            }
+            else {
+                while (warning != null) {
+                    if (warning.getType() == TokenTypes.EXPR) {
+                        final DetailAST fChild = warning.getFirstChild();
+                        switch (fChild.getType()) {
+                            //typical case
+                            case TokenTypes.STRING_LITERAL:
+                                final String warningText =
+                                    removeQuotes(warning.getFirstChild().getText());
+                                logMatch(warning.getLineNo(),
+                                        warning.getColumnNo(), warningText);
+                                break;
+                            // conditional case
+                            // ex:
+                            // @SuppressWarnings((false) ? (true) ? "unchecked" : "foo" : "unused")
+                            case TokenTypes.QUESTION:
+                                walkConditional(fChild);
+                                break;
+                            // param in constant case
+                            // ex: public static final String UNCHECKED = "unchecked";
+                            // @SuppressWarnings(UNCHECKED)
+                            // or
+                            // @SuppressWarnings(SomeClass.UNCHECKED)
+                            case TokenTypes.IDENT:
+                            case TokenTypes.DOT:
+                                break;
+                            default:
+                                // Known limitation: cases like @SuppressWarnings("un" + "used") or
+                                // @SuppressWarnings((String) "unused") are not properly supported,
+                                // but they should not cause exceptions.
+                        }
+                    }
+                    warning = warning.getNextSibling();
                 }
             }
-            warning = warning.getNextSibling();
         }
     }
 
@@ -301,15 +302,15 @@ public class SuppressWarningsCheck extends AbstractCheck {
      * {@link TokenTypes#QUESTION QUESTION}
      */
     private void walkConditional(final DetailAST cond) {
-        if (cond.getType() != TokenTypes.QUESTION) {
-            final String warningText =
-                removeQuotes(cond.getText());
-            logMatch(cond.getLineNo(), cond.getColumnNo(), warningText);
-            return;
+        if (cond.getType() == TokenTypes.QUESTION) {
+            walkConditional(getCondLeft(cond));
+            walkConditional(getCondRight(cond));
         }
-
-        walkConditional(getCondLeft(cond));
-        walkConditional(getCondRight(cond));
+        else {
+            final String warningText =
+                    removeQuotes(cond.getText());
+            logMatch(cond.getLineNo(), cond.getColumnNo(), warningText);
+        }
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheck.java
@@ -115,12 +115,10 @@ public class AvoidNestedBlocksCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         final DetailAST parent = ast.getParent();
-        if (parent.getType() == TokenTypes.SLIST) {
-            if (allowInSwitchCase
-                    && parent.getParent().getType() == TokenTypes.CASE_GROUP
-                    && parent.getNumberOfChildren() == 1) {
-                return;
-            }
+        if (parent.getType() == TokenTypes.SLIST
+                && (!allowInSwitchCase
+                    || parent.getParent().getType() != TokenTypes.CASE_GROUP
+                    || parent.getNumberOfChildren() != 1)) {
             log(ast.getLineNo(), ast.getColumnNo(), MSG_KEY_BLOCK_NESTED);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -175,22 +175,19 @@ public class RightCurlyCheck extends AbstractCheck {
         final Details details = getDetails(ast);
         final DetailAST rcurly = details.rcurly;
 
-        if (rcurly == null || rcurly.getType() != TokenTypes.RCURLY) {
-            // we need to have both tokens to perform the check
-            return;
-        }
+        if (rcurly != null && rcurly.getType() == TokenTypes.RCURLY) {
+            final String violation;
+            if (shouldStartLine) {
+                final String targetSourceLine = getLines()[rcurly.getLineNo() - 1];
+                violation = validate(details, option, true, targetSourceLine);
+            }
+            else {
+                violation = validate(details, option, false, "");
+            }
 
-        final String violation;
-        if (shouldStartLine) {
-            final String targetSourceLine = getLines()[rcurly.getLineNo() - 1];
-            violation = validate(details, option, true, targetSourceLine);
-        }
-        else {
-            violation = validate(details, option, false, "");
-        }
-
-        if (!violation.isEmpty()) {
-            log(rcurly, violation, "}", rcurly.getColumnNo() + 1);
+            if (!violation.isEmpty()) {
+                log(rcurly, violation, "}", rcurly.getColumnNo() + 1);
+            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
@@ -68,14 +68,12 @@ public class ArrayTrailingCommaCheck extends AbstractCheck {
 
         // if curlies are on the same line
         // or array is empty then check nothing
-        if (arrayInit.getLineNo() == rcurly.getLineNo()
-            || arrayInit.getChildCount() == 1) {
-            return;
-        }
-
-        final DetailAST prev = rcurly.getPreviousSibling();
-        if (prev.getType() != TokenTypes.COMMA) {
-            log(rcurly.getLineNo(), MSG_KEY);
+        if (arrayInit.getLineNo() != rcurly.getLineNo()
+            && arrayInit.getChildCount() != 1) {
+            final DetailAST prev = rcurly.getPreviousSibling();
+            if (prev.getType() != TokenTypes.COMMA) {
+                log(rcurly.getLineNo(), MSG_KEY);
+            }
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -73,31 +73,29 @@ public class ExplicitInitializationCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (isSkipCase(ast)) {
-            return;
-        }
+        if (!isSkipCase(ast)) {
+            final DetailAST ident = ast.findFirstToken(TokenTypes.IDENT);
+            final DetailAST assign = ast.findFirstToken(TokenTypes.ASSIGN);
+            final DetailAST exprStart =
+                assign.getFirstChild().getFirstChild();
+            final DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
+            if (isObjectType(type)
+                && exprStart.getType() == TokenTypes.LITERAL_NULL) {
+                log(ident, MSG_KEY, ident.getText(), "null");
+            }
 
-        final DetailAST ident = ast.findFirstToken(TokenTypes.IDENT);
-        final DetailAST assign = ast.findFirstToken(TokenTypes.ASSIGN);
-        final DetailAST exprStart =
-            assign.getFirstChild().getFirstChild();
-        final DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
-        if (isObjectType(type)
-            && exprStart.getType() == TokenTypes.LITERAL_NULL) {
-            log(ident, MSG_KEY, ident.getText(), "null");
-        }
-
-        final int primitiveType = type.getFirstChild().getType();
-        if (primitiveType == TokenTypes.LITERAL_BOOLEAN
-            && exprStart.getType() == TokenTypes.LITERAL_FALSE) {
-            log(ident, MSG_KEY, ident.getText(), "false");
-        }
-        if (isNumericType(primitiveType) && isZero(exprStart)) {
-            log(ident, MSG_KEY, ident.getText(), "0");
-        }
-        if (primitiveType == TokenTypes.LITERAL_CHAR
-            && isZeroChar(exprStart)) {
-            log(ident, MSG_KEY, ident.getText(), "\\0");
+            final int primitiveType = type.getFirstChild().getType();
+            if (primitiveType == TokenTypes.LITERAL_BOOLEAN
+                && exprStart.getType() == TokenTypes.LITERAL_FALSE) {
+                log(ident, MSG_KEY, ident.getText(), "false");
+            }
+            if (isNumericType(primitiveType) && isZero(exprStart)) {
+                log(ident, MSG_KEY, ident.getText(), "0");
+            }
+            if (primitiveType == TokenTypes.LITERAL_CHAR
+                && isZeroChar(exprStart)) {
+                log(ident, MSG_KEY, ident.getText(), "\\0");
+            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -133,20 +133,17 @@ public class FallThroughCheck extends AbstractCheck {
     public void visitToken(DetailAST ast) {
         final DetailAST nextGroup = ast.getNextSibling();
         final boolean isLastGroup = nextGroup.getType() != TokenTypes.CASE_GROUP;
-        if (isLastGroup && !checkLastCaseGroup) {
-            // we do not need to check last group
-            return;
-        }
+        if (!isLastGroup || checkLastCaseGroup) {
+            final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
 
-        final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
-
-        if (slist != null && !isTerminated(slist, true, true)
-            && !hasFallThroughComment(ast, nextGroup)) {
-            if (isLastGroup) {
-                log(ast, MSG_FALL_THROUGH_LAST);
-            }
-            else {
-                log(nextGroup, MSG_FALL_THROUGH);
+            if (slist != null && !isTerminated(slist, true, true)
+                && !hasFallThroughComment(ast, nextGroup)) {
+                if (isLastGroup) {
+                    log(ast, MSG_FALL_THROUGH_LAST);
+                }
+                else {
+                    log(nextGroup, MSG_FALL_THROUGH);
+                }
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -200,18 +200,16 @@ public class IllegalInstantiationCheck
     private void postProcessLiteralNew(DetailAST newTokenAst) {
         final DetailAST typeNameAst = newTokenAst.getFirstChild();
         final AST nameSibling = typeNameAst.getNextSibling();
-        if (nameSibling.getType() == TokenTypes.ARRAY_DECLARATOR) {
-            // ast == "new Boolean[]"
-            return;
-        }
-
-        final FullIdent typeIdent = FullIdent.createFullIdent(typeNameAst);
-        final String typeName = typeIdent.getText();
-        final int lineNo = newTokenAst.getLineNo();
-        final int colNo = newTokenAst.getColumnNo();
-        final String fqClassName = getIllegalInstantiation(typeName);
-        if (fqClassName != null) {
-            log(lineNo, colNo, MSG_KEY, fqClassName);
+        if (nameSibling.getType() != TokenTypes.ARRAY_DECLARATOR) {
+            // ast != "new Boolean[]"
+            final FullIdent typeIdent = FullIdent.createFullIdent(typeNameAst);
+            final String typeName = typeIdent.getText();
+            final int lineNo = newTokenAst.getLineNo();
+            final int colNo = newTokenAst.getColumnNo();
+            final String fqClassName = getIllegalInstantiation(typeName);
+            if (fqClassName != null) {
+                log(lineNo, colNo, MSG_KEY, fqClassName);
+            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -207,26 +207,21 @@ public class MagicNumberCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (ignoreAnnotation && isChildOf(ast, TokenTypes.ANNOTATION)) {
-            return;
-        }
+        if ((!ignoreAnnotation || !isChildOf(ast, TokenTypes.ANNOTATION))
+                && !isInIgnoreList(ast)
+                && (!ignoreHashCodeMethod || !isInHashCodeMethod(ast))) {
+            final DetailAST constantDefAST = findContainingConstantDef(ast);
 
-        if (isInIgnoreList(ast)
-            || ignoreHashCodeMethod && isInHashCodeMethod(ast)) {
-            return;
-        }
-
-        final DetailAST constantDefAST = findContainingConstantDef(ast);
-
-        if (constantDefAST == null) {
-            if (!ignoreFieldDeclaration || !isFieldDeclaration(ast)) {
-                reportMagicNumber(ast);
+            if (constantDefAST == null) {
+                if (!ignoreFieldDeclaration || !isFieldDeclaration(ast)) {
+                    reportMagicNumber(ast);
+                }
             }
-        }
-        else {
-            final boolean found = isMagicNumberExists(ast, constantDefAST);
-            if (found) {
-                reportMagicNumber(ast);
+            else {
+                final boolean found = isMagicNumberExists(ast, constantDefAST);
+                if (found) {
+                    reportMagicNumber(ast);
+                }
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -130,19 +130,18 @@ public class MultipleStringLiteralsCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (isInIgnoreOccurrenceContext(ast)) {
-            return;
-        }
-        final String currentString = ast.getText();
-        if (pattern == null || !pattern.matcher(currentString).find()) {
-            List<StringInfo> hitList = stringMap.get(currentString);
-            if (hitList == null) {
-                hitList = Lists.newArrayList();
-                stringMap.put(currentString, hitList);
+        if (!isInIgnoreOccurrenceContext(ast)) {
+            final String currentString = ast.getText();
+            if (pattern == null || !pattern.matcher(currentString).find()) {
+                List<StringInfo> hitList = stringMap.get(currentString);
+                if (hitList == null) {
+                    hitList = Lists.newArrayList();
+                    stringMap.put(currentString, hitList);
+                }
+                final int line = ast.getLineNo();
+                final int col = ast.getColumnNo();
+                hitList.add(new StringInfo(line, col));
             }
-            final int line = ast.getLineNo();
-            final int col = ast.getColumnNo();
-            hitList.add(new StringInfo(line, col));
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleVariableDeclarationsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleVariableDeclarationsCheck.java
@@ -76,42 +76,38 @@ public class MultipleVariableDeclarationsCheck extends AbstractCheck {
     public void visitToken(DetailAST ast) {
         DetailAST nextNode = ast.getNextSibling();
 
-        if (nextNode == null) {
-            // no next statement - no check
-            return;
-        }
+        if (nextNode != null) {
+            final boolean isCommaSeparated = nextNode.getType() == TokenTypes.COMMA;
 
-        final boolean isCommaSeparated = nextNode.getType() == TokenTypes.COMMA;
+            if (isCommaSeparated
+                || nextNode.getType() == TokenTypes.SEMI) {
+                nextNode = nextNode.getNextSibling();
+            }
 
-        if (isCommaSeparated
-            || nextNode.getType() == TokenTypes.SEMI) {
-            nextNode = nextNode.getNextSibling();
-        }
-
-        if (nextNode != null
-                && nextNode.getType() == TokenTypes.VARIABLE_DEF) {
-            final DetailAST firstNode = CheckUtils.getFirstNode(ast);
-            if (isCommaSeparated) {
-                // Check if the multiple variable declarations are in a
-                // for loop initializer. If they are, then no warning
-                // should be displayed. Declaring multiple variables in
-                // a for loop initializer is a good way to minimize
-                // variable scope. Refer Feature Request Id - 2895985
-                // for more details
-                if (ast.getParent().getType() != TokenTypes.FOR_INIT) {
-                    log(firstNode, MSG_MULTIPLE_COMMA);
+            if (nextNode != null
+                    && nextNode.getType() == TokenTypes.VARIABLE_DEF) {
+                final DetailAST firstNode = CheckUtils.getFirstNode(ast);
+                if (isCommaSeparated) {
+                    // Check if the multiple variable declarations are in a
+                    // for loop initializer. If they are, then no warning
+                    // should be displayed. Declaring multiple variables in
+                    // a for loop initializer is a good way to minimize
+                    // variable scope. Refer Feature Request Id - 2895985
+                    // for more details
+                    if (ast.getParent().getType() != TokenTypes.FOR_INIT) {
+                        log(firstNode, MSG_MULTIPLE_COMMA);
+                    }
                 }
-                return;
-            }
+                else {
+                    final DetailAST lastNode = getLastNode(ast);
+                    final DetailAST firstNextNode = CheckUtils.getFirstNode(nextNode);
 
-            final DetailAST lastNode = getLastNode(ast);
-            final DetailAST firstNextNode = CheckUtils.getFirstNode(nextNode);
-
-            if (firstNextNode.getLineNo() == lastNode.getLineNo()) {
-                log(firstNode, MSG_MULTIPLE);
+                    if (firstNextNode.getLineNo() == lastNode.getLineNo()) {
+                        log(firstNode, MSG_MULTIPLE);
+                    }
+                }
             }
         }
-
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
@@ -34,6 +34,18 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * (2 by default). Ignores specified methods ({@code equals()} by default).
  * </p>
  * <p>
+ * <b>max</b> property will only check returns in methods and lambdas that
+ * return a specific value (Ex: 'return 1;').
+ * </p>
+ * <p>
+ * <b>maxForVoid</b> property will only check returns in methods, constructors,
+ * and lambdas that have no return type (IE 'return;'). It will only count
+ * visible return statements. Return statements not normally written, but
+ * implied, at the end of the method/constructor definition will not be taken
+ * into account. To disallow "return;" in void return type methods, use a value
+ * of 0.
+ * </p>
+ * <p>
  * Rationale: Too many return points can be indication that code is
  * attempting to do too much or may be difficult to understand.
  * </p>
@@ -58,6 +70,8 @@ public final class ReturnCountCheck extends AbstractCheck {
 
     /** Maximum allowed number of return statements. */
     private int max = 2;
+    /** Maximum allowed number of return statements for void methods. */
+    private int maxForVoid = 1;
     /** Current method context. */
     private Context context;
 
@@ -97,19 +111,19 @@ public final class ReturnCountCheck extends AbstractCheck {
     }
 
     /**
-     * Getter for max property.
-     * @return maximum allowed number of return statements.
-     */
-    public int getMax() {
-        return max;
-    }
-
-    /**
      * Setter for max property.
      * @param max maximum allowed number of return statements.
      */
     public void setMax(int max) {
         this.max = max;
+    }
+
+    /**
+     * Setter for maxForVoid property.
+     * @param maxForVoid maximum allowed number of return statements for void methods.
+     */
+    public void setMaxForVoid(int maxForVoid) {
+        this.maxForVoid = maxForVoid;
     }
 
     @Override
@@ -129,7 +143,7 @@ public final class ReturnCountCheck extends AbstractCheck {
                 visitLambda();
                 break;
             case TokenTypes.LITERAL_RETURN:
-                context.visitLiteralReturn();
+                visitReturn(ast);
                 break;
             default:
                 throw new IllegalStateException(ast.toString());
@@ -181,6 +195,21 @@ public final class ReturnCountCheck extends AbstractCheck {
     }
 
     /**
+     * Examines the return statement and tells context about it.
+     * @param ast return statement to check.
+     */
+    private void visitReturn(DetailAST ast) {
+        // we can't identify which max to use for lambdas, so we can only assign
+        // after the first return statement is seen
+        if (ast.getFirstChild().getType() == TokenTypes.SEMI) {
+            context.visitLiteralReturn(maxForVoid);
+        }
+        else {
+            context.visitLiteralReturn(max);
+        }
+    }
+
+    /**
      * Class to encapsulate information about one method.
      * @author <a href="mailto:simon@redhillconsulting.com.au">Simon Harris</a>
      */
@@ -189,6 +218,8 @@ public final class ReturnCountCheck extends AbstractCheck {
         private final boolean checking;
         /** Counter for return statements. */
         private int count;
+        /** Maximum allowed number of return statements. */
+        private Integer maxAllowed;
 
         /**
          * Creates new method context.
@@ -196,23 +227,28 @@ public final class ReturnCountCheck extends AbstractCheck {
          */
         Context(boolean checking) {
             this.checking = checking;
-            count = 0;
         }
 
-        /** Increase number of return statements. */
-        public void visitLiteralReturn() {
+        /**
+         * Increase the number of return statements.
+         * @param maxAssigned Maximum allowed number of return statements.
+         */
+        public void visitLiteralReturn(int maxAssigned) {
+            if (maxAllowed == null) {
+                maxAllowed = maxAssigned;
+            }
+
             ++count;
         }
 
         /**
-         * Checks if number of return statements in method more
+         * Checks if number of return statements in the method are more
          * than allowed.
          * @param ast method def associated with this context.
          */
         public void checkCount(DetailAST ast) {
-            if (checking && count > getMax()) {
-                log(ast.getLineNo(), ast.getColumnNo(), MSG_KEY,
-                    count, getMax());
+            if (checking && maxAllowed != null && count > maxAllowed) {
+                log(ast.getLineNo(), ast.getColumnNo(), MSG_KEY, count, maxAllowed);
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
@@ -74,18 +74,17 @@ public class SimplifyBooleanReturnCheck
         // don't bother if this is not if then else
         final AST elseLiteral =
             ast.findFirstToken(TokenTypes.LITERAL_ELSE);
-        if (elseLiteral == null) {
-            return;
-        }
-        final AST elseStatement = elseLiteral.getFirstChild();
+        if (elseLiteral != null) {
+            final AST elseStatement = elseLiteral.getFirstChild();
 
-        // skip '(' and ')'
-        final AST condition = ast.getFirstChild().getNextSibling();
-        final AST thenStatement = condition.getNextSibling().getNextSibling();
+            // skip '(' and ')'
+            final AST condition = ast.getFirstChild().getNextSibling();
+            final AST thenStatement = condition.getNextSibling().getNextSibling();
 
-        if (canReturnOnlyBooleanLiteral(thenStatement)
-            && canReturnOnlyBooleanLiteral(elseStatement)) {
-            log(ast.getLineNo(), ast.getColumnNo(), MSG_KEY);
+            if (canReturnOnlyBooleanLiteral(thenStatement)
+                && canReturnOnlyBooleanLiteral(elseStatement)) {
+                log(ast.getLineNo(), ast.getColumnNo(), MSG_KEY);
+            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -231,38 +231,36 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
         final int type = ast.getType();
         final DetailAST parent = ast.getParent();
 
-        if (type == TokenTypes.ASSIGN
-            && parent.getType() == TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {
-            // shouldn't process assign in annotation pairs
-            return;
-        }
+        // shouldn't process assign in annotation pairs
+        if (type != TokenTypes.ASSIGN
+            || parent.getType() != TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {
+            // An expression is surrounded by parentheses.
+            if (type == TokenTypes.EXPR) {
 
-        // An expression is surrounded by parentheses.
-        if (type == TokenTypes.EXPR) {
+                // If 'parentToSkip' == 'ast', then we've already logged a
+                // warning about an immediate child node in visitToken, so we don't
+                // need to log another one here.
 
-            // If 'parentToSkip' == 'ast', then we've already logged a
-            // warning about an immediate child node in visitToken, so we don't
-            // need to log another one here.
+                if (parentToSkip != ast && isExprSurrounded(ast)) {
+                    if (assignDepth >= 1) {
+                        log(ast, MSG_ASSIGN);
+                    }
+                    else if (ast.getParent().getType() == TokenTypes.LITERAL_RETURN) {
+                        log(ast, MSG_RETURN);
+                    }
+                    else {
+                        log(ast, MSG_EXPR);
+                    }
+                }
 
-            if (parentToSkip != ast && isExprSurrounded(ast)) {
-                if (assignDepth >= 1) {
-                    log(ast, MSG_ASSIGN);
-                }
-                else if (ast.getParent().getType() == TokenTypes.LITERAL_RETURN) {
-                    log(ast, MSG_RETURN);
-                }
-                else {
-                    log(ast, MSG_EXPR);
-                }
+                parentToSkip = null;
+            }
+            else if (isInTokenList(type, ASSIGNMENTS)) {
+                assignDepth--;
             }
 
-            parentToSkip = null;
+            super.leaveToken(ast);
         }
-        else if (isInTokenList(type, ASSIGNMENTS)) {
-            assignDepth--;
-        }
-
-        super.leaveToken(ast);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -125,20 +125,18 @@ public class FinalClassCheck
 
     @Override
     public void leaveToken(DetailAST ast) {
-        if (ast.getType() != TokenTypes.CLASS_DEF) {
-            return;
-        }
-
-        final ClassDesc desc = classes.pop();
-        if (desc.isWithPrivateCtor()
-            && !desc.isDeclaredAsAbstract()
-            && !desc.isDeclaredAsFinal()
-            && !desc.isWithNonPrivateCtor()
-            && !desc.isWithNestedSubclass()
-            && !ScopeUtils.isInInterfaceOrAnnotationBlock(ast)) {
-            final String qualifiedName = desc.getQualifiedName();
-            final String className = getClassNameFromQualifiedName(qualifiedName);
-            log(ast.getLineNo(), MSG_KEY, className);
+        if (ast.getType() == TokenTypes.CLASS_DEF) {
+            final ClassDesc desc = classes.pop();
+            if (desc.isWithPrivateCtor()
+                && !desc.isDeclaredAsAbstract()
+                && !desc.isDeclaredAsFinal()
+                && !desc.isWithNonPrivateCtor()
+                && !desc.isWithNestedSubclass()
+                && !ScopeUtils.isInInterfaceOrAnnotationBlock(ast)) {
+                final String qualifiedName = desc.getQualifiedName();
+                final String className = getClassNameFromQualifiedName(qualifiedName);
+                log(ast.getLineNo(), MSG_KEY, className);
+            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -58,34 +58,33 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (isAbstract(ast)) {
-            // abstract class could not have private constructor
-            return;
-        }
-        final boolean hasStaticModifier = isStatic(ast);
+        // abstract class could not have private constructor
+        if (!isAbstract(ast)) {
+            final boolean hasStaticModifier = isStatic(ast);
 
-        final Details details = new Details(ast);
-        details.invoke();
+            final Details details = new Details(ast);
+            details.invoke();
 
-        final boolean hasDefaultCtor = details.isHasDefaultCtor();
-        final boolean hasPublicCtor = details.isHasPublicCtor();
-        final boolean hasMethodOrField = details.isHasMethodOrField();
-        final boolean hasNonStaticMethodOrField = details.isHasNonStaticMethodOrField();
-        final boolean hasNonPrivateStaticMethodOrField =
-                details.isHasNonPrivateStaticMethodOrField();
+            final boolean hasDefaultCtor = details.isHasDefaultCtor();
+            final boolean hasPublicCtor = details.isHasPublicCtor();
+            final boolean hasMethodOrField = details.isHasMethodOrField();
+            final boolean hasNonStaticMethodOrField = details.isHasNonStaticMethodOrField();
+            final boolean hasNonPrivateStaticMethodOrField =
+                    details.isHasNonPrivateStaticMethodOrField();
 
-        final boolean hasAccessibleCtor = hasDefaultCtor || hasPublicCtor;
+            final boolean hasAccessibleCtor = hasDefaultCtor || hasPublicCtor;
 
-        // figure out if class extends java.lang.object directly
-        // keep it simple for now and get a 99% solution
-        final boolean extendsJlo =
-            ast.findFirstToken(TokenTypes.EXTENDS_CLAUSE) == null;
+            // figure out if class extends java.lang.object directly
+            // keep it simple for now and get a 99% solution
+            final boolean extendsJlo =
+                ast.findFirstToken(TokenTypes.EXTENDS_CLAUSE) == null;
 
-        final boolean isUtilClass = extendsJlo && hasMethodOrField
-            && !hasNonStaticMethodOrField && hasNonPrivateStaticMethodOrField;
+            final boolean isUtilClass = extendsJlo && hasMethodOrField
+                && !hasNonStaticMethodOrField && hasNonPrivateStaticMethodOrField;
 
-        if (isUtilClass && hasAccessibleCtor && !hasStaticModifier) {
-            log(ast.getLineNo(), ast.getColumnNo(), MSG_KEY);
+            if (isUtilClass && hasAccessibleCtor && !hasStaticModifier) {
+                log(ast.getLineNo(), ast.getColumnNo(), MSG_KEY);
+            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -145,24 +145,22 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
      * @throws ConversionException if the header cannot be interpreted
      */
     public void setHeader(String header) {
-        if (CommonUtils.isBlank(header)) {
-            return;
-        }
+        if (!CommonUtils.isBlank(header)) {
+            checkHeaderNotInitialized();
 
-        checkHeaderNotInitialized();
+            final String headerExpandedNewLines = ESCAPED_LINE_FEED_PATTERN
+                    .matcher(header).replaceAll("\n");
 
-        final String headerExpandedNewLines = ESCAPED_LINE_FEED_PATTERN
-                .matcher(header).replaceAll("\n");
-
-        final Reader headerReader = new StringReader(headerExpandedNewLines);
-        try {
-            loadHeader(headerReader);
-        }
-        catch (final IOException ex) {
-            throw new ConversionException("unable to load header", ex);
-        }
-        finally {
-            Closeables.closeQuietly(headerReader);
+            final Reader headerReader = new StringReader(headerExpandedNewLines);
+            try {
+                loadHeader(headerReader);
+            }
+            catch (final IOException ex) {
+                throw new ConversionException("unable to load header", ex);
+            }
+            finally {
+                Closeables.closeQuietly(headerReader);
+            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
@@ -78,12 +78,12 @@ public class HeaderCheck extends AbstractHeaderCheck {
     public void setIgnoreLines(int... list) {
         if (list.length == 0) {
             ignoreLines = EMPTY_INT_ARRAY;
-            return;
         }
-
-        ignoreLines = new int[list.length];
-        System.arraycopy(list, 0, ignoreLines, 0, list.length);
-        Arrays.sort(ignoreLines);
+        else {
+            ignoreLines = new int[list.length];
+            System.arraycopy(list, 0, ignoreLines, 0, list.length);
+            Arrays.sort(ignoreLines);
+        }
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -70,12 +70,12 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck {
     public void setMultiLines(int... list) {
         if (list.length == 0) {
             multiLines = EMPTY_INT_ARRAY;
-            return;
         }
-
-        multiLines = new int[list.length];
-        System.arraycopy(list, 0, multiLines, 0, list.length);
-        Arrays.sort(multiLines);
+        else {
+            multiLines = new int[list.length];
+            System.arraycopy(list, 0, multiLines, 0, list.length);
+            Arrays.sort(multiLines);
+        }
     }
 
     @Override
@@ -171,13 +171,12 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck {
      */
     @Override
     public void setHeader(String header) {
-        if (CommonUtils.isBlank(header)) {
-            return;
+        if (!CommonUtils.isBlank(header)) {
+            if (!CommonUtils.isPatternValid(header)) {
+                throw new ConversionException("Unable to parse format: " + header);
+            }
+            super.setHeader(header);
         }
-        if (!CommonUtils.isPatternValid(header)) {
-            throw new ConversionException("Unable to parse format: " + header);
-        }
-        super.setHeader(header);
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -492,10 +492,13 @@ public class CustomImportOrderCheck extends AbstractCheck {
     @Override
     public void finishTree(DetailAST rootAST) {
 
-        if (importToGroupList.isEmpty()) {
-            return;
+        if (!importToGroupList.isEmpty()) {
+            finishImportList();
         }
+    }
 
+    /** Examine the order of all the imports and log any violations. */
+    private void finishImportList() {
         final ImportDetails firstImport = importToGroupList.get(0);
         String currentGroup = getImportGroup(firstImport.isStaticImport(),
                 firstImport.getImportFullPath());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -154,16 +154,14 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
      */
     public void setFile(final String name) {
         // Handle empty param
-        if (CommonUtils.isBlank(name)) {
-            return;
-        }
-
-        try {
-            root = ImportControlLoader.load(new File(name).toURI());
-            fileLocation = name;
-        }
-        catch (final CheckstyleException ex) {
-            throw new ConversionException(UNABLE_TO_LOAD + name, ex);
+        if (!CommonUtils.isBlank(name)) {
+            try {
+                root = ImportControlLoader.load(new File(name).toURI());
+                fileLocation = name;
+            }
+            catch (final CheckstyleException ex) {
+                throw new ConversionException(UNABLE_TO_LOAD + name, ex);
+            }
         }
     }
 
@@ -175,22 +173,21 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
      */
     public void setUrl(final String url) {
         // Handle empty param
-        if (CommonUtils.isBlank(url)) {
-            return;
-        }
-        final URI uri;
-        try {
-            uri = URI.create(url);
-        }
-        catch (final IllegalArgumentException ex) {
-            throw new ConversionException("Syntax error in url " + url, ex);
-        }
-        try {
-            root = ImportControlLoader.load(uri);
-            fileLocation = url;
-        }
-        catch (final CheckstyleException ex) {
-            throw new ConversionException(UNABLE_TO_LOAD + url, ex);
+        if (!CommonUtils.isBlank(url)) {
+            final URI uri;
+            try {
+                uri = URI.create(url);
+            }
+            catch (final IllegalArgumentException ex) {
+                throw new ConversionException("Syntax error in url " + url, ex);
+            }
+            try {
+                root = ImportControlLoader.load(uri);
+                fileLocation = url;
+            }
+            catch (final CheckstyleException ex) {
+                throw new ConversionException(UNABLE_TO_LOAD + url, ex);
+            }
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -457,32 +457,30 @@ public class ImportOrderCheck
      */
     private void doVisitTokenInSameGroup(boolean isStatic,
             boolean previous, String name, int line) {
-        if (!ordered) {
-            return;
-        }
-
-        if (option == ImportOrderOption.INFLOW) {
-            // out of lexicographic order
-            if (compare(lastImport, name, caseSensitive) > 0) {
-                log(line, MSG_ORDERING, name);
+        if (ordered) {
+            if (option == ImportOrderOption.INFLOW) {
+                // out of lexicographic order
+                if (compare(lastImport, name, caseSensitive) > 0) {
+                    log(line, MSG_ORDERING, name);
+                }
             }
-        }
-        else {
-            final boolean shouldFireError =
-                // previous non-static but current is static (above)
-                // or
-                // previous static but current is non-static (under)
-                previous
-                    ||
-                    // current and previous static or current and
-                    // previous non-static
-                    lastImportStatic == isStatic
-                &&
-                // and out of lexicographic order
-                compare(lastImport, name, caseSensitive) > 0;
+            else {
+                final boolean shouldFireError =
+                    // previous non-static but current is static (above)
+                    // or
+                    // previous static but current is non-static (under)
+                    previous
+                        ||
+                        // current and previous static or current and
+                        // previous non-static
+                        lastImportStatic == isStatic
+                    &&
+                    // and out of lexicographic order
+                    compare(lastImport, name, caseSensitive) > 0;
 
-            if (shouldFireError) {
-                log(line, MSG_ORDERING, name);
+                if (shouldFireError) {
+                    log(line, MSG_ORDERING, name);
+                }
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -288,44 +288,42 @@ public abstract class AbstractExpressionHandler {
                                   IndentLevel indentLevel,
                                   boolean firstLineMatches,
                                   int firstLine) {
-        if (lines.isEmpty()) {
-            return;
-        }
+        if (!lines.isEmpty()) {
+            // check first line
+            final int startLine = lines.firstLine();
+            final int endLine = lines.lastLine();
+            final int startCol = lines.firstLineCol();
 
-        // check first line
-        final int startLine = lines.firstLine();
-        final int endLine = lines.lastLine();
-        final int startCol = lines.firstLineCol();
+            final int realStartCol =
+                getLineStart(indentCheck.getLine(startLine - 1));
 
-        final int realStartCol =
-            getLineStart(indentCheck.getLine(startLine - 1));
+            if (realStartCol == startCol) {
+                checkLineIndent(startLine, startCol, indentLevel,
+                    firstLineMatches);
+            }
 
-        if (realStartCol == startCol) {
-            checkLineIndent(startLine, startCol, indentLevel,
-                firstLineMatches);
-        }
+            // if first line starts the line, following lines are indented
+            // one level; but if the first line of this expression is
+            // nested with the previous expression (which is assumed if it
+            // doesn't start the line) then don't indent more, the first
+            // indentation is absorbed by the nesting
 
-        // if first line starts the line, following lines are indented
-        // one level; but if the first line of this expression is
-        // nested with the previous expression (which is assumed if it
-        // doesn't start the line) then don't indent more, the first
-        // indentation is absorbed by the nesting
+            IndentLevel theLevel = indentLevel;
+            if (firstLineMatches
+                || firstLine > mainAst.getLineNo() && shouldIncreaseIndent()) {
+                theLevel = new IndentLevel(indentLevel, getBasicOffset());
+            }
 
-        IndentLevel theLevel = indentLevel;
-        if (firstLineMatches
-            || firstLine > mainAst.getLineNo() && shouldIncreaseIndent()) {
-            theLevel = new IndentLevel(indentLevel, getBasicOffset());
-        }
+            // check following lines
+            for (int i = startLine + 1; i <= endLine; i++) {
+                final Integer col = lines.getStartColumn(i);
+                // startCol could be null if this line didn't have an
+                // expression that was required to be checked (it could be
+                // checked by a child expression)
 
-        // check following lines
-        for (int i = startLine + 1; i <= endLine; i++) {
-            final Integer col = lines.getStartColumn(i);
-            // startCol could be null if this line didn't have an
-            // expression that was required to be checked (it could be
-            // checked by a child expression)
-
-            if (col != null) {
-                checkLineIndent(i, col, theLevel, false);
+                if (col != null) {
+                    checkLineIndent(i, col, theLevel, false);
+                }
             }
         }
     }
@@ -496,23 +494,21 @@ public abstract class AbstractExpressionHandler {
      */
     protected final void findSubtreeLines(LineSet lines, DetailAST tree,
         boolean allowNesting) {
-        if (indentCheck.getHandlerFactory().isHandledType(tree.getType())) {
-            return;
-        }
+        if (!indentCheck.getHandlerFactory().isHandledType(tree.getType())) {
+            final int lineNum = tree.getLineNo();
+            final Integer colNum = lines.getStartColumn(lineNum);
 
-        final int lineNum = tree.getLineNo();
-        final Integer colNum = lines.getStartColumn(lineNum);
+            final int thisLineColumn = expandedTabsColumnNo(tree);
+            if (colNum == null || thisLineColumn < colNum) {
+                lines.addLineAndCol(lineNum, thisLineColumn);
+            }
 
-        final int thisLineColumn = expandedTabsColumnNo(tree);
-        if (colNum == null || thisLineColumn < colNum) {
-            lines.addLineAndCol(lineNum, thisLineColumn);
-        }
-
-        // check children
-        for (DetailAST node = tree.getFirstChild();
-            node != null;
-            node = node.getNextSibling()) {
-            findSubtreeLines(lines, node, allowNesting);
+            // check children
+            for (DetailAST node = tree.getFirstChild();
+                node != null;
+                node = node.getNextSibling()) {
+                findSubtreeLines(lines, node, allowNesting);
+            }
         }
     }
 
@@ -605,11 +601,10 @@ public abstract class AbstractExpressionHandler {
     protected final void checkLParen(final DetailAST lparen) {
         // the rcurly can either be at the correct indentation, or on the
         // same line as the lcurly
-        if (lparen == null
-            || getIndent().isAcceptable(expandedTabsColumnNo(lparen))
-            || !isOnStartOfLine(lparen)) {
-            return;
+        if (lparen != null
+                && !getIndent().isAcceptable(expandedTabsColumnNo(lparen))
+                && isOnStartOfLine(lparen)) {
+            logError(lparen, "lparen", expandedTabsColumnNo(lparen));
         }
-        logError(lparen, "lparen", expandedTabsColumnNo(lparen));
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -92,14 +92,12 @@ public class BlockParentHandler extends AbstractExpressionHandler {
     protected void checkTopLevelToken() {
         final DetailAST topLevel = getTopLevelAst();
 
-        if (topLevel == null
-            || getIndent().isAcceptable(expandedTabsColumnNo(topLevel)) || hasLabelBefore()) {
-            return;
+        if (topLevel != null
+                && !getIndent().isAcceptable(expandedTabsColumnNo(topLevel))
+                && !hasLabelBefore()
+                && (shouldTopLevelStartLine() || isOnStartOfLine(topLevel))) {
+            logError(topLevel, "", expandedTabsColumnNo(topLevel));
         }
-        if (!shouldTopLevelStartLine() && !isOnStartOfLine(topLevel)) {
-            return;
-        }
-        logError(topLevel, "", expandedTabsColumnNo(topLevel));
     }
 
     /**
@@ -158,11 +156,9 @@ public class BlockParentHandler extends AbstractExpressionHandler {
         final DetailAST lcurly = getLCurly();
         final int lcurlyPos = expandedTabsColumnNo(lcurly);
 
-        if (curlyIndent().isAcceptable(lcurlyPos) || !isOnStartOfLine(lcurly)) {
-            return;
+        if (!curlyIndent().isAcceptable(lcurlyPos) && isOnStartOfLine(lcurly)) {
+            logError(lcurly, "lcurly", lcurlyPos, curlyIndent());
         }
-
-        logError(lcurly, "lcurly", lcurlyPos, curlyIndent());
     }
 
     /**
@@ -202,12 +198,11 @@ public class BlockParentHandler extends AbstractExpressionHandler {
         final DetailAST rcurly = getRCurly();
         final int rcurlyPos = expandedTabsColumnNo(rcurly);
 
-        if (curlyIndent().isAcceptable(rcurlyPos)
-            || !shouldStartWithRCurly() && !isOnStartOfLine(rcurly)
-            || areOnSameLine(rcurly, lcurly)) {
-            return;
+        if (!curlyIndent().isAcceptable(rcurlyPos)
+                && (shouldStartWithRCurly() || isOnStartOfLine(rcurly))
+                && !areOnSameLine(rcurly, lcurly)) {
+            logError(rcurly, "rcurly", rcurlyPos, curlyIndent());
         }
-        logError(rcurly, "rcurly", rcurlyPos, curlyIndent());
     }
 
     /**
@@ -224,12 +219,10 @@ public class BlockParentHandler extends AbstractExpressionHandler {
      */
     private void checkNonListChild() {
         final DetailAST nonList = getNonListChild();
-        if (nonList == null) {
-            return;
+        if (nonList != null) {
+            final IndentLevel expected = new IndentLevel(getIndent(), getBasicOffset());
+            checkExpressionSubtree(nonList, expected, false, false);
         }
-
-        final IndentLevel expected = new IndentLevel(getIndent(), getBasicOffset());
-        checkExpressionSubtree(nonList, expected, false, false);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ElseHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ElseHandler.java
@@ -49,14 +49,16 @@ public class ElseHandler extends BlockParentHandler {
 
         final DetailAST ifAST = getMainAst().getParent();
         final DetailAST slist = ifAST.findFirstToken(TokenTypes.SLIST);
-        if (slist != null) {
+        if (slist == null) {
+            super.checkTopLevelToken();
+        }
+        else {
             final DetailAST lcurly = slist.getLastChild();
-            if (lcurly.getLineNo() == getMainAst().getLineNo()) {
-                // indentation checked as part of LITERAL IF check
-                return;
+            // indentation checked as part of LITERAL IF check
+            if (lcurly.getLineNo() != getMainAst().getLineNo()) {
+                super.checkTopLevelToken();
             }
         }
-        super.checkTopLevelToken();
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IfHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IfHandler.java
@@ -72,11 +72,9 @@ public class IfHandler extends BlockParentHandler {
 
     @Override
     protected void checkTopLevelToken() {
-        if (isIfAfterElse()) {
-            return;
+        if (!isIfAfterElse()) {
+            super.checkTopLevelToken();
         }
-
-        super.checkTopLevelToken();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -148,27 +148,24 @@ public class MethodCallHandler extends AbstractExpressionHandler {
     @Override
     public void checkIndentation() {
         final DetailAST exprNode = getMainAst().getParent();
-        if (exprNode.getParent().getType() != TokenTypes.SLIST) {
-            return;
+        if (exprNode.getParent().getType() == TokenTypes.SLIST) {
+            final DetailAST methodName = getMainAst().getFirstChild();
+            checkExpressionSubtree(methodName, getIndent(), false, false);
+
+            final DetailAST lparen = getMainAst();
+            final DetailAST rparen = getMainAst().findFirstToken(TokenTypes.RPAREN);
+            checkLParen(lparen);
+
+            if (rparen.getLineNo() != lparen.getLineNo()) {
+                checkExpressionSubtree(
+                    getMainAst().findFirstToken(TokenTypes.ELIST),
+                    new IndentLevel(getIndent(), getBasicOffset()),
+                    false, true);
+
+                checkRParen(lparen, rparen);
+                checkWrappingIndentation(getMainAst(), getMethodCallLastNode(getMainAst()));
+            }
         }
-        final DetailAST methodName = getMainAst().getFirstChild();
-        checkExpressionSubtree(methodName, getIndent(), false, false);
-
-        final DetailAST lparen = getMainAst();
-        final DetailAST rparen = getMainAst().findFirstToken(TokenTypes.RPAREN);
-        checkLParen(lparen);
-
-        if (rparen.getLineNo() == lparen.getLineNo()) {
-            return;
-        }
-
-        checkExpressionSubtree(
-            getMainAst().findFirstToken(TokenTypes.ELIST),
-            new IndentLevel(getIndent(), getBasicOffset()),
-            false, true);
-
-        checkRParen(lparen, rparen);
-        checkWrappingIndentation(getMainAst(), getMethodCallLastNode(getMainAst()));
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
@@ -112,11 +112,10 @@ public class MethodDefHandler extends BlockParentHandler {
         checkThrows();
 
         checkWrappingIndentation(getMainAst(), getMethodDefParamRightParen(getMainAst()));
-        if (getLCurly() == null) {
-            // abstract method def -- no body
-            return;
+        // abstract method def -- no body
+        if (getLCurly() != null) {
+            super.checkIndentation();
         }
-        super.checkIndentation();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
@@ -81,11 +81,9 @@ public class ObjectBlockHandler extends BlockParentHandler {
         // only do this if we have a new for a parent (anonymous inner
         // class)
         final DetailAST parentAST = getMainAst().getParent();
-        if (parentAST.getType() != TokenTypes.LITERAL_NEW) {
-            return;
+        if (parentAST.getType() == TokenTypes.LITERAL_NEW) {
+            super.checkIndentation();
         }
-
-        super.checkIndentation();
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
@@ -122,10 +122,9 @@ public class SlistHandler extends BlockParentHandler {
     public void checkIndentation() {
         // only need to check this if parent is not
         // an if, else, while, do, ctor, method
-        if (hasBlockParent() || isSameLineCaseGroup()) {
-            return;
+        if (!hasBlockParent() && !isSameLineCaseGroup()) {
+            super.checkIndentation();
         }
-        super.checkIndentation();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -480,33 +480,31 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     private void checkComment(DetailAST ast, TextBlock comment) {
         final List<JavadocTag> tags = getMethodTags(comment);
 
-        if (hasShortCircuitTag(ast, tags)) {
-            return;
-        }
-
-        final Iterator<JavadocTag> it = tags.iterator();
-        if (ast.getType() == TokenTypes.ANNOTATION_FIELD_DEF) {
-            checkReturnTag(tags, ast.getLineNo(), true);
-        }
-        else {
-            // Check for inheritDoc
-            boolean hasInheritDocTag = false;
-            while (!hasInheritDocTag && it.hasNext()) {
-                hasInheritDocTag = it.next().isInheritDocTag();
+        if (!hasShortCircuitTag(ast, tags)) {
+            final Iterator<JavadocTag> it = tags.iterator();
+            if (ast.getType() == TokenTypes.ANNOTATION_FIELD_DEF) {
+                checkReturnTag(tags, ast.getLineNo(), true);
             }
-            final boolean reportExpectedTags = !hasInheritDocTag && !hasAllowedAnnotations(ast);
+            else {
+                // Check for inheritDoc
+                boolean hasInheritDocTag = false;
+                while (!hasInheritDocTag && it.hasNext()) {
+                    hasInheritDocTag = it.next().isInheritDocTag();
+                }
+                final boolean reportExpectedTags = !hasInheritDocTag && !hasAllowedAnnotations(ast);
 
-            checkParamTags(tags, ast, reportExpectedTags);
-            checkThrowsTags(tags, getThrows(ast), reportExpectedTags);
-            if (CheckUtils.isNonVoidMethod(ast)) {
-                checkReturnTag(tags, ast.getLineNo(), reportExpectedTags);
+                checkParamTags(tags, ast, reportExpectedTags);
+                checkThrowsTags(tags, getThrows(ast), reportExpectedTags);
+                if (CheckUtils.isNonVoidMethod(ast)) {
+                    checkReturnTag(tags, ast.getLineNo(), reportExpectedTags);
+                }
             }
-        }
 
-        // Dump out all unused tags
-        for (JavadocTag javadocTag : tags) {
-            if (!javadocTag.isSeeOrInheritDocTag()) {
-                log(javadocTag.getLineNo(), MSG_UNUSED_TAG_GENERAL);
+            // Dump out all unused tags
+            for (JavadocTag javadocTag : tags) {
+                if (!javadocTag.isSeeOrInheritDocTag()) {
+                    log(javadocTag.getLineNo(), MSG_UNUSED_TAG_GENERAL);
+                }
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
@@ -70,22 +70,21 @@ public class JavadocPackageCheck extends AbstractFileSetCheck {
     protected void processFiltered(File file, List<String> lines) {
         // Check if already processed directory
         final File dir = file.getParentFile();
-        if (directoriesChecked.contains(dir)) {
-            return;
-        }
-        directoriesChecked.add(dir);
+        if (!directoriesChecked.contains(dir)) {
+            directoriesChecked.add(dir);
 
-        // Check for the preferred file.
-        final File packageInfo = new File(dir, "package-info.java");
-        final File packageHtml = new File(dir, "package.html");
+            // Check for the preferred file.
+            final File packageInfo = new File(dir, "package-info.java");
+            final File packageHtml = new File(dir, "package.html");
 
-        if (packageInfo.exists()) {
-            if (packageHtml.exists()) {
-                log(0, MSG_LEGACY_PACKAGE_HTML);
+            if (packageInfo.exists()) {
+                if (packageHtml.exists()) {
+                    log(0, MSG_LEGACY_PACKAGE_HTML);
+                }
             }
-        }
-        else if (!allowLegacy || !packageHtml.exists()) {
-            log(0, MSG_PACKAGE_INFO);
+            else if (!allowLegacy || !packageHtml.exists()) {
+                log(0, MSG_PACKAGE_INFO);
+            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -201,19 +201,19 @@ public class JavadocStyleCheck
             if (getFileContents().inPackageInfo()) {
                 log(ast.getLineNo(), MSG_JAVADOC_MISSING);
             }
-            return;
         }
+        else {
+            if (checkFirstSentence) {
+                checkFirstSentenceEnding(ast, comment);
+            }
 
-        if (checkFirstSentence) {
-            checkFirstSentenceEnding(ast, comment);
-        }
+            if (checkHtml) {
+                checkHtmlTags(ast, comment);
+            }
 
-        if (checkHtml) {
-            checkHtmlTags(ast, comment);
-        }
-
-        if (checkEmptyJavadoc) {
-            checkJavadocIsNotEmpty(comment);
+            if (checkEmptyJavadoc) {
+                checkJavadocIsNotEmpty(comment);
+            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -84,18 +84,17 @@ public class JavadocTagContinuationIndentationCheck extends AbstractJavadocCheck
 
     @Override
     public void visitJavadocToken(DetailNode ast) {
-        if (isInlineDescription(ast)) {
-            return;
-        }
-        final List<DetailNode> textNodes = getAllNewlineNodes(ast);
-        for (DetailNode newlineNode : textNodes) {
-            final DetailNode textNode = JavadocUtils.getNextSibling(JavadocUtils
-                    .getNextSibling(newlineNode));
-            if (textNode != null && textNode.getType() == JavadocTokenTypes.TEXT
-                    && textNode.getChildren().length > 1) {
-                final DetailNode whitespace = JavadocUtils.getFirstChild(textNode);
-                if (whitespace.getText().length() - 1 < offset) {
-                    log(textNode.getLineNumber(), MSG_KEY, offset);
+        if (!isInlineDescription(ast)) {
+            final List<DetailNode> textNodes = getAllNewlineNodes(ast);
+            for (DetailNode newlineNode : textNodes) {
+                final DetailNode textNode = JavadocUtils.getNextSibling(JavadocUtils
+                        .getNextSibling(newlineNode));
+                if (textNode != null && textNode.getType() == JavadocTokenTypes.TEXT
+                        && textNode.getChildren().length > 1) {
+                    final DetailNode whitespace = JavadocUtils.getFirstChild(textNode);
+                    if (whitespace.getText().length() - 1 < offset) {
+                        log(textNode.getLineNumber(), MSG_KEY, offset);
+                    }
                 }
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -276,23 +276,21 @@ public class JavadocTypeCheck
      */
     private void checkTag(int lineNo, List<JavadocTag> tags, String tagName,
                           Pattern formatPattern, String format) {
-        if (formatPattern == null) {
-            return;
-        }
-
-        int tagCount = 0;
-        final String tagPrefix = "@";
-        for (int i = tags.size() - 1; i >= 0; i--) {
-            final JavadocTag tag = tags.get(i);
-            if (tag.getTagName().equals(tagName)) {
-                tagCount++;
-                if (!formatPattern.matcher(tag.getFirstArg()).find()) {
-                    log(lineNo, MSG_TAG_FORMAT, tagPrefix + tagName, format);
+        if (formatPattern != null) {
+            int tagCount = 0;
+            final String tagPrefix = "@";
+            for (int i = tags.size() - 1; i >= 0; i--) {
+                final JavadocTag tag = tags.get(i);
+                if (tag.getTagName().equals(tagName)) {
+                    tagCount++;
+                    if (!formatPattern.matcher(tag.getFirstArg()).find()) {
+                        log(lineNo, MSG_TAG_FORMAT, tagPrefix + tagName, format);
+                    }
                 }
             }
-        }
-        if (tagCount == 0) {
-            log(lineNo, MSG_MISSING_TAG, tagPrefix + tagName);
+            if (tagCount == 0) {
+                log(lineNo, MSG_MISSING_TAG, tagPrefix + tagName);
+            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
@@ -172,30 +172,27 @@ public class WriteTagCheck
      * @param comment the Javadoc comment for the type definition.
      */
     private void checkTag(int lineNo, String... comment) {
-        if (tagRegExp == null) {
-            return;
-        }
-
-        int tagCount = 0;
-        for (int i = 0; i < comment.length; i++) {
-            final String commentValue = comment[i];
-            final Matcher matcher = tagRegExp.matcher(commentValue);
-            if (matcher.find()) {
-                tagCount += 1;
-                final int contentStart = matcher.start(1);
-                final String content = commentValue.substring(contentStart);
-                if (tagFormatRegExp == null || tagFormatRegExp.matcher(content).find()) {
-                    logTag(lineNo + i - comment.length, tag, content);
-                }
-                else {
-                    log(lineNo + i - comment.length, MSG_TAG_FORMAT, tag, tagFormat);
+        if (tagRegExp != null) {
+            int tagCount = 0;
+            for (int i = 0; i < comment.length; i++) {
+                final String commentValue = comment[i];
+                final Matcher matcher = tagRegExp.matcher(commentValue);
+                if (matcher.find()) {
+                    tagCount += 1;
+                    final int contentStart = matcher.start(1);
+                    final String content = commentValue.substring(contentStart);
+                    if (tagFormatRegExp == null || tagFormatRegExp.matcher(content).find()) {
+                        logTag(lineNo + i - comment.length, tag, content);
+                    }
+                    else {
+                        log(lineNo + i - comment.length, MSG_TAG_FORMAT, tag, tagFormat);
+                    }
                 }
             }
+            if (tagCount == 0) {
+                log(lineNo, MSG_MISSING_TAG, tag);
+            }
         }
-        if (tagCount == 0) {
-            log(lineNo, MSG_MISSING_TAG, tag);
-        }
-
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java
@@ -96,34 +96,32 @@ class SinglelineDetector {
     private void checkLine(int lineNo, String line, Matcher matcher,
             int startPosition) {
         final boolean foundMatch = matcher.find(startPosition);
-        if (!foundMatch) {
-            return;
-        }
-
-        // match is found, check for intersection with comment
-        final int startCol = matcher.start(0);
-        final int endCol = matcher.end(0);
-        // Note that Matcher.end(int) returns the offset AFTER the
-        // last matched character, but shouldSuppress()
-        // needs column number of the last character.
-        // So we need to use (endCol - 1) here.
-        if (options.getSuppressor()
-                .shouldSuppress(lineNo, startCol, lineNo, endCol - 1)) {
-            if (endCol < line.length()) {
-                // check if the expression is on the rest of the line
-                checkLine(lineNo, line, matcher, endCol);
-            }
-            return;
-        }
-
-        currentMatches++;
-        if (currentMatches > options.getMaximum()) {
-            if (options.getMessage().isEmpty()) {
-                options.getReporter().log(lineNo, MSG_REGEXP_EXCEEDED,
-                        matcher.pattern().toString());
+        if (foundMatch) {
+            // match is found, check for intersection with comment
+            final int startCol = matcher.start(0);
+            final int endCol = matcher.end(0);
+            // Note that Matcher.end(int) returns the offset AFTER the
+            // last matched character, but shouldSuppress()
+            // needs column number of the last character.
+            // So we need to use (endCol - 1) here.
+            if (options.getSuppressor()
+                    .shouldSuppress(lineNo, startCol, lineNo, endCol - 1)) {
+                if (endCol < line.length()) {
+                    // check if the expression is on the rest of the line
+                    checkLine(lineNo, line, matcher, endCol);
+                }
             }
             else {
-                options.getReporter().log(lineNo, options.getMessage());
+                currentMatches++;
+                if (currentMatches > options.getMaximum()) {
+                    if (options.getMessage().isEmpty()) {
+                        options.getReporter().log(lineNo, MSG_REGEXP_EXCEEDED,
+                                matcher.pattern().toString());
+                    }
+                    else {
+                        options.getReporter().log(lineNo, options.getMessage());
+                    }
+                }
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
@@ -127,26 +127,25 @@ public class MethodParamPadCheck
         else {
             parenAST = ast.findFirstToken(TokenTypes.LPAREN);
             // array construction => parenAST == null
-            if (parenAST == null) {
-                return;
-            }
         }
 
-        final String line = getLines()[parenAST.getLineNo() - 1];
-        if (CommonUtils.hasWhitespaceBefore(parenAST.getColumnNo(), line)) {
-            if (!allowLineBreaks) {
-                log(parenAST, MSG_LINE_PREVIOUS, parenAST.getText());
+        if (parenAST != null) {
+            final String line = getLines()[parenAST.getLineNo() - 1];
+            if (CommonUtils.hasWhitespaceBefore(parenAST.getColumnNo(), line)) {
+                if (!allowLineBreaks) {
+                    log(parenAST, MSG_LINE_PREVIOUS, parenAST.getText());
+                }
             }
-        }
-        else {
-            final int before = parenAST.getColumnNo() - 1;
-            if (option == PadOption.NOSPACE
-                && Character.isWhitespace(line.charAt(before))) {
-                log(parenAST, MSG_WS_PRECEDED, parenAST.getText());
-            }
-            else if (option == PadOption.SPACE
-                     && !Character.isWhitespace(line.charAt(before))) {
-                log(parenAST, MSG_WS_NOT_PRECEDED, parenAST.getText());
+            else {
+                final int before = parenAST.getColumnNo() - 1;
+                if (option == PadOption.NOSPACE
+                    && Character.isWhitespace(line.charAt(before))) {
+                    log(parenAST, MSG_WS_PRECEDED, parenAST.getText());
+                }
+                else if (option == PadOption.SPACE
+                         && !Character.isWhitespace(line.charAt(before))) {
+                    log(parenAST, MSG_WS_NOT_PRECEDED, parenAST.getText());
+                }
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
@@ -201,31 +201,28 @@ public class OperatorWrapCheck
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (ast.getType() == TokenTypes.COLON) {
-            final DetailAST parent = ast.getParent();
-            if (parent.getType() == TokenTypes.LITERAL_DEFAULT
-                || parent.getType() == TokenTypes.LITERAL_CASE) {
-                //we do not want to check colon for cases and defaults
-                return;
+        final DetailAST parent = ast.getParent();
+        //we do not want to check colon for cases and defaults
+        if (ast.getType() != TokenTypes.COLON
+                || parent.getType() != TokenTypes.LITERAL_DEFAULT
+                    && parent.getType() != TokenTypes.LITERAL_CASE) {
+            final String text = ast.getText();
+            final int colNo = ast.getColumnNo();
+            final int lineNo = ast.getLineNo();
+            final String currentLine = getLine(lineNo - 1);
+
+            // Check if rest of line is whitespace, and not just the operator
+            // by itself. This last bit is to handle the operator on a line by
+            // itself.
+            if (option == WrapOption.NL
+                    && !text.equals(currentLine.trim())
+                    && CommonUtils.isBlank(currentLine.substring(colNo + text.length()))) {
+                log(lineNo, colNo, MSG_LINE_NEW, text);
             }
-        }
-
-        final String text = ast.getText();
-        final int colNo = ast.getColumnNo();
-        final int lineNo = ast.getLineNo();
-        final String currentLine = getLine(lineNo - 1);
-
-        // Check if rest of line is whitespace, and not just the operator
-        // by itself. This last bit is to handle the operator on a line by
-        // itself.
-        if (option == WrapOption.NL
-                && !text.equals(currentLine.trim())
-                && CommonUtils.isBlank(currentLine.substring(colNo + text.length()))) {
-            log(lineNo, colNo, MSG_LINE_NEW, text);
-        }
-        else if (option == WrapOption.EOL
-                && CommonUtils.hasWhitespaceBefore(colNo - 1, currentLine)) {
-            log(lineNo, colNo, MSG_LINE_PREVIOUS, text);
+            else if (option == WrapOption.EOL
+                    && CommonUtils.hasWhitespaceBefore(colNo - 1, currentLine)) {
+                log(lineNo, colNo, MSG_LINE_PREVIOUS, text);
+            }
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -364,29 +364,27 @@ public class WhitespaceAroundCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         final int currentType = ast.getType();
-        if (isNotRelevantSituation(ast, currentType)) {
-            return;
-        }
+        if (!isNotRelevantSituation(ast, currentType)) {
+            final String line = getLine(ast.getLineNo() - 1);
+            final int before = ast.getColumnNo() - 1;
+            final int after = ast.getColumnNo() + ast.getText().length();
 
-        final String line = getLine(ast.getLineNo() - 1);
-        final int before = ast.getColumnNo() - 1;
-        final int after = ast.getColumnNo() + ast.getText().length();
-
-        if (before >= 0) {
-            final char prevChar = line.charAt(before);
-            if (shouldCheckSeparationFromPreviousToken(ast)
-                    && !Character.isWhitespace(prevChar)) {
-                log(ast.getLineNo(), ast.getColumnNo(),
-                        MSG_WS_NOT_PRECEDED, ast.getText());
+            if (before >= 0) {
+                final char prevChar = line.charAt(before);
+                if (shouldCheckSeparationFromPreviousToken(ast)
+                        && !Character.isWhitespace(prevChar)) {
+                    log(ast.getLineNo(), ast.getColumnNo(),
+                            MSG_WS_NOT_PRECEDED, ast.getText());
+                }
             }
-        }
 
-        if (after < line.length()) {
-            final char nextChar = line.charAt(after);
-            if (shouldCheckSeparationFromNextToken(ast, nextChar)
-                    && !Character.isWhitespace(nextChar)) {
-                log(ast.getLineNo(), ast.getColumnNo() + ast.getText().length(),
-                        MSG_WS_NOT_FOLLOWED, ast.getText());
+            if (after < line.length()) {
+                final char nextChar = line.charAt(after);
+                if (shouldCheckSeparationFromNextToken(ast, nextChar)
+                        && !Character.isWhitespace(nextChar)) {
+                    log(ast.getLineNo(), ast.getColumnNo() + ast.getText().length(),
+                            MSG_WS_NOT_FOLLOWED, ast.getText());
+                }
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
@@ -343,14 +343,13 @@ public final class CommonUtils {
      *            Closeable object
      */
     public static void close(Closeable closeable) {
-        if (closeable == null) {
-            return;
-        }
-        try {
-            closeable.close();
-        }
-        catch (IOException ex) {
-            throw new IllegalStateException("Cannot close the stream", ex);
+        if (closeable != null) {
+            try {
+                closeable.close();
+            }
+            catch (IOException ex) {
+                throw new IllegalStateException("Cannot close the stream", ex);
+            }
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
@@ -51,8 +51,10 @@ public class ReturnCountCheckTest extends BaseCheckTestSupport {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ReturnCountCheck.class);
         final String[] expected = {
-            "18:5: " + getCheckMessage(MSG_KEY, 7, 2),
-            "35:17: " + getCheckMessage(MSG_KEY, 6, 2),
+            "18:5: " + getCheckMessage(MSG_KEY, 7, 1),
+            "30:5: " + getCheckMessage(MSG_KEY, 2, 1),
+            "35:17: " + getCheckMessage(MSG_KEY, 6, 1),
+            "49:5: " + getCheckMessage(MSG_KEY, 7, 2),
         };
         verify(checkConfig, getPath("InputReturnCount.java"), expected);
     }
@@ -64,8 +66,10 @@ public class ReturnCountCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("format", "^$");
         final String[] expected = {
             "5:5: " + getCheckMessage(MSG_KEY, 7, 2),
-            "18:5: " + getCheckMessage(MSG_KEY, 7, 2),
-            "35:17: " + getCheckMessage(MSG_KEY, 6, 2),
+            "18:5: " + getCheckMessage(MSG_KEY, 7, 1),
+            "30:5: " + getCheckMessage(MSG_KEY, 2, 1),
+            "35:17: " + getCheckMessage(MSG_KEY, 6, 1),
+            "49:5: " + getCheckMessage(MSG_KEY, 7, 2),
         };
         verify(checkConfig, getPath("InputReturnCount.java"), expected);
     }
@@ -137,5 +141,19 @@ public class ReturnCountCheckTest extends BaseCheckTestSupport {
         catch (IllegalStateException ex) {
             // it is OK
         }
+    }
+
+    @Test
+    public void testMaxForVoid() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ReturnCountCheck.class);
+        checkConfig.addAttribute("max", "2");
+        checkConfig.addAttribute("maxForVoid", "0");
+        final String[] expected = {
+            "4:5: " + getCheckMessage(MSG_KEY, 1, 0),
+            "8:5: " + getCheckMessage(MSG_KEY, 1, 0),
+            "14:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "30:5: " + getCheckMessage(MSG_KEY, 3, 2),
+        };
+        verify(checkConfig, getPath("InputReturnCountVoid.java"), expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
@@ -216,37 +216,36 @@ public class XDocsPagesTest {
     private static void validateCheckstyleXml(String fileName, String code,
             String unserializedSource) throws IOException {
         // can't process non-existent examples, or out of context snippets
-        if (code.contains("com.mycompany") || code.contains("checkstyle-packages")
-                || code.contains("MethodLimit") || code.contains("<suppress ")
-                || code.contains("<import-control ") || unserializedSource.startsWith("<property ")
-                || unserializedSource.startsWith("<taskdef ")) {
-            return;
-        }
-
-        // validate checkstyle structure and contents
-        try {
-            final Properties properties = new Properties();
-
-            properties.setProperty("checkstyle.header.file",
-                    new File("config/java.header").getCanonicalPath());
-
-            final PropertiesExpander expander = new PropertiesExpander(properties);
-            final Configuration config = ConfigurationLoader.loadConfiguration(new InputSource(
-                    new StringReader(code)), expander, false);
-            final Checker checker = new Checker();
-
+        if (!code.contains("com.mycompany") && !code.contains("checkstyle-packages")
+                && !code.contains("MethodLimit") && !code.contains("<suppress ")
+                && !code.contains("<import-control ")
+                && !unserializedSource.startsWith("<property ")
+                && !unserializedSource.startsWith("<taskdef ")) {
+            // validate checkstyle structure and contents
             try {
-                final ClassLoader moduleClassLoader = Checker.class.getClassLoader();
-                checker.setModuleClassLoader(moduleClassLoader);
-                checker.configure(config);
+                final Properties properties = new Properties();
+
+                properties.setProperty("checkstyle.header.file",
+                        new File("config/java.header").getCanonicalPath());
+
+                final PropertiesExpander expander = new PropertiesExpander(properties);
+                final Configuration config = ConfigurationLoader.loadConfiguration(new InputSource(
+                        new StringReader(code)), expander, false);
+                final Checker checker = new Checker();
+
+                try {
+                    final ClassLoader moduleClassLoader = Checker.class.getClassLoader();
+                    checker.setModuleClassLoader(moduleClassLoader);
+                    checker.configure(config);
+                }
+                finally {
+                    checker.destroy();
+                }
             }
-            finally {
-                checker.destroy();
+            catch (CheckstyleException ex) {
+                Assert.fail(fileName + " has invalid Checkstyle xml (" + ex.getMessage() + "): "
+                        + unserializedSource);
             }
-        }
-        catch (CheckstyleException ex) {
-            Assert.fail(fileName + " has invalid Checkstyle xml (" + ex.getMessage() + "): "
-                    + unserializedSource);
         }
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputReturnCount.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputReturnCount.java
@@ -45,6 +45,19 @@ public class InputReturnCount
             };
         return;
     }
+
+    public boolean foo2() {
+        int i = 1;
+        switch (i) {
+        case 1: return true;
+        case 2: return true;
+        case 3: return true;
+        case 4: return true;
+        case 5: return true;
+        case 6: return true;
+        }
+        return false;
+    }
 }
 
 class Test {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputReturnCountVoid.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputReturnCountVoid.java
@@ -1,0 +1,40 @@
+package com.puppycrawl.tools.checkstyle.checks.coding;
+
+class InputReturnCountVoid {
+    public InputReturnCountVoid() {
+        return;
+    }
+
+    public void method() {
+        if (true) {
+            return;
+        }
+    }
+
+    public void method2() {
+        if (true) {
+            return;
+        }
+
+        return;
+    }
+
+    public int method3() {
+        if (true) {
+            return 0;
+        }
+
+        return 0;
+    }
+
+    public int method4() {
+        if (true) {
+            return 0;
+        }
+        if (false) {
+            return 0;
+        }
+
+        return 0;
+    }
+}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -3455,6 +3455,18 @@ public static class B {
         </p>
 
         <p>
+          <b>max</b> property will only check returns in methods and lambdas that return a specific value (Ex: 'return 1;').
+        </p>
+
+        <p>
+          <b>maxForVoid</b> property will only check returns in methods, constructors, and lambdas that have no return type (IE
+          'return;').
+          It will only count visible return statements. Return statements not normally written, but implied, at
+          the end of the method/constructor definition will not be taken into account.
+          To disallow "return;" in void return type methods, use a value of 0.
+        </p>
+
+        <p>
           Rationale: Too many return points can mean that code is
           attempting to do too much or may be difficult to understand.
         </p>
@@ -3470,9 +3482,15 @@ public static class B {
           </tr>
           <tr>
             <td>max</td>
-            <td>maximum allowed number of return statements</td>
+            <td>maximum allowed number of return statements in non-void methods/lambdas</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>2</code></td>
+          </tr>
+          <tr>
+            <td>maxForVoid</td>
+            <td>maximum allowed number of return statements in void methods/constructors/lambdas</td>
+            <td><a href="property_types.html#integer">Integer</a></td>
+            <td><code>1</code></td>
           </tr>
           <tr>
             <td>format</td>
@@ -3507,6 +3525,28 @@ public static class B {
         <source>
 &lt;module name=&quot;ReturnCount&quot;&gt;
     &lt;property name=&quot;max&quot; value=&quot;3&quot;/&gt;
+&lt;/module&gt;
+        </source>
+
+        <p>
+          To configure the check so that it doesn't allow any
+          return statements per void method:
+        </p>
+        <source>
+&lt;module name=&quot;ReturnCount&quot;&gt;
+    &lt;property name=&quot;maxForVoid&quot; value=&quot;0&quot;/&gt;
+&lt;/module&gt;
+        </source>
+
+        <p>
+          To configure the check so that it doesn't allow more than 2
+          return statements per method (ignoring the <code>equals()</code>
+          method) and more than 1 return statements per void method:
+        </p>
+        <source>
+&lt;module name=&quot;ReturnCount&quot;&gt;
+    &lt;property name=&quot;max&quot; value=&quot;2&quot;/&gt;
+    &lt;property name=&quot;maxForVoid&quot; value=&quot;1&quot;/&gt;
 &lt;/module&gt;
         </source>
 


### PR DESCRIPTION
Issue #3143

**maxForVoid** counts empty return statements.
**max** counts non-empty return statements.

Any violation I wasn't sure how to fix properly, I left as a suppression. Feel free to provide any insight on the best way to fix them.

Questions:
(1)
> This code ... with maxForVoid=1 should fire violation.
private void checkThrows() {
...
        if (throwsAst == null) {
            return; /// should be violation with maxForVoid=1, as one return is at end of method
        }
....
    }

Are we sure we want to include *hidden* return statements at the end of the method in the count?
It isn't specifically written out in the code and some people may not understand that there is an implied `return` statement there.
Count for `max` is based on *written* returns, so it seems that `maxForVoid` should follow suite.
The above can show violations when `maxForVoid` is set to 0, meaning no `return` statement should be written.