### PR TITLE
Minor Code Style Fixes Found By Eclipse

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -242,7 +242,7 @@ final class PropertyCacheFile {
      * @param resourceLocations locations of external configuration resources.
      * @return a set of {@link ExternalResource}.
      */
-    private Set<ExternalResource> loadExternalResources(Set<String> resourceLocations) {
+    private static Set<ExternalResource> loadExternalResources(Set<String> resourceLocations) {
         final Set<ExternalResource> resources = Sets.newHashSet();
         for (String location : resourceLocations) {
             String contentHashSum = null;
@@ -270,7 +270,7 @@ final class PropertyCacheFile {
      * @return array of bytes which respresents the content of external resource in binary form.
      * @throws CheckstyleException if error while loading occurs.
      */
-    private byte[] loadExternalResource(String location) throws CheckstyleException {
+    private static byte[] loadExternalResource(String location) throws CheckstyleException {
         byte[] content = null;
         final URI uri = CommonUtils.getUriByFilename(location);
         InputStream resourceReader = null;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -481,7 +481,7 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
      * @param checks a set of checks.
      * @return a set of external configuration resource locations which are used by the checks set.
      */
-    private Set<String> getExternalResourceLocations(Set<AbstractCheck> checks) {
+    private static Set<String> getExternalResourceLocations(Set<AbstractCheck> checks) {
         final Set<String> externalConfigurationResources = Sets.newHashSet();
         for (AbstractCheck check : checks) {
             if (check instanceof ExternalResourceHolder) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -234,7 +234,7 @@ public class NeedBracesCheck extends AbstractCheck {
      * @param ast ast token.
      * @return true if current loop statement does not have body.
      */
-    private boolean isEmptyLoopBody(DetailAST ast) {
+    private static boolean isEmptyLoopBody(DetailAST ast) {
         boolean noBodyLoop = false;
 
         if (ast.getType() == TokenTypes.LITERAL_FOR

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -337,7 +337,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
      * @param expr the argument expression
      * @return - true if any child matches the set of tokens, false if not
      */
-    private boolean containsAllSafeTokens(final DetailAST expr) {
+    private static boolean containsAllSafeTokens(final DetailAST expr) {
         DetailAST arg = expr.getFirstChild();
         arg = skipVariableAssign(arg);
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -366,7 +366,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
      * @param ast token to be checked
      * @return true if should be updated, else false
      */
-    private boolean shouldUpdateUninitializedVariables(DetailAST ast) {
+    private static boolean shouldUpdateUninitializedVariables(DetailAST ast) {
         return ast.getType() != TokenTypes.LITERAL_TRY
                 && ast.getType() != TokenTypes.LITERAL_CATCH
                 && ast.getType() != TokenTypes.LITERAL_FINALLY

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -1212,7 +1212,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @return true if the set contains a definition with the
          *     same name and number of parameters.
          */
-        private boolean containsMethodDef(Set<DetailAST> set, DetailAST ident) {
+        private static boolean containsMethodDef(Set<DetailAST> set, DetailAST ident) {
             boolean result = false;
             for (DetailAST ast: set) {
                 if (isSimilarSignature(ident, ast)) {
@@ -1230,7 +1230,7 @@ public class RequireThisCheck extends AbstractCheck {
          * @return true if a method definition has the same name and number of parameters
          *     as the method call.
          */
-        private boolean isSimilarSignature(DetailAST ident, DetailAST ast) {
+        private static boolean isSimilarSignature(DetailAST ident, DetailAST ast) {
             boolean result = false;
             final DetailAST elistToken = ident.getParent().findFirstToken(TokenTypes.ELIST);
             if (elistToken != null && ident.getText().equals(ast.getText())) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -233,7 +233,7 @@ public class FinalClassCheck
      * @param classAst class
      * @return super class name or null if super class is not specified
      */
-    private String getSuperClassName(DetailAST classAst) {
+    private static String getSuperClassName(DetailAST classAst) {
         String superClassName = null;
         final DetailAST classExtend = classAst.findFirstToken(TokenTypes.EXTENDS_CLAUSE);
         if (classExtend != null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -687,7 +687,7 @@ public class VisibilityModifierCheck
      * @param isCanonicalName whether type name is in canonical form.
      * @return generic type arguments token.
      */
-    private DetailAST getGenericTypeArgs(DetailAST type, boolean isCanonicalName) {
+    private static DetailAST getGenericTypeArgs(DetailAST type, boolean isCanonicalName) {
         final DetailAST typeArgs;
         if (isCanonicalName) {
             // if type class name is in canonical form, abstract tree has specific structure
@@ -743,7 +743,7 @@ public class VisibilityModifierCheck
      * @param variableDef field in consideration.
      * @return true if current field is final.
      */
-    private boolean isFinalField(DetailAST variableDef) {
+    private static boolean isFinalField(DetailAST variableDef) {
         final DetailAST modifiers = variableDef.findFirstToken(TokenTypes.MODIFIERS);
         return modifiers.branchContains(TokenTypes.FINAL);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -238,7 +238,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
      * @param previousSibling the statement to check.
      * @return true if the statement can have or always have curly brackets.
      */
-    private boolean isStatementWithPossibleCurlies(DetailAST previousSibling) {
+    private static boolean isStatementWithPossibleCurlies(DetailAST previousSibling) {
         return previousSibling.getType() == TokenTypes.LITERAL_IF
             || previousSibling.getType() == TokenTypes.LITERAL_TRY
             || previousSibling.getType() == TokenTypes.LITERAL_FOR
@@ -253,7 +253,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
      * @param previousSibling the statement to check.
      * @return true if the statement is a kind of definition.
      */
-    private boolean isDefinition(DetailAST previousSibling) {
+    private static boolean isDefinition(DetailAST previousSibling) {
         return previousSibling.getType() == TokenTypes.METHOD_DEF
             || previousSibling.getType() == TokenTypes.CLASS_DEF
             || previousSibling.getType() == TokenTypes.INTERFACE_DEF
@@ -779,7 +779,7 @@ public class CommentsIndentationCheck extends AbstractCheck {
      * @param comment the comment to process.
      * @return a message key.
      */
-    private String getMessageKey(DetailAST comment) {
+    private static String getMessageKey(DetailAST comment) {
         final String msgKey;
         if (comment.getType() == TokenTypes.SINGLE_LINE_COMMENT) {
             msgKey = MSG_KEY_SINGLE;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -93,7 +93,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
      * @param ast2 Ast2
      * @return True if ast2 begins on the same level that ast1 ends
      */
-    private boolean areMethodsChained(DetailAST ast1, DetailAST ast2) {
+    private static boolean areMethodsChained(DetailAST ast1, DetailAST ast2) {
         final DetailAST rparen = ast1.findFirstToken(TokenTypes.RPAREN);
         return rparen.getLineNo() == ast2.getLineNo();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -334,7 +334,7 @@ public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public final void testSetClassName() {
+    public void testSetClassName() {
         final String customName = "customName";
         final CheckstyleAntTask.Listener listener = new CheckstyleAntTask.Listener();
         listener.setClassname(customName);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -394,7 +394,7 @@ public class TranslationCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testWrongUserSpecifiedLanguageCodes() throws Exception {
+    public void testWrongUserSpecifiedLanguageCodes() {
         final TranslationCheck check = new TranslationCheck();
         try {
             check.setRequiredTranslations("11");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -93,7 +93,7 @@ public class FinalClassCheckTest
     }
 
     @Test
-    public void testImproperToken() throws Exception {
+    public void testImproperToken() {
         final FinalClassCheck finalClassCheck = new FinalClassCheck();
         final DetailAST badAst = new DetailAST();
         final int unsupportedTokenByCheck = TokenTypes.EOF;


### PR DESCRIPTION
Methods can be static
Exceptions not actually thrown
Unnecessary casts

No actual logic changed.