### PR TITLE
Issue #2971: Add allowPublicFinalFields option for VisibilityModifier

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -117,6 +117,7 @@ public class VisibilityModifierCheckTest
     public void testAllowPublicFinalFieldsInImmutableClass() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicImmutableFields", "true");
         final String[] expected = {
             "12:39: " + getCheckMessage(MSG_KEY, "includes"),
             "13:39: " + getCheckMessage(MSG_KEY, "excludes"),
@@ -129,14 +130,51 @@ public class VisibilityModifierCheckTest
     }
 
     @Test
+    public void testDisAllowPublicFinalAndImmutableFieldsInImmutableClass() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        final String[] expected = {
+            "11:22: " + getCheckMessage(MSG_KEY, "someIntValue"),
+            "12:39: " + getCheckMessage(MSG_KEY, "includes"),
+            "13:39: " + getCheckMessage(MSG_KEY, "excludes"),
+            "14:35: " + getCheckMessage(MSG_KEY, "notes"),
+            "15:29: " + getCheckMessage(MSG_KEY, "money"),
+            "16:23: " + getCheckMessage(MSG_KEY, "list"),
+            "30:28: " + getCheckMessage(MSG_KEY, "f"),
+            "31:30: " + getCheckMessage(MSG_KEY, "bool"),
+            "32:35: " + getCheckMessage(MSG_KEY, "uri"),
+            "33:35: " + getCheckMessage(MSG_KEY, "file"),
+            "34:20: " + getCheckMessage(MSG_KEY, "value"),
+            "35:35: " + getCheckMessage(MSG_KEY, "url"),
+            "36:24: " + getCheckMessage(MSG_KEY, "bValue"),
+            "37:31: " + getCheckMessage(MSG_KEY, "longValue"),
+            };
+        verify(checkConfig, getPath("InputImmutable.java"), expected);
+    }
+
+    @Test
+    public void testAllowPublicFinalFieldsInNonFinalClass() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicFinalFields", "true");
+        final String[] expected = {
+            "34:20: " + getCheckMessage(MSG_KEY, "value"),
+            "36:24: " + getCheckMessage(MSG_KEY, "bValue"),
+            "37:31: " + getCheckMessage(MSG_KEY, "longValue"),
+        };
+        verify(checkConfig, getPath("InputImmutable.java"), expected);
+    }
+
+    @Test
     public void testUserSpecifiedImmutableClassesList() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicImmutableFields", "true");
         checkConfig.addAttribute("immutableClassCanonicalNames", "java.util.List,"
                 + "com.google.common.collect.ImmutableSet");
         final String[] expected = {
             "14:35: " + getCheckMessage(MSG_KEY, "notes"),
-            "15:29: " + getCheckMessage(MSG_KEY, "value"),
+            "15:29: " + getCheckMessage(MSG_KEY, "money"),
             "32:35: " + getCheckMessage(MSG_KEY, "uri"),
             "33:35: " + getCheckMessage(MSG_KEY, "file"),
             "34:20: " + getCheckMessage(MSG_KEY, "value"),
@@ -151,6 +189,7 @@ public class VisibilityModifierCheckTest
     public void testImmutableSpecifiedSameTypeName() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicImmutableFields", "true");
         checkConfig.addAttribute("immutableClassCanonicalNames",
                  "com.puppycrawl.tools.checkstyle.checks.coding.InputGregorianCalendar,"
                  + "com.puppycrawl.tools.checkstyle.checks.design.InetSocketAddress");
@@ -162,9 +201,10 @@ public class VisibilityModifierCheckTest
     }
 
     @Test
-    public void testImmutableDefaultValueSameTypeName() throws Exception {
+    public void testImmutableValueSameTypeName() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicImmutableFields", "true");
         final String[] expected = {
             "7:46: " + getCheckMessage(MSG_KEY, "calendar"),
             "8:41: " + getCheckMessage(MSG_KEY, "calendar2"),
@@ -178,6 +218,7 @@ public class VisibilityModifierCheckTest
     public void testImmutableStarImportFalseNegative() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicImmutableFields", "true");
         checkConfig.addAttribute("immutableClassCanonicalNames", "java.util.Arrays");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputImmutableStarImport.java"), expected);
@@ -187,6 +228,7 @@ public class VisibilityModifierCheckTest
     public void testImmutableStarImportNoWarn() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicImmutableFields", "true");
         checkConfig.addAttribute("immutableClassCanonicalNames",
                  "com.google.common.collect.ImmutableSet");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -284,7 +326,6 @@ public class VisibilityModifierCheckTest
     public void testPublicImmutableFieldsNotAllowed() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(VisibilityModifierCheck.class);
-        checkConfig.addAttribute("allowPublicImmutableFields", "false");
         final String[] expected = {
             "10:22: " + getCheckMessage(MSG_KEY, "someIntValue"),
             "11:39: " + getCheckMessage(MSG_KEY, "includes"),
@@ -293,6 +334,42 @@ public class VisibilityModifierCheckTest
             "14:23: " + getCheckMessage(MSG_KEY, "list"),
         };
         verify(checkConfig, getPath("InputPublicImmutable.java"), expected);
+    }
+
+    @Test
+    public void testPublicFinalFieldsNotAllowed() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        final String[] expected = {
+            "10:22: " + getCheckMessage(MSG_KEY, "someIntValue"),
+            "11:39: " + getCheckMessage(MSG_KEY, "includes"),
+            "12:35: " + getCheckMessage(MSG_KEY, "notes"),
+            "13:29: " + getCheckMessage(MSG_KEY, "value"),
+            "14:23: " + getCheckMessage(MSG_KEY, "list"),
+        };
+        verify(checkConfig, getPath("InputPublicImmutable.java"), expected);
+    }
+
+    @Test
+    public void testPublicFinalFieldsAllowed() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicFinalFields", "true");
+        checkConfig.addAttribute("immutableClassCanonicalNames",
+            "com.google.common.collect.ImmutableSet");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputPublicImmutable.java"), expected);
+    }
+
+    @Test
+    public void testPublicFinalFieldInEnum() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicImmutableFields", "true");
+        final String[] expected = {
+            "15:23: " + getCheckMessage(MSG_KEY, "hole"),
+        };
+        verify(checkConfig, getPath("InputEnumIsSealed.java"), expected);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -307,6 +384,7 @@ public class VisibilityModifierCheckTest
     public void testNullModifiers() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicImmutableFields", "true");
         final String[] expected = {
             "11:50: " + getCheckMessage(MSG_KEY, "i"),
         };

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputEnumIsSealed.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputEnumIsSealed.java
@@ -1,0 +1,16 @@
+
+package com.puppycrawl.tools.checkstyle.checks.design;
+
+/** Shows that sealed enum is good as final. */
+public enum InputEnumIsSealed {
+    SOME_VALUE;
+
+    static class Hole {
+    }
+
+    /** Normally disallowed if final enclosing class is required. */
+    public final int someField = Integer.MAX_VALUE;
+
+    /** Disallowed because mutable. */
+    public final Hole hole = null;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputImmutable.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputImmutable.java
@@ -12,14 +12,14 @@ public final class InputImmutable
     public final ImmutableSet<String> includes;
     public final ImmutableSet<String> excludes;
     public final java.lang.String notes;
-    public final BigDecimal value;
+    public final BigDecimal money;
     public final List list;
 
     public InputImmutable(Collection<String> includes, Collection<String> excludes,
              BigDecimal value, String notes, int someValue, List l) {
         this.includes = ImmutableSet.copyOf(includes);
         this.excludes = ImmutableSet.copyOf(excludes);
-        this.value = value;
+        this.money = value;
         this.notes = notes;
         this.someIntValue = someValue;
         this.list = l;

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -793,8 +793,12 @@ public class Foo{
           named the same type without consideration of package
         </p>
         <p>
-          <b>allowPublicImmutableFields</b> - which allows immutable fields be declared as
-          public if defined in final class. Default value is <b>true</b>
+          <b>allowPublicFinalFields</b> - which allows public final fields.
+          Default value is <b>false</b>
+        </p>
+        <p>
+          <b>allowPublicImmutableFields</b> - which allows immutable fields to be declared as
+          public if defined in final class. Default value is <b>false</b>
         </p>
         <p>
           Field is known to be immutable if:
@@ -814,7 +818,10 @@ public class Foo{
         <p>
           <b>Restriction</b>: Check doesn't check if class is immutable, there's no
           checking if accessory methods are missing and all fields are immutable, we only check
-          <b>if current field is immutable and defined in final class</b>
+          <b>if current field is immutable or final</b>. Under the flag
+          <b>allowPublicImmutableFields</b>, the enclosing class must also be final, to encourage
+          immutability. Under the flag <b>allowPublicFinalFields</b>, the final modifier on
+          the enclosing class is optional.
         </p>
         <p>
           Star imports are out of scope of this Check. So if one of type imported via
@@ -850,10 +857,16 @@ public class Foo{
             <td><code>^serialVersionUID$</code></td>
           </tr>
           <tr>
-            <td>allowPublicImmutableFields</td>
-            <td>allows immutable fields be declared as public if defined in final class</td>
+            <td>allowPublicFinalFields</td>
+            <td>allows public final fields</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
+            <td><code>false</code></td>
+          </tr>
+          <tr>
+            <td>allowPublicImmutableFields</td>
+            <td>allows immutable fields to be declared as public if defined in final class</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>false</code></td>
           </tr>
           <tr>
             <td>immutableClassCanonicalNames</td>
@@ -904,7 +917,9 @@ public class Foo{
           (mostly for immutable classes):
         </p>
         <source>
-&lt;module name=&quot;VisibilityModifier&quot;/&gt;
+&lt;module name=&quot;VisibilityModifier&quot;&gt;
+    &lt;property name=&quot;allowPublicImmutableFields&quot; value=&quot;true&quot;/&gt;
+ &lt;/module&gt;
         </source>
         <p>
           Example of allowed public immutable fields:
@@ -928,10 +943,11 @@ public class ImmutableClass
 }
         </source>
         <p>
-          To configure the Check which allows user specified immutable class names:
+          To configure the Check in order to allow user specified immutable class names:
         </p>
         <source>
 &lt;module name=&quot;VisibilityModifier&quot;&gt;
+    &lt;property name=&quot;allowPublicImmutableFields&quot; value=&quot;true&quot;/&gt;
     &lt;property name=&quot;immutableClassCanonicalNames&quot; value=&quot;
     com.google.common.collect.ImmutableSet&quot;/&gt;
 &lt;/module&gt;
@@ -1026,6 +1042,69 @@ class SomeClass
     @mypackage.annotation.CustomAnnotation
     String customAnnotatedAnotherPackage; // another package but short name matches
                                           // so no violation
+}
+        </source>
+
+        <p>
+          To understand the difference between allowPublicImmutableFields and
+          allowPublicFinalFields options, please, study the following examples.
+        </p>
+        <p>
+           1) To configure the check to use only 'allowPublicImmutableFields' option:
+        </p>
+        <source>
+&lt;module name=&quot;VisibilityModifier&quot;&gt;
+  &lt;property name=&quot;allowPublicImmutableFields&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Code example:
+        </p>
+        <source>
+public class InputPublicImmutable {
+  public final int someIntValue; // violation
+  public final ImmutableSet&lt;String&gt; includes; // violation
+  public final java.lang.String notes; // violation
+  public final BigDecimal value; // violation
+  public final List list; // violation
+
+  public InputPublicImmutable(Collection&lt;String&gt; includes,
+        BigDecimal value, String notes, int someValue, List l) {
+    this.includes = ImmutableSet.copyOf(includes);
+    this.value = value;
+    this.notes = notes;
+    this.someIntValue = someValue;
+    this.list = l;
+  }
+}
+        </source>
+        <p>
+          2) To configure the check to use only 'allowPublicFinalFields' option:
+        </p>
+        <source>
+&lt;module name=&quot;VisibilityModifier&quot;&gt;
+  &lt;property name=&quot;allowPublicFinalFields&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Code example:
+        </p>
+        <source>
+public class InputPublicImmutable {
+  public final int someIntValue;
+  public final ImmutableSet&lt;String&gt; includes;
+  public final java.lang.String notes;
+  public final BigDecimal value;
+  public final List list;
+
+  public InputPublicImmutable(Collection&lt;String&gt; includes,
+        BigDecimal value, String notes, int someValue, List l) {
+    this.includes = ImmutableSet.copyOf(includes);
+    this.value = value;
+    this.notes = notes;
+    this.someIntValue = someValue;
+    this.list = l;
+  }
 }
         </source>
       </subsection>


### PR DESCRIPTION
#2971

@romani 

>
1) please fix CIs
2) please update xdoc files documentation, with config+code examples for new option. As options are very similar to each other, we need to help user to see a difference by examples.
3) Please generate html report with your option on opensource projects to make sure there are no exceptions and reported violations as ok.
Please use this tool - https://github.com/checkstyle/contribution/tree/master/checkstyle-tester , please read README file.
4) Please generate diff-report of execution without your option and with you options to make sure there are no regression.
Please use this tool - https://github.com/checkstyle/contribution/tree/master/patch-diff-report-tool
5) To resolve Travis failures please rebase code over latest master, it is already resolved.

1) Fixed, I had to change confdig_design.xml a bit to satisfy UTs.
2) Done.
3) Reports (allowPublicFinalFields = true, allowPublicImmutableFields = false):

[checkstyle + sevntu-checkstyle](http://mezk.github.io/i2971-VisibilityModifier/after/checkstyle/checkstyle.html)
[guava](http://mezk.github.io/i2971-VisibilityModifier/after/guava/checkstyle.html)
[pmd](http://mezk.github.io/i2971-VisibilityModifier/after/pmd/checkstyle.html)

Reports look good to me.

There are to much noise (over 2000+ violations) on such projects as Spring, Hibernate, Orekit, OpenJDK 8, findbugs. For example: [findbugs](http://mezk.github.io/i2971-VisibilityModifier/after/findbugs/checkstyle.html)

4)

Test projects: checkstyle, sevntu-checkstyle, hibernate, guava, spring, openjdk8, findbugs, pmd, lombok, elasticsearch, java-design-patterns, MaterialDesignLibrary, Orekit, apache-ant, android-launcher, apache-jsecurity, Hbase, infinispan.

4.1)
before
allowPublicImmutableFields = false

after
allowPublicImmutableFields = false
allowPublicFinalFields = false

diff reports are equal

4.2)
before
allowPublicImmutableFields = true

after
allowPublicImmutableFields = true
allowPublicFinalFields = false

diff reports are equal

5) Rebased over latest master.

@som-snytt 
Please, let me know, if you want to include your name into authors section of VisibilityModifierCheck's javadoc.
