### PR TITLE
Issue #941: Update import ordering in google_checks.xml

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/CustomImportOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/CustomImportOrderTest.java
@@ -53,16 +53,13 @@ public class CustomImportOrderTest extends BaseCheckTestSupport {
         final String[] expected = {
             "4: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Button.ABORT",
                 "java.io.File.createTempFile"),
-            "7: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.awt.Button"),
-            "8: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.awt.Frame"),
-            "9: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.awt.Dialog"),
-            "10: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.awt.event.ActionEvent"),
-            "11: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "javax.swing.JComponent"),
-            "12: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "javax.swing.JTable"),
-            "13: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.io.File"),
-            "14: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.io.IOException"),
-            "15: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.io.InputStream"),
-            "16: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.io.Reader"),
+            "9: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Dialog", "java.awt.Frame"),
+            "13: " + getCheckMessage(clazz, MSG_LEX, "java.io.File", "javax.swing.JTable"),
+            "14: " + getCheckMessage(clazz, MSG_LEX, "java.io.IOException", "javax.swing.JTable"),
+            "15: " + getCheckMessage(clazz, MSG_LEX, "java.io.InputStream", "javax.swing.JTable"),
+            "16: " + getCheckMessage(clazz, MSG_LEX, "java.io.Reader", "javax.swing.JTable"),
+            "20: " + getCheckMessage(clazz, MSG_LEX, "com.google.common.base.Ascii",
+                "javax.swing.JTable"),
         };
 
         final Configuration checkConfig = getCheckConfig("CustomImportOrder");
@@ -78,16 +75,16 @@ public class CustomImportOrderTest extends BaseCheckTestSupport {
         final String[] expected = {
             "4: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Button.ABORT",
                 "java.io.File.createTempFile"),
-            "7: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.List"),
-            "8: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.StringTokenizer"),
-            "9: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.*"),
-            "10: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL,
+            "9: " + getCheckMessage(clazz, MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
+            "11: " + getCheckMessage(clazz, MSG_LEX, "java.util.concurrent.*",
                 "java.util.concurrent.AbstractExecutorService"),
-            "11: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.concurrent.*"),
-            "14: " + getCheckMessage(clazz, MSG_SEPARATOR,
-                "com.sun.xml.internal.xsom.impl.scd.Iterators"),
-            "16: " + getCheckMessage(clazz, MSG_ORDER, SPECIAL, STD,
-                "com.google.common.reflect.*"),
+            "13: " + getCheckMessage(clazz, MSG_LEX,
+                "com.google.checkstyle.test.chapter2filebasic.rule21filename.*",
+                "java.util.concurrent.AbstractExecutorService"),
+            "14: " + getCheckMessage(clazz, MSG_LEX, "com.sun.xml.internal.xsom.impl.scd.Iterators",
+                "java.util.concurrent.AbstractExecutorService"),
+            "16: " + getCheckMessage(clazz, MSG_LEX, "com.google.common.reflect.*",
+                "java.util.concurrent.AbstractExecutorService"),
         };
 
         final Configuration checkConfig = getCheckConfig("CustomImportOrder");
@@ -103,15 +100,16 @@ public class CustomImportOrderTest extends BaseCheckTestSupport {
         final String[] expected = {
             "4: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Button.ABORT",
                 "java.io.File.createTempFile"),
-            "8: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.StringTokenizer"),
-            "9: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.*"),
-            "10: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL,
+            "9: " + getCheckMessage(clazz, MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
+            "11: " + getCheckMessage(clazz, MSG_LEX, "java.util.concurrent.*",
                 "java.util.concurrent.AbstractExecutorService"),
-            "11: " + getCheckMessage(clazz, MSG_ORDER, STD, SPECIAL, "java.util.concurrent.*"),
-            "14: " + getCheckMessage(clazz, MSG_SEPARATOR,
-                "com.sun.xml.internal.xsom.impl.scd.Iterators"),
-            "16: " + getCheckMessage(clazz, MSG_ORDER, SPECIAL, STD,
-                "com.google.common.reflect.*"),
+            "13: " + getCheckMessage(clazz, MSG_LEX,
+                "com.google.checkstyle.test.chapter2filebasic.rule21filename.*",
+                "java.util.concurrent.AbstractExecutorService"),
+            "14: " + getCheckMessage(clazz, MSG_LEX, "com.sun.xml.internal.xsom.impl.scd.Iterators",
+                "java.util.concurrent.AbstractExecutorService"),
+            "16: " + getCheckMessage(clazz, MSG_LEX, "com.google.common.reflect.*",
+                "java.util.concurrent.AbstractExecutorService"),
         };
 
         final Configuration checkConfig = getCheckConfig("CustomImportOrder");

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/CustomImportOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/CustomImportOrderTest.java
@@ -31,13 +31,13 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class CustomImportOrderTest extends BaseCheckTestSupport {
 
-    private static final String MSG_SEPARATOR = "custom.import.order.line.separator";
-    private static final String MSG_LEX = "custom.import.order.lex";
-    private static final String MSG_ORDER = "custom.import.order";
-
     /** Shortcuts to make code more compact. */
-    private static final String STD = CustomImportOrderCheck.STANDARD_JAVA_PACKAGE_RULE_GROUP;
-    private static final String SPECIAL = CustomImportOrderCheck.SPECIAL_IMPORTS_RULE_GROUP;
+    private static final String MSG_LINE_SEPARATOR = CustomImportOrderCheck.MSG_LINE_SEPARATOR;
+    private static final String MSG_LEX = CustomImportOrderCheck.MSG_LEX;
+    private static final String MSG_NONGROUP_EXPECTED =
+        CustomImportOrderCheck.MSG_NONGROUP_EXPECTED;
+
+    private static final String STATIC = CustomImportOrderCheck.STATIC_RULE_GROUP;
 
     private final Class<CustomImportOrderCheck> clazz = CustomImportOrderCheck.class;
 
@@ -53,12 +53,13 @@ public class CustomImportOrderTest extends BaseCheckTestSupport {
         final String[] expected = {
             "4: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Button.ABORT",
                 "java.io.File.createTempFile"),
-            "9: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Dialog", "java.awt.Frame"),
-            "13: " + getCheckMessage(clazz, MSG_LEX, "java.io.File", "javax.swing.JTable"),
-            "14: " + getCheckMessage(clazz, MSG_LEX, "java.io.IOException", "javax.swing.JTable"),
-            "15: " + getCheckMessage(clazz, MSG_LEX, "java.io.InputStream", "javax.swing.JTable"),
-            "16: " + getCheckMessage(clazz, MSG_LEX, "java.io.Reader", "javax.swing.JTable"),
-            "20: " + getCheckMessage(clazz, MSG_LEX, "com.google.common.base.Ascii",
+            "6: " + getCheckMessage(clazz, MSG_LINE_SEPARATOR, "java.awt.Button"),
+            "8: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Dialog", "java.awt.Frame"),
+            "12: " + getCheckMessage(clazz, MSG_LEX, "java.io.File", "javax.swing.JTable"),
+            "13: " + getCheckMessage(clazz, MSG_LEX, "java.io.IOException", "javax.swing.JTable"),
+            "14: " + getCheckMessage(clazz, MSG_LEX, "java.io.InputStream", "javax.swing.JTable"),
+            "15: " + getCheckMessage(clazz, MSG_LEX, "java.io.Reader", "javax.swing.JTable"),
+            "18: " + getCheckMessage(clazz, MSG_LEX, "com.google.common.base.Ascii",
                 "javax.swing.JTable"),
         };
 
@@ -98,17 +99,19 @@ public class CustomImportOrderTest extends BaseCheckTestSupport {
     public void customImportTest3() throws Exception {
 
         final String[] expected = {
-            "4: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Button.ABORT",
+            "4: " + getCheckMessage(clazz, MSG_LINE_SEPARATOR, "java.awt.Dialog"),
+            "5: " + getCheckMessage(clazz, MSG_NONGROUP_EXPECTED, STATIC,
+                "javax.swing.WindowConstants.*"),
+            "8: " + getCheckMessage(clazz, MSG_LEX,
+                "com.google.checkstyle.test.chapter2filebasic.rule21filename.*", "java.awt.Dialog"),
+            "9: " + getCheckMessage(clazz, MSG_LEX, "com.google.common.reflect.*",
+                "java.awt.Dialog"),
+            "10: " + getCheckMessage(clazz, MSG_LEX, "com.sun.xml.internal.xsom.impl.scd.Iterators",
+                "java.awt.Dialog"),
+            "12: " + getCheckMessage(clazz, MSG_NONGROUP_EXPECTED, STATIC,
                 "java.io.File.createTempFile"),
-            "9: " + getCheckMessage(clazz, MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
-            "11: " + getCheckMessage(clazz, MSG_LEX, "java.util.concurrent.*",
-                "java.util.concurrent.AbstractExecutorService"),
-            "13: " + getCheckMessage(clazz, MSG_LEX,
-                "com.google.checkstyle.test.chapter2filebasic.rule21filename.*",
-                "java.util.concurrent.AbstractExecutorService"),
-            "14: " + getCheckMessage(clazz, MSG_LEX, "com.sun.xml.internal.xsom.impl.scd.Iterators",
-                "java.util.concurrent.AbstractExecutorService"),
-            "16: " + getCheckMessage(clazz, MSG_LEX, "com.google.common.reflect.*",
+            "14: " + getCheckMessage(clazz, MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
+            "16: " + getCheckMessage(clazz, MSG_LEX, "java.util.concurrent.*",
                 "java.util.concurrent.AbstractExecutorService"),
         };
 

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrder1.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrder1.java
@@ -3,8 +3,7 @@ package com.google.checkstyle.test.chapter3filestructure.rule333orderingandspaci
 import static java.io.File.createTempFile;
 import static java.awt.Button.ABORT; //warn
 import static javax.swing.WindowConstants.*;
-
-import java.awt.Button;
+import java.awt.Button; //warn
 import java.awt.Frame;
 import java.awt.Dialog; //warn
 import java.awt.event.ActionEvent;
@@ -14,7 +13,6 @@ import java.io.File; //warn
 import java.io.IOException; //warn
 import java.io.InputStream; //warn
 import java.io.Reader; //warn
-
 
 
 import com.google.common.base.Ascii; //warn

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrder1.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrder1.java
@@ -4,12 +4,12 @@ import static java.io.File.createTempFile;
 import static java.awt.Button.ABORT; //warn
 import static javax.swing.WindowConstants.*;
 
-import java.awt.Button; //warn
-import java.awt.Frame; //warn
+import java.awt.Button;
+import java.awt.Frame;
 import java.awt.Dialog; //warn
-import java.awt.event.ActionEvent; //warn
-import javax.swing.JComponent; //warn
-import javax.swing.JTable; //warn
+import java.awt.event.ActionEvent;
+import javax.swing.JComponent;
+import javax.swing.JTable;
 import java.io.File; //warn
 import java.io.IOException; //warn
 import java.io.InputStream; //warn
@@ -17,6 +17,6 @@ import java.io.Reader; //warn
 
 
 
-import com.google.common.base.Ascii;
+import com.google.common.base.Ascii; //warn
 
 public class InputCustomImportOrder1 {}

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrder2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrder2.java
@@ -4,13 +4,13 @@ import static java.io.File.createTempFile;
 import static java.awt.Button.ABORT; //warn
 import static javax.swing.WindowConstants.*;
 
-import java.util.List; //warn
-import java.util.StringTokenizer; //warn
+import java.util.List;
+import java.util.StringTokenizer;
 import java.util.*; //warn
-import java.util.concurrent.AbstractExecutorService; //warn
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.*; //warn
 
-import com.google.checkstyle.test.chapter2filebasic.rule21filename.*;
+import com.google.checkstyle.test.chapter2filebasic.rule21filename.*; //warn
 import com.sun.xml.internal.xsom.impl.scd.Iterators; //warn
 
 import com.google.common.reflect.*; //warn

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrder3.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrder3.java
@@ -1,19 +1,19 @@
 package com.google.checkstyle.test.chapter3filestructure.rule333orderingandspacing;
 
-import static java.io.File.createTempFile;
-import static java.awt.Button.ABORT; //warn
-import static javax.swing.WindowConstants.*;
+import static java.awt.Button.ABORT;
+import java.awt.Dialog; //warn
+import static javax.swing.WindowConstants.*; //warn
 
 
+import com.google.checkstyle.test.chapter2filebasic.rule21filename.*; //warn
+import com.google.common.reflect.*; //warn
+import com.sun.xml.internal.xsom.impl.scd.Iterators; //warn
+import java.io.File;
+import static java.io.File.createTempFile; //warn
 import java.util.StringTokenizer;
 import java.util.*; //warn
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.*; //warn
-
-import com.google.checkstyle.test.chapter2filebasic.rule21filename.*; //warn
-import com.sun.xml.internal.xsom.impl.scd.Iterators; //warn
-
-import com.google.common.reflect.*; //warn
 
 public class InputCustomImportOrder3 {
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrder3.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrder3.java
@@ -5,12 +5,12 @@ import static java.awt.Button.ABORT; //warn
 import static javax.swing.WindowConstants.*;
 
 
-import java.util.StringTokenizer; //warn
+import java.util.StringTokenizer;
 import java.util.*; //warn
-import java.util.concurrent.AbstractExecutorService; //warn
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.*; //warn
 
-import com.google.checkstyle.test.chapter2filebasic.rule21filename.*;
+import com.google.checkstyle.test.chapter2filebasic.rule21filename.*; //warn
 import com.sun.xml.internal.xsom.impl.scd.Iterators; //warn
 
 import com.google.common.reflect.*; //warn

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrderValid.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrderValid.java
@@ -6,16 +6,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
-
 import com.sun.accessibility.internal.resources.*;
-import org.apache.commons.beanutils.converters.ArrayConverter;
-
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import javax.accessibility.Accessible;
+import org.apache.commons.beanutils.converters.ArrayConverter;
+
 
 public class InputCustomImportOrderValid {
 }

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -159,9 +159,9 @@
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
-            <property name="specialImportsRegExp" value="com.google"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
         </module>
         <module name="MethodParamPad"/>
         <module name="OperatorWrap">


### PR DESCRIPTION
Google's guidelines for formatting Java code have changed recently: https://github.com/google/styleguide/commit/b075cb7cad464b224103fb2ec8fdb8521ec08e7f (see https://google.github.io/styleguide/javaguide.html#s3.3.3-import-ordering-and-spacing for the current version).

From now on there should only be two groups of imports: The static ones and all others.
Imports from `com.google.*`, `java.*` or `javax.*` are no longer listed separately.

This PR is supposed to update the `google_checks.xml` accordingly.