### PR TITLE
Issue #3239: fixed checks that fail on new receiver parameter

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
@@ -176,7 +176,8 @@ public class FinalParametersCheck extends AbstractCheck {
      * @param param parameter to check.
      */
     private void checkParam(final DetailAST param) {
-        if (!param.branchContains(TokenTypes.FINAL) && !isIgnoredParam(param)) {
+        if (!param.branchContains(TokenTypes.FINAL) && !isIgnoredParam(param)
+                && !CheckUtils.isReceiverParameter(param)) {
             final DetailAST paramName = param.findFirstToken(TokenTypes.IDENT);
             final DetailAST firstNode = CheckUtils.getFirstNode(param);
             log(firstNode.getLineNo(), firstNode.getColumnNo(),

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -29,6 +29,7 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtils;
 
@@ -299,6 +300,7 @@ public class HiddenFieldCheck
      */
     private void processVariable(DetailAST ast) {
         if (!ScopeUtils.isInInterfaceOrAnnotationBlock(ast)
+            && !CheckUtils.isReceiverParameter(ast)
             && (ScopeUtils.isLocalVariableDef(ast)
                 || ast.getType() == TokenTypes.PARAMETER_DEF)) {
             // local variable or parameter. Does it shadow a field?

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
 
 /**
  * <p>
@@ -236,7 +237,8 @@ public final class ParameterAssignmentCheck extends AbstractCheck {
             ast.findFirstToken(TokenTypes.PARAMETER_DEF);
 
         while (parameterDefAST != null) {
-            if (parameterDefAST.getType() == TokenTypes.PARAMETER_DEF) {
+            if (parameterDefAST.getType() == TokenTypes.PARAMETER_DEF
+                    && !CheckUtils.isReceiverParameter(parameterDefAST)) {
                 final DetailAST param =
                     parameterDefAST.findFirstToken(TokenTypes.IDENT);
                 parameterNames.add(param.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtils;
 
 /**
@@ -321,8 +322,10 @@ public class RequireThisCheck extends AbstractCheck {
                 collectVariableDeclarations(ast, frame);
                 break;
             case TokenTypes.PARAMETER_DEF :
-                final DetailAST parameterIdent = ast.findFirstToken(TokenTypes.IDENT);
-                frame.addIdent(parameterIdent);
+                if (!CheckUtils.isReceiverParameter(ast)) {
+                    final DetailAST parameterIdent = ast.findFirstToken(TokenTypes.IDENT);
+                    frame.addIdent(parameterIdent);
+                }
                 break;
             case TokenTypes.CLASS_DEF :
             case TokenTypes.INTERFACE_DEF :

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -220,7 +221,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
     private boolean isIgnoreSituation(DetailAST ast) {
         final DetailAST modifiers = ast.getFirstChild();
 
-        boolean result = false;
+        final boolean result;
         if (ast.getType() == TokenTypes.VARIABLE_DEF) {
             if ((ignoreFinal || ignoreStatic)
                     && isInterfaceDeclaration(ast)) {
@@ -237,6 +238,9 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
         else if (ast.getType() == TokenTypes.METHOD_DEF) {
             result = ignoreOverriddenMethods
                     && hasOverrideAnnotation(modifiers);
+        }
+        else {
+            result = CheckUtils.isReceiverParameter(ast);
         }
         return result;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming;
 import com.google.common.base.Optional;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
 
 /**
 * <p>
@@ -105,7 +106,8 @@ public class ParameterNameCheck
     protected boolean mustCheckName(DetailAST ast) {
         boolean checkName = true;
         if (ignoreOverridden && isOverriddenMethod(ast)
-                || ast.getParent().getType() == TokenTypes.LITERAL_CATCH) {
+                || ast.getParent().getType() == TokenTypes.LITERAL_CATCH
+                || CheckUtils.isReceiverParameter(ast)) {
             checkName = false;
         }
         return checkName;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtils.java
@@ -410,4 +410,19 @@ public final class CheckUtils {
         }
         return returnValue;
     }
+
+    /**
+     * Checks whether a parameter is a receiver.
+     *
+     * @param parameterDefAst the parameter node.
+     * @return true if the parameter is a receiver.
+     */
+    public static boolean isReceiverParameter(DetailAST parameterDefAst) {
+        boolean returnValue = false;
+        if (parameterDefAst.getType() == TokenTypes.PARAMETER_DEF
+                && parameterDefAst.findFirstToken(TokenTypes.IDENT) == null) {
+            returnValue = parameterDefAst.branchContains(TokenTypes.LITERAL_THIS);
+        }
+        return returnValue;
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheckTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class FinalParametersCheckTest extends BaseCheckTestSupport {
     @Override
@@ -126,5 +127,13 @@ public class FinalParametersCheckTest extends BaseCheckTestSupport {
             "10:32: " + getCheckMessage(MSG_KEY, "s"),
         };
         verify(checkConfig, getPath("InputFinalParametersPrimitiveTypes.java"), expected);
+    }
+
+    @Test
+    public void testRecieverParameters() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(FinalParametersCheck.class);
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputFinalParametersReceiver.java"), expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class HiddenFieldCheckTest
     extends BaseCheckTestSupport {
@@ -401,5 +402,12 @@ public class HiddenFieldCheckTest
             "290:19: " + getCheckMessage(MSG_KEY, "i"),
         };
         verify(checkConfig, getPath("InputHiddenField.java"), expected);
+    }
+
+    @Test
+    public void testReceiverParameter() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(HiddenFieldCheck.class);
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputHiddenFieldReceiver.java"), expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
@@ -31,6 +31,7 @@ import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class ParameterAssignmentCheckTest extends BaseCheckTestSupport {
     @Override
@@ -52,6 +53,13 @@ public class ParameterAssignmentCheckTest extends BaseCheckTestSupport {
         };
         verify(checkConfig, getPath("InputParameterAssignment.java"),
                expected);
+    }
+
+    @Test
+    public void testReceiverParameter() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ParameterAssignmentCheck.class);
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputParameterAssignmentReceiver.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -240,4 +240,11 @@ public class RequireThisCheckTest extends BaseCheckTestSupport {
         };
         verify(checkConfig, getPath("InputValidateOnlyOverlappingTrue.java"), expected);
     }
+
+    @Test
+    public void testReceiverParameter() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RequireThisCheck.class);
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputRequireThisReceiver.java"), expected);
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
@@ -319,4 +319,13 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
     private String getWarningMessage(String typeName, int expectedCapitalCount) {
         return getCheckMessage(MSG_KEY, typeName, expectedCapitalCount);
     }
+
+    @Test
+    public void testReceiver() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(AbbreviationAsWordInNameCheck.class);
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig, getPath("InputAbbreviationAsWordReceiver.java"), expected);
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -147,4 +147,11 @@ public class ParameterNameCheckTest
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputOverrideAnnotationNoNPE.java"), expected);
     }
+
+    @Test
+    public void testReceiverParameter() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ParameterNameCheck.class);
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputParameterNameReceiver.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/InputFinalParametersReceiver.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/InputFinalParametersReceiver.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.checks;
+
+public class InputFinalParametersReceiver {
+    public void foo4(InputFinalParametersReceiver this) {}
+
+    private class Inner {
+        public Inner(InputFinalParametersReceiver InputFinalParametersReceiver.this) {}
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputHiddenFieldReceiver.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputHiddenFieldReceiver.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.checks.coding;
+
+public class InputHiddenFieldReceiver {
+    public void foo4(InputHiddenFieldReceiver this) {}
+
+    private class Inner {
+        public Inner(InputHiddenFieldReceiver InputHiddenFieldReceiver.this) {}
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputParameterAssignmentReceiver.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputParameterAssignmentReceiver.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.checks.coding;
+
+public class InputParameterAssignmentReceiver {
+    public void foo4(InputParameterAssignmentReceiver this) {}
+
+    private class Inner {
+        public Inner(InputParameterAssignmentReceiver InputParameterAssignmentReceiver.this) {}
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputRequireThisReceiver.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputRequireThisReceiver.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.checks.coding;
+
+public class InputRequireThisReceiver {
+    public void foo4(InputRequireThisReceiver this) {}
+
+    private class Inner {
+        public Inner(InputRequireThisReceiver InputRequireThisReceiver.this) {}
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputAbbreviationAsWordReceiver.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputAbbreviationAsWordReceiver.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+public class InputAbbreviationAsWordReceiver {
+    public void foo4(InputAbbreviationAsWordReceiver this) {}
+
+    private class Inner {
+        public Inner(InputAbbreviationAsWordReceiver InputAbbreviationAsWordReceiver.this) {}
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputParameterNameReceiver.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputParameterNameReceiver.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+public class InputParameterNameReceiver {
+    public void foo4(InputParameterNameReceiver this) {}
+
+    private class Inner {
+        public Inner(InputParameterNameReceiver InputParameterNameReceiver.this) {}
+    }
+}


### PR DESCRIPTION
Issue #3239 

Identified as an issue in https://github.com/checkstyle/checkstyle/pull/3259#issuecomment-225621597

Reason receiver parameters are ignored in these checks:
* Receiver parameters can't be `final`.
* Receiver parameters can't be renamed.
* Variables can't be named `this` to conflict with receiver parameters.
* `this` can't be re-assigned from a receiver parameter.