### PR TITLE
Issue 3212: aligned setters to be arrays like properties for xdoc validation (breaking compatibility)

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -131,8 +131,8 @@ public class SuppressWarningsHolder
      * paramnum}.
      * @param aliasList the list of comma-separated alias assignments
      */
-    public void setAliasList(String aliasList) {
-        for (String sourceAlias : aliasList.split(",")) {
+    public void setAliasList(String... aliasList) {
+        for (String sourceAlias : aliasList) {
             final int index = sourceAlias.indexOf('=');
             if (index > 0) {
                 registerAlias(sourceAlias.substring(0, index), sourceAlias

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -70,8 +70,6 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
      */
     public static final String MSG_KEY = "at.clause.order";
 
-    /** Comma literal. */
-    private static final String COMMA_SEPARATOR = ",";
     /**
      * Default order of atclauses.
      */
@@ -103,26 +101,24 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
 
     /**
      * Sets custom targets.
-     * @param target user's targets.
+     * @param targets user's targets.
      */
-    public void setTarget(String target) {
+    public void setTarget(String... targets) {
         final List<Integer> customTarget = new ArrayList<>();
-        final String[] sTarget = target.split(COMMA_SEPARATOR);
-        for (String aSTarget : sTarget) {
-            customTarget.add(TokenUtils.getTokenId(aSTarget.trim()));
+        for (String temp : targets) {
+            customTarget.add(TokenUtils.getTokenId(temp.trim()));
         }
-        this.target = customTarget;
+        target = customTarget;
     }
 
     /**
      * Sets custom order of atclauses.
-     * @param order user's order.
+     * @param orders user's orders.
      */
-    public void setTagOrder(String order) {
+    public void setTagOrder(String... orders) {
         final List<String> customOrder = new ArrayList<>();
-        final String[] sOrder = order.split(COMMA_SEPARATOR);
-        for (String aSOrder : sOrder) {
-            customOrder.add(aSOrder.trim());
+        for (String order : orders) {
+            customOrder.add(order.trim());
         }
         tagOrder = customOrder;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
@@ -80,9 +79,8 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
      *
      * @param tags to be ignored by check.
      */
-    public void setIgnoredTags(String tags) {
-        ignoredTags =
-            Lists.newArrayList(Splitter.on(",").omitEmptyStrings().trimResults().split(tags));
+    public void setIgnoredTags(String... tags) {
+        ignoredTags = Lists.newArrayList(tags);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
@@ -492,7 +492,7 @@ public class XDocsPagesTest {
                         propertyName);
                 final Class<?> clss = descriptor.getPropertyType();
                 final String expectedTypeName =
-                        getCheckPropertyExpectedTypeName(clss, propertyName);
+                        getCheckPropertyExpectedTypeName(clss, instance, propertyName);
                 final String expectedValue = getCheckPropertyExpectedValue(clss, instance,
                         propertyName);
 
@@ -510,7 +510,9 @@ public class XDocsPagesTest {
         }
     }
 
-    private static String getCheckPropertyExpectedTypeName(Class<?> clss, String propertyName) {
+    private static String getCheckPropertyExpectedTypeName(Class<?> clss, Object instance,
+            String propertyName) {
+        final String instanceName = instance.getClass().getSimpleName();
         String result = null;
 
         if (clss == boolean.class) {
@@ -527,7 +529,9 @@ public class XDocsPagesTest {
         }
         else if (clss == String[].class) {
             if (propertyName.endsWith("Tokens") || propertyName.endsWith("Token")
-                    || "ignoreOccurrenceContext".equals(propertyName)) {
+                    || "AtclauseOrderCheck".equals(instanceName) && "target".equals(propertyName)
+                    || "MultipleStringLiteralsCheck".equals(instanceName)
+                            && "ignoreOccurrenceContext".equals(propertyName)) {
                 result = "subset of tokens TokenTypes";
             }
             else {
@@ -536,6 +540,11 @@ public class XDocsPagesTest {
         }
         else if (clss != String.class) {
             Assert.fail("Unknown property type: " + clss.getSimpleName());
+        }
+
+        if ("SuppressWarningsHolder".equals(instanceName)) {
+            result = result + " in a format of comma separated attribute=value entries. The "
+                    + "attribute is the fully qualified name of the Check and value is its alias.";
         }
 
         return result;

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -698,7 +698,7 @@ public static final int COUNTER = 10; // violation as javadoc exists
           <tr>
             <td>aliasList</td>
             <td>Aliases for check names that can be used in code within <code>SuppressWarnings</code></td>
-            <td><a href="property_types.html#string">String</a> in a format of comma separated attribute=value entries.
+            <td><a href="property_types.html#stringSet">String Set</a> in a format of comma separated attribute=value entries.
             The attribute is the fully qualified name of the Check and value is its alias.</td>
             <td>null</td>
           </tr>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -40,12 +40,7 @@
             <td>target</td>
             <td>allows to specify targets to check at-clauses.</td>
             <td>subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
             </td>
             <td>
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
@@ -59,7 +54,7 @@
           <tr>
             <td>tagOrder</td>
             <td>allows to specify the order by tags.</td>
-            <td><a href="property_types.html#string">String</a></td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>&#64;author, &#64;version, &#64;param,
                   &#64;return, &#64;throws, &#64;exception, &#64;see, &#64;since, &#64;serial,
                   &#64;serialField, &#64;serialData, &#64;deprecated</code></td>
@@ -1466,7 +1461,7 @@ public boolean isSomething()
           <tr>
             <td>ignoredTags</td>
             <td>allows to specify at-clauses which are ignored by the check.</td>
-            <td><a href="property_types.html#string">String</a></td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>null</code></td>
           </tr>
           <tr>


### PR DESCRIPTION
Issue #3212

This is the last one for the string arrays.
Affected modules: SuppressWarningsHolder , AtclauseOrderCheck, SingleLineJavadocCheck

This PR basically changed only:
`````
void setProperty(String s) {
    field = s.split(",");
}
````
into:
````
void setProperty(String... s) {
    field = s;
}
````

**Breaking Compatibility:**
As stated in in other PR at https://github.com/checkstyle/checkstyle/pull/3189#issuecomment-220032301, old code didn't properly split comma delimited inputs from the configuration. Spaces were left in and these caused properties like `1, 2` to be seen as `1` and `<space>2`. This caused checks like `IllegalInstantiation` to not identify classes properly and hid what should have been violations.