### PR TITLE
Issue #3378: Fixed TransaltionCheckTest to not depend on a specific o…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -24,7 +24,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -196,7 +195,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
      * @param translationCodes a comma separated list of language codes.
      */
     public void setRequiredTranslations(String... translationCodes) {
-        requiredTranslations = Sets.newLinkedHashSet(Arrays.asList(translationCodes));
+        requiredTranslations = Sets.newHashSet(translationCodes);
         validateUserSpecifiedLanguageCodes(requiredTranslations);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -24,6 +24,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -195,7 +196,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
      * @param translationCodes a comma separated list of language codes.
      */
     public void setRequiredTranslations(String... translationCodes) {
-        requiredTranslations = Sets.newHashSet(translationCodes);
+        requiredTranslations = Sets.newLinkedHashSet(Arrays.asList(translationCodes));
         validateUserSpecifiedLanguageCodes(requiredTranslations);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -158,7 +158,8 @@ public class BaseCheckTestSupport {
         try (LineNumberReader lnr = new LineNumberReader(
                 new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
 
-            final List<String> actuals = lnr.lines().sorted().collect(Collectors.toList());
+            final List<String> actuals = lnr.lines().limit(expected.length)
+                    .sorted().collect(Collectors.toList());
             Arrays.sort(expected);
 
             for (int i = 0; i < expected.length; i++) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -31,12 +31,14 @@ import java.io.LineNumberReader;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Predicate;
@@ -156,10 +158,12 @@ public class BaseCheckTestSupport {
         try (LineNumberReader lnr = new LineNumberReader(
                 new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
 
+            final List<String> actuals = lnr.lines().sorted().collect(Collectors.toList());
+            Arrays.sort(expected);
+
             for (int i = 0; i < expected.length; i++) {
                 final String expectedResult = messageFileName + ":" + expected[i];
-                final String actual = lnr.readLine();
-                assertEquals("error message " + i, expectedResult, actual);
+                assertEquals("error message " + i, expectedResult, actuals.get(i));
             }
 
             assertEquals("unexpected output: " + lnr.readLine(),


### PR DESCRIPTION
Issue #3378 

`TransaltionCheckTest#testRegexpToMatchPartOfBaseName` calls `BaseCheckTestSupport#verify` which calls `Checker#process` which calls `TranslationCheck#finishProcessing` and finally `TranslationCheck#checkExistenceOfRequiredTranslations` creates a HashSet which can be ordered in any way. I changed this to a LinkedHashSet so that `verify` knows what order theFiles will be in.