### PR TITLE
Issue #3177: Remove validation of rw access for output file in Main#validateCli

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -253,13 +253,6 @@ public final class Main {
                     result.add(String.format("Could not find file '%s'.", propertiesLocation));
                 }
             }
-            if (cmdLine.hasOption(OPTION_O_NAME)) {
-                final String outputLocation = cmdLine.getOptionValue(OPTION_O_NAME);
-                final File file = new File(outputLocation);
-                if (file.exists() && !file.canWrite()) {
-                    result.add(String.format("Permission denied : '%s'.", outputLocation));
-                }
-            }
         }
         else {
             result.add("Must specify a config XML file.");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle;
 
 import static com.puppycrawl.tools.checkstyle.internal.TestUtils.assertUtilsClassHasPrivateConstructor;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -384,49 +385,14 @@ public class MainTest {
     }
 
     @Test
-    public void testExistingTargetFilePlainOutputToFileWithoutRwPermissions()
-            throws Exception {
-        final File file = temporaryFolder.newFile("file.output");
-        assertTrue(file.setReadable(true, true));
-        assertTrue(file.setWritable(false, false));
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() throws IOException {
-                assertEquals("Permission denied : '" + file.getCanonicalPath() + "'."
-                        + System.lineSeparator(), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
-        });
+    public void testCreateNonExistingOutputFile() throws Exception {
+        final String outputFile = temporaryFolder.getRoot().getCanonicalPath() + "nonexisting.out";
+        assertFalse(new File(outputFile).exists());
         Main.main("-c", getPath("config-classname.xml"),
                 "-f", "plain",
-                "-o", file.getCanonicalPath(),
+                "-o", outputFile,
                 getPath("InputMain.java"));
-    }
-
-    @Test
-    public void testExistingFilePlainOutputToFileWithoutReadAndRwPermissions()
-            throws Exception {
-        final File file = temporaryFolder.newFile("file.output");
-        // That works fine on Linux/Unix, but ....
-        // It's not possible to make a file unreadable in Windows NTFS for owner.
-        // http://stackoverflow.com/a/4354686
-        // https://github.com/google/google-oauth-java-client/issues/55#issuecomment-69403681
-        //assertTrue(file.setReadable(false, false));
-        assertTrue(file.setWritable(false, false));
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() throws IOException {
-                assertEquals("Permission denied : '" + file.getCanonicalPath() + "'."
-                        + System.lineSeparator(), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
-        });
-        Main.main("-c", getPath("config-classname.xml"),
-                "-f", "plain",
-                "-o", file.getCanonicalPath(),
-                getPath("InputMain.java"));
+        assertTrue(new File(outputFile).exists());
     }
 
     @Test


### PR DESCRIPTION
#3177 
Removed validation of rw access for output file in Main#validateCli and as a result two UTs:
```
MainTest.testExistingFilePlainOutputToFileWithoutReadAndRwPermissions
MainTest.testExistingTargetFilePlainOutputToFileWithoutRwPermissions
```
were also deleted.

After merge of https://github.com/checkstyle/checkstyle/pull/3259 and this PR the issue #3177 will be resolved.