### PR TITLE
Avoid catching of InvalidPathException and AccessDeniedException in PropertyCacheFile#persist

### DIFF
--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -55,5 +55,5 @@
     <!-- testing for catch Error is part of 100% coverage -->
     <suppress checks="IllegalCatchExtended"
               files="CheckerTest\.java"
-              lines="579"/>
+              lines="545"/>
 </suppressions>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -30,9 +30,7 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.net.URI;
-import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
@@ -138,14 +136,9 @@ final class PropertyCacheFile {
      * @throws IOException  when there is a problems with file save
      */
     public void persist() throws IOException {
-        try {
-            final Path directory = Paths.get(fileName).getParent();
-            if (directory != null) {
-                Files.createDirectories(directory);
-            }
-        }
-        catch (InvalidPathException | AccessDeniedException ex) {
-            throw new IllegalStateException(ex.getMessage(), ex);
+        final Path directory = Paths.get(fileName).getParent();
+        if (directory != null) {
+            Files.createDirectories(directory);
         }
         FileOutputStream out = null;
         try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -19,16 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.doThrow;
-import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -38,9 +32,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -61,21 +53,6 @@ public class PropertyCacheFileTest {
 
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    @Test
-    public void testNonAccessibleFile() throws IOException {
-        final Configuration config = new DefaultConfiguration("myName");
-        final File file = temporaryFolder.newFile("file.output");
-        file.setReadable(true, false);
-        file.setWritable(false, false);
-        try {
-            new PropertyCacheFile(config, file.getAbsolutePath()).persist();
-            fail("FileNotFoundException is expected, since access to the file was denied!");
-        }
-        catch (FileNotFoundException ex) {
-            assertThat(ex.getMessage(), containsString("file.output"));
-        }
-    }
 
     @Test
     public void testCtor() {
@@ -134,63 +111,6 @@ public class PropertyCacheFileTest {
 
         if (Files.exists(Paths.get(filePath))) {
             Files.delete(Paths.get(filePath));
-        }
-    }
-
-    @Test
-    public void testPathToCacheFileContainsIllegalCharacters() throws IOException {
-        final Configuration config = new DefaultConfiguration("myName");
-        final String filePath = "\\\0:FOO\\server.properties";
-        final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
-        try {
-            cache.persist();
-            fail("Exception is expected!");
-        }
-        catch (IllegalStateException ex) {
-            assertThat(ex.getCause(), instanceOf(InvalidPathException.class));
-            assertThat(ex.getMessage(), endsWith("server.properties"));
-        }
-    }
-
-    @Test
-    public void testNonAccessibleDirectory() throws Exception {
-
-        final PropertyCacheFile cache;
-        final String failMessage;
-
-        // That works fine on Linux/Unix, but ....
-        // It's not possible to make a directory/file unreadable in Windows NTFS for owner, that
-        // is why we use mock for testing on OS Windows.
-        // http://stackoverflow.com/a/4354686
-        // https://github.com/google/google-oauth-java-client/issues/55#issuecomment-69403681
-        if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows")) {
-            // We use mock on Windows just to satisfy coverage rate
-            cache = mock(PropertyCacheFile.class);
-            final String mockExceptionMessage = "...cache";
-            final AccessDeniedException mockException =
-                new AccessDeniedException(mockExceptionMessage);
-            doThrow(new IllegalStateException(mockException)).when(cache).persist();
-            failMessage = "AccessDeniedException is expected since we use the mock object.";
-
-        }
-        else {
-            final Configuration config = new DefaultConfiguration("myName");
-            final File directory = temporaryFolder.newFolder("directory");
-            directory.setReadable(true, false);
-            directory.setWritable(false, false);
-            final String filePath = String.format(Locale.getDefault(), "%s%2$sscache%2$stemp.cache",
-                directory.getAbsolutePath(), File.separator);
-            cache = new PropertyCacheFile(config, filePath);
-            failMessage = "AccessDeniedException is expected since directory is readonly.";
-        }
-
-        try {
-            cache.persist();
-            fail(failMessage);
-        }
-        catch (IllegalStateException ex) {
-            assertTrue(ex.getCause() instanceof AccessDeniedException);
-            assertThat(ex.getMessage(), endsWith("cache"));
         }
     }
 


### PR DESCRIPTION
#3259

There is no need in catching of InvalidPathException since it extends RuntimeException and we just wrap it in IllegalStateException which extends RuntimeException too without additional information.