### PR TITLE
Issue #3369: Fixed XDocsPagesTest to not make assumptions about order…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
@@ -417,8 +417,15 @@ public class XDocsPagesTest {
         if (AbstractCheck.class.isAssignableFrom(clss)) {
             final AbstractCheck check = (AbstractCheck) instance;
 
-            if (!Arrays.equals(check.getAcceptableTokens(), check.getDefaultTokens())
-                    || !Arrays.equals(check.getAcceptableTokens(), check.getRequiredTokens())) {
+            final int[] acceptableTokens = check.getAcceptableTokens();
+            Arrays.sort(acceptableTokens);
+            final int[] defaultTokens = check.getDefaultTokens();
+            Arrays.sort(defaultTokens);
+            final int[] requiredTokens = check.getRequiredTokens();
+            Arrays.sort(requiredTokens);
+
+            if (!Arrays.equals(acceptableTokens, defaultTokens)
+                    || !Arrays.equals(acceptableTokens, requiredTokens)) {
                 properties.add("tokens");
             }
         }


### PR DESCRIPTION
Issue #3369 

`XDocsPagesTest.testAllCheckSections` has a similar problem in which it assumes that the order of HashMap will be the same everytime. This fixes that assumption.