### PR TITLE
Issue #3369: Changed 2 tests to not make assumptions about the order …

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -177,17 +177,23 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
     @Test
     public void testGetRequiredTokens() {
         final IndentationCheck checkObj = new IndentationCheck();
+        final int[] requiredTokens = checkObj.getRequiredTokens();
         final HandlerFactory handlerFactory = new HandlerFactory();
         final int[] expected = handlerFactory.getHandledTypes();
-        assertArrayEquals(expected, checkObj.getRequiredTokens());
+        Arrays.sort(expected);
+        Arrays.sort(requiredTokens);
+        assertArrayEquals(expected, requiredTokens);
     }
 
     @Test
     public void testGetAcceptableTokens() {
         final IndentationCheck checkObj = new IndentationCheck();
+        final int[] acceptableTokens = checkObj.getAcceptableTokens();
         final HandlerFactory handlerFactory = new HandlerFactory();
         final int[] expected = handlerFactory.getHandledTypes();
-        assertArrayEquals(expected, checkObj.getAcceptableTokens());
+        Arrays.sort(expected);
+        Arrays.sort(acceptableTokens);
+        assertArrayEquals(expected, acceptableTokens);
     }
 
     @Test


### PR DESCRIPTION
Issue: #3369 

One way to remove the assumption the code is making is to simply sort the arrays before asserting that they are equal. This guarantees they will be in the same order.