### PR TITLE
doc: fixed checkstyle download url

### DIFF
--- a/src/xdocs/cmdline.xml.vm
+++ b/src/xdocs/cmdline.xml.vm
@@ -126,7 +126,7 @@ java -D&lt;property&gt;=&lt;value&gt;  \
     <section name="Download and Run">
       <p>
           It is possible to run Checkstyle directly from the JAR file using
-          the <code>-jar</code> option. Download latest <a href="http://iweb.dl.sourceforge.net/project/checkstyle/checkstyle/${projectVersion}/checkstyle-${projectVersion}-all.jar">
+          the <code>-jar</code> option. Download latest <a href="http://downloads.sourceforge.net/project/checkstyle/checkstyle/${projectVersion}/checkstyle-${projectVersion}-all.jar">
           checkstyle-${projectVersion}-all.jar</a>.
           An example of run would be:
         <source>
@@ -139,7 +139,7 @@ java -jar checkstyle-${projectVersion}-all.jar -c /google_checks.xml MyClass.jav
       </p>
       <p>
           To run <a href="writingchecks.html#The_Checkstyle_SDK_Gui">Checkstyle UI viewer</a> for AST tree directly from the JAR file using
-          the <code>-jar</code> option. Download latest <a href="http://iweb.dl.sourceforge.net/project/checkstyle/checkstyle/${projectVersion}/checkstyle-${projectVersion}-all.jar">
+          the <code>-jar</code> option. Download latest <a href="http://downloads.sourceforge.net/project/checkstyle/checkstyle/${projectVersion}/checkstyle-${projectVersion}-all.jar">
           checkstyle-${projectVersion}-all.jar</a>.
           An example of run would be (path to java file is optional):
         <source>
@@ -178,7 +178,7 @@ java -jar target/checkstyle-X.X-SNAPSHOT-all.jar -c /sun_checks.xml MyClass.java
     <section name="Usage by Classpath update">
       <p>
         The easiest way is to include
-        <a href="http://iweb.dl.sourceforge.net/project/checkstyle/checkstyle/${projectVersion}/checkstyle-${projectVersion}-all.jar">checkstyle-${projectVersion}-all.jar</a> in the
+        <a href="http://downloads.sourceforge.net/project/checkstyle/checkstyle/${projectVersion}/checkstyle-${projectVersion}-all.jar">checkstyle-${projectVersion}-all.jar</a> in the
         <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html#sthref10">classpath</a>. Alternatively, you must include the
         <code>compile</code> third party dependencies listed in
 


### PR DESCRIPTION
Identified as an issue at https://github.com/checkstyle/checkstyle/issues/3300#issuecomment-228360821

This is the same download URL that web-tester uses.