### PR TITLE
config: set -source for maven-javadoc-plugin to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.4</version>
           <configuration>
-            <source>1.7</source>
+            <source>1.8</source>
             <failOnError>true</failOnError>
             <linksource>true</linksource>
             <tags>


### PR DESCRIPTION
Should be set for maven-javadoc-plugin as it blocks usage of Java 1.8 features.
https://travis-ci.org/checkstyle/checkstyle/jobs/138544588#L464