### PR TITLE
Issue #3335: prevented static variables being checked for RequireThis

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -53,7 +53,6 @@ public class RequireThisCheckTest extends BaseCheckTestSupport {
             "31:9: " + getCheckMessage(MSG_VARIABLE, "i", ""),
             "49:13: " + getCheckMessage(MSG_VARIABLE, "z", ""),
             "56:9: " + getCheckMessage(MSG_VARIABLE, "z", ""),
-            "86:16: " + getCheckMessage(MSG_VARIABLE, "CONST", ""),
             "113:9: " + getCheckMessage(MSG_VARIABLE, "i", ""),
             "114:9: " + getCheckMessage(MSG_VARIABLE, "i", ""),
             "115:9: " + getCheckMessage(MSG_METHOD, "instanceMethod", ""),
@@ -94,7 +93,6 @@ public class RequireThisCheckTest extends BaseCheckTestSupport {
             "31:9: " + getCheckMessage(MSG_VARIABLE, "i", ""),
             "49:13: " + getCheckMessage(MSG_VARIABLE, "z", ""),
             "56:9: " + getCheckMessage(MSG_VARIABLE, "z", ""),
-            "86:16: " + getCheckMessage(MSG_VARIABLE, "CONST", ""),
             "113:9: " + getCheckMessage(MSG_VARIABLE, "i", ""),
             "114:9: " + getCheckMessage(MSG_VARIABLE, "i", ""),
             "122:13: " + getCheckMessage(MSG_VARIABLE, "i", "Issue2240."),
@@ -175,7 +173,6 @@ public class RequireThisCheckTest extends BaseCheckTestSupport {
             "60:9: " + getCheckMessage(MSG_VARIABLE, "fieldFinal1", ""),
             "61:9: " + getCheckMessage(MSG_VARIABLE, "fieldFinal2", ""),
             "80:9: " + getCheckMessage(MSG_VARIABLE, "field1", ""),
-            "84:9: " + getCheckMessage(MSG_VARIABLE, "fieldStatic", ""),
             "119:9: " + getCheckMessage(MSG_VARIABLE, "field1", ""),
             "128:9: " + getCheckMessage(MSG_VARIABLE, "field1", ""),
             "132:9: " + getCheckMessage(MSG_METHOD, "method1", ""),
@@ -201,18 +198,10 @@ public class RequireThisCheckTest extends BaseCheckTestSupport {
             "275:18: " + getCheckMessage(MSG_METHOD, "addSuffixToField", ""),
             "301:9: " + getCheckMessage(MSG_VARIABLE, "field1", ""),
             "340:9: " + getCheckMessage(MSG_VARIABLE, "field1", ""),
-            "360:9: " + getCheckMessage(MSG_VARIABLE, "fieldStatic", ""),
             "374:40: " + getCheckMessage(MSG_METHOD, "getServletRelativeAction", ""),
             "376:20: " + getCheckMessage(MSG_METHOD, "processAction", ""),
             "383:9: " + getCheckMessage(MSG_VARIABLE, "servletRelativeAction", ""),
             "384:16: " + getCheckMessage(MSG_METHOD, "processAction", ""),
-            "443:9: " + getCheckMessage(MSG_VARIABLE, "fieldStatic", ""),
-            "447:9: " + getCheckMessage(MSG_VARIABLE, "fieldStatic", ""),
-            "451:9: " + getCheckMessage(MSG_VARIABLE, "fieldStatic", ""),
-            "455:9: " + getCheckMessage(MSG_VARIABLE, "fieldStatic", ""),
-            "459:9: " + getCheckMessage(MSG_VARIABLE, "fieldStatic", ""),
-            "463:9: " + getCheckMessage(MSG_VARIABLE, "fieldStatic", ""),
-
         };
         verify(checkConfig, getPath("InputValidateOnlyOverlappingFalse.java"), expected);
     }
@@ -233,10 +222,6 @@ public class RequireThisCheckTest extends BaseCheckTestSupport {
             "275:9: " + getCheckMessage(MSG_VARIABLE, "field1", ""),
             "301:9: " + getCheckMessage(MSG_VARIABLE, "field1", ""),
             "339:9: " + getCheckMessage(MSG_VARIABLE, "field1", ""),
-            "359:9: " + getCheckMessage(MSG_VARIABLE, "fieldStatic", ""),
-            "442:9: " + getCheckMessage(MSG_VARIABLE, "fieldStatic", ""),
-            "450:9: " + getCheckMessage(MSG_VARIABLE, "fieldStatic", ""),
-            "454:9: " + getCheckMessage(MSG_VARIABLE, "fieldStatic", ""),
         };
         verify(checkConfig, getPath("InputValidateOnlyOverlappingTrue.java"), expected);
     }
@@ -254,5 +239,13 @@ public class RequireThisCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("validateOnlyOverlapping", "false");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputRequireThisBraceAlone.java"), expected);
+    }
+
+    @Test
+    public void testStatic() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RequireThisCheck.class);
+        checkConfig.addAttribute("validateOnlyOverlapping", "false");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputRequireThisStatic.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputRequireThisStatic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputRequireThisStatic.java
@@ -1,0 +1,51 @@
+package com.puppycrawl.tools.checkstyle.checks.coding;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+
+public final class InputRequireThisStatic {
+    public static String staticField1 = "";
+
+    public static String staticField2 = new String(staticField1);
+
+    public String instanceField1;
+    public BufferedReader instanceField2;
+    
+    static {
+        try (BufferedReader instanceField2 = new BufferedReader(new FileReader(""))) {
+            instanceField2.readLine();
+        }
+        catch (FileNotFoundException e) {
+        }
+        catch (IOException e) {
+        }
+    }
+
+    public String get() {
+        return staticField1;
+    }
+
+    void foo50(String staticField1) {
+        staticField1 = staticField1;
+    }
+
+    void foo52(String staticField1) {
+        staticField1 += staticField1;
+    }
+
+    static void test(String instanceField1) {
+        if (instanceField1 == null) {
+            instanceField1 = staticField1;
+        }
+    }
+
+    static void test2() {
+        try (BufferedReader instanceField2 = new BufferedReader(new FileReader(""))) {
+            instanceField2.readLine();
+        }
+        catch (IOException e) {
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputValidateOnlyOverlappingFalse.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputValidateOnlyOverlappingFalse.java
@@ -81,7 +81,7 @@ public class InputValidateOnlyOverlappingFalse {
     }
 
     void foo4(String methodParam) {
-        fieldStatic = methodParam; // violation
+        fieldStatic = methodParam;
     }
 
     void foo5(String methodParam) {
@@ -357,7 +357,7 @@ public class InputValidateOnlyOverlappingFalse {
     }
 
     void foo43(String fieldStatic) {
-        fieldStatic = fieldStatic; // violation
+        fieldStatic = fieldStatic;
     }
 
     void foo44(String fieldStatic) {
@@ -440,27 +440,27 @@ public class InputValidateOnlyOverlappingFalse {
     }
 
     void foo50(String fieldStatic) {
-        fieldStatic = fieldStatic; // violation
+        fieldStatic = fieldStatic;
     }
 
     void foo51(String methodParam) {
-        fieldStatic = methodParam; // violation
+        fieldStatic = methodParam;
     }
 
     void foo52(String fieldStatic) {
-        fieldStatic += fieldStatic; // violation
+        fieldStatic += fieldStatic;
     }
 
     void foo53(String fieldStatic) {
-        fieldStatic += fieldStatic; // violation
+        fieldStatic += fieldStatic;
     }
 
     void foo54(String methodParam) {
-        fieldStatic += methodParam; // violation
+        fieldStatic += methodParam;
     }
 
     void foo55(String methodParam) {
-        fieldStatic += fieldStatic; // violation
+        fieldStatic += fieldStatic;
     }
 
     void foo56(boolean booleanField) { booleanField = this.booleanField; }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputValidateOnlyOverlappingTrue.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputValidateOnlyOverlappingTrue.java
@@ -356,7 +356,7 @@ public class InputValidateOnlyOverlappingTrue {
     }
 
     void foo43(String fieldStatic) {
-        fieldStatic = fieldStatic; // violation
+        fieldStatic = fieldStatic;
     }
 
     void foo44(String fieldStatic) {
@@ -439,7 +439,7 @@ public class InputValidateOnlyOverlappingTrue {
     }
 
     void foo50(String fieldStatic) {
-        fieldStatic = fieldStatic; // violation
+        fieldStatic = fieldStatic;
     }
 
     void foo51(String methodParam) {
@@ -447,11 +447,11 @@ public class InputValidateOnlyOverlappingTrue {
     }
 
     void foo52(String fieldStatic) {
-        fieldStatic += fieldStatic; // violation
+        fieldStatic += fieldStatic;
     }
 
     void foo53(String fieldStatic) {
-        fieldStatic += fieldStatic; // violation
+        fieldStatic += fieldStatic;
     }
 
     void foo54(String methodParam) {


### PR DESCRIPTION
Issue #3335
This prevents static variables from being reported as requiring `this`.

My changes to do this are:
Line 308 -https://github.com/checkstyle/checkstyle/compare/master...rnveach:issue_3335_final?expand=1#diff-110729384f4c9d098bd29eafab295062R308
Line 787 - https://github.com/checkstyle/checkstyle/compare/master...rnveach:issue_3335_final?expand=1#diff-110729384f4c9d098bd29eafab295062R787
Line 815 - https://github.com/checkstyle/checkstyle/compare/master...rnveach:issue_3335_final?expand=1#diff-110729384f4c9d098bd29eafab295062R815

I tried to make my changes similar to `getMethodWithoutThis` which seem to respect static variables.

The other changes are lines were I could not keep line/branch coverage, so they had to be removed.
I did multiple regressions, first with my above changes and looked for any additional cases to keep coverage. The ones I did find I placed in `InputRequireThisStatic`, which don't match the issue's example.
Most removed lines are null pointer checks, except:
Line 421 - https://github.com/checkstyle/checkstyle/compare/master...rnveach:issue_3335_final?expand=1#diff-110729384f4c9d098bd29eafab295062L421
Line 678 - https://github.com/checkstyle/checkstyle/compare/master...rnveach:issue_3335_final?expand=1#diff-110729384f4c9d098bd29eafab295062L678

New regression to come.