### PR TITLE
Issue #3334: fixed RequireThis when can't find end block token

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -481,15 +481,19 @@ public class RequireThisCheck extends AbstractCheck {
         final DetailAST blockStartToken = definitionToken.findFirstToken(TokenTypes.SLIST);
         final DetailAST blockEndToken = getBlockEndToken(blockFrameNameIdent, blockStartToken);
 
-        final Set<DetailAST> variableUsagesInsideBlock =
-            getAllTokensWhichAreEqualToCurrent(definitionToken, ident, blockEndToken.getLineNo());
-
         boolean userDefinedArrangementOfThis = false;
-        for (DetailAST variableUsage : variableUsagesInsideBlock) {
-            final DetailAST prevSibling = variableUsage.getPreviousSibling();
-            if (prevSibling != null
-                    && prevSibling.getType() == TokenTypes.LITERAL_THIS) {
-                userDefinedArrangementOfThis = true;
+
+        if (blockEndToken != null) {
+            final Set<DetailAST> variableUsagesInsideBlock =
+                getAllTokensWhichAreEqualToCurrent(definitionToken, ident,
+                    blockEndToken.getLineNo());
+
+            for (DetailAST variableUsage : variableUsagesInsideBlock) {
+                final DetailAST prevSibling = variableUsage.getPreviousSibling();
+                if (prevSibling != null
+                        && prevSibling.getType() == TokenTypes.LITERAL_THIS) {
+                    userDefinedArrangementOfThis = true;
+                }
             }
         }
         return userDefinedArrangementOfThis;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -247,4 +247,12 @@ public class RequireThisCheckTest extends BaseCheckTestSupport {
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputRequireThisReceiver.java"), expected);
     }
+
+    @Test
+    public void testBraceAlone() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RequireThisCheck.class);
+        checkConfig.addAttribute("validateOnlyOverlapping", "false");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputRequireThisBraceAlone.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputRequireThisBraceAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputRequireThisBraceAlone.java
@@ -1,0 +1,17 @@
+package com.puppycrawl.tools.checkstyle.checks.coding;
+
+public final class InputRequireThisBraceAlone {
+    protected void test() throws Exception {
+        {
+            boolean var1 = false;
+
+            var1 = true;
+        }
+
+        {
+            boolean var2 = false;
+
+            var2 = true;
+        }
+    }
+}


### PR DESCRIPTION
Issue #3334

`getBlockEndToken` can return `null` and there was no check to make sure it wasn't null before trying to use it.