### PR TITLE
Issue #3142: Add proper support for generics in VisibilityModifierCheck

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -123,6 +123,8 @@
     <suppress checks="MethodCount" files="[\\/]JavadocMethodCheck.java$"/>
     <!-- Apart from a complex logic there is a lot of small methods for a better readability.  -->
     <suppress checks="MethodCount" files="[\\/]CommentsIndentationCheck.java$"/>
+    <!--VisibilityModifierCheck has 7 options which require 7 additional methods (setters)-->
+    <suppress checks="MethodCount" files="[\\/]VisibilityModifierCheck.java$"/>
 
     <!-- getDetails() method - huge Switch, it has to be monolithic -->
     <suppress checks="ExecutableStatementCount" files="RightCurlyCheck\.java" lines="313"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -171,9 +171,8 @@ public class VisibilityModifierCheckTest
                 createCheckConfig(VisibilityModifierCheck.class);
         checkConfig.addAttribute("allowPublicImmutableFields", "true");
         checkConfig.addAttribute("immutableClassCanonicalNames", "java.util.List,"
-                + "com.google.common.collect.ImmutableSet");
+                + "com.google.common.collect.ImmutableSet, java.lang.String");
         final String[] expected = {
-            "14:35: " + getCheckMessage(MSG_KEY, "notes"),
             "15:29: " + getCheckMessage(MSG_KEY, "money"),
             "32:35: " + getCheckMessage(MSG_KEY, "uri"),
             "33:35: " + getCheckMessage(MSG_KEY, "file"),
@@ -230,7 +229,7 @@ public class VisibilityModifierCheckTest
                 createCheckConfig(VisibilityModifierCheck.class);
         checkConfig.addAttribute("allowPublicImmutableFields", "true");
         checkConfig.addAttribute("immutableClassCanonicalNames",
-                 "com.google.common.collect.ImmutableSet");
+            "java.lang.String, com.google.common.collect.ImmutableSet");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputImmutableStarImport2.java"), expected);
     }
@@ -389,5 +388,39 @@ public class VisibilityModifierCheckTest
             "11:50: " + getCheckMessage(MSG_KEY, "i"),
         };
         verify(checkConfig, getPath("InputNullModifiers.java"), expected);
+    }
+
+    @Test
+    public void testVisibilityModifiersOfGenericFields() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(VisibilityModifierCheck.class);
+        checkConfig.addAttribute("allowPublicImmutableFields", "true");
+        checkConfig.addAttribute("immutableClassCanonicalNames",
+            "com.google.common.collect.ImmutableMap,"
+            + "java.lang.String,"
+            + "com.google.common.base.Optional,"
+            + "java.math.BigDecimal");
+        final String[] expected = {
+            "16:56: " + getCheckMessage(MSG_KEY, "perfSeries"),
+            "17:66: " + getCheckMessage(MSG_KEY, "peopleMap"),
+            "18:66: " + getCheckMessage(MSG_KEY, "someMap"),
+            "19:76: " + getCheckMessage(MSG_KEY, "newMap"),
+            "21:45: " + getCheckMessage(MSG_KEY, "optionalOfObject"),
+            "22:35: " + getCheckMessage(MSG_KEY, "obj"),
+            "24:19: " + getCheckMessage(MSG_KEY, "rqUID"),
+            "25:29: " + getCheckMessage(MSG_KEY, "rqTime"),
+            "26:45: " + getCheckMessage(MSG_KEY, "rates"),
+            "27:50: " + getCheckMessage(MSG_KEY, "loans"),
+            "28:60: " + getCheckMessage(MSG_KEY, "cards"),
+            "29:60: " + getCheckMessage(MSG_KEY, "values"),
+            "30:70: " + getCheckMessage(MSG_KEY, "permissions"),
+            "32:38: " + getCheckMessage(MSG_KEY, "mapOfStrings"),
+            "33:48: " + getCheckMessage(MSG_KEY, "names"),
+            "34:48: " + getCheckMessage(MSG_KEY, "links"),
+            "35:38: " + getCheckMessage(MSG_KEY, "presentations"),
+            "36:48: " + getCheckMessage(MSG_KEY, "collection"),
+            "39:73: " + getCheckMessage(MSG_KEY, "exceptions"),
+        };
+        verify(checkConfig, getPath("InputVisibilityModifierGenerics.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputVisibilityModifierGenerics.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputVisibilityModifierGenerics.java
@@ -1,0 +1,60 @@
+package com.puppycrawl.tools.checkstyle.checks.design;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+
+public final class InputVisibilityModifierGenerics {
+
+    public final String name;
+    public final Optional<String> keyword;
+    public final ImmutableMap<String, BigDecimal> uuidMap;
+    public final ImmutableMap<String, ArrayList<Long>> perfSeries; // violation
+    public final ImmutableMap<java.lang.String, ArrayList<Long>> peopleMap; // violation
+    public final ImmutableMap<String, java.util.ArrayList<Long>> someMap; // violation
+    public final ImmutableMap<java.lang.String, java.util.ArrayList<Long>> newMap; // violation
+    public final ImmutableMap<java.lang.String, java.math.BigDecimal> orders;
+    public final Optional<java.lang.Object> optionalOfObject; // violation
+    public final Optional<Object> obj; // violation
+
+    public String rqUID; // violation
+    public Optional<String> rqTime; // violation
+    public ImmutableMap<String, BigDecimal> rates; // violation
+    public ImmutableMap<String, ArrayList<Long>> loans; // violation
+    public ImmutableMap<java.lang.String, ArrayList<Long>> cards; // violation
+    public ImmutableMap<String, java.util.ArrayList<Long>> values; // violation
+    public ImmutableMap<java.lang.String, java.util.ArrayList<Long>> permissions; // violation
+
+    public final Map<String, String> mapOfStrings; // violation
+    public final java.util.Map<String, String> names; // violation
+    public final java.util.Map<String, Object> links; // violation
+    public final Map<String, Object> presentations; // violation
+    public final Map<String, java.lang.Object> collection; // violation
+
+    public final com.google.common.collect.ImmutableMap<String, BigDecimal> prices;
+    public final com.google.common.collect.ImmutableMap<String, Object> exceptions; // violation
+
+    public InputVisibilityModifierGenerics() {
+        this.name = "John Doe";
+        this.keyword = Optional.absent();
+        this.perfSeries = ImmutableMap.of();
+        this.uuidMap = ImmutableMap.of();
+        this.peopleMap = ImmutableMap.of();
+        this.someMap = ImmutableMap.of();
+        this.newMap = ImmutableMap.of();
+        this.orders = ImmutableMap.of();
+        this.optionalOfObject = Optional.absent();
+        this.obj = Optional.absent();
+        this.mapOfStrings = new HashMap<>(1);
+        this.names = new HashMap<>(1);
+        this.links = new HashMap<>(1);
+        this.presentations = new HashMap<>(1);
+        this.collection = new HashMap<>(1);
+        this.prices = ImmutableMap.of();
+        this.exceptions =  ImmutableMap.of();
+    }
+}

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -977,6 +977,36 @@ public class ImmutableClass
         </source>
 
         <p>
+          Note, if allowPublicImmutableFields is set to true, the check will also check whether
+          generic type parameters are immutable. If at least one generic type parameter is mutable,
+          there will be a violation.
+        </p>
+        <source>
+&lt;module name=&quot;VisibilityModifier&quot;&gt;
+  &lt;property name=&quot;allowPublicImmutableFields&quot; value=&quot;true&quot;/&gt;
+  &lt;property name=&quot;immutableClassCanonicalNames&quot; value=&quot;
+  com.google.common.collect.ImmutableSet, com.google.common.collect.ImmutableMap,java.lang.String&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example of how the check works:
+        </p>
+        <source>
+public final class Test {
+    public final String s;
+    public final ImmutableSet&lt;String&gt; names;
+    public final ImmutableSet&lt;Object&gt; objects; // violation (Object class is mutable)
+    public final ImmutableMap&lt;String, Object&gt; links; // violation (Object class is mutable)
+
+    public Test() {
+        s = "Hello!";
+        names = ImmutableSet.of();
+        objects = ImmutableSet.of();
+        links = ImmutableMap.of();
+    }
+}
+        </source>
+        <p>
           To configure the Check passing fields annotated with @com.annotation.CustomAnnotation:
         </p>
         <source>


### PR DESCRIPTION
#3142

@romani 
Added support of generic types for the Check. If allowPublicImmutableFields is set to true, the check will also check whether generic type parameters are immutable. If at least one parameter is mutable the check will rise violation. The changes work for both canonical and ordinary class names of type parameters.

Regression reports were generated against the following projects:
1) openjdk8
2) pmd
3) lombok
4) spring-framework
5) java-design-patterns
6) MaterialDesignLibrary
7) Hbase
8) Orekit
9) apache-ant
10) apache-jsecurity
11) android-launcher
13) infinispan
14) protonpack
15) jOOL
16) RxJava
17) checkstyle-with-excludes
18) sevntu-checkstyle-with-excludes
19) findbugs-with-excldues
20) hibernate-orm-with-excludes
21) guava-mvnstyle

with the following configuration:

```xml

`<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
<module name = "Checker">
    <property name="charset" value="UTF-8"/>
    <property name="severity" value="warning"/>
    <module name="TreeWalker">
         <module name="VisibilityModifier">
            <property name="allowPublicImmutableFields" value="true"/>  
         </module> 
    </module>
</module>
```

The reports showed no differences between 'before' and 'after' results. Please, let me know, if we need additional regression tests.

@KTannenberg 
From issue report:
>It will be nice to have TextArea with automatical word-wrapping instead of TextField in check's configuration window

I think it should be posted at Checkstyle-Eclipse/Idea plugin's issue tracker.
