### PR TITLE
Issue #3187: validate property types

### DIFF
--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -49,19 +49,19 @@ public String getNameIfPresent() { ... }
           <tr>
             <td>allowSamelineMultipleAnnotations</td>
             <td>To allow annotation to be located on the same line as target element.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
            <td><code>false</code></td>
           </tr>
           <tr>
             <td>allowSamelineSingleParameterlessAnnotation</td>
             <td>To allow single prameterless annotation to be located on the same line as target element.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
           <tr>
             <td>allowSamelineParameterizedAnnotation</td>
             <td>To allow parameterized annotation to be located on the same line as target element.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
@@ -328,7 +328,7 @@ public String getNameIfPresent() { ... }
             present but either @deprecated is missing from JavaDoc or
             @deprecated is missing from the element.
             </td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
           </tr>
         </table>
@@ -419,7 +419,7 @@ public static final int COUNTER = 10; // violation as javadoc exists
                 check. It is recommended to only use it on Java 5 source </b>
             </td>
             <td>
-              <a href="property_types.html#boolean">boolean</a>
+              <a href="property_types.html#boolean">Boolean</a>
             </td>
             <td>
               <code>false</code>

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -99,7 +99,7 @@ switch (a)
           <tr>
             <td>allowInSwitchCase</td>
             <td>Allow nested blocks in case statements</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
         </table>
@@ -437,7 +437,7 @@ try {
           <tr>
             <td>ignoreEnums</td>
             <td>If true, Check will ignore enums when left curly brace policy is EOL</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>true</td>
           </tr>
           <tr>
@@ -445,7 +445,7 @@ try {
             <td>maximum number of characters in a line. ATTENTION:
                 The option has been marked as <b>deprecated</b>
                 since checkstyle 6.10 release.</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>80</code></td>
           </tr>
           <tr>
@@ -589,13 +589,13 @@ try {
           <tr>
             <td>allowSingleLineStatement</td>
             <td>allows single-line statements without braces</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
           </tr>
           <tr>
             <td>allowEmptyLoopBody</td>
             <td>allows loops with empty bodies</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
           </tr>
           <tr>
@@ -767,7 +767,7 @@ for(int i = 0; i &lt; 10; value.incrementValue()); // OK
             <td>shouldStartLine</td>
             <td>should we check if <code>'}'</code>
             starts line.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
           <tr>

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -585,7 +585,7 @@ String nullString = null;
           <tr>
             <td>ignoreEqualsIgnoreCase</td>
             <td>whether to ignore <code>String.equalsIgnoreCase()</code> invocations</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
           </tr>
         </table>
@@ -1280,7 +1280,7 @@ class SomeClass
           <tr>
             <td>illegalClassNames</td>
             <td>exception class names to reject</td>
-            <td><a href="property_types.html#stringSet">list of strings</a></td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>&quot;java.lang.Exception,
             java.lang.Throwable, java.lang.RuntimeException&quot;</code></td>
           </tr>
@@ -1467,7 +1467,7 @@ class SomeClass
           <tr>
             <td>illegalClassNames</td>
             <td>throw class names to reject</td>
-            <td><a href="property_types.html#stringSet">list of strings</a></td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
             <td>
               <code>&quot;java.lang.Throwable,
               java.lang.Error, java.lang.RuntimeException&quot;</code>
@@ -1476,7 +1476,7 @@ class SomeClass
           <tr>
             <td>ignoredMethodNames</td>
             <td>names of methods to ignore</td>
-            <td><a href="property_types.html#stringSet">list of strings</a></td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>finalize</code></td>
           </tr>
           <tr>
@@ -1770,7 +1770,7 @@ class SomeClass
           <tr>
             <td>validateAbstractClassNames</td>
             <td>Whether to validate abstract class names</td>
-            <td>boolean</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
           </tr>
           <tr>
@@ -1996,44 +1996,32 @@ static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
           <tr>
             <td>ignoreNumbers</td>
             <td>non-magic numbers</td>
-            <td>list of numbers</td>
+            <td><a href="property_types.html#intSet">Number Set</a></td>
             <td>-1, 0, 1, 2</td>
           </tr>
           <tr>
             <td>ignoreHashCodeMethod</td>
             <td>ignore magic numbers in hashCode methods</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><span class="default">false</span></td>
           </tr>
           <tr>
             <td>ignoreAnnotation</td>
             <td>ignore magic numbers in annotation declarations.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><span class="default">false</span></td>
           </tr>
           <tr>
               <td>ignoreFieldDeclaration</td>
               <td>ignore magic numbers in field declarations.</td>
-              <td><a href="property_types.html#boolean">boolean</a></td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
               <td><span class="default">false</span></td>
           </tr>
           <tr>
               <td>constantWaiverParentToken</td>
               <td>Token that are allowed in the AST path from the number literal to the enclosing constant definition.</td>
               <td>subset of tokens
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">ASSIGN</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">ARRAY_INIT</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">EXPR</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">UNARY_PLUS</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">UNARY_MINUS</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">TYPECAST</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELIST">ELIST</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">LITERAL_NEW</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">METHOD_CALL</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">STAR</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">DIV</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">PLUS</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">MINUS</a>.
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
               </td>
               <td>
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">ASSIGN</a>,
@@ -2473,9 +2461,8 @@ class MyClass {
               annotations or static initializers from the check.
             </td>
             <td>
-              <a href="property_types.html#stringSet">list</a> of
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">token type</a>
-              names
+              subset of tokens
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
             </td>
             <td>
               <code>ANNOTATION</code>
@@ -3286,19 +3273,19 @@ public void foo(int i, String s) {}
           <tr>
             <td>checkFields</td>
             <td>Whether to check references to fields.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
           <tr>
             <td>checkMethods</td>
             <td>Whether to check references to methods.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
           <tr>
             <td>validateOnlyOverlapping</td>
             <td>Whether to check only overlapping by variables or arguments.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
         </table>
@@ -4061,7 +4048,7 @@ if (&quot;something&quot;.equals(x))
           <tr>
             <td>allowedDistance</td>
             <td>A distance between declaration of variable and its first usage</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td>3</td>
           </tr>
 

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -834,13 +834,13 @@ public class Foo{
           <tr>
             <td>packageAllowed</td>
             <td>whether package visible members are allowed</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
             <td>protectedAllowed</td>
             <td>whether protected members are allowed</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
@@ -852,7 +852,7 @@ public class Foo{
           <tr>
             <td>allowPublicImmutableFields</td>
             <td>allows immutable fields be declared as public if defined in final class</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
           <tr>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -54,7 +54,7 @@
                accepts an audit event if and only if there is not a match
                between the event's severity level and property severity.
             </td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
         </table>
@@ -146,13 +146,13 @@
               <tr>
                   <td>checkCPP</td>
                   <td>whether to check C++ style comments (<code>//</code>)</td>
-                  <td><a href="property_types.html#boolean">boolean</a></td>
+                  <td><a href="property_types.html#boolean">Boolean</a></td>
                   <td><code>true</code></td>
               </tr>
               <tr>
                   <td>checkC</td>
                   <td>whether to check C style comments (<code>/* ... */</code>)</td>
-                  <td><a href="property_types.html#boolean">boolean</a></td>
+                  <td><a href="property_types.html#boolean">Boolean</a></td>
                   <td><code>true</code></td>
               </tr>
           </table>
@@ -431,7 +431,7 @@ public static void foo() {
                    true and file is not found, the filter accept all
                    audit events.
                </td>
-               <td><a href="property_types.html#boolean">boolean</a></td>
+               <td><a href="property_types.html#boolean">Boolean</a></td>
                <td><code>false</code></td>
              </tr>
           </table>
@@ -774,13 +774,13 @@ public static void foo() {
                 <tr>
                     <td>checkCPP</td>
                     <td>whether to check C++ style comments (<code>//</code>)</td>
-                    <td><a href="property_types.html#boolean">boolean</a></td>
+                    <td><a href="property_types.html#boolean">Boolean</a></td>
                     <td><code>true</code></td>
                 </tr>
                 <tr>
                     <td>checkC</td>
                     <td>whether to check C style comments (<code>/* ... */</code>)</td>
-                    <td><a href="property_types.html#boolean">boolean</a></td>
+                    <td><a href="property_types.html#boolean">Boolean</a></td>
                     <td><code>true</code></td>
                 </tr>
             </table>

--- a/src/xdocs/config_header.xml
+++ b/src/xdocs/config_header.xml
@@ -86,7 +86,7 @@ line 5: ////////////////////////////////////////////////////////////////////
           <tr>
             <td>ignoreLines</td>
             <td>line numbers to ignore</td>
-            <td><a href="property_types.html#intSet">list of integers</a></td>
+            <td><a href="property_types.html#intSet">Integer Set</a></td>
             <td><code>{}</code></td>
           </tr>
           <tr>
@@ -285,7 +285,7 @@ line 6: ^\W*$
           <tr>
             <td>multiLines</td>
             <td>line numbers to repeat (zero or more times)</td>
-            <td><a href="property_types.html#intSet">list of integers</a></td>
+            <td><a href="property_types.html#intSet">Integer Set</a></td>
             <td><code>{}</code></td>
           </tr>
           <tr>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -50,7 +50,7 @@
               is not recursive, subpackages of excluded packages are not
               automatically excluded.
             </td>
-            <td><a href="property_types.html#stringSet">list of strings</a></td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>empty list</code></td>
           </tr>
           <tr>
@@ -167,7 +167,7 @@
               import of each static member in the Math class
               individually like <code>java.lang.Math.PI</code>.
             </td>
-            <td><a href="property_types.html#stringSet">list of strings</a></td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>empty list</code></td>
           </tr>
         </table>
@@ -356,7 +356,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
           <tr>
             <td>separateLineBetweenGroups</td>
             <td>Force empty line separator between import groups.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
           <tr>
@@ -364,7 +364,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
             <td>Force grouping alphabetically, in
                 <a href="https://en.wikipedia.org/wiki/ASCII#Order">
                    ASCII sort order</a>.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
         </table>
@@ -604,7 +604,7 @@ import android.*;
           <tr>
             <td>illegalPkgs</td>
             <td>packages to reject</td>
-            <td><a href="property_types.html#stringSet">list of strings</a></td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>sun</code></td>
           </tr>
         </table>
@@ -844,7 +844,7 @@ import android.*;
               common prefix string, or by a regular expression enclosed
               in forward slashes (e.g. <code>/regexp/</code>)
             </td>
-            <td><a href="property_types.html#stringSet">list of strings</a></td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>empty list</code></td>
           </tr>
           <tr>
@@ -1195,7 +1195,7 @@ class FooBar {
           <tr>
             <td>processJavadoc</td>
             <td>whether to process Javadoc</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
         </table>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -226,7 +226,7 @@ public int checkReturnTag(final int aTagIndex,
           <tr>
             <td>validateThrows</td>
             <td>Allows validating throws tags.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
@@ -245,21 +245,21 @@ public int checkReturnTag(final int aTagIndex,
             <td>allowUndeclaredRTE</td>
             <td>whether to allow documented exceptions that
             are not declared if they are a subclass of <code>java.lang.RuntimeException</code></td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
             <td>allowThrowsTagsForSubclasses</td>
             <td>whether to allow documented exceptions that
             are subclass of one of declared exception.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
             <td>allowMissingParamTags</td>
             <td>whether to ignore errors when a method has parameters
             but does not have matching param tags in the javadoc.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
@@ -267,20 +267,20 @@ public int checkReturnTag(final int aTagIndex,
             <td>whether to ignore errors when a method declares
             that it throws exceptions but does have matching throws tags
             in the javadoc.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
             <td>allowMissingReturnTag</td>
             <td>whether to ignore errors when a method returns
             non-void type does have a return tag in the javadoc.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
             <td>allowMissingJavadoc</td>
             <td>whether to ignore errors when a method javadoc is missed.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
@@ -307,7 +307,7 @@ public boolean isSomething()
 }
               </pre>
             </td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
@@ -322,7 +322,7 @@ public boolean isSomething()
             typo or refactoring problem in the
             javadoc and logs the problem in the normal checkstyle report
             (potentially masking a configuration error).</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
           <tr>
@@ -334,7 +334,7 @@ public boolean isSomething()
             logLoadErrors is set true are suppressed from being reported as
             violations in the checkstyle report.
             </td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
@@ -514,7 +514,7 @@ public boolean isSomething()
               If set then allow the use of a
               <code>package.html</code> file.
             </td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
@@ -797,7 +797,7 @@ public boolean isSomething()
             <td>
               Whether to check the first sentence for proper end of sentence.
             </td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
           <tr>
@@ -813,13 +813,13 @@ public boolean isSomething()
             <td>
               Whether to check if the Javadoc is missing a describing text.
             </td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
             <td>checkHtml</td>
             <td>Whether to check for incomplete HTML tags.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
           <tr>
@@ -1109,13 +1109,13 @@ public boolean isSomething()
             <td>allowMissingParamTags</td>
             <td>whether to ignore errors when a class has type parameters
                 but does not have matching param tags in the javadoc.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
             <td>allowUnknownTags</td>
             <td>whether to ignore errors when a Javadoc tag is not recognised.</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -63,7 +63,7 @@
               the maximum allowed number of boolean operations in one
               expression.
             </td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>3</code></td>
           </tr>
           <tr>
@@ -177,7 +177,7 @@
           <tr>
             <td>max</td>
             <td>the maximum threshold allowed</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>7</code></td>
           </tr>
           <tr>
@@ -274,7 +274,7 @@
           <tr>
             <td>max</td>
             <td>the maximum threshold allowed</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>20</code></td>
           </tr>
           <tr>
@@ -391,13 +391,13 @@
           <tr>
             <td>max</td>
             <td>the maximum threshold allowed</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>10</code></td>
           </tr>
           <tr>
             <td>switchBlockAsSingleDecisionPoint</td>
             <td>whether to treat the whole switch block as a single decision point</td>
-            <td><a href="property_types.html#integer">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
 
@@ -597,7 +597,7 @@ class SwitchExample {
               the maximum allowed number of non commenting lines in a
               method.
             </td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#Integer">Integer</a></td>
             <td><code>50</code></td>
           </tr>
           <tr>
@@ -606,7 +606,7 @@ class SwitchExample {
               the maximum allowed number of non commenting lines in a
               class.
             </td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>1500</code></td>
           </tr>
           <tr>
@@ -615,7 +615,7 @@ class SwitchExample {
               the maximum allowed number of non commenting lines in a
               file including all top level and nested classes.
             </td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>2000</code></td>
           </tr>
         </table>
@@ -765,7 +765,7 @@ class SwitchExample {
           <tr>
             <td>max</td>
             <td>the maximum threshold allowed</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>200</code></td>
           </tr>
 

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -539,8 +539,10 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
           <tr>
             <td>limitedTokens</td>
             <td>set of tokens with limited occurrences as descendants</td>
-            <td>subset of tokens declared in <a
-            href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a></td>
+            <td>
+             subset of tokens
+             <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
+            </td>
             <td>empty set</td>
           </tr>
           <tr>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -54,8 +54,8 @@
             <td>allowedAbbreviationLength</td>
             <td>indicates on the allowed amount of capital letters in targeted identifiers
              (abbreviations in the classes, interfaces, variables and methods names, ... ).</td>
-            <td><a href="property_types.html#integer">3</a></td>
-            <td>true</td>
+            <td><a href="property_types.html#integer">Integer</a></td>
+            <td>3</td>
           </tr>
           <tr>
             <td>allowedAbbreviations</td>

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -47,7 +47,7 @@
           <tr>
             <td>max</td>
             <td>maximum allowable number of lines</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td>20</td>
           </tr>
         </table>
@@ -117,7 +117,7 @@
           <tr>
             <td>max</td>
             <td>the maximum threshold allowed</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>30</code></td>
           </tr>
           <tr>
@@ -219,7 +219,7 @@
           <tr>
             <td>max</td>
             <td>maximum allowable number of lines</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td>2000</td>
           </tr>
           <tr>
@@ -312,7 +312,7 @@
           <tr>
             <td>max</td>
             <td>maximum allowable line length</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td>80</td>
           </tr>
         </table>
@@ -419,31 +419,31 @@
           <tr>
             <td>maxTotal</td>
             <td>maximum allowable number of methods at all scope levels</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td>100</td>
           </tr>
           <tr>
             <td>maxPrivate</td>
             <td>maximum allowable number of <code>private</code> methods</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td>100</td>
           </tr>
           <tr>
             <td>maxPackage</td>
             <td>maximum allowable number of <code>package</code> methods</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td>100</td>
           </tr>
           <tr>
             <td>maxProtected</td>
             <td>maximum allowable number of <code>protected</code> methods</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td>100</td>
           </tr>
           <tr>
             <td>maxPublic</td>
             <td>maximum allowable number of <code>public</code> methods</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td>100</td>
           </tr>
 
@@ -563,7 +563,7 @@
           <tr>
             <td>max</td>
             <td>maximum allowable number of lines</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td>150</td>
           </tr>
           <tr>
@@ -572,7 +572,7 @@
               whether to count empty lines and single line comments of the
               form <code>//</code>
             </td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
           <tr>
@@ -691,7 +691,7 @@
           <tr>
             <td>max</td>
             <td>maximum allowable number of outer types</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td>1</td>
           </tr>
         </table>
@@ -769,13 +769,13 @@
           <tr>
             <td>max</td>
             <td>maximum allowable number of parameters</td>
-            <td><a href="property_types.html#integer">integer</a></td>
+            <td><a href="property_types.html#integer">Integer</a></td>
             <td>7</td>
           </tr>
           <tr>
             <td>ignoreOverriddenMethods</td>
             <td>Ignore number of parameters for methods with @Override annotation</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
           </tr>
           <tr>

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -229,19 +229,19 @@ for (Iterator foo = very.long.line.iterator();
           <tr>
             <td>allowNoEmptyLineBetweenFields</td>
             <td>Allow no empty line between fields</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
           </tr>
           <tr>
              <td>allowMultipleEmptyLines</td>
              <td>Allow multiple empty lines between class members</td>
-             <td><a href="property_types.html#boolean">boolean</a></td>
+             <td><a href="property_types.html#boolean">Boolean</a></td>
              <td>true</td>
           </tr>
             <tr>
                 <td>allowMultipleEmptyLinesInsideClassMembers</td>
                 <td>Allow multiple empty lines inside class members</td>
-                <td><a href="property_types.html#boolean">boolean</a></td>
+                <td><a href="property_types.html#boolean">Boolean</a></td>
                 <td>true</td>
             </tr>
           <tr>
@@ -461,7 +461,7 @@ class Foo
           <tr>
             <td>eachLine</td>
             <td>whether to report on each line containing a tab, or just the first instance</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
@@ -668,7 +668,7 @@ sort(list, Comparable::&lt;String&gt;compareTo);             // Method reference
               whether a line break between the identifier and left parenthesis
               is allowed
             </td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
@@ -941,7 +941,7 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
             <td>
               whether whitespace is allowed if the token is at a linebreak
             </td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
           <tr>
@@ -1081,7 +1081,7 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
             <td>
               whether whitespace is allowed if the token is at a linebreak
             </td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
@@ -1903,37 +1903,37 @@ new Properties() {{
           <tr>
             <td>allowEmptyConstructors</td>
             <td>allow empty constructor bodies</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
             <td>allowEmptyMethods</td>
             <td>allow empty method bodies</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
             <td>allowEmptyTypes</td>
             <td>allow empty class, interface and enum bodies</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
             <td>allowEmptyLoops</td>
             <td>allow empty loop bodies</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
             <td>allowEmptyLambdas</td>
             <td>allow empty lambda bodies</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
           <tr>
             <td>ignoreEnhancedForColon</td>
             <td>ignore whitespace around colon in for-each loops</td>
-            <td><a href="property_types.html#boolean">boolean</a></td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
           </tr>
           <tr>


### PR DESCRIPTION
Issue #3187.
This won't close the issue, it is just a start.

Added validation of xdoc config property types.
Strings are ignored for now.

Most xdoc changes are simple.
Types should start with uppercase (looks more official). Only 1 invalid type.