### PR TITLE
Issue #3369: Added NonDex to pom.xml and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ matrix:
     - jdk: oraclejdk8
       env: DESC="tests and deploy" CMD="mvn clean integration-test failsafe:verify" COVERAGE_CMD="" DEPLOY="true"
 
+    # NonDex (oraclejdk8)
+    - jdk: oraclejdk8
+      env: DESC="NonDex" CMD="mvn clean nondex:nondex" COVERAGE_CMD="" DEPLOY="false"
+
     # checkstyle (oraclejdk8)
     - jdk: oraclejdk8
       env:

--- a/pom.xml
+++ b/pom.xml
@@ -993,6 +993,11 @@
         </execution>
       </executions>
     </plugin>
+      <plugin>
+        <groupId>edu.illinois</groupId>
+        <artifactId>nondex-maven-plugin</artifactId>
+        <version>1.0.1</version>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Issue #3369

Added NonDex to prevent tests that assume a deterministic order on non-deterministic APIs.

NonDex runs the tests and randomly explores different orderings of certain APIs.