### PR TITLE
Issue #3117: Add ability to differentiate annotation placement in foreach, for loops, parameter definition

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
@@ -158,4 +158,18 @@ public class AnnotationLocationCheckTest extends BaseCheckTestSupport {
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputAnnotationLocation3.java"), expected);
     }
+
+    @Test
+    public void testAnnotationInForEachLoopParameterAndVariableDef() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(AnnotationLocationCheck.class);
+        checkConfig.addAttribute("tokens", "CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF,"
+            + " CTOR_DEF, VARIABLE_DEF, PARAMETER_DEF, ANNOTATION_DEF, TYPECAST, LITERAL_THROWS,"
+            + " IMPLEMENTS_CLAUSE, TYPE_ARGUMENT, LITERAL_NEW, DOT, ANNOTATION_FIELD_DEF,"
+            + " TYPE_ARGUMENT");
+        checkConfig.addAttribute("allowSamelineMultipleAnnotations", "false");
+        checkConfig.addAttribute("allowSamelineSingleParameterlessAnnotation", "false");
+        checkConfig.addAttribute("allowSamelineParameterizedAnnotation", "false");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputAnnotationLocation4.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/InputAnnotationLocation4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/InputAnnotationLocation4.java
@@ -1,0 +1,50 @@
+package com.puppycrawl.tools.checkstyle.checks.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+public class InputAnnotationLocation4 {
+    @Deprecated // <--class, separate line
+    public class Annotation
+    {
+        @Deprecated // <--method, separate line
+        public void test(@MyAnnotation String s) { // <--parameter, same line
+            @MyAnnotation // <--variable, separate line
+            Integer i;
+            for (@MyAnnotation char c : s.toCharArray()) { // <--variable in for each, same line
+            }
+        }
+    }
+
+    public class Test {
+        public void foo1() {
+            try {
+                // some code
+            }
+            catch (@MyAnnotation Exception ex) {
+
+            }
+        }
+
+        public void foo2() {
+            for (@MyAnnotation int i = 0; i < 10; i++) {
+
+            }
+        }
+
+        public void foo3() {
+            MathOperation c = (@MyAnnotation int a, @MyAnnotation int b) -> a + b;
+        }
+
+        public void foo4(@MyAnnotation int a, @MyAnnotation int b) {}
+
+        public void foo5(@SuppressWarnings("unchecked") int a) {}
+    }
+
+    interface MathOperation {
+        int operation(int a, int b);
+    }
+
+    @Target(ElementType.TYPE_USE)
+    public @interface MyAnnotation {}
+}

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -153,6 +153,34 @@ public String getNameIfPresent() { ... }
     &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
+       <p>
+         The following example demonstrates how the check validates annotations of method parameters,
+         catch parameters, foreach, for-loop variable definitions.
+       </p>
+       <p>Configuration:</p>
+       <source>
+&lt;module name=&quot;AnnotationLocation&quot;&gt;
+    &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;false&quot;/&gt;
+    &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot; value=&quot;false&quot;/&gt;
+    &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
+    &lt;property name=&quot;tokens&quot; value=&quot;VARIABLE_DEF, PARAMETER_DEF&quot;/&gt;
+ &lt;/module&gt;
+       </source>
+       <p>Code example:</p>
+       <source>
+public void test(&#64;MyAnnotation String s) { // OK
+  ...
+  for (&#64;MyAnnotation char c : s.toCharArray()) { ... }  // OK
+  ...
+  try { ... }
+  catch (&#64;MyAnnotation Exception ex) { ... } // OK
+  ...
+  for (&#64;MyAnnotation int i = 0; i &lt; 10; i++) { ... } // OK
+  ...
+  MathOperation c = (&#64;MyAnnotation int a, &#64;MyAnnotation int b) -&gt; a + b; // OK
+  ...
+}
+       </source>
       </subsection>
 
       <subsection name="Example of Usage">


### PR DESCRIPTION
#3117 

@romani 
Fixed for foreach, for loops, catch, method, lambdas parameters.
I'm not able to generate regression reports against Apache-Apex, as I have got the following exceptions (before and after changes):

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.3:site (default-site) on project sample: Execution default-site of goal org.apache.maven.plugins:maven-site-plugin:3.3:site failed. NullPointerException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.3:site (default-site) on project sample: Execution default-site of goal org.apache.maven.plugins:maven-site-plugin:3.3:site failed.
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:212)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-site of goal org.apache.maven.plugins:maven-site-plugin:3.3:site failed.
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:145)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
	... 20 more
Caused by: java.lang.NullPointerException
	at org.apache.maven.jxr.pacman.JavaFileImpl.parse(JavaFileImpl.java:108)
	at org.apache.maven.jxr.pacman.JavaFileImpl.<init>(JavaFileImpl.java:64)
	at org.apache.maven.jxr.pacman.FileManager.getFile(FileManager.java:68)
	at org.apache.maven.jxr.pacman.PackageManager.parse(PackageManager.java:123)
	at org.apache.maven.jxr.pacman.PackageManager.process(PackageManager.java:161)
	at org.apache.maven.jxr.JXR.xref(JXR.java:262)
	at org.apache.maven.plugin.jxr.AbstractJxrReport.createXref(AbstractJxrReport.java:279)
	at org.apache.maven.plugin.jxr.AbstractJxrReport.executeReport(AbstractJxrReport.java:473)
	at org.apache.maven.reporting.AbstractMavenReport.generate(AbstractMavenReport.java:255)
	at org.apache.maven.plugins.site.ReportDocumentRenderer.renderDocument(ReportDocumentRenderer.java:219)
	at org.apache.maven.doxia.siterenderer.DefaultSiteRenderer.renderModule(DefaultSiteRenderer.java:319)
	at org.apache.maven.doxia.siterenderer.DefaultSiteRenderer.render(DefaultSiteRenderer.java:135)
	at org.apache.maven.plugins.site.SiteMojo.renderLocale(SiteMojo.java:175)
	at org.apache.maven.plugins.site.SiteMojo.execute(SiteMojo.java:138)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	... 21 more
[ERROR] 
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
```

However,  I generated regression reports against the following projects:
1) pmd
2) lombok
3) spring-framework
4) java-design-patterns
5) MaterialDesignLibrary
6) Hbase
7) apache-ant
8) apache-jsecurity
9) android-launcher
10) infinispan
11) protonpack
12) jOOL
13) RxJava
14) checkstyle-with-excludes
15) sevntu-checkstyle-with-excludes
16) findbugs-with-excldues
17) hibernate-orm-with-excludes
18) guava-mvnstyle

with the following configuration:

```xml
<module name = "Checker">
    <property name="charset" value="UTF-8"/>
    <property name="severity" value="warning"/>
    <module name="TreeWalker">
         <module name="AnnotationLocation">
         	 <property name="allowSamelineMultipleAnnotations" value="false"/>
         	 <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
         	 <property name="allowSamelineParameterizedAnnotation" value="false"/>
         	 <property name="tokens" value="CLASS_DEF, INTERFACE_DEF,
ENUM_DEF, METHOD_DEF, 
CTOR_DEF, VARIABLE_DEF, 
ANNOTATION_DEF, TYPECAST,
LITERAL_THROWS, IMPLEMENTS_CLAUSE, 
TYPE_ARGUMENT, LITERAL_NEW, 
DOT, ANNOTATION_FIELD_DEF"/>
         </module> 
    </module>
</module>
```

Take into account that I had to exclude PARAMETER_DEF from tokens as it produces to much noise. Reports before and after are equal which is quite strange (I can't believe that all the projects do not use annotations in foreach / for loops, for instance Spring, Hibernate). 
Nevertheless, I generated report against Guava and added PARAMETER_DEF into tokens set. As you can see from the report there is a huge regression: annotations for parameter types were removed from report after changes.
http://mezk.github.io/i3117-AnnotationLocationCheck/guava_diff/index.html