### PR TITLE
Issue #3101: Add new 'useContainerOrderingForStatic' option for ImportOrderCheck

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -158,7 +158,7 @@
     <!-- equals() - a lot of fields to check -->
     <suppress checks="CyclomaticComplexity" files="LocalizedMessage\.java" lines="210"/>
     <!-- SWITCH was transformed into IF-ELSE -->
-    <suppress checks="CyclomaticComplexity" files="ImportOrderCheck\.java" lines="344"/>
+    <suppress checks="CyclomaticComplexity" files="ImportOrderCheck\.java" lines="357"/>
 
     <!-- Just big SWITCH block which contains IF blocks in 'visitToken'.
      If we split the block to several methods it will demage readibility. -->

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -483,4 +483,51 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
 
         verify(checkConfig, getPath("InputImportOrder_EclipseDefaultNegative.java"), expected);
     }
+
+    @Test
+    public void testUseContainerOrderingForStaticTrue() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("groups", "/^javax?\\./,org");
+        checkConfig.addAttribute("ordered", "true");
+        checkConfig.addAttribute("separated", "true");
+        checkConfig.addAttribute("option", "top");
+        checkConfig.addAttribute("caseSensitive", "false");
+        checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
+        checkConfig.addAttribute("useContainerOrderingForStatic", "true");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getNonCompilablePath("InputEclipseStaticImportsOrder.java"), expected);
+    }
+
+    @Test
+    public void testUseContainerOrderingForStaticFalse() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("groups", "/^javax?\\./,org");
+        checkConfig.addAttribute("ordered", "true");
+        checkConfig.addAttribute("separated", "true");
+        checkConfig.addAttribute("option", "top");
+        checkConfig.addAttribute("caseSensitive", "false");
+        checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
+        checkConfig.addAttribute("useContainerOrderingForStatic", "false");
+        final String[] expected = {
+            "6: " + getCheckMessage(MSG_ORDERING,
+                "io.netty.handler.codec.http.HttpHeaders.Names.addDate"),
+        };
+        verify(checkConfig, getNonCompilablePath("InputEclipseStaticImportsOrder.java"), expected);
+    }
+
+    @Test
+    public void testUseContainerOrderingForStaticTrueCaseSensitive() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("groups", "/^javax?\\./,org");
+        checkConfig.addAttribute("ordered", "true");
+        checkConfig.addAttribute("separated", "true");
+        checkConfig.addAttribute("option", "top");
+        checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
+        checkConfig.addAttribute("useContainerOrderingForStatic", "true");
+        final String[] expected = {
+            "7: " + getCheckMessage(MSG_ORDERING,
+                "io.netty.handler.codec.http.HttpHeaders.Names.DATE"),
+            };
+        verify(checkConfig, getNonCompilablePath("InputEclipseStaticImportsOrder.java"), expected);
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/InputEclipseStaticImportsOrder.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/InputEclipseStaticImportsOrder.java
@@ -1,0 +1,10 @@
+package com.puppycrawl.tools.checkstyle.checks.imports;
+
+import static io.netty.handler.codec.http.HttpConstants.COLON;
+import static io.netty.handler.codec.http.HttpHeaders.addHeader;
+import static io.netty.handler.codec.http.HttpHeaders.setHeader;
+import static io.netty.handler.codec.http.HttpHeaders.Names.addDate;
+import static io.netty.handler.codec.http.HttpHeaders.Names.DATE;
+
+public class InputEclipseStaticImportsOrder {
+}

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -878,6 +878,12 @@ import android.*;
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
           </tr>
+          <tr>
+            <td>useContainerOrderingForStatic</td>
+            <td>whether to use container ordering (Eclipse IDE term) for static imports or not</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td>false</td>
+          </tr>
 
           <tr>
             <td>tokens</td>
@@ -1007,6 +1013,56 @@ import java.util.Set; //  Wrong order for 'java.util.Set' import.
 public class SomeClass { ... }
         </source>
 
+        <p>
+          The following example shows the idea of 'useContainerOrderingForStatic' option that is
+          useful for Eclipse IDE users to match ordering validation.
+          This is how the import comparison works for static imports: we first compare
+          the container of the static import, container is the type enclosing the static element
+          being imported. When the result of the comparison is 0 (containers are equal),
+          we compare the fully qualified import names.
+          For e.g. this is what is considered to be container names for the given example:
+
+          import static HttpConstants.COLON     => HttpConstants
+          import static HttpHeaders.addHeader   => HttpHeaders
+          import static HttpHeaders.setHeader   => HttpHeaders
+          import static HttpHeaders.Names.DATE  => HttpHeaders.Names
+
+          According to this logic, HttpHeaders.Names should come after HttpHeaders.
+        </p>
+        <source>
+&lt;module name=&quot;ImportOrder&quot;&gt;
+    &lt;property name=&quot;useContainerOrderingForStatic&quot; value=&quot;true&quot;/&gt;
+    &lt;property name=&quot;ordered&quot; value=&quot;true&quot;/&gt;
+    &lt;property name=&quot;option&quot; value=&quot;top&quot;/&gt;
+    &lt;property name=&quot;caseSensitive&quot; value=&quot;false&quot;/&gt;
+    &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <source>
+import static io.netty.handler.codec.http.HttpConstants.COLON;
+import static io.netty.handler.codec.http.HttpHeaders.addHeader;
+import static io.netty.handler.codec.http.HttpHeaders.setHeader;
+import static io.netty.handler.codec.http.HttpHeaders.Names.DATE;
+
+public class InputEclipseStaticImportsOrder { }
+        </source>
+        <source>
+&lt;module name=&quot;ImportOrder&quot;&gt;
+    &lt;property name=&quot;useContainerOrderingForStatic&quot; value=&quot;false&quot;/&gt;
+    &lt;property name=&quot;ordered&quot; value=&quot;true&quot;/&gt;
+    &lt;property name=&quot;option&quot; value=&quot;top&quot;/&gt;
+    &lt;property name=&quot;caseSensitive&quot; value=&quot;false&quot;/&gt;
+    &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <source>
+import static io.netty.handler.codec.http.HttpConstants.COLON;
+import static io.netty.handler.codec.http.HttpHeaders.addHeader;
+import static io.netty.handler.codec.http.HttpHeaders.setHeader;
+import static io.netty.handler.codec.http.HttpHeaders.Names.DATE; // violation
+
+public class InputEclipseStaticImportsOrder { }
+        </source>
       </subsection>
 
       <subsection name="Example of Usage">


### PR DESCRIPTION
#3101 

**Reports before and after**

Config before:
```xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
<module name = "Checker">
    <property name="charset" value="UTF-8"/>
    <property name="severity" value="warning"/>
    <module name="TreeWalker">
        <module name="ImportOrder"/>
    </module>
</module>
```

Config after (useContainerOrderingForStatic = false):

```xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
<module name = "Checker">
    <property name="charset" value="UTF-8"/>
    <property name="severity" value="warning"/>
    <module name="TreeWalker">
        <module name="ImportOrder">
            <property name="useContainerOrderingForStatic" value="false"/>
        </module>
    </module>
</module>
```
Reports are equal.

Config after (useContainerOrderingForStatic = true): 

```xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
<module name = "Checker">
    <property name="charset" value="UTF-8"/>
    <property name="severity" value="warning"/>
    <module name="TreeWalker">
        <module name="ImportOrder">
            <property name="useContainerOrderingForStatic" value="true"/>
        </module>
    </module>
</module>
```

Diff report: http://mezk.github.io/i3101-ImportOrderCheck/index.html

Projects: openjdk8, pmd, lombok-ast, spring-framework, elasticsearch, java-design-patterns, MaterialDesignLibrary, Hbase, Orekit, apache-ant, apache-jsecurity, android-launcher, checkstyle-with-excludes, sevntu-checkstyle-with-exclude, findbugs-with-excldues, hibernate-orm-with-excludes, guava-mvnstyle, apache-struts.