### PR TITLE
Issue #3308: fixed EqualsHashCode equals method parameter test

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
@@ -25,11 +25,17 @@ import java.util.Map;
 import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
 
 /**
  * <p>
- * Checks that classes that override equals() also override hashCode().
+ * Checks that classes that either override {@code equals()} or {@code hashCode()} also
+ * overrides the other.
+ * This checks only verifies that the method declarations match {@link Object#equals(Object)} and
+ * {@link Object#hashCode()} exactly to be considered an override. This check does not verify
+ * invalid method names, parameters other than {@code Object}, or anything else.
  * </p>
  * <p>
  * Rationale: The contract of equals() and hashCode() requires that
@@ -91,48 +97,62 @@ public class EqualsHashCodeCheck
 
     @Override
     public void visitToken(DetailAST ast) {
-        final DetailAST modifiers = ast.getFirstChild();
-        final AST type = ast.findFirstToken(TokenTypes.TYPE);
-        final AST methodName = ast.findFirstToken(TokenTypes.IDENT);
-        final DetailAST parameters = ast.findFirstToken(TokenTypes.PARAMETERS);
-
-        if (type.getFirstChild().getType() == TokenTypes.LITERAL_BOOLEAN
-                && "equals".equals(methodName.getText())
-                && modifiers.branchContains(TokenTypes.LITERAL_PUBLIC)
-                && parameters.getChildCount() == 1
-                && isObjectParam(parameters.getFirstChild())
-            ) {
+        if (isEqualsMethod(ast)) {
             objBlockWithEquals.put(ast.getParent(), ast);
         }
-        else if (type.getFirstChild().getType() == TokenTypes.LITERAL_INT
-                && "hashCode".equals(methodName.getText())
-                && modifiers.branchContains(TokenTypes.LITERAL_PUBLIC)
-                && parameters.getFirstChild() == null) {
+        else if (isHashCodeMethod(ast)) {
             objBlockWithHashCode.put(ast.getParent(), ast);
         }
     }
 
     /**
-     * Determines if an AST is a formal param of type Object (or subclass).
-     * @param firstChild the AST to check
-     * @return true iff firstChild is a parameter of an Object type.
+     * Determines if an AST is a valid Equals method implementation.
+     *
+     * @param ast the AST to check
+     * @return true if the {code ast} is a Equals method.
      */
-    private static boolean isObjectParam(AST firstChild) {
-        final AST modifiers = firstChild.getFirstChild();
-        final AST type = modifiers.getNextSibling();
-        switch (type.getFirstChild().getType()) {
-            case TokenTypes.LITERAL_BOOLEAN:
-            case TokenTypes.LITERAL_BYTE:
-            case TokenTypes.LITERAL_CHAR:
-            case TokenTypes.LITERAL_DOUBLE:
-            case TokenTypes.LITERAL_FLOAT:
-            case TokenTypes.LITERAL_INT:
-            case TokenTypes.LITERAL_LONG:
-            case TokenTypes.LITERAL_SHORT:
-                return false;
-            default:
-                return true;
-        }
+    private static boolean isEqualsMethod(DetailAST ast) {
+        final DetailAST modifiers = ast.getFirstChild();
+        final DetailAST parameters = ast.findFirstToken(TokenTypes.PARAMETERS);
+
+        return CheckUtils.isEqualsMethod(ast)
+                && modifiers.branchContains(TokenTypes.LITERAL_PUBLIC)
+                && isObjectParam(parameters.getFirstChild())
+                && (ast.branchContains(TokenTypes.SLIST)
+                        || modifiers.branchContains(TokenTypes.LITERAL_NATIVE));
+    }
+
+    /**
+     * Determines if an AST is a valid HashCode method implementation.
+     *
+     * @param ast the AST to check
+     * @return true if the {code ast} is a HashCode method.
+     */
+    private static boolean isHashCodeMethod(DetailAST ast) {
+        final DetailAST modifiers = ast.getFirstChild();
+        final AST type = ast.findFirstToken(TokenTypes.TYPE);
+        final AST methodName = ast.findFirstToken(TokenTypes.IDENT);
+        final DetailAST parameters = ast.findFirstToken(TokenTypes.PARAMETERS);
+
+        return type.getFirstChild().getType() == TokenTypes.LITERAL_INT
+                && "hashCode".equals(methodName.getText())
+                && modifiers.branchContains(TokenTypes.LITERAL_PUBLIC)
+                && !modifiers.branchContains(TokenTypes.LITERAL_STATIC)
+                && parameters.getFirstChild() == null
+                && (ast.branchContains(TokenTypes.SLIST)
+                        || modifiers.branchContains(TokenTypes.LITERAL_NATIVE));
+    }
+
+    /**
+     * Determines if an AST is a formal param of type Object.
+     * @param paramNode the AST to check
+     * @return true if firstChild is a parameter of an Object type.
+     */
+    private static boolean isObjectParam(DetailAST paramNode) {
+        final DetailAST typeNode = paramNode.findFirstToken(TokenTypes.TYPE);
+        final FullIdent fullIdent = FullIdent.createFullIdentBelow(typeNode);
+        final String name = fullIdent.getText();
+        return "Object".equals(name) || "java.lang.Object".equals(name);
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheckTest.java
@@ -45,9 +45,7 @@ public class EqualsHashCodeCheckTest
         final DefaultConfiguration checkConfig =
             createCheckConfig(EqualsHashCodeCheck.class);
         final String[] expected = {
-            "57:9: " + getCheckMessage(MSG_KEY_HASHCODE),
             "94:13: " + getCheckMessage(MSG_KEY_HASHCODE),
-            "122:9: " + getCheckMessage(MSG_KEY_HASHCODE),
         };
         verify(checkConfig, getPath("InputSemantic.java"), expected);
     }
@@ -68,6 +66,23 @@ public class EqualsHashCodeCheckTest
             createCheckConfig(EqualsHashCodeCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputEqualsHashCode.java"), expected);
+    }
+
+    @Test
+    public void testEqualsParameter() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(EqualsHashCodeCheck.class);
+        final String[] expected = {
+            "10:9: " + getCheckMessage(MSG_KEY_EQUALS),
+            "18:9: " + getCheckMessage(MSG_KEY_HASHCODE),
+            "48:9: " + getCheckMessage(MSG_KEY_HASHCODE),
+            "53:9: " + getCheckMessage(MSG_KEY_EQUALS),
+            "65:9: " + getCheckMessage(MSG_KEY_EQUALS),
+            "68:9: " + getCheckMessage(MSG_KEY_HASHCODE),
+            "75:9: " + getCheckMessage(MSG_KEY_EQUALS),
+            "82:9: " + getCheckMessage(MSG_KEY_HASHCODE),
+        };
+        verify(checkConfig, getPath("InputEqualsParameter.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputEqualsHashCode.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputEqualsHashCode.java
@@ -17,6 +17,10 @@ public class InputEqualsHashCode {
         return false;
     }
     
+    private boolean equals(String s) {
+        return false;
+    }
+    
     protected int notHashCode() {
         return 1;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputEqualsParameter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputEqualsParameter.java
@@ -1,0 +1,96 @@
+package com.puppycrawl.tools.checkstyle.checks.coding;
+
+public class InputEqualsParameter {
+    public static class TestClass1 { // no violation
+        public boolean equals(String o) {
+            return true;
+        }
+    }
+    public static class TestClass2 { // violation, no correct `equals`
+        public int hashCode() {
+            return 1;
+        }
+        public boolean equals(String o) {
+            return true;
+        }
+    }
+    public static class TestClass3 { // violation, no `hashCode`
+        public boolean equals(Object o) {
+            return true;
+        }
+        public boolean equals(String o) {
+            return false;
+        }
+    }
+    public static class TestClass4 { // no violation
+        public int hashCode() {
+            return 1;
+        }
+        public boolean equals(Object o) {
+            return true;
+        }
+        public boolean equals(String o) {
+            return false;
+        }
+    }
+    public static class TestClass5 { // no violation
+        public int hashCode() {
+            return 1;
+        }
+        public boolean equals(java.lang.Object o) {
+            return true;
+        }
+    }
+    public static class TestClass6 { // violation, no `hashCode` implementation
+        public static int hashCode(int i) {
+            return 1;
+        }
+        public boolean equals(Object o) {
+            return true;
+        }
+    }
+    public static class TestClass7 { // violation, no `equals` implementation
+        public int hashCode() {
+            return 1;
+        }
+        public static boolean equals(Object o, Object o2) {
+            return true;
+        }
+    }
+    public static class TestClass8 { // no violation
+        public native int hashCode();
+        public native boolean equals(Object o);
+    }
+    public static class TestClass9 { // violation, no `equals` implementation
+        public native int hashCode();
+    }
+    public static class TestClass10 { // violation, no `hashCode` implementation
+        public native boolean equals(Object o);
+    }
+    public static abstract class TestClass11 { // no violation
+        public abstract int hashCode();
+        public abstract boolean equals(Object o);
+    }
+    public static abstract class TestClass12 { // violation, no `equals` implementation
+        public int hashCode() {
+            return 1;
+        }
+        public abstract boolean equals(Object o);
+    }
+    public static abstract class TestClass13 { // violation, no `hashCode` implementation
+        public abstract int hashCode();
+        public boolean equals(java.lang.Object o) {
+            return true;
+        }
+    }
+    public interface TestClass14 { // no violation
+        public int hashCode();
+        public boolean equals(Object o);
+    }
+    public interface TestClass15 { // no violation
+        public boolean equals(Object o);
+    }
+    public interface TestClass16 { // no violation
+        public int hashCode();
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputSemantic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputSemantic.java
@@ -54,7 +54,7 @@ class InputSemantic
 
     public class EqualsVsHashCode2
     {
-        public boolean equals(String a) // flag
+        public boolean equals(String a) // don't flag
         {
             return true;
         }
@@ -119,7 +119,7 @@ class InputSemantic
 
     public class EqualsVsHashCode6
     {
-        public <A> boolean equals(Comparable<A> a) // flag, weven with generics
+        public <A> boolean equals(Comparable<A> a) // don't flag
         {
             return true;
         }

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -642,8 +642,12 @@ String nullString = null;
     <section name="EqualsHashCode">
       <subsection name="Description">
         <p>
-          Checks that classes that override <code>equals()</code>
-          also override <code>hashCode()</code>.
+          Checks that classes that either override <code>equals()</code>
+          or <code>hashCode()</code> also overrides the other.
+          This checks only verifies that the method declarations match
+          <code>Object.equals(Object)}</code> and <code>Object.hashCode()</code> exactly to be
+          considered an override. This check does not verify invalid method names, parameters
+          other than <code>Object</code>, or anything else.
         </p>
 
         <p>


### PR DESCRIPTION
Issue #3308

Updated documentation. Changed some code to use our utility method, which checked for static that our old code didn't. Checking parameter for `Object` or `java.lang.Object`.
Regression to come.