### PR TITLE
Issue #3381: Update Google style coverage to state of 12 July 2016

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule51identifiernames/CatchParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule51identifiernames/CatchParameterNameTest.java
@@ -38,13 +38,10 @@ public class CatchParameterNameTest extends BaseCheckTestSupport {
     public void catchParameterNameTest() throws Exception {
         final Configuration checkConfig = getCheckConfig("CatchParameterName");
         final String msgKey = "name.invalidPattern";
-        final String format = "^[a-z][a-z0-9][a-zA-Z0-9]*$";
+        final String format = "^[a-z][a-zA-Z0-9]*$";
 
         final String[] expected = {
-            "6:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "e", format),
-            "24:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "t", format),
-            "47:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "iException", format),
-            "50:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "x", format),
+            "24:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "T", format),
         };
 
         final String filePath = getPath("InputCatchParameterName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java
@@ -57,12 +57,8 @@ public class ParameterNameTest extends BaseCheckTestSupport {
             "11:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "a_rg4", format),
             "12:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_arg5", format),
             "13:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "arg6_", format),
-            "14:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aArg7", format),
-            "15:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aArg8", format),
             "16:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aar_g", format),
-            "26:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bB", format),
             "49:22: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "llll_llll", format),
-            "50:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bB", format),
         };
 
         final String filePath = getPath("InputParameterNameSimple.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
@@ -51,17 +51,15 @@ public class LocalVariableNameTest extends BaseCheckTestSupport {
     public void localVariableNameTest() throws Exception {
 
         final String[] expected = {
-            "26:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "a", format),
-            "27:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aA", format),
-            "28:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "a1_a", format),
-            "29:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "A_A", format),
-            "30:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aa2_a", format),
-            "31:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_a", format),
-            "32:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_aa", format),
-            "33:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aa_", format),
-            "34:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aaa$aaa", format),
-            "35:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$aaaaaa", format),
-            "36:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aaaaaa$", format),
+            "26:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "a1_a", format),
+            "27:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "A_A", format),
+            "28:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aa2_a", format),
+            "29:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_a", format),
+            "30:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_aa", format),
+            "31:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aa_", format),
+            "32:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aaa$aaa", format),
+            "33:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$aaaaaa", format),
+            "34:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aaaaaa$", format),
         };
 
         final String filePath = getPath("InputLocalVariableNameSimple.java");
@@ -74,7 +72,6 @@ public class LocalVariableNameTest extends BaseCheckTestSupport {
     public void oneCharTest() throws Exception {
 
         final String[] expected = {
-            "15:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "i", format),
             "21:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "I_ndex", format),
             "45:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "i_ndex", format),
             "49:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "ii_i1", format),

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule51identifiernames/InputCatchParameterName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule51identifiernames/InputCatchParameterName.java
@@ -3,7 +3,7 @@ package com.google.checkstyle.test.chapter5naming.rule51identifiernames;
 public class InputCatchParameterName {
     {
         try {
-        } catch (Exception e) { // warn
+        } catch (Exception e) { // ok
         }
         try {
         } catch (Exception ex) { // ok
@@ -21,7 +21,7 @@ public class InputCatchParameterName {
         } catch (Exception noWorries) { // ok
         }
         try {
-        } catch (Throwable t) { // warn
+        } catch (Throwable T) { // warn
         }
         try {
             throw new InterruptedException("interruptedException");
@@ -44,10 +44,10 @@ public class InputCatchParameterName {
             }
         }
         try {
-        } catch (Exception iException) { // warn
+        } catch (Exception iException) { // ok
         }
         try {
-        } catch (Exception x) { // warn
+        } catch (Exception x) { // ok
         }
     }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputParameterNameSimple.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule526parameternames/InputParameterNameSimple.java
@@ -11,8 +11,8 @@ final class InputSimple
     		int a_rg4, //warn
     		int _arg5, //warn
     		int arg6_, //warn
-    		int aArg7, //warn
-    		int aArg8, //warn
+    		int aArg7, //ok
+    		int aArg8, //ok
     		int aar_g) //warn
             
     {}
@@ -23,7 +23,7 @@ class InputSimple2
 
     /** Some more Javadoc. */
     public void doSomething(int aaa, int abn, String aaA, 
-            boolean bB) //warn
+            boolean bB) //ok
     {
         for (Object O : new java.util.ArrayList())
         {
@@ -47,5 +47,5 @@ enum MyEnum1
     
     public void doEnum(int aaaL,
     		long llll_llll, //warn
-            boolean bB) {} //warn 
+            boolean bB) {} //ok
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputLocalVariableNameOneCharVarName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputLocalVariableNameOneCharVarName.java
@@ -12,7 +12,7 @@ class InputOneCharInitVarName
             //some code
         }
         
-        int i = 0; //warn
+        int i = 0; //ok
         
         for(int index = 1; index < 10; index++) { //ok
             //some code

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputLocalVariableNameSimple.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputLocalVariableNameSimple.java
@@ -23,8 +23,6 @@ final class InputSimple
     private void localVariables()
     {
         //bad examples
-        int a; //warn
-        int aA; //warn
         int a1_a; //warn
         int A_A; //warn
         int aa2_a; //warn

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
@@ -41,6 +41,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
   <li><span class="code">private</span></li>
   <li><span class="code">abstract</span></li>
+  <li><span class="code">default</span></li>
   <li><span class="code">static</span></li>
   <li><span class="code">final</span></li>
   <li><span class="code">transient</span></li>
@@ -84,8 +85,8 @@ public class ModifierOrderCheck
      * 8.3.1 and 8.4.3 of the JLS.
      */
     private static final String[] JLS_ORDER = {
-        "public", "protected", "private", "abstract", "static", "final",
-        "transient", "volatile", "synchronized", "native", "strictfp", "default",
+        "public", "protected", "private", "abstract", "default", "static",
+        "final", "transient", "volatile", "synchronized", "native", "strictfp",
     };
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -153,11 +153,11 @@ public class ParameterNameCheck
      * @return the scope of the method/constructor
      */
     private static Scope calculateScope(final DetailAST ast) {
-        if (ast.getParent().getType() == TokenTypes.LITERAL_CATCH) {
-            return Scope.PRIVATE;
-        }
         final DetailAST params = ast.getParent();
         final DetailAST meth = params.getParent();
+        if (ScopeUtils.isInCodeBlock(meth)) {
+            return Scope.PRIVATE;
+        }
         final DetailAST mods = meth.findFirstToken(TokenTypes.MODIFIERS);
         Scope declaredScope = ScopeUtils.getScopeFromMods(mods);
         if (ScopeUtils.isInInterfaceOrAnnotationBlock(ast)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -155,7 +155,7 @@ public class ParameterNameCheck
     private static Scope calculateScope(final DetailAST ast) {
         final DetailAST params = ast.getParent();
         final DetailAST meth = params.getParent();
-        if (ScopeUtils.isInCodeBlock(meth)) {
+        if (meth.getType() != TokenTypes.METHOD_DEF) {
             return Scope.PRIVATE;
         }
         final DetailAST mods = meth.findFirstToken(TokenTypes.MODIFIERS);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
@@ -70,6 +70,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *  {@link TokenTypes#SL_ASSIGN SL_ASSIGN},
  *  {@link TokenTypes#SR_ASSIGN SR_ASSIGN},
  *  {@link TokenTypes#STAR_ASSIGN STAR_ASSIGN}.
+ *  {@link TokenTypes#DOUBLE_COLON DOUBLE_COLON}.
  * </p>
  *  <p>
  * An example of how to configure the check is:
@@ -190,6 +191,7 @@ public class OperatorWrapCheck
             TokenTypes.BXOR_ASSIGN,       // "^="
             TokenTypes.BOR_ASSIGN,        // "|="
             TokenTypes.BAND_ASSIGN,       // "&="
+            TokenTypes.METHOD_REF,        // "::"
 
         };
     }

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -102,18 +102,25 @@
              value="Member name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="ParameterName">
-            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+            <property name="excludeScope" value="public"/>
             <message key="name.invalidPattern"
              value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z][a-zA-Z0-9]+$"/>
+            <property name="scope" value="public"/>
+            <message key="name.invalidPattern"
+             value="Public parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
         <module name="CatchParameterName">
-            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
              value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="LocalVariableName">
             <property name="tokens" value="VARIABLE_DEF"/>
-            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <property name="allowOneCharVarInForLoop" value="true"/>
             <message key="name.invalidPattern"
              value="Local variable name ''{0}'' must match pattern ''{1}''."/>
@@ -166,7 +173,7 @@
         <module name="MethodParamPad"/>
         <module name="OperatorWrap">
             <property name="option" value="NL"/>
-            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
         </module>
         <module name="AnnotationLocation">
             <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
@@ -66,6 +66,7 @@ public class ModifierOrderCheckTest
             "34:13: " + getCheckMessage(MSG_ANNOTATION_ORDER, "@MyAnnotation2"),
             "39:13: " + getCheckMessage(MSG_ANNOTATION_ORDER, "@MyAnnotation2"),
             "49:35: " + getCheckMessage(MSG_ANNOTATION_ORDER, "@MyAnnotation4"),
+            "157:13: " + getCheckMessage(MSG_MODIFIER_ORDER, "public"),
         };
         verify(checkConfig, getPath("InputModifier.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
@@ -78,6 +78,8 @@ public class RedundantModifierCheckTest
             "118:5: " + getCheckMessage(MSG_KEY, "static"),
             "120:5: " + getCheckMessage(MSG_KEY, "public"),
             "121:5: " + getCheckMessage(MSG_KEY, "abstract"),
+            "152:5: " + getCheckMessage(MSG_KEY, "public"),
+            "157:13: " + getCheckMessage(MSG_KEY, "public"),
         };
         verify(checkConfig, getPath("InputModifier.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
@@ -136,6 +137,67 @@ public class ParameterNameCheckTest
             "28:62: " + getCheckMessage(MSG_INVALID_PATTERN, "packageNames", pattern),
             };
         verify(checkConfig, getPath("InputOverrideAnnotation.java"), expected);
+    }
+
+    @Test
+    public void testScope()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ParameterNameCheck.class);
+        checkConfig.addAttribute("format", "^h$");
+        checkConfig.addAttribute("scope", Scope.PUBLIC.getName());
+
+        final String pattern = "^h$";
+
+        final String[] expected = {
+            "13:24: " + getCheckMessage(MSG_INVALID_PATTERN, "pubpub", pattern),
+            "24:21: " + getCheckMessage(MSG_INVALID_PATTERN, "pubifc", pattern),
+            };
+        verify(checkConfig, getPath("InputScope.java"), expected);
+    }
+
+    @Test
+    public void testExcludeScope()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ParameterNameCheck.class);
+        checkConfig.addAttribute("format", "^h$");
+        checkConfig.addAttribute("excludeScope", Scope.PROTECTED.getName());
+
+        final String pattern = "^h$";
+
+        final String[] expected = {
+            "17:17: " + getCheckMessage(MSG_INVALID_PATTERN, "pubpack", pattern),
+            "19:25: " + getCheckMessage(MSG_INVALID_PATTERN, "pubpriv", pattern),
+            "38:24: " + getCheckMessage(MSG_INVALID_PATTERN, "packpub", pattern),
+            "40:27: " + getCheckMessage(MSG_INVALID_PATTERN, "packprot", pattern),
+            "42:17: " + getCheckMessage(MSG_INVALID_PATTERN, "packpack", pattern),
+            "44:25: " + getCheckMessage(MSG_INVALID_PATTERN, "packpriv", pattern),
+            "54:21: " + getCheckMessage(MSG_INVALID_PATTERN, "packifc", pattern),
+            };
+        verify(checkConfig, getPath("InputScope.java"), expected);
+    }
+
+    @Test
+    public void testScopeExcludeScope()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ParameterNameCheck.class);
+        checkConfig.addAttribute("format", "^h$");
+        checkConfig.addAttribute("scope", Scope.PACKAGE.getName());
+        checkConfig.addAttribute("excludeScope", Scope.PUBLIC.getName());
+
+        final String pattern = "^h$";
+
+        final String[] expected = {
+            "15:27: " + getCheckMessage(MSG_INVALID_PATTERN, "pubprot", pattern),
+            "17:17: " + getCheckMessage(MSG_INVALID_PATTERN, "pubpack", pattern),
+            "38:24: " + getCheckMessage(MSG_INVALID_PATTERN, "packpub", pattern),
+            "40:27: " + getCheckMessage(MSG_INVALID_PATTERN, "packprot", pattern),
+            "42:17: " + getCheckMessage(MSG_INVALID_PATTERN, "packpack", pattern),
+            "54:21: " + getCheckMessage(MSG_INVALID_PATTERN, "packifc", pattern),
+            };
+        verify(checkConfig, getPath("InputScope.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/InputModifier.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/InputModifier.java
@@ -144,3 +144,17 @@ enum TestEnum {
     public void method() {
     }
 }
+
+/** holder for interface specific modifier check. */
+interface InputDefaultPublicModifier
+{
+    /** correct order */
+    public default void a()
+    {
+    }
+
+    /** wrong order */
+    default public void b() // violation
+    {
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputScope.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputScope.java
@@ -1,0 +1,57 @@
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+public class InputScope {
+
+    public void v1(int h) {}
+
+    protected void v4(int h) {}
+
+    void v2(int h) {} 
+
+    private void v3(int h) {}
+
+    public void i1(int pubpub) {}
+
+    protected void i4(int pubprot) {}
+
+    void i2(int pubpack) {}
+
+    private void i3(int pubpriv) {}
+
+    public interface InterfaceScope {
+        void v1(int h);
+
+        void i1(int pubifc);
+    }
+}
+
+class PrivateScope {
+
+    public void v1(int h) {}
+
+    protected void v4(int h) {}
+
+    void v2(int h) {} 
+
+    private void v3(int h) {}
+
+    public void i1(int packpub) {}
+
+    protected void i4(int packprot) {}
+
+    void i2(int packpack) {}
+
+    private void i3(int packpriv) {
+        try {
+            /* Make sure catch var is ignored */
+        } catch (Exception exc) {
+        }
+    }
+
+    interface InterfaceScope {
+        void v1(int h);
+
+        void i1(int packifc);
+    }
+}
+

--- a/src/xdocs/config_modifier.xml
+++ b/src/xdocs/config_modifier.xml
@@ -27,8 +27,9 @@
           Checks that the order of modifiers conforms to the suggestions in
           the <a
           href="http://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html">Java
-          Language specification, sections 8.1.1, 8.3.1 and 8.4.3</a>. The
-          correct order is:
+          Language specification, sections 8.1.1, 8.3.1, 8.4.3</a> and <a
+          href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html">
+          9.4</a>. The correct order is:
         </p>
 
         <ol>
@@ -43,6 +44,9 @@
           </li>
           <li>
             <code>abstract</code>
+          </li>
+          <li>
+            <code>default</code>
           </li>
           <li>
             <code>static</code>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -1179,6 +1179,18 @@ public boolean equals(Object o) {
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>
+          <tr>
+            <td>scope</td>
+            <td>Visibility scope of methods where parameters are checked.</td>
+            <td><a href="property_types.html#scope">scope</a></td>
+            <td><code>private</code></td>
+          </tr>
+          <tr>
+            <td>excludeScope</td>
+            <td>Visibility scope of methods where parameters are not checked.</td>
+            <td><a href="property_types.html#scope">scope</a></td>
+            <td><code>null</code></td>
+          </tr>
         </table>
       </subsection>
 

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1229,7 +1229,8 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">SL_ASSIGN</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">BXOR_ASSIGN</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">BOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">BAND_ASSIGN</a>.
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">BAND_ASSIGN</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">METHOD_REF</a>.
             </td>
 
             <td>

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -786,7 +786,7 @@
                             <td><a name="4.8.2.2"/><a href="#4.8.2.2"><img src="images/anchor.png" alt=""/></a></td>
                             <td>
                                 <a
-                                    href="http://checkstyle.sourceforge.net/reports/google-java-style.html#s4.8.2.2-variables-limited-scope">4.8.2.2 Declared when needed, initialized as soon as
+                                    href="http://checkstyle.sourceforge.net/reports/google-java-style.html#s4.8.2.2-variables-limited-scope">4.8.2.2 Declared when needed
                                     possible
                                 </a>
                             </td>
@@ -1505,6 +1505,23 @@
                                     alt="" />
                                 <a href="config_javadoc.html#JavadocMethod">JavadocMethod</a>
                                 <br/> Overrides are checked by presence of "@Override" annotation on method.
+                            </td>
+                            <td>
+                                <a
+                                    href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMethod">config</a><br/>
+                                <a
+                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/JavadocMethodTest.java">test</a>
+                            </td>
+                            <td><a name="7.3.4"/><a href="#7.3.4"><img src="images/anchor.png" alt=""/></a></td>
+                            <td>
+                                <a
+                                    href="http://checkstyle.sourceforge.net/reports/google-java-style.html#s7.3.4-javadoc-non-required">7.3.4</a>
+                            </td>
+                            <td>
+                                <img
+                                    src="images/ok_green.png"
+                                    alt="" />
+                                <a href="config_javadoc.html#JavadocMethod">JavadocMethod</a>
                             </td>
                             <td>
                                 <a


### PR DESCRIPTION
Issue #3381 

Update Google Style coverage:
* par 4.5: method reference (::) behaves like dot separator etc
* par 4.8.7: moved "default" modifier to the correct place according to Google and Oracle
* par 5.2.6: parameter names can be one-character long in non-public methods
To implement the last item, I have added two new attributes to ParameterName, i.e. "scope"  and "excludeScope". 
**Note**: this patch permits an uppercase letter as the second character of an identifier since I could not find where the Google document disallows it (not even in the old revision of the docs). That's why so many test classes have changed.

This patch does not address par. 3.3.3: Import order (already addressed by #941), and I did  not change the coverage doc in this regard.