### PR TITLE
config: deactivate dsm-maven-plugin as it does not support Java 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1011,14 +1011,18 @@
         </reportSets>
       </plugin>
 
-      <plugin>
-        <groupId>com.github.sevntu-checkstyle</groupId>
-        <artifactId>dsm-maven-plugin</artifactId>
-        <version>2.1.4</version>
-        <configuration>
-          <obfuscatePackageNames>true</obfuscatePackageNames>
-        </configuration>
-      </plugin>
+      <!--
+       dsm-maven plugin does not support Java 1.8
+       Deactivated until https://github.com/sevntu-checkstyle/dsm-maven-plugin/issues/31
+       -->
+      <!--<plugin>-->
+        <!--<groupId>com.github.sevntu-checkstyle</groupId>-->
+        <!--<artifactId>dsm-maven-plugin</artifactId>-->
+        <!--<version>2.1.4</version>-->
+        <!--<configuration>-->
+          <!--<obfuscatePackageNames>true</obfuscatePackageNames>-->
+        <!--</configuration>-->
+      <!--</plugin>-->
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
dsm-maven plugin was deactivated until https://github.com/sevntu-checkstyle/dsm-maven-plugin/issues/31 be resolved.