### PR TITLE
Issue #3086: added debug option

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -144,7 +144,7 @@
 
     <!-- Suppressions from PMD configuration-->
     <!-- validateCli is not reasonable to split as encapsulation of logic will be damaged -->
-    <suppress checks="CyclomaticComplexity" files="Main\.java"  lines="222"/>
+    <suppress checks="CyclomaticComplexity" files="Main\.java"  lines="212"/>
     <!-- JavadocMethodCheck, JavadocStyleCheck, JavadocUtils.getJavadocTags() - deprecated -->
     <suppress checks="CyclomaticComplexity" files="JavadocMethodCheck\.java"/>
     <suppress checks="CyclomaticComplexity" files="JavadocStyleCheck\.java"/>
@@ -165,7 +165,6 @@
               lines="105, 143, 174"/>
 
     <!-- Not reasonable to split as encapsulation of logic will be damaged. -->
-    <suppress checks="ExecutableStatementCount" files="Main\.java" lines="114"/>
-    <suppress checks="CyclomaticComplexity" files="Main\.java"  lines="114"/>
-    <suppress checks="JavaNCSS" files="Main\.java"  lines="114"/>
+    <suppress checks="ExecutableStatementCount" files="Main\.java" lines="128"/>
+    <suppress checks="JavaNCSS" files="Main\.java"  lines="128"/>
 </suppressions>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle;
 
 import static com.puppycrawl.tools.checkstyle.internal.TestUtils.assertUtilsClassHasPrivateConstructor;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -54,6 +55,7 @@ public class MainTest {
           "usage: java com.puppycrawl.tools.checkstyle.Main [options] -c <config.xml>"
         + " file...%n"
         + " -c <arg>                Sets the check configuration file to use.%n"
+        + " -d,--debug              Print all debug logging of CheckStyle utility%n"
         + " -f <arg>                Sets the output format. (plain|xml). Defaults to"
         + " plain%n"
         + " -j,--javadocTree        Print Parse tree of the Javadoc comment%n"
@@ -835,5 +837,16 @@ public class MainTest {
         });
 
         Main.main("-o", file.getCanonicalPath(), "-t", getPath("checks/metrics"));
+    }
+
+    @Test
+    public void testDebugOption() throws Exception {
+        exit.checkAssertionAfterwards(new Assertion() {
+            @Override
+            public void checkAssertion() {
+                assertNotEquals("", systemErr.getLog());
+            }
+        });
+        Main.main("-c", "/google_checks.xml", getPath("InputMain.java"), "-d");
     }
 }

--- a/src/xdocs/cmdline.xml.vm
+++ b/src/xdocs/cmdline.xml.vm
@@ -100,6 +100,9 @@ java -D&lt;property&gt;=&lt;value&gt;  \
           cannot be used other options and requires exactly one file to run on to be specified.
         </li>
         <li>
+          <code>-d, --debug</code> - Print all debug logging of CheckStyle utility.
+        </li>
+        <li>
           <code>-v</code> - print product version and exit. Any other option is ignored.
         </li>
       </ul>


### PR DESCRIPTION
Issue #3086

Added debug option using existing code. No clue if it will need to be changed with slf4j (Issue #3199)

This was going to be a 2 part PR, with the second part adding more messages, but I will have to confirm if I can do so without much hassle from code complexity without slf4j.

The code for enabling the debug level output, and to STDOUT, was the only way I could find to get it to activate at runtime.
This will interfer with any other text going to STDOUT, but really this option should only be used for debugging purposes anyways.

Split `Main` into `Main.runCli` because of violation:
> Main.java:[145,13] (extension) ChildBlockLength: Block length is 56 lines, but should be lesser or equal to 53 lines.