### PR TITLE
Issue #3116: removed requirement right curlies must be first on line

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
@@ -78,11 +78,6 @@ public class ArrayInitHandler extends BlockParentHandler {
     }
 
     @Override
-    protected boolean shouldStartWithRCurly() {
-        return false;
-    }
-
-    @Override
     protected boolean canChildrenBeNested() {
         return true;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -171,15 +171,6 @@ public class BlockParentHandler extends AbstractExpressionHandler {
     }
 
     /**
-     * Determines if the right curly brace must be at the start of the line.
-     *
-     * @return true
-     */
-    protected boolean shouldStartWithRCurly() {
-        return true;
-    }
-
-    /**
      * Determines if child elements within the expression may be nested.
      *
      * @return false
@@ -192,15 +183,11 @@ public class BlockParentHandler extends AbstractExpressionHandler {
      * Check the indentation of the right curly brace.
      */
     protected void checkRCurly() {
-        // the rcurly can either be at the correct indentation, or
-        // on the same line as the lcurly
-        final DetailAST lcurly = getLCurly();
         final DetailAST rcurly = getRCurly();
         final int rcurlyPos = expandedTabsColumnNo(rcurly);
 
         if (!curlyIndent().isAcceptable(rcurlyPos)
-                && (shouldStartWithRCurly() || isOnStartOfLine(rcurly))
-                && !areOnSameLine(rcurly, lcurly)) {
+                && isOnStartOfLine(rcurly)) {
             logError(rcurly, "rcurly", rcurlyPos, curlyIndent());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1039,7 +1039,6 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
 
             "225: " + getCheckMessage(MSG_ERROR, "if", 10, 12),
             "229: " + getCheckMessage(MSG_CHILD_ERROR, "if", 18, 20),
-            "233: " + getCheckMessage(MSG_ERROR, "if rcurly", 40, 8),
             "240: " + getCheckMessage(MSG_ERROR, "if rparen", 10, 8),
             "245: " + getCheckMessage(MSG_ERROR, "if rparen", 6, 8),
             "251: " + getCheckMessage(MSG_ERROR, "if lparen", 6, 8),
@@ -1112,9 +1111,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("tabWidth", "4");
         checkConfig.addAttribute("throwsIndent", "4");
         final String fileName = getPath("InputInvalidAnonymousClassIndent.java");
-        final String[] expected = {
-            "28: " + getCheckMessage(MSG_ERROR_MULTI, "method def rcurly", 17, "12, 16"),
-        };
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verifyWarns(checkConfig, fileName, expected);
     }
 
@@ -1153,7 +1150,6 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
             "70: " + getCheckMessage(MSG_CHILD_ERROR, "for", 10, 12),
             "71: " + getCheckMessage(MSG_CHILD_ERROR, "for", 14, 16),
             "72: " + getCheckMessage(MSG_CHILD_ERROR, "for", 10, 12),
-            "77: " + getCheckMessage(MSG_ERROR, "for rcurly", 39, 8),
             "81: " + getCheckMessage(MSG_ERROR, "for rparen", 12, 8),
         };
         verifyWarns(checkConfig, fileName, expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidAnonymousClassIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidAnonymousClassIndent.java
@@ -25,7 +25,7 @@ public class InputInvalidAnonymousClassIndent { //indent:0 exp:0
                     return new Thread(); //indent:20 exp:20
                 } else { //indent:16 exp:16
                     return new Thread(); //indent:20 exp:20
-                }}}); //indent:16 ioffset:1 exp:12,16 warn
+                }}}); //indent:16 exp:16
         return; //indent:8 exp:8
     } //indent:4 exp:4
 } //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidForIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidForIndent.java
@@ -74,7 +74,7 @@ public class InputInvalidForIndent { //indent:0 exp:0
         } //indent:8 exp:8
 
         for (int i=0; i<10; i++) { //indent:8 exp:8
-            System.getProperty("foo"); } //indent:12 ioffset:27 exp:8 warn
+            System.getProperty("foo"); } //indent:12 exp:12
 
         for (int i=0;  //indent:8 exp:8
             i<10; i++ //indent:12 exp:>=12

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidIfIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidIfIndent.java
@@ -230,7 +230,7 @@ System.getProperty("blah"); //indent:0 exp:12 warn
                 } //indent:16 exp:16
 
         if (test) { //indent:8 exp:8
-            System.getProperty("blah"); } //indent:12 ioffset:28 exp:8 warn
+            System.getProperty("blah"); } //indent:12 exp:12
     } //indent:4 exp:4
 
     public void parenIfTest() { //indent:4 exp:4


### PR DESCRIPTION
Issue #3116

Problem extended from `BlockParentHandler.shouldStartWithRCurly` which was saying the right curly should start the line. Since this method goes against not forcing users to split their lines, it was removed.
`|| areOnSameLine(rcurly, lcurly)` was removed as `|| !isOnStartOfLine(rcurly)` takes precedence and can't be hit for code coverage.

I did not remove the `ioffset` code incase we need it again, if that is all right.
Regression will be shortly.