### PR TITLE
Issue #3381: add "default" to list of method modifiers

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
@@ -41,6 +41,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
   <li><span class="code">private</span></li>
   <li><span class="code">abstract</span></li>
+  <li><span class="code">default</span></li>
   <li><span class="code">static</span></li>
   <li><span class="code">final</span></li>
   <li><span class="code">transient</span></li>
@@ -84,8 +85,8 @@ public class ModifierOrderCheck
      * 8.3.1 and 8.4.3 of the JLS.
      */
     private static final String[] JLS_ORDER = {
-        "public", "protected", "private", "abstract", "static", "final",
-        "transient", "volatile", "synchronized", "native", "strictfp", "default",
+        "public", "protected", "private", "abstract", "default", "static", 
+        "final", "transient", "volatile", "synchronized", "native", "strictfp"
     };
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
@@ -66,6 +66,7 @@ public class ModifierOrderCheckTest
             "34:13: " + getCheckMessage(MSG_ANNOTATION_ORDER, "@MyAnnotation2"),
             "39:13: " + getCheckMessage(MSG_ANNOTATION_ORDER, "@MyAnnotation2"),
             "49:35: " + getCheckMessage(MSG_ANNOTATION_ORDER, "@MyAnnotation4"),
+            "157:13: " + getCheckMessage(MSG_MODIFIER_ORDER, "public"),
         };
         verify(checkConfig, getPath("InputModifier.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
@@ -78,6 +78,8 @@ public class RedundantModifierCheckTest
             "118:5: " + getCheckMessage(MSG_KEY, "static"),
             "120:5: " + getCheckMessage(MSG_KEY, "public"),
             "121:5: " + getCheckMessage(MSG_KEY, "abstract"),
+            "152:5: " + getCheckMessage(MSG_KEY, "public"),
+            "157:13: " + getCheckMessage(MSG_KEY, "public"),
         };
         verify(checkConfig, getPath("InputModifier.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/InputModifier.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/InputModifier.java
@@ -144,3 +144,17 @@ enum TestEnum {
     public void method() {
     }
 }
+
+/** holder for interface specific modifier check. */
+interface InputDefaultPublicModifier
+{
+    /** correct order */
+    public default void a()
+    {
+    }
+
+    /** wrong order */
+    default public void b() // violation
+    {
+    }
+}

--- a/src/xdocs/config_modifier.xml
+++ b/src/xdocs/config_modifier.xml
@@ -27,8 +27,9 @@
           Checks that the order of modifiers conforms to the suggestions in
           the <a
           href="http://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html">Java
-          Language specification, sections 8.1.1, 8.3.1 and 8.4.3</a>. The
-          correct order is:
+          Language specification, sections 8.1.1, 8.3.1, 8.4.3</a> and <a
+          href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html">
+          9.4</a>. The correct order is:
         </p>
 
         <ol>
@@ -43,6 +44,9 @@
           </li>
           <li>
             <code>abstract</code>
+          </li>
+          <li>
+            <code>default</code>
           </li>
           <li>
             <code>static</code>


### PR DESCRIPTION
Moved "default"  parameter to the right place, according to Google (and Oracle) guidelines