### PR TITLE
Issue #2618: refactored indentation import and package logic

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -236,9 +236,9 @@ public abstract class AbstractExpressionHandler {
      *
      * @return the start of the specified line
      */
-    protected final int getLineStart(String line) {
+    private int getLineStart(String line) {
         int index = 0;
-        while (index < line.length() && Character.isWhitespace(line.charAt(index))) {
+        while (Character.isWhitespace(line.charAt(index))) {
             index++;
         }
         return CommonUtils.lengthExpandedTabs(
@@ -253,27 +253,6 @@ public abstract class AbstractExpressionHandler {
      */
     protected boolean shouldIncreaseIndent() {
         return true;
-    }
-
-    /**
-     * Check the indentation of consecutive lines for the expression we are
-     * handling.
-     *
-     * @param startLine     the first line to check
-     * @param endLine       the last line to check
-     * @param indentLevel   the required indent level
-     */
-    protected final void checkLinesIndent(int startLine, int endLine,
-        IndentLevel indentLevel) {
-        // check first line
-        checkLineIndent(startLine, indentLevel);
-
-        // check following lines
-        final IndentLevel offsetLevel =
-            new IndentLevel(indentLevel, getBasicOffset());
-        for (int i = startLine + 1; i <= endLine; i++) {
-            checkLineIndent(i, offsetLevel);
-        }
     }
 
     /**
@@ -324,22 +303,6 @@ public abstract class AbstractExpressionHandler {
                 if (col != null) {
                     checkLineIndent(i, col, theLevel, false);
                 }
-            }
-        }
-    }
-
-    /**
-     * Check the indent level for a single line.
-     *
-     * @param lineNum       the line number to check
-     * @param indentLevel   the required indent level
-     */
-    private void checkLineIndent(int lineNum, IndentLevel indentLevel) {
-        final String line = indentCheck.getLine(lineNum - 1);
-        if (!line.isEmpty()) {
-            final int start = getLineStart(line);
-            if (indentLevel.isGreaterThan(start)) {
-                logChildError(lineNum, start, indentLevel);
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ImportHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ImportHandler.java
@@ -43,12 +43,14 @@ public class ImportHandler extends AbstractExpressionHandler {
 
     @Override
     public void checkIndentation() {
-        final int lineStart = getMainAst().getLineNo();
-        final DetailAST semi = getMainAst().findFirstToken(TokenTypes.SEMI);
-        final int lineEnd = semi.getLineNo();
+        final int columnNo = expandedTabsColumnNo(getMainAst());
 
-        if (getMainAst().getLineNo() != lineEnd) {
-            checkLinesIndent(lineStart, lineEnd, getIndent());
+        if (!getIndent().isAcceptable(columnNo) && isOnStartOfLine(getMainAst())) {
+            logError(getMainAst(), "", columnNo);
         }
+
+        final DetailAST semi = getMainAst().findFirstToken(TokenTypes.SEMI);
+
+        checkWrappingIndentation(getMainAst(), semi);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -201,7 +201,8 @@ public class LineWrappingHandler {
                         && node.equals(lastAnnotationNode);
                 if (isCurrentNodeCloseAnnotationAloneInLine
                         || node.getType() == TokenTypes.AT
-                        && parentNode.getParent().getType() == TokenTypes.MODIFIERS) {
+                        && (parentNode.getParent().getType() == TokenTypes.MODIFIERS
+                            || parentNode.getParent().getType() == TokenTypes.ANNOTATIONS)) {
                     logWarningMessage(node, firstNodeIndent);
                 }
                 else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/PackageDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/PackageDefHandler.java
@@ -44,12 +44,13 @@ public class PackageDefHandler extends AbstractExpressionHandler {
     @Override
     public void checkIndentation() {
         final int columnNo = expandedTabsColumnNo(getMainAst());
-        if (!getIndent().isAcceptable(columnNo)) {
+
+        if (!getIndent().isAcceptable(columnNo) && isOnStartOfLine(getMainAst())) {
             logError(getMainAst(), "", columnNo);
         }
 
-        checkLinesIndent(getMainAst().getLineNo(),
-            getMainAst().findFirstToken(TokenTypes.SEMI).getLineNo(),
-            getIndent());
+        final DetailAST semi = getMainAst().findFirstToken(TokenTypes.SEMI);
+
+        checkWrappingIndentation(getMainAst(), semi);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1467,7 +1467,8 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("basicOffset", "8");
         checkConfig.addAttribute("tabWidth", "4");
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_CHILD_ERROR, "import", 2, 8),
+            "4: " + getCheckMessage(MSG_ERROR, ".", 2, 4),
+            "5: " + getCheckMessage(MSG_ERROR, "import", 1, 0),
         };
         verifyWarns(checkConfig, getPath("InputInvalidImportIndent.java"), expected);
     }
@@ -1605,6 +1606,24 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
             "1: " + getCheckMessage(MSG_ERROR, "package def", 1, 0),
         };
         verifyWarns(checkConfig, getPath("InputPackageDeclaration.java"), expected);
+    }
+
+    @Test
+    public void testPackageDeclaration2() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+        checkConfig.addAttribute("tabWidth", "4");
+        final String[] expected = {
+            "2: " + getCheckMessage(MSG_ERROR, "package def", 1, 0),
+        };
+        verifyWarns(checkConfig, getNonCompilablePath("InputPackageDeclaration2.java"), expected);
+    }
+
+    @Test
+    public void testPackageDeclaration3() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+        checkConfig.addAttribute("tabWidth", "4");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, getPath("InputPackageDeclaration3.java"), expected);
     }
 
     @Test

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/InputPackageDeclaration2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/InputPackageDeclaration2.java
@@ -1,0 +1,4 @@
+ @Deprecated //indent:1 exp:1
+ package com.puppycrawl.tools.checkstyle.checks.indentation;//indent:1 exp:0 warn
+
+public class InputPackageDeclaration2 {}//indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidImportIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidImportIndent.java
@@ -1,7 +1,10 @@
 package com.puppycrawl.tools.checkstyle.checks.indentation; //indent:0 exp:0
 
 import java.util //indent:0 exp:0
-  .RandomAccess; //indent:2 exp:8 warn
+  .RandomAccess; import java.util.RandomAccess; //indent:2 exp:4 warn
+ import java.util.RandomAccess; //indent:1 exp:0 warn
+import java.util //indent:0 exp:0
+                   .RandomAccess; //indent:19 exp:>=8
 
 /**                                                                           //indent:0 exp:0
  * This test-input is intended to be checked using following configuration:   //indent:1 exp:1

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputPackageDeclaration3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputPackageDeclaration3.java
@@ -1,0 +1,3 @@
+/** Comment */ package com.puppycrawl.tools.checkstyle.checks.indentation;//indent:0 exp:>=0
+
+public class InputPackageDeclaration3 {}//indent:0 exp:0


### PR DESCRIPTION
Issue #2618

`checkLinesIndent` is only used by these 2 classes, and they seem like an attempt to mimic `LineWrappingHandler`. I removed them for in favor of `LineWrappingHandler`.
Regression will be shortly.

Unanswered question: https://github.com/checkstyle/checkstyle/issues/2618#issuecomment-213997415 This code uses `lineWrappingIndentation`.