### PR TITLE
Issue #3159: Reduce the number of tasks performed by Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,49 +76,6 @@ matrix:
         - CMD=$CMD1$CMD2$CMD3$CMD4$CMD5$CMD6
         - COVERAGE_CMD=""
 
-    # NoErrorTest - Orekit (oraclejdk8)
-    - jdk: oraclejdk8
-      env:
-        - DESC="NoErrorTest - Orekit"
-        - CMD1="mvn clean install -DskipTests -DskipITs -Dcobertura.skip=true "
-        - CMD2="              -Dpmd.skip=true -Dfindbugs.skip=true "
-        - CMD3="              -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dxml.skip=true"
-        - CMD4=" && CS_POM_VERSION=$(mvn -q -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)"
-        - CMD5=" && echo CS_version:\$CS_POM_VERSION"
-        - CMD6=" && git clone https://github.com/checkstyle/Orekit.git && cd Orekit"
-        - CMD7=" && mvn compile checkstyle:check -Dorekit.checkstyle.version=\$CS_POM_VERSION"
-        - CMD=$CMD1$CMD2$CMD3$CMD4$CMD5$CMD6$CMD7
-        - COVERAGE_CMD=""
-
-    # NoErrorTest - XWiki (oraclejdk8)
-    - jdk: oraclejdk8
-      env:
-        - DESC="NoErrorTest - XWiki"
-        - CMD1="mvn clean install -DskipTests -DskipITs -Dcobertura.skip=true"
-        - CMD2="              -Dpmd.skip=true -Dfindbugs.skip=true "
-        - CMD3="              -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dxml.skip=true"
-        - CMD4=" && CS_POM_VERSION=$(mvn -q -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)"
-        - CMD5=" && echo CS_version:\$CS_POM_VERSION"
-        - CMD6=" && git clone https://github.com/checkstyle/xwiki-commons/ "
-        - CMD7=" && cd xwiki-commons && git checkout checkstyle-regression "
-        - CS_CMD="  && mvn install -DskipTests -Dxwiki.clirr.skip=true checkstyle:check -Dcheckstyle.version=\$CS_POM_VERSION"
-        - CMD=$CMD1$CMD2$CMD3$CMD4$CMD5$CMD6$CMD7$CS_CMD
-        - COVERAGE_CMD=""
-
-    # NoErrorTest - Apache Apex (oraclejdk8)
-    - jdk: oraclejdk8
-      env:
-        - DESC="NoErrorTest - Apache Apex"
-        - CMD1="mvn clean install -DskipTests -DskipITs -Dcobertura.skip=true"
-        - CMD2="              -Dpmd.skip=true -Dfindbugs.skip=true "
-        - CMD3="              -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dxml.skip=true"
-        - CMD4=" && CS_POM_VERSION=$(mvn -q -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)"
-        - CMD5=" && echo CS_version:\$CS_POM_VERSION"
-        - CMD6=" && git clone https://github.com/apache/incubator-apex-core/ && cd incubator-apex-core"
-        - CS_CMD=" && mvn compile checkstyle:check -Dcheckstyle.version=\$CS_POM_VERSION"
-        - CMD=$CMD1$CMD2$CMD3$CMD4$CMD5$CMD6$CMD7$CS_CMD
-        - COVERAGE_CMD=""
-
     # NoExceptiontest - Checkstyle, sevntu-checkstyle (oraclejdk8)
     - jdk: oraclejdk8
       env:
@@ -273,31 +230,6 @@ matrix:
         - CMD=$CMD1$CMD2$CMD3
         - COVERAGE_CMD=""
 
-    # unit tests in German locale (oraclejdk8)
-    - jdk: oraclejdk8
-      env: DESC="tests de" CMD="mvn clean integration-test failsafe:verify -DargLine='-Duser.language=de -Duser.country=DE'" COVERAGE_CMD=""
-    # unit tests in Spanish locale (oraclejdk8)
-    - jdk: oraclejdk8
-      env: DESC="tests es" CMD="mvn clean integration-test failsafe:verify -DargLine='-Duser.language=es -Duser.country=ES'" COVERAGE_CMD=""
-    # unit tests in Finnish locale (oraclejdk8)
-    - jdk: oraclejdk8
-      env: DESC="tests fi" CMD="mvn clean integration-test failsafe:verify -DargLine='-Duser.language=fi -Duser.country=FI'" COVERAGE_CMD=""
-    # unit tests in French locale (oraclejdk8)
-    - jdk: oraclejdk8
-      env: DESC="tests fr" CMD="mvn clean integration-test failsafe:verify -DargLine='-Duser.language=fr -Duser.country=FR'" COVERAGE_CMD=""
-    # unit tests in Chinese locale (oraclejdk8)
-    - jdk: oraclejdk8
-      env: DESC="tests zh" CMD="mvn clean integration-test failsafe:verify -DargLine='-Duser.language=zh -Duser.country=CN'" COVERAGE_CMD=""
-    # unit tests in Japanese locale (oraclejdk8)
-    - jdk: oraclejdk8
-      env: DESC="tests ja" CMD="mvn clean integration-test failsafe:verify -DargLine='-Duser.language=ja -Duser.country=JP'" COVERAGE_CMD=""
-    # unit tests in Portuguese locale (oraclejdk8)
-    - jdk: oraclejdk8
-      env: DESC="tests pt" CMD="mvn clean integration-test failsafe:verify -DargLine='-Duser.language=pt -Duser.country=PT'" COVERAGE_CMD=""
-    # unit tests in Turkish locale (oraclejdk8)
-    - jdk: oraclejdk8
-      env: DESC="tests tr" CMD="mvn clean integration-test failsafe:verify -DargLine='-Duser.language=tr -Duser.country=TR'" COVERAGE_CMD=""
-
     # No java8 support on Travis for MacOS
     # Config is disabled till https://github.com/travis-ci/travis-ci/issues/2317
     # MacOS verify (till cache is not working, we can not do verify)
@@ -324,14 +256,6 @@ matrix:
         - CMD=$CMD0$CMD1$CMD2$CMD3$CMD4$CMD5$CMD6$CMD7$CMD8$CMD9
         - COVERAGE_CMD=""
 
-    # java 8 compile (oraclejdk8)
-    - jdk: oraclejdk8
-      env:
-        - DESC="java 8 inputs should NOT be in resources-noncompilable"
-        - CMD1="if [ \$(grep -rl --include='*.java' '//Compilable with Java8' src/test/resources-noncompilable | wc -l) -eq 0 ];"
-        - CMD2="  then echo 'OK'; else echo 'please move all java8 resources to src/test/resources' && false; fi"
-        - CMD=$CMD1$CMD2
-        - COVERAGE_CMD=""
     # testing of PR format
     - env:
         - DESC="test Issue ref in PR description"

--- a/wercker.yml
+++ b/wercker.yml
@@ -13,6 +13,56 @@ build:
       code: |-
         mvn clean integration-test failsafe:verify
 
+  # NoErrorTest - Orekit (oraclejdk8)
+  - script:
+      name: NoErrorTest - Orekit
+      code: >
+        mvn clean install -DskipTests -DskipITs -Dcobertura.skip=true
+        -Dpmd.skip=true -Dfindbugs.skip=true
+        -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dxml.skip=true
+        && CS_POM_VERSION=$(mvn -q -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+        && echo CS_version: ${CS_POM_VERSION}
+        && git clone https://github.com/checkstyle/Orekit.git && cd Orekit
+        && mvn compile checkstyle:check -Dorekit.checkstyle.version=${CS_POM_VERSION}
+
+  # NoErrorTest - XWiki (oraclejdk8)
+  - script:
+      name: NoErrorTest - XWiki
+      code: >
+        mvn clean install -DskipTests -DskipITs -Dcobertura.skip=true
+        -Dpmd.skip=true -Dfindbugs.skip=true
+        -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dxml.skip=true
+        && CS_POM_VERSION=$(mvn -q -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+        && echo CS_version: ${CS_POM_VERSION}
+        && git clone https://github.com/checkstyle/xwiki-commons/
+        && cd xwiki-commons && git checkout checkstyle-regression
+        && mvn install -DskipTests -Dxwiki.clirr.skip=true checkstyle:check -Dcheckstyle.version=${CS_POM_VERSION}
+
+  # NoErrorTest - Apache Apex (oraclejdk8)
+  - script:
+      name: NoErrorTest - Apache Apex
+      code: >
+        mvn clean install -DskipTests -DskipITs -Dcobertura.skip=true
+        -Dpmd.skip=true -Dfindbugs.skip=true
+        -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dxml.skip=true
+        && CS_POM_VERSION=$(mvn -q -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+        && echo CS_version: ${CS_POM_VERSION}
+        && git clone https://github.com/apache/incubator-apex-core/ && cd incubator-apex-core
+        && mvn compile checkstyle:check -Dcheckstyle.version=${CS_POM_VERSION}
+
+  # NoExceptiontest - Apache Struts (oraclejdk8)
+  - script:
+      name: NoExceptiontest - Apache Struts
+      code: >
+        rm -rf contribution
+        && git clone https://github.com/checkstyle/contribution && cd contribution/checkstyle-tester
+        && sed -i.'' 's/projects-to-test-on.properties/projects-for-wercker.properties/' launch.sh
+        && cd ../../ && mvn clean install -DskipTests -DskipITs -Dcobertura.skip=true
+        -Dpmd.skip=true -Dfindbugs.skip=true
+        -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dxml.skip=true
+        && cd contribution/checkstyle-tester
+        && ./launch.sh -Dcheckstyle.config.location=checks-nonjavadoc-error.xml
+
   # unit tests in German locale (oraclejdk8)
   - script:
       name: tests de
@@ -71,18 +121,3 @@ build:
         else
         echo 'please move all java8 resources to src/test/resources' && false;
         fi
-
-  # Releasenotes generation - validaton
-  - script:
-      name: Releasenotes generation
-      code: >
-        if [ "${WERCKER_GIT_BRANCH}" != "master" ]; then return 0; fi
-        && git clone https://github.com/checkstyle/contribution && cd contribution/releasenotes-xdoc-builder
-        && mvn clean compile package
-        && cd ../../ && git clone https://github.com/checkstyle/checkstyle && cd checkstyle
-        && LATEST_RELEASE_TAG=$(git describe $(git rev-list --tags --max-count=1)) && cd ../
-        && CS_RELEASE_VERSION=$(mvn -q -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec | sed 's/-SNAPSHOT//' )
-        && echo LATEST_RELEASE_TAG=${LATEST_RELEASE_TAG} && echo CS_RELEASE_VERSION=${CS_RELEASE_VERSION}
-        && java -jar contribution/releasenotes-xdoc-builder/target/releasenotes-xdoc-builder-1.0-all.jar
-        -localRepoPath checkstyle -startRef ${LATEST_RELEASE_TAG} -releaseNumber ${CS_RELEASE_VERSION} -authToken ${GITHUB_AUTH_TOKEN}
-        && cat releasenotes.xml


### PR DESCRIPTION
#3159 

1) Moved "NoErrorTests - xxx " from Travis CI to Wercker CI.
2) Removed "test locale" and "java 8 compile (oraclejdk8)" from Travis CI as they are already performed by Wercker CI.
3) Added "NoExceptiontest - Apache Struts" step fro Wercker CI.
4) Removed releasenotes generation step fro Wercker CI (https://github.com/checkstyle/checkstyle/pull/3292#issuecomment-227435298).

The Wercker CI should be relaunched and the PR should be merged after https://github.com/checkstyle/contribution/pull/95