### PR TITLE
Issue #3322: added RedundantModifiers for final in abstract methods

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
@@ -210,4 +210,17 @@ public class RedundantModifierCheckTest
         };
         verify(checkConfig, getPath("InputFinalInTryWithResource.java"), expected);
     }
+
+    @Test
+    public void testFinalInAbstractMethods() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RedundantModifierCheck.class);
+        final String[] expected = {
+            "4:33: " + getCheckMessage(MSG_KEY, "final"),
+            "8:49: " + getCheckMessage(MSG_KEY, "final"),
+            "11:17: " + getCheckMessage(MSG_KEY, "final"),
+            "16:24: " + getCheckMessage(MSG_KEY, "final"),
+            "25:33: " + getCheckMessage(MSG_KEY, "final"),
+        };
+        verify(checkConfig, getPath("InputFinalInAbstractMethods.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/InputFinalInAbstractMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/InputFinalInAbstractMethods.java
@@ -1,0 +1,26 @@
+package com.puppycrawl.tools.checkstyle.checks.modifier;
+
+public abstract class InputFinalInAbstractMethods {
+    public abstract void method(final String param); // violation
+
+    public abstract void method2(String param);
+
+    public abstract void method3(String param1, final String param2); // violation
+}
+interface IWhatever {
+    void method(final String param); // violation
+
+    void method2(String param);
+}
+class CWhatever {
+    native void method(final String param); // violation
+
+    native void method2(String param);
+}
+enum EWhatever {
+    TEST() {
+        public void method(String s) {};
+    };
+
+    public abstract void method(final String s); // violation
+}


### PR DESCRIPTION
Issue #3322

I expanded the issue to all methods with no declaration, not just the ones written in the issue.

I refactored the code a little bit in this issue.
1)
`visitToken` was re-ordered/structured so classes were first and children were next.
`processInterfaceOrAnnotation` was moved to a separate if statement. It conflicted with `processMethods` and I felt I shouldn't change that method to basically call the other one when `processMethods` should take priority because of its more common name and global reach.
2)
I created a new method `checkForRedundantModifier` as we had a lot of duplicated code mimicking this behavior in this check.

Regression to come.