### PR TITLE
Cut down on Checkstyle's dependencies on Guava

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
@@ -36,7 +37,6 @@ import java.util.regex.Pattern;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
@@ -306,7 +306,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
             fileNameRegexp = String.format(Locale.ROOT,
                 REGEXP_FORMAT_TO_CHECK_REQUIRED_TRANSLATIONS, baseName, languageCode, extension);
         }
-        Optional<String> missingFileName = Optional.absent();
+        Optional<String> missingFileName = Optional.empty();
         if (!bundle.containsFile(fileNameRegexp)) {
             if (searchForDefaultTranslation) {
                 missingFileName = Optional.of(String.format(Locale.ROOT,
@@ -372,7 +372,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
      */
     private static Optional<ResourceBundle> findBundle(Set<ResourceBundle> bundles,
                                                        ResourceBundle targetBundle) {
-        Optional<ResourceBundle> result = Optional.absent();
+        Optional<ResourceBundle> result = Optional.empty();
         for (ResourceBundle currentBundle : bundles) {
             if (targetBundle.getBaseName().equals(currentBundle.getBaseName())
                     && targetBundle.getExtension().equals(currentBundle.getExtension())

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -19,9 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
+import java.util.Optional;
 import java.util.regex.Pattern;
 
-import com.google.common.base.Optional;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -217,9 +217,9 @@ public class UncommentedMainCheck
 
         if (params.getChildCount() == 1) {
             final DetailAST parameterType = params.getFirstChild().findFirstToken(TokenTypes.TYPE);
-            final Optional<DetailAST> arrayDecl = Optional.fromNullable(
+            final Optional<DetailAST> arrayDecl = Optional.ofNullable(
                 parameterType.findFirstToken(TokenTypes.ARRAY_DECLARATOR));
-            final Optional<DetailAST> varargs = Optional.fromNullable(
+            final Optional<DetailAST> varargs = Optional.ofNullable(
                 params.getFirstChild().findFirstToken(TokenTypes.ELLIPSIS));
 
             if (arrayDecl.isPresent()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -25,8 +25,8 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 
-import com.google.common.base.Optional;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -288,7 +288,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
      * @return Optional of {@link FinalVariableCandidate} for ast from scopeStack.
      */
     private Optional<FinalVariableCandidate> getFinalCandidate(DetailAST ast) {
-        Optional<FinalVariableCandidate> result = Optional.absent();
+        Optional<FinalVariableCandidate> result = Optional.empty();
         final Iterator<ScopeData> iterator = scopeStack.descendingIterator();
         while (iterator.hasNext() && !result.isPresent()) {
             final ScopeData scopeData = iterator.next();
@@ -635,10 +635,10 @@ public class FinalLocalVariableCheck extends AbstractCheck {
          * @return Optional of {@link FinalVariableCandidate}.
          */
         public Optional<FinalVariableCandidate> findFinalVariableCandidateForAst(DetailAST ast) {
-            Optional<FinalVariableCandidate> result = Optional.absent();
+            Optional<FinalVariableCandidate> result = Optional.empty();
             DetailAST storedVariable = null;
             final Optional<FinalVariableCandidate> candidate =
-                Optional.fromNullable(scope.get(ast.getText()));
+                Optional.ofNullable(scope.get(ast.getText()));
             if (candidate.isPresent()) {
                 storedVariable = candidate.get().variableIdent;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -19,7 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
+
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
@@ -123,11 +124,11 @@ public class ParameterNameCheck
 
         final DetailAST parent = ast.getParent().getParent();
         final Optional<DetailAST> annotation =
-            Optional.fromNullable(parent.getFirstChild().getFirstChild());
+            Optional.ofNullable(parent.getFirstChild().getFirstChild());
 
         if (annotation.isPresent() && annotation.get().getType() == TokenTypes.ANNOTATION) {
             final Optional<DetailAST> overrideToken =
-                Optional.fromNullable(annotation.get().findFirstToken(TokenTypes.IDENT));
+                Optional.ofNullable(annotation.get().findFirstToken(TokenTypes.IDENT));
             if (overrideToken.isPresent() && "Override".equals(overrideToken.get().getText())) {
                 overridden = true;
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
-
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -398,7 +397,7 @@ public class VisibilityModifierCheckTest
         checkConfig.addAttribute("immutableClassCanonicalNames",
             "com.google.common.collect.ImmutableMap,"
             + "java.lang.String,"
-            + "com.google.common.base.Optional,"
+            + "java.util.Optional,"
             + "java.math.BigDecimal");
         final String[] expected = {
             "16:56: " + getCheckMessage(MSG_KEY, "perfSeries"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputVisibilityModifierGenerics.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputVisibilityModifierGenerics.java
@@ -4,8 +4,8 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 public final class InputVisibilityModifierGenerics {
@@ -40,15 +40,15 @@ public final class InputVisibilityModifierGenerics {
 
     public InputVisibilityModifierGenerics() {
         this.name = "John Doe";
-        this.keyword = Optional.absent();
+        this.keyword = Optional.empty();
         this.perfSeries = ImmutableMap.of();
         this.uuidMap = ImmutableMap.of();
         this.peopleMap = ImmutableMap.of();
         this.someMap = ImmutableMap.of();
         this.newMap = ImmutableMap.of();
         this.orders = ImmutableMap.of();
-        this.optionalOfObject = Optional.absent();
-        this.obj = Optional.absent();
+        this.optionalOfObject = Optional.empty();
+        this.obj = Optional.empty();
         this.mapOfStrings = new HashMap<>(1);
         this.names = new HashMap<>(1);
         this.links = new HashMap<>(1);


### PR DESCRIPTION
#3293 

Since now we use Java 1.8, it worth cutting down on Checkstyle's dependencies on Guava library:

1) Guava's Optional replaced with Java's native.
2) Guava's Predicate and Iterables should be replaced with Java's Predicate and streams. We cannot do this until we resolve or find workaround for Cobertura report generation problem on Java 1.8. (https://github.com/checkstyle/checkstyle/pull/3269#issuecomment-226986404, https://github.com/mojohaus/cobertura-maven-plugin/issues/21)
3) ...

P.S.
Teamcity's violations are not correct as java.util.Optional is not an unused import.