### PR TITLE
Issue #3177: Fix broken UTs (Docker container: Ubuntu 14.04, Java 8, Maven 3)

### DIFF
--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -55,5 +55,5 @@
     <!-- testing for catch Error is part of 100% coverage -->
     <suppress checks="IllegalCatchExtended"
               files="CheckerTest\.java"
-              lines="577"/>
+              lines="579"/>
 </suppressions>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -47,6 +47,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.powermock.api.mockito.PowerMockito;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
@@ -400,7 +401,8 @@ public class CheckerTest extends BaseCheckTestSupport {
             checker.setCacheFile(file.getAbsolutePath());
         }
         else {
-            checker.setCacheFile(File.separator + ":invalid");
+            final int wrongFileNameLength = 300;
+            checker.setCacheFile(Strings.padEnd(File.separator, wrongFileNameLength, '*'));
         }
         try {
             checker.destroy();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -505,7 +505,7 @@ public class MainTest {
                 method.invoke(null, new File(file.getAbsolutePath()));
             }
             else {
-                method.invoke(null, new File(File.separator + ":invalid"));
+                method.invoke(null, new File(File.separator + "\0:invalid"));
             }
             fail("Exception was expected");
         }


### PR DESCRIPTION
#3177 
Fixed 2 of 6 broken UTs.

The following UTs remains broken at Docker's container ([profile](https://github.com/carlossg/docker-maven/blob/40cbcd2edc2719c64062af39baac6ae38d0becf9/jdk-8/Dockerfile)):

```
Failed tests: 
  MainTest.testExistingFilePlainOutputToFileWithoutReadAndRwPermissions System.exit has not been called.
  MainTest.testExistingTargetFilePlainOutputToFileWithoutRwPermissions System.exit has not been called.
  PropertyCacheFileTest.testNonAccessibleDirectory:189 AccessDeniedException is expected since directory is readonly.
  PropertyCacheFileTest.testNonAccessibleFile:73 FileNotFoundException is expected, since access to the file was denied!
```

See https://github.com/checkstyle/checkstyle/issues/3177#issuecomment-221933462
