### PR TITLE
Issue #3159: Reduce the number of tasks performed by Travis CI

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -5,9 +5,92 @@ build:
       name: setup mvn local repo
       code: |-
         export MAVEN_OPTS="-Dmaven.repo.local=${WERCKER_CACHE_DIR}"
+        mvn -version
 
   # unit tests (oraclejdk8)
   - script:
       name: tests
       code: |-
         mvn clean integration-test failsafe:verify
+
+  # unit tests in German locale (oraclejdk8)
+  - script:
+      name: tests de
+      code: >
+        mvn clean integration-test failsafe:verify -DargLine='-Duser.language=de
+        -Duser.country=DE -XX:-UseSplitVerifier'
+
+  # unit tests in Spanish locale (oraclejdk8)
+  - script:
+      name: tests es
+      code: >
+        mvn clean integration-test failsafe:verify -DargLine='-Duser.language=es
+        -Duser.country=ES -XX:-UseSplitVerifier'
+
+  # unit tests in Finnish locale (oraclejdk8)
+  - script:
+      name: tests fi
+      code: >
+        mvn clean integration-test failsafe:verify -DargLine='-Duser.language=fi
+        -Duser.country=FI -XX:-UseSplitVerifier'
+
+  # unit tests in French locale (oraclejdk8)
+  - script:
+      name: tests fr
+      code: >
+        mvn clean integration-test failsafe:verify -DargLine='-Duser.language=fr
+        -Duser.country=FR -XX:-UseSplitVerifier'
+
+  # unit tests in Chinese locale (oraclejdk8)
+  - script:
+      name: tests zh
+      code: >
+        mvn clean integration-test failsafe:verify -DargLine='-Duser.language=zh
+        -Duser.country=CN -XX:-UseSplitVerifier'
+
+  # unit tests in Japanese locale (oraclejdk8)
+  - script:
+      name: tests ja
+      code: >
+        mvn clean integration-test failsafe:verify -DargLine='-Duser.language=ja
+        -Duser.country=JP -XX:-UseSplitVerifier'
+
+  # unit tests in Portuguese locale (oraclejdk8)
+  - script:
+      name: tests pt
+      code: >
+        mvn clean integration-test failsafe:verify -DargLine='-Duser.language=pt
+        -Duser.country=PT -XX:-UseSplitVerifier'
+
+  # unit tests in Turkish locale (oraclejdk8)
+  - script:
+      name: tests tr
+      code: >
+        mvn clean integration-test failsafe:verify -DargLine='-Duser.language=tr
+        -Duser.country=TR -XX:-UseSplitVerifier'
+
+
+  # java 8 compile (oraclejdk8)
+  - script:
+      name: java 8 inputs should NOT be in resources-noncompilable
+      code: >
+        if [ $(grep -rl --include='*.java' '//Compilable with Java8' src/test/resources-noncompilable | wc -l) -eq 0 ]; then
+        echo 'OK';
+        else
+        echo 'please move all java8 resources to src/test/resources' && false;
+        fi
+
+  # Releasenotes generation - validaton
+  - script:
+      name: Releasenotes generation
+      code: >
+        if [ "${WERCKER_GIT_BRANCH}" != "master" ]; then return 0; fi
+        && git clone https://github.com/checkstyle/contribution && cd contribution/releasenotes-xdoc-builder
+        && mvn clean compile package
+        && cd ../../ && git clone https://github.com/checkstyle/checkstyle && cd checkstyle
+        && LATEST_RELEASE_TAG=$(git describe $(git rev-list --tags --max-count=1)) && cd ../
+        && CS_RELEASE_VERSION=$(mvn -q -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec | sed 's/-SNAPSHOT//' )
+        && echo LATEST_RELEASE_TAG=${LATEST_RELEASE_TAG} && echo CS_RELEASE_VERSION=${CS_RELEASE_VERSION}
+        && java -jar contribution/releasenotes-xdoc-builder/target/releasenotes-xdoc-builder-1.0-all.jar
+        -localRepoPath checkstyle -startRef ${LATEST_RELEASE_TAG} -releaseNumber ${CS_RELEASE_VERSION} -authToken ${GITHUB_AUTH_TOKEN}
+        && cat releasenotes.xml


### PR DESCRIPTION
#3159 

@romani

1) All Travis CI's jobs were copied to Wercker CI except for generation of release notes and testing of PR format. nemo.sonarqube.com phase was commented out since I do not have permissions.
2) Cache was set up for Maven to avoid reloading of dependencies during execution.
3) I have to add ```rm -rf contribution``` for NoExceptionTests to avoid the following prblem:
![wercker_issue1](https://cloud.githubusercontent.com/assets/7242568/16176860/9790afe6-3623-11e6-8165-0d06c80e30a9.png)
4) We have to decide which phases will migrate to Wercker CI from Travis CI.
5) We have to design worckflow for Checkstyle at Wercker CI. See http://devcenter.wercker.com/docs/workflows/index.html
6) We have to create pipelines in order to execute jobs in parallel and use different containers (aka boxes) to test on different OS. The profiles can be found at https://hub.docker.com/ . Wercker CI offers free account which allows to execute two pipelines in parallel at once (http://wercker.com/pricing/). Each pipeline should set up mvn cache to the same folder.

As I see it:
![screenshot at 2016-06-19 13 30 44](https://cloud.githubusercontent.com/assets/7242568/16176862/ac98182a-3623-11e6-997a-23e6097c3c72.png)

7) Test, compile phases should be copied to Wercker CI for sure as we faced probles with Docker (https://github.com/checkstyle/checkstyle/issues/3177). 
8) Lets create projects-for-wercker.properties. Apache Struts should definitely be there.

Wercker CI's build for my local checkstyle repo with only one pipeline (all steps are executed successively):
https://app.wercker.com/#MEZk/checkstyle/build/57666e3d7cab8d010000f304