### PR TITLE
minor: fix hardcoded messages in UTs

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.blocks;
 
+import static com.puppycrawl.tools.checkstyle.checks.blocks.EmptyCatchBlockCheck.MSG_KEY_CATCH_BLOCK_EMPTY;
 import static org.junit.Assert.assertArrayEquals;
 
 import java.io.File;
@@ -54,8 +55,8 @@ public class EmptyCatchBlockCheckTest extends BaseCheckTestSupport {
         final DefaultConfiguration checkConfig =
             createCheckConfig(EmptyCatchBlockCheck.class);
         final String[] expected = {
-            "35: Empty catch block.",
-            "42: Empty catch block.",
+            "35: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
+            "42: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
         };
         verify(checkConfig, getPath("InputEmptyCatchBlock.java"), expected);
     }
@@ -67,14 +68,14 @@ public class EmptyCatchBlockCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("exceptionVariableName", "expected|ignore|myException");
         checkConfig.addAttribute("commentFormat", "This is expected");
         final String[] expected = {
-            "35: Empty catch block.",
-            "63: Empty catch block.",
-            "97: Empty catch block.",
-            "186: Empty catch block.",
-            "195: Empty catch block.",
-            "214: Empty catch block.",
-            "230: Empty catch block.",
-            "239: Empty catch block.",
+            "35: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
+            "63: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
+            "97: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
+            "186: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
+            "195: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
+            "214: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
+            "230: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
+            "239: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
         };
         verify(checkConfig, getPath("InputEmptyCatchBlock.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
@@ -170,14 +170,10 @@ public class VariableDeclarationUsageDistanceCheckTest extends
             "471: " + getCheckMessage(MSG_KEY, "l1", 3, 1),
             "471: " + getCheckMessage(MSG_KEY, "l2", 2, 1),
             "479: " + getCheckMessage(MSG_KEY, "myOption", 7, 1),
-            "491: Distance between variable 'myOption' declaration and its first usage is 6,"
-                + " but allowed 1.",
-            "505: Distance between variable 'files' declaration and its first usage is 2,"
-                + " but allowed 1.",
-            "540: Distance between variable 'id' declaration and its first usage is 2,"
-                + " but allowed 1.",
-            "542: Distance between variable 'parentId' declaration and its first usage is 4,"
-                + " but allowed 1.",
+            "491: " + getCheckMessage(MSG_KEY, "myOption", 6, 1),
+            "505: " + getCheckMessage(MSG_KEY, "files", 2, 1),
+            "540: " + getCheckMessage(MSG_KEY, "id", 2, 1),
+            "542: " + getCheckMessage(MSG_KEY, "parentId", 4, 1),
         };
         verify(checkConfig, getPath("InputVariableDeclarationUsageDistance.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -194,7 +194,7 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
             createCheckConfig(ImportOrderCheck.class);
         checkConfig.addAttribute("option", "under");
         final String[] expected = {
-            "5: Wrong order for 'java.awt.Dialog' import.",
+            "5: " + getCheckMessage(MSG_ORDERING, "java.awt.Dialog"),
             "11: " + getCheckMessage(MSG_ORDERING, "java.awt.Button.ABORT"),
             "14: " + getCheckMessage(MSG_ORDERING, "java.io.File"),
         };


### PR DESCRIPTION
#3385 

I reviewed all Checkstyle UTs and found 15 hardcoded messages.
One more proof that Maven does not switch locale correctly before execution of Checkstyle's UTs. Similar problems must be detected after fix for (https://github.com/checkstyle/checkstyle/issues/3377).

