### PR TITLE
Issue #3381: allow one-char parameters in non public methods

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -22,8 +22,10 @@ package com.puppycrawl.tools.checkstyle.checks.naming;
 import java.util.Optional;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
+import com.puppycrawl.tools.checkstyle.utils.ScopeUtils;
 
 /**
 * <p>
@@ -33,9 +35,13 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
  * and defaults to
  * <strong>^[a-z][a-zA-Z0-9]*$</strong>.
  * </p>
- * <p>The check has the following option:</p>
+ * <p>The check has the following options:</p>
  * <p><b>ignoreOverridden</b> - allows to skip methods with Override annotation from
  * validation. Default values is <b>false</b> .</p>
+ * <p><b>scope</b> - visibility scope of methods to be checked.
+ *  Default values is <b>private</b> .</p>
+ * <p><b>excludeScope</b> - visibility scope of methods not to be checked.
+ *  Default values is <b>null</b> .</p>
  * <p>
  * An example of how to configure the check is:
  * </p>
@@ -72,6 +78,12 @@ public class ParameterNameCheck
      */
     private boolean ignoreOverridden;
 
+    /** The visibility scope where methods are checked. */
+    private Scope scope = Scope.PRIVATE;
+
+    /** The visibility scope where methods shouldn't be checked. */
+    private Scope excludeScope;
+
     /**
      * Creates a new {@code ParameterNameCheck} instance.
      */
@@ -87,6 +99,25 @@ public class ParameterNameCheck
     public void setIgnoreOverridden(boolean ignoreOverridden) {
         this.ignoreOverridden = ignoreOverridden;
     }
+
+    /**
+     * Set the scope.
+     * 
+     * @param from a {@code String} value
+     */
+    public void setScope(String from) {
+        scope = Scope.getInstance(from);
+    }
+
+    /**
+     * Set the excludeScope.
+     * 
+     * @param excludeScope a {@code String} value
+     */
+    public void setExcludeScope(String excludeScope) {
+        this.excludeScope = Scope.getInstance(excludeScope);
+    }
+
 
     @Override
     public int[] getDefaultTokens() {
@@ -105,13 +136,54 @@ public class ParameterNameCheck
 
     @Override
     protected boolean mustCheckName(DetailAST ast) {
+        final Scope theScope = calculateScope(ast);
         boolean checkName = true;
         if (ignoreOverridden && isOverriddenMethod(ast)
                 || ast.getParent().getType() == TokenTypes.LITERAL_CATCH
-                || CheckUtils.isReceiverParameter(ast)) {
+                || CheckUtils.isReceiverParameter(ast)
+                || !matchScope(ast, theScope)) {
             checkName = false;
         }
         return checkName;
+    }
+
+    /**
+     * Returns the scope for the method/constructor at the specified AST. If
+     * the method is in an interface or annotation block, the scope is assumed
+     * to be public.
+     *
+     * @param ast the token of the method/constructor
+     * @return the scope of the method/constructor
+     */
+    private static Scope calculateScope(final DetailAST ast) {
+        if (ast.getParent().getType() == TokenTypes.LITERAL_CATCH) {
+            return Scope.PRIVATE;
+        }
+        final DetailAST params = ast.getParent();
+        final DetailAST meth = params.getParent(); 
+        final DetailAST mods = meth.findFirstToken(TokenTypes.MODIFIERS);
+        final Scope declaredScope = ScopeUtils.getScopeFromMods(mods);
+        if (ScopeUtils.isInInterfaceOrAnnotationBlock(ast)) {
+            return Scope.PUBLIC;
+        }
+        else {
+            return declaredScope;
+        }
+    }
+
+
+    /**
+     * Checks whether a method has the correct scope to be checked.
+     * @param ast a fiven node
+     * @param nodeScope the scope of the method
+     * @return whether the method matches the expected scope
+     */
+    private boolean matchScope(final DetailAST ast, final Scope nodeScope) {
+        final Scope surroundingScope = ScopeUtils.getSurroundingScope(ast);
+        return nodeScope.isIn(scope) && surroundingScope.isIn(scope)
+            && (excludeScope == null
+                || !nodeScope.isIn(excludeScope)
+                || !surroundingScope.isIn(excludeScope));
     }
 
     /**

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -102,18 +102,25 @@
              value="Member name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="ParameterName">
-            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+            <property name="excludeScope" value="public"/>
             <message key="name.invalidPattern"
              value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z][a-zA-Z0-9]+$"/>
+            <property name="scope" value="public"/>
+            <message key="name.invalidPattern"
+             value="Public parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
         <module name="CatchParameterName">
-            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
              value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="LocalVariableName">
             <property name="tokens" value="VARIABLE_DEF"/>
-            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <property name="allowOneCharVarInForLoop" value="true"/>
             <message key="name.invalidPattern"
              value="Local variable name ''{0}'' must match pattern ''{1}''."/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
@@ -136,6 +137,67 @@ public class ParameterNameCheckTest
             "28:62: " + getCheckMessage(MSG_INVALID_PATTERN, "packageNames", pattern),
             };
         verify(checkConfig, getPath("InputOverrideAnnotation.java"), expected);
+    }
+
+    @Test
+    public void testScope()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ParameterNameCheck.class);
+        checkConfig.addAttribute("format", "^h$");
+        checkConfig.addAttribute("scope", Scope.PUBLIC.getName());
+
+        final String pattern = "^h$";
+
+        final String[] expected = {
+            "13:24: " + getCheckMessage(MSG_INVALID_PATTERN, "pubpub", pattern),
+            "24:21: " + getCheckMessage(MSG_INVALID_PATTERN, "pubifc", pattern),
+            };
+        verify(checkConfig, getPath("InputScope.java"), expected);
+    }
+
+    @Test
+    public void testExcludeScope()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ParameterNameCheck.class);
+        checkConfig.addAttribute("format", "^h$");
+        checkConfig.addAttribute("excludeScope", Scope.PROTECTED.getName());
+
+        final String pattern = "^h$";
+
+        final String[] expected = {
+            "17:17: " + getCheckMessage(MSG_INVALID_PATTERN, "pubpack", pattern),
+            "19:25: " + getCheckMessage(MSG_INVALID_PATTERN, "pubpriv", pattern),
+            "38:24: " + getCheckMessage(MSG_INVALID_PATTERN, "packpub", pattern),
+            "40:27: " + getCheckMessage(MSG_INVALID_PATTERN, "packprot", pattern),
+            "42:17: " + getCheckMessage(MSG_INVALID_PATTERN, "packpack", pattern),
+            "44:25: " + getCheckMessage(MSG_INVALID_PATTERN, "packpriv", pattern),
+            "54:21: " + getCheckMessage(MSG_INVALID_PATTERN, "packifc", pattern),
+            };
+        verify(checkConfig, getPath("InputScope.java"), expected);
+    }
+
+    @Test
+    public void testScopeExcludeScope()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ParameterNameCheck.class);
+        checkConfig.addAttribute("format", "^h$");
+        checkConfig.addAttribute("scope", Scope.PACKAGE.getName());
+        checkConfig.addAttribute("excludeScope", Scope.PUBLIC.getName());
+
+        final String pattern = "^h$";
+
+        final String[] expected = {
+            "15:27: " + getCheckMessage(MSG_INVALID_PATTERN, "pubprot", pattern),
+            "17:17: " + getCheckMessage(MSG_INVALID_PATTERN, "pubpack", pattern),
+            "38:24: " + getCheckMessage(MSG_INVALID_PATTERN, "packpub", pattern),
+            "40:27: " + getCheckMessage(MSG_INVALID_PATTERN, "packprot", pattern),
+            "42:17: " + getCheckMessage(MSG_INVALID_PATTERN, "packpack", pattern),
+            "54:21: " + getCheckMessage(MSG_INVALID_PATTERN, "packifc", pattern),
+            };
+        verify(checkConfig, getPath("InputScope.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputScope.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputScope.java
@@ -1,0 +1,57 @@
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+public class InputScope {
+
+    public void v1(int h) {}
+
+    protected void v4(int h) {}
+
+    void v2(int h) {} 
+
+    private void v3(int h) {}
+
+    public void i1(int pubpub) {}
+
+    protected void i4(int pubprot) {}
+
+    void i2(int pubpack) {}
+
+    private void i3(int pubpriv) {}
+
+    public interface InterfaceScope {
+        void v1(int h);
+
+        void i1(int pubifc);
+    }
+}
+
+class PrivateScope {
+
+    public void v1(int h) {}
+
+    protected void v4(int h) {}
+
+    void v2(int h) {} 
+
+    private void v3(int h) {}
+
+    public void i1(int packpub) {}
+
+    protected void i4(int packprot) {}
+
+    void i2(int packpack) {}
+
+    private void i3(int packpriv) {
+        try {
+            /* Make sure catch var is ignored */
+        } catch (Exception exc) {
+        }
+    }
+
+    interface InterfaceScope {
+        void v1(int h);
+
+        void i1(int packifc);
+    }
+}
+

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -1179,6 +1179,18 @@ public boolean equals(Object o) {
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
+          <tr>
+            <td>scope</td>
+            <td>Visibility scope of methods where parameters are checked.</td>
+            <td><a href="property_types.html#scope">scope</a></td>
+            <td><code>private</code></td>
+          </tr>
+          <tr>
+            <td>excludeScope</td>
+            <td>Visibility scope of methods where parameters are not checked.</td>
+            <td><a href="property_types.html#scope">scope</a></td>
+            <td><code>null</code></td>
+          </tr>
         </table>
       </subsection>
 


### PR DESCRIPTION
Added new "scope" and "excludeScope" attributes to ParameterName check.
Adjusted google_checks.xml to allow non public methods to have one character long parameters