### PR TITLE
minor: fixed debug option bleeding into other tests

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -34,8 +34,12 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -67,6 +71,10 @@ public class MainTest {
         + " including comments%n"
         + " -v                      Print product version and exit%n");
 
+    private static Logger logger;
+    private static Handler[] handlers;
+    private static Level originalLogLevel;
+
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
     @Rule
@@ -93,6 +101,32 @@ public class MainTest {
         // Set locale to root to prevent check message fail
         // in other language environment.
         Locale.setDefault(Locale.ROOT);
+
+        logger = Logger.getLogger(MainTest.class.getName()).getParent();
+        handlers = logger.getHandlers();
+        originalLogLevel = logger.getLevel();
+    }
+
+    @Before
+    public void setUp() {
+        // restore original logging level and handlers to prevent bleeding into other tests
+
+        logger.setLevel(originalLogLevel);
+
+        for (Handler handler : logger.getHandlers()) {
+            boolean found = false;
+
+            for (Handler savedHandler : handlers) {
+                if (handler == savedHandler) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                logger.removeHandler(handler);
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
This fixes the issue seen running pitest on CS in Windows.

The 3 tests that were causing the problem for me were, in the specific order:
*    com.puppycrawl.tools.checkstyle.MainTest.testDebugOption
*    com.puppycrawl.tools.checkstyle.internal.XDocsPagesTest.testAllCheckSections
*    com.puppycrawl.tools.checkstyle.internal.XDocsPagesTest.testAllXmlExamples

Which caused the following exception in Windows, but not on Linux:
`FINE : MINION : FAIL Description [testClass=com.puppycrawl.tools.checkstyle.internal.XDocsPagesTest, name=testAllXmlExamples(com.puppycrawl.tools.checkstyle.internal.XDocsPagesTest)] -> java.lang.OutOfMemoryError: Java heap space`

Basically our junit testing the debug option is bleeding into other tests, leaving logging on the highest. `XDocsPages` test run alot of code that logs a lot of ignorable exceptions which is why it is the point of failure.

Pitest uses its own custom ordering for junits, so that coupled with the modifications it makes to the code is probably why travis or I haven't run into this before.

Full discussion on pitest: https://github.com/hcoles/pitest/issues/272