### PR TITLE
Pull 3406: Replace Guava's Joiner with Java 8 native approach

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -210,6 +210,10 @@
   </rule>
 
   <rule ref="rulesets/java/migrating.xml"/>
+  <rule ref="rulesets/java/migrating.xml/JUnit4TestShouldUseTestAnnotation">
+    <!-- False positive of PMD. Non-test methods can be named as 'test' -->
+    <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='PackageObjectFactory']"/>
+  </rule>
 
   <rule ref="rulesets/java/naming.xml">
     <!-- we use CheckstyleCustomShortVariable, to control lenght (will be fixed in PMD 5.4) and skip Override methods -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -22,11 +22,12 @@ package com.puppycrawl.tools.checkstyle;
 import java.lang.reflect.Constructor;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
@@ -90,9 +91,9 @@ public class PackageObjectFactory implements ModuleFactory {
             instance = createObjectWithIgnoringProblems(nameCheck, getAllPossibleNames(nameCheck));
             if (instance == null) {
 
-                final String attemptedNames = joinPackageNamesWithClassName(name)
+                final String attemptedNames = joinPackageNamesWithClassName(name, packages)
                         + STRING_SEPARATOR + nameCheck + STRING_SEPARATOR
-                        + joinPackageNamesWithClassName(nameCheck);
+                        + joinPackageNamesWithClassName(nameCheck, packages);
                 final LocalizedMessage exceptionMessage = new LocalizedMessage(0,
                     Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
                     new String[] {name, attemptedNames}, null, getClass(), null);
@@ -137,11 +138,16 @@ public class PackageObjectFactory implements ModuleFactory {
     /**
      * Creates a string by joining package names with a class name.
      * @param className name of the class for joining.
+     * @param packages packages names.
      * @return a string which is obtained by joining package names with a class name.
      */
-    private String joinPackageNamesWithClassName(String className) {
-        final Joiner joiner = Joiner.on(className + STRING_SEPARATOR).skipNulls();
-        return joiner.join(packages) + className;
+    private static String joinPackageNamesWithClassName(String className, Set<String> packages) {
+        return packages.stream().filter(new Predicate<String>() {
+            @Override
+            public boolean test(String name) {
+                return name != null;
+            }
+        }).collect(Collectors.joining(className + STRING_SEPARATOR, "", className));
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
@@ -22,8 +22,6 @@ package com.puppycrawl.tools.checkstyle.api;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.common.base.Joiner;
-
 /**
  * Represents a full identifier, including dots, with associated
  * position information.
@@ -76,7 +74,7 @@ public final class FullIdent {
      * @return the text
      */
     public String getText() {
-        return Joiner.on("").join(elements);
+        return String.join("", elements);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -24,8 +24,6 @@ import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 
-import com.google.common.base.Joiner;
-
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -159,7 +157,7 @@ public class FinalClassCheck
                 qualifiedNameParts.add(0, traverse.findFirstToken(TokenTypes.IDENT).getText());
                 traverse = traverse.findFirstToken(TokenTypes.DOT);
             }
-            className = Joiner.on(PACKAGE_SEPARATOR).join(qualifiedNameParts);
+            className = String.join(PACKAGE_SEPARATOR, qualifiedNameParts);
         }
         else {
             className = classExtend.findFirstToken(TokenTypes.IDENT).getText();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -19,9 +19,13 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -58,5 +62,18 @@ public class PackageObjectFactoryTest {
                 (ConstantNameCheck) factory.createModule(
                         "com.puppycrawl.tools.checkstyle.checks.naming.ConstantName");
         assertNotNull(check);
+    }
+
+    @Test
+    public void testJoinPackageNamesWhichContainNullWithClassName() throws Exception {
+        final Class<PackageObjectFactory> clazz = PackageObjectFactory.class;
+        final Method method =
+            clazz.getDeclaredMethod("joinPackageNamesWithClassName", String.class, Set.class);
+        method.setAccessible(true);
+        final Set<String> packages = Collections.singleton(null);
+        final String className = "SomeClass";
+        final String actual =
+            String.valueOf(method.invoke(PackageObjectFactory.class, className, packages));
+        assertEquals(className, actual);
     }
 }


### PR DESCRIPTION
#3406
One more step to cut down on Checkstyle's dependencies on third-party libraries. The first one was made in https://github.com/checkstyle/checkstyle/pull/3293

Guava's Joiner was replaced with Java 8 native approach ([String#join](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#join-java.lang.CharSequence-java.lang.Iterable-)).

I do not replace usage of Joiner in [PackageObjectFactory](https://github.com/MEZk/checkstyle/blob/6b82f01378346226e0c999370c0e614cc6af878b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java#L143) as it allows to skip nulls. If we use Java 8 approach in order to skip nulls it will require to do the following: http://www.leveluplunch.com/java/examples/stringjoiner-example/#join-list-skipping-null and as far as I know (http://blog.codefx.org/java/stream-performance/) streams performance leaves a lot to be desired.

@romani 
Are you OK with such changes?


