### PR TITLE
Issue #3090: Fix wrong enforcement of same brace policy for LITERAL_DO in RightCurlyCheck

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
@@ -21,6 +21,7 @@ package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
 import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_ALONE;
 import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_NEW;
+import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_SAME;
 
 import java.io.File;
 import java.io.IOException;
@@ -70,5 +71,20 @@ public class RightCurlyTest extends BaseCheckTestSupport {
         final String filePath = getPath("InputRightCurlySame.java");
         final Integer[] warnList = getLinesWithWarn(filePath);
         verify(newCheckConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void testRightCurlySameAndLiteralDo() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option", RightCurlyOption.SAME.toString());
+        checkConfig.addAttribute("tokens", "LITERAL_DO");
+        final String[] expected = {
+            "62:9: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_SAME, "}", 9),
+            "67:13: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_SAME, "}", 13),
+            "83:9: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_SAME, "}", 9),
+        };
+        final String filePath = getPath("InputRightCurlyDoWhile.java");
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
     }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyDoWhile.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyDoWhile.java
@@ -1,0 +1,93 @@
+package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
+
+import java.util.Scanner;
+
+/**
+ * Test input for GitHub issue #3090.
+ * https://github.com/checkstyle/checkstyle/issues/3090
+ */
+public class InputRightCurlyDoWhile {
+
+    public void foo1() {
+        do {
+        } while (true);
+    }
+
+    public void foo2() {
+        int i = 1;
+        while (i < 5) {
+            System.out.print(i + " ");
+            i++;
+        }
+    }
+
+    public void foo3() {
+        int i = 1;
+        do {
+            i++;
+            System.out.print(i + " ");
+        } while (i < 5);
+    }
+
+    public void foo4() {
+        int prog, user;
+        prog = (int)(Math.random() * 10) + 1;
+        Scanner input = new Scanner(System.in);
+        if( input.hasNextInt() ) {
+            do {
+                user = input.nextInt();
+                if(user == prog) {
+                    System.out.println("Good!");
+                } else {
+                    if (user > 0 && user <= 10) {
+                        System.out.print("Bad! ");
+                        if( prog < user ) {
+                            System.out.println("My number is less than yours.");
+                        } else {
+                            System.out.println("My number is greater than yours.");
+                        }
+                    } else {
+                        System.out.println("Error!");
+                    }
+                }
+            } while( user != prog );
+        } else {
+            System.out.println("Error!");
+        }
+        System.out.println("Goodbye!");
+    }
+
+    public void foo5() {
+        do {
+        } // warn
+        while (true);
+    }
+
+    public void foo6() {
+        do {} // warn
+        while (true);
+    }
+
+    public void foo7() {
+        do
+        {
+
+        } while (true);
+    }
+
+    public void foo8() {
+        do
+
+        {
+
+        } // warn
+
+        while
+
+            (true);
+    }
+
+    public void foo9() {
+        do {} while (true);
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -365,9 +365,14 @@ public class RightCurlyCheck extends AbstractCheck {
                 rcurly = lcurly.getLastChild();
                 nextToken = getNextToken(ast);
                 break;
+            case TokenTypes.LITERAL_DO:
+                nextToken = ast.findFirstToken(TokenTypes.DO_WHILE);
+                lcurly = ast.findFirstToken(TokenTypes.SLIST);
+                rcurly = lcurly.getLastChild();
+                break;
             default:
                 // ATTENTION! We have default here, but we expect case TokenTypes.METHOD_DEF,
-                // TokenTypes.LITERAL_FOR, TokenTypes.LITERAL_WHILE, TokenTypes.LITERAL_DO only.
+                // TokenTypes.LITERAL_FOR, TokenTypes.LITERAL_WHILE, only.
                 // It has been done to improve coverage to 100%. I couldn't replace it with
                 // if-else-if block because code was ugly and didn't pass pmd check.
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages.properties
@@ -9,7 +9,7 @@ line.new=''{0}'' at column {1} should be on a new line.
 line.previous=''{0}'' at column {1} should be on the previous line.
 line.same=''{0}'' at column {1} should be on the same line as the next part of \
           a multi-block statement (one that directly contains multiple blocks: \
-          if/else-if/else or try/catch/finally).
+          if/else-if/else, do/while or try/catch/finally).
 
 needBraces=''{0}'' construct must use '''{}'''s.
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_de.properties
@@ -8,8 +8,8 @@ line.alone=''{0}'' in Spalten {1} sollte allein in der Zeile stehen.
 line.new=''{0}'' in Spalten {1} sollte in einer neuen Zeile stehen.
 line.previous=''{0}'' in Spalten {1} sollte in der vorhergehenden Zeile stehen.
 line.same=''{0}'' in Spalte {1} auf der gleichen Linie wie der nächste Teil einer \
-          Multi-Block-Anweisung (eine, die direkt mehrere Blöcke enthält: if/else-if/else oder \
-          try/catch/finally) sein sollte.
+          Multi-Block-Anweisung (eine, die direkt mehrere Blöcke enthält: if/else-if/else, \
+          do/while oder try/catch/finally) sein sollte.
 
 needBraces=Das ''{0}''-Konstrukt muss '''{}''' benutzen.
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_es.properties
@@ -9,7 +9,7 @@ line.new=''{0}'' en la columna {1} debería estar en una nueva línea.
 line.previous=''{0}'' en la columna {1} debería estar en la línea anterior.
 line.same=''{0}'' en la columna {1} debe estar en la misma línea que la siguiente parte \
           de una declaración de bloques múltiples (uno que contiene directamente varios bloques: \
-          if/else-if/else o try/catch/finally).
+          if/else-if/else, do/while o try/catch/finally).
 
 needBraces=La construcción ''{0}'' debe usar '''{}'' (llaves).
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_fi.properties
@@ -8,8 +8,8 @@ line.alone=''{0}'' sarakkeen {1} pitää olla yksinään rivillä.
 line.new=''{0}'' sarakkeen {1} pitää olla uudella rivillä.
 line.previous=''{0}'' sarakkeen {1} pitää olla edellisellä rivillä.
 line.same=''{0}'' sarakkeessa {1} pitäisi olla samalla rivillä kuin seuraava osa monen \
-          lohkon toteamus (joka välittömästi sisältää useita lohkoja: if/else-if/else tai \
-          try/catch/finally).
+          lohkon toteamus (joka välittömästi sisältää useita lohkoja: if/else-if/else,\
+          do/while tai try/catch/finally).
 
 needBraces=''{0}''-rakenteen pitää käyttää '''{}'':a.
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_fr.properties
@@ -9,7 +9,7 @@ line.new=''{0}'' à la colonne {1} devrait être sur une nouvelle ligne.
 line.previous=''{0}'' à la colonne {1} devrait être sur la ligne précédente.
 line.same=''{0}'' dans la colonne {1} devrait être sur la même ligne que la prochaine partie \
           d'une instruction multi-bloc (celui qui contient directement plusieurs blocs: \
-          if/else-if/else ou try/catch/finally).
+          if/else-if/else, do/while ou try/catch/finally).
 
 needBraces=L''instruction ''{0}'' devrait utiliser des accolades  ('''{''' et '''}''').
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_ja.properties
@@ -8,7 +8,7 @@ line.alone=''{0}'' 列 {1} には、行の一人であるべきです。
 line.new=''{0}'' 列に {1} 新しい行にする必要があります。
 line.previous=''{0}'' 列に {1} 前の行にする必要があります。
 line.same=''{0}'' 欄で {1} はマルチブロック文を直接複数のブロックが含まれています \
-          (の次の部分と同じ行にあるべき欄で： if/else-if/else または try/catch/finally).
+          (の次の部分と同じ行にあるべき欄で： if/else-if/else, do/while または try/catch/finally).
 
 needBraces=''{0}'' 文では '''{}''' を使用しなければなりません。
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_pt.properties
@@ -8,8 +8,8 @@ line.alone=''{0}'' na coluna {1} deve estar sozinho numa linha.
 line.new=''{0}'' na coluna {1} deve estar numa nova linha.
 line.previous=''{0}'' na coluna {1} deve estar na linha anterior.
 line.same=''{0}'' na coluna {1} deve estar na mesma linha que a próxima parte de uma \
-          instrução multi-bloco (aquele que contém directamente vários blocos: if/else-if/else ou\
-          try/catch/finally).
+          instrução multi-bloco (aquele que contém directamente vários blocos: if/else-if/else \
+          do/while ou try/catch/finally).
 
 needBraces=A estrutura sintáctica ''{0}'' deve utilizar '''{}'''s.
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_tr.properties
@@ -10,8 +10,8 @@ line.alone    = ''{0}'' sütun {1} bir çizgi üzerinde yalnız olmalıdır.
 line.new      = ''{0}'' sütun {1} yeni bir satırda olmalıdır.
 line.previous = ''{0}'' sütun {1} önceki satırda olmalıdır.
 line.same     = ''{0}'' {1} multi-blok deyiminin sonraki parçası olarak aynı satırda olmalıdır \
-                sütunda (doğrudan çoklu blokları içeren tek bir: if/else-if/else veya başka bir \
-                try/catch/finally).
+                sütunda (doğrudan çoklu blokları içeren tek bir: if/else-if/else, do/while \
+                veya başka bir try/catch/finally).
 
 needBraces = ''{0}'' yapısı süslü parantezler ('''{}''') kullanmalı.
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_zh.properties
@@ -8,7 +8,7 @@ line.alone=第 {1} 个字符 ''{0}'' 应独占一行。
 line.new=第 {1} 个字符 ''{0}'' 应位于新行。
 line.previous=第 {1} 个字符 ''{0}'' 应位于前一行。
 line.same= 第 {1} 个字符 ''{0}''应该与当前多代码块的下一部分 \
-         （if/else-if/else 或 try/catch/finally）位于同一行。
+         （if/else-if/else, do/while 或 try/catch/finally）位于同一行。
 
 needBraces=''{0}'' 结构必须使用大括号 '''{}'''。
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -282,4 +282,16 @@ public class RightCurlyCheckTest extends BaseCheckTestSupport {
 
         verify(checkConfig, getPath("InputRightCurly.java"), expected);
     }
+
+    @Test
+    public void testRightCurlySameAndLiteralDo() throws Exception {
+        checkConfig.addAttribute("option", RightCurlyOption.SAME.toString());
+        checkConfig.addAttribute("tokens", "LITERAL_DO");
+        final String[] expected = {
+            "62:9: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 9),
+            "67:13: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 13),
+            "83:9: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 9),
+        };
+        verify(checkConfig, getPath("InputRightCurlyDoWhile.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputRightCurlyDoWhile.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputRightCurlyDoWhile.java
@@ -1,0 +1,94 @@
+package com.puppycrawl.tools.checkstyle.checks.blocks;
+
+import java.util.Scanner;
+
+/**
+ * Test input for GitHub issue #3090.
+ * https://github.com/checkstyle/checkstyle/issues/3090
+ */
+public class InputRightCurlyDoWhile {
+
+    public void foo1() {
+        do {
+        } while (true);
+    }
+
+    public void foo2() {
+        int i = 1;
+        while (i < 5) {
+            System.out.print(i + " ");
+            i++;
+        }
+    }
+
+    public void foo3() {
+        int i = 1;
+        do {
+            i++;
+            System.out.print(i + " ");
+        } while (i < 5);
+    }
+
+    public void foo4() {
+        int prog, user;
+        prog = (int)(Math.random() * 10) + 1;
+        Scanner input = new Scanner(System.in);
+        if( input.hasNextInt() ) {
+            do {
+                user = input.nextInt();
+                if(user == prog) {
+                    System.out.println("Good!");
+                } else {
+                    if (user > 0 && user <= 10) {
+                        System.out.print("Bad! ");
+                        if( prog < user ) {
+                            System.out.println("My number is less than yours.");
+                        } else {
+                            System.out.println("My number is greater than yours.");
+                        }
+                    } else {
+                        System.out.println("Error!");
+                    }
+                }
+            } while( user != prog );
+        } else {
+            System.out.println("Error!");
+        }
+        System.out.println("Goodbye!");
+    }
+
+    public void foo5() {
+        do {
+        } // violation
+        while (true);
+    }
+
+    public void foo6() {
+        do {} // violation
+        while (true);
+    }
+
+    public void foo7() {
+        do
+        {
+
+        } while (true);
+    }
+
+    public void foo8() {
+        do
+
+        {
+
+        } // violation
+
+        while
+
+        (true);
+    }
+
+    public void foo9() {
+        do {} while (true);
+    }
+}
+


### PR DESCRIPTION
#3090

1) The problem was fixed.
2) Added new UT.
3) Added new IT.

Regression reports were generated against the following projects:
1) pmd
2) lombok
3) spring-framework
4) java-design-patterns
5) MaterialDesignLibrary
6) Hbase
7) apache-ant
8) apache-jsecurity
9) android-launcher
10) infinispan
11) protonpack
12) jOOL
13) RxJava
14) checkstyle-with-excludes
15) sevntu-checkstyle-with-excludes
16) findbugs-with-excldues
17) hibernate-orm-with-excludes
18) guava-mvnstyle

Configuration:
```xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
<module name = "Checker">
    <property name="charset" value="UTF-8"/>
    <property name="severity" value="warning"/>
    <module name="TreeWalker">
         <module name="RightCurly">
         	 <property name="option" value="same"/>
	    	 <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH,
 LITERAL_FINALLY, LITERAL_IF, 
LITERAL_ELSE, CLASS_DEF,
 METHOD_DEF, CTOR_DEF, 
LITERAL_FOR, LITERAL_WHILE,
 LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/> 
         </module> 
    </module>
</module>
```

I had to build Checkstyle artifact with changes without changing of violation message in order to generate diff report properly without noise because of new message format.

Diff reports: http://mezk.github.io/i3090-RightCurlyCheck/diff/index.html
Diff reports looks ok to me. I checked all 270 differences.