### PR TITLE
Pull #3412: Fix ForbidCertainImports config

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -87,8 +87,14 @@
             <property name="requiredParameters" value="value"/>
         </module>
         <module name="ForbidCertainImports">
-            <property name="packageNameRegexp" value="^.*(api|utils).*$"/>
-            <property name="forbiddenImportsRegexp" value="^.*checks.*|java\.util\.Vector|java\.util\.Stack$"/>
+            <property name="packageNameRegexp" value=".+"/>
+            <property name="forbiddenImportsRegexp" value="java\.util\.Stack|java\.util\.Vector"/>
+            <property name="forbiddenImportsExcludesRegexp" value=""/>
+        </module>
+        <module name="ForbidCertainImports">
+            <property name="packageNameRegexp" value=".+\.checkstyle\.api.*|.+\.checkstyle\.utils.*"/>
+            <property name="forbiddenImportsRegexp" value=".+\.checks\..+"/>
+            <property name="forbiddenImportsExcludesRegexp" value=""/>
         </module>
         <module name="LineLengthExtended">
             <property name="max" value="100"/>

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -56,4 +56,11 @@
     <suppress checks="IllegalCatchExtended"
               files="CheckerTest\.java"
               lines="543"/>
+
+    <!--JavadocTagInfo.java, JavadocTags.java, InvalidJavadocTag.java, JavadocTag.java will be
+    deprecated as we completely switch to ANTLR parser for javadoc. All of the mentioned classes
+    are required only for old javadoc parsers and their usage will be excluded from
+    JavadocUtils.java and JavadocUtilsTest.java. -->
+    <suppress checks="ForbidCertainImports"
+              files="JavadocUtils\.java|JavadocUtilsTest\.java"/>
 </suppressions>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailNode.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailNode.java
@@ -19,14 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
-import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl;
-
 /**
  * DetailNode is used to construct tree during parsing Javadoc comments.
  * Contains array of children, parent node and other useful fields.
  *
  * @author Baratali Izmailov
- * @see JavadocNodeImpl
+ * @see com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl
  * @see com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck
  */
 public interface DetailNode {


### PR DESCRIPTION
#3412

1) Usage of java.util.Stack and java.util.Vector was disallowed for the whole project.
2) Usage of classes from 'com.puppycrawl.tools.checkstyle.checks.*' package was disallowed for 'com.puppycrawl.tools.checkstyle.api' and 'com.puppycrawl.tools.checkstyle.utils' packages.

New violations appeared due to the second restriction. What should we do with them?
```
main/java/com/puppycrawl/tools/checkstyle/api/DetailNode.java
This import should not match '.+\.checks\..+' pattern, it is forbidden in com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl.	22

main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
This import should not match '.+\.checks\..+' pattern, it is forbidden in com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocTag.	34
This import should not match '.+\.checks\..+' pattern, it is forbidden in com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTag.	35
This import should not match '.+\.checks\..+' pattern, it is forbidden in com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo.	36
This import should not match '.+\.checks\..+' pattern, it is forbidden in com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTags.	37

test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java
This import should not match '.+\.checks\..+' pattern, it is forbidden in com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl.	36
This import should not match '.+\.checks\..+' pattern, it is forbidden in com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTag.	37
This import should not match '.+\.checks\..+' pattern, it is forbidden in com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo.	38
This import should not match '.+\.checks\..+' pattern, it is forbidden in com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTags.	39
```

Violation messages have incorrect structure. 
`This import should not match '.+\.checks\..+' pattern, it is forbidden in com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl.	36`
Should be:
`
This import should not match '.+\.checks\..+' pattern, it is forbidden in test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java.
`
or
`
Import 'com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTags' should not match '.+\.checks\..+' pattern, it is forbidden in test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java.
`







