### PR TITLE
Issue 3187: validate default types

### DIFF
--- a/src/xdocs/config_regexp.xml
+++ b/src/xdocs/config_regexp.xml
@@ -103,7 +103,7 @@
               value is used as the maximum number of allowed duplicates, if the
               limit is exceeded errors will be logged.</td>
             <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>-1</code></td>
+            <td><code>0</code></td>
           </tr>
           <tr>
             <td>errorLimit</td>


### PR DESCRIPTION
Issue #3187 

Added default value validation except for strings and string arrays.
`RegExpCheck` changed default value to align with what the xdoc says, otherwise the xdoc has to be changed to `0`.