### PR TITLE
Issue #3233: Resolve IntelijIdea inspection violations for java8 migration

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -34,7 +34,7 @@
         <option name="m_maxLength" value="64" />
     </inspection_tool>
     <inspection_tool class="Annotator" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="Anonymous2MethodRef" enabled="false" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="Anonymous2MethodRef" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="AnonymousClassComplexity" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="m_limit" value="3" />
     </inspection_tool>
@@ -424,10 +424,10 @@
     <inspection_tool class="ContinueStatementWithLabelJS" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="Contract" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ControlFlowStatementWithoutBraces" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="Convert2Diamond" enabled="false" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="Convert2Lambda" enabled="false" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="Convert2MethodRef" enabled="false" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="Convert2streamapi" enabled="false" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="Convert2Diamond" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="Convert2Lambda" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="Convert2MethodRef" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="Convert2streamapi" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ConvertAnnotations" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ConvertJavadoc" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ConvertOldAnnotations" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -894,7 +894,7 @@
     <inspection_tool class="GroovyWhileLoopSpinsOnField" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="ignoreNonEmtpyLoops" value="false" />
     </inspection_tool>
-    <inspection_tool class="Guava" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="Guava" enabled="true" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="GuavaFluentIterable" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="HardCodedStringLiteral" enabled="false" level="ERROR" enabled_by_default="false">
         <option name="ignoreForAssertStatements" value="true" />
@@ -1710,7 +1710,7 @@
         <option name="ignoreEmptySuperMethods" value="false" />
         <option name="onlyReportWhenAnnotated" value="true" />
     </inspection_tool>
-    <inspection_tool class="RemoveExplicitTypeArguments" enabled="false" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="RemoveExplicitTypeArguments" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ReplaceAllDot" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ReplaceAssignmentWithOperatorAssignment" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="ignoreLazyOperators" value="true" />

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -13,10 +13,7 @@
          See https://github.com/checkstyle/checkstyle/issues/2285-->
     <suppress checks="IllegalCatch"
               files="Checker.java"
-              lines="278"/>
-    <suppress checks="IllegalCatch"
-              files="Checker.java"
-              lines="388"/>
+              lines="272"/>
     <!--Test to reproduce error catching in Checker and satisfy coverage rate. -->
     <suppress checks="IllegalCatch"
               files="CheckerTest.java"
@@ -149,7 +146,7 @@
 
     <!-- Suppressions from PMD configuration-->
     <!-- validateCli is not reasonable to split as encapsulation of logic will be damaged -->
-    <suppress checks="CyclomaticComplexity" files="Main\.java"  lines="249"/>
+    <suppress checks="CyclomaticComplexity" files="Main\.java"  lines="247"/>
     <!-- JavadocMethodCheck, JavadocStyleCheck, JavadocUtils.getJavadocTags() - deprecated -->
     <suppress checks="CyclomaticComplexity" files="JavadocMethodCheck\.java"/>
     <suppress checks="CyclomaticComplexity" files="JavadocStyleCheck\.java"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -196,15 +196,11 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
         processFiles(files);
 
         // Finish up
-        for (final FileSetCheck fsc : fileSetChecks) {
-            // It may also log!!!
-            fsc.finishProcessing();
-        }
+        // It may also log!!!
+        fileSetChecks.forEach(FileSetCheck::finishProcessing);
 
-        for (final FileSetCheck fsc : fileSetChecks) {
-            // It may also log!!!
-            fsc.destroy();
-        }
+        // It may also log!!!
+        fileSetChecks.forEach(FileSetCheck::destroy);
 
         final int errorCount = counter.getCount();
         fireAuditFinished();
@@ -219,20 +215,18 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
      */
     private Set<String> getExternalResourceLocations() {
         final Set<String> externalResources = Sets.newHashSet();
-        for (FileSetCheck check : fileSetChecks) {
-            if (check instanceof ExternalResourceHolder) {
+        fileSetChecks.stream().filter(check -> check instanceof ExternalResourceHolder)
+            .forEach(check -> {
                 final Set<String> locations =
                     ((ExternalResourceHolder) check).getExternalResourceLocations();
                 externalResources.addAll(locations);
-            }
-        }
-        for (Filter filter : filters.getFilters()) {
-            if (filter instanceof ExternalResourceHolder) {
+            });
+        filters.getFilters().stream().filter(filter -> filter instanceof ExternalResourceHolder)
+            .forEach(filter -> {
                 final Set<String> locations =
                     ((ExternalResourceHolder) filter).getExternalResourceLocations();
                 externalResources.addAll(locations);
-            }
-        }
+            });
         return externalResources;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -167,9 +167,7 @@ public final class Main {
                 if (cliViolations) {
                     exitStatus = exitWithCliViolation;
                     errorCounter = 1;
-                    for (String message : messages) {
-                        System.out.println(message);
-                    }
+                    messages.forEach(System.out::println);
                 }
                 else {
                     errorCounter = runCli(commandLine, filesToProcess);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle;
 import java.lang.reflect.Constructor;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
@@ -129,9 +128,8 @@ public class PackageObjectFactory implements ModuleFactory {
      */
     private Set<String> getAllPossibleNames(String name) {
         final Set<String> names = Sets.newHashSet();
-        for (String packageName : packages) {
-            names.add(packageName + name);
-        }
+        names.addAll(packages.stream().map(packageName -> packageName + name)
+            .collect(Collectors.toList()));
         return names;
     }
 
@@ -142,12 +140,8 @@ public class PackageObjectFactory implements ModuleFactory {
      * @return a string which is obtained by joining package names with a class name.
      */
     private static String joinPackageNamesWithClassName(String className, Set<String> packages) {
-        return packages.stream().filter(new Predicate<String>() {
-            @Override
-            public boolean test(String name) {
-                return name != null;
-            }
-        }).collect(Collectors.joining(className + STRING_SEPARATOR, "", className));
+        return packages.stream().filter(name -> name != null)
+            .collect(Collectors.joining(className + STRING_SEPARATOR, "", className));
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -456,12 +456,8 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
 
     @Override
     public void destroy() {
-        for (AbstractCheck check : ordinaryChecks) {
-            check.destroy();
-        }
-        for (AbstractCheck check : commentChecks) {
-            check.destroy();
-        }
+        ordinaryChecks.forEach(AbstractCheck::destroy);
+        commentChecks.forEach(AbstractCheck::destroy);
         super.destroy();
     }
 
@@ -483,13 +479,11 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
      */
     private static Set<String> getExternalResourceLocations(Set<AbstractCheck> checks) {
         final Set<String> externalConfigurationResources = Sets.newHashSet();
-        for (AbstractCheck check : checks) {
-            if (check instanceof ExternalResourceHolder) {
-                final Set<String> checkExternalResources =
-                    ((ExternalResourceHolder) check).getExternalResourceLocations();
-                externalConfigurationResources.addAll(checkExternalResources);
-            }
-        }
+        checks.stream().filter(check -> check instanceof ExternalResourceHolder).forEach(check -> {
+            final Set<String> checkExternalResources =
+                ((ExternalResourceHolder) check).getExternalResourceLocations();
+            externalConfigurationResources.addAll(checkExternalResources);
+        });
         return externalConfigurationResources;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -55,7 +55,7 @@ public final class LocalizedMessage
      * Avoids repetitive calls to ResourceBundle.getBundle().
      */
     private static final Map<String, ResourceBundle> BUNDLE_CACHE =
-        Collections.synchronizedMap(new HashMap<String, ResourceBundle>());
+        Collections.synchronizedMap(new HashMap<>());
 
     /** The default severity level if one is not specified. */
     private static final SeverityLevel DEFAULT_SEVERITY = SeverityLevel.ERROR;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -258,9 +258,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
                 traverseFieldFrameTree(child);
             }
             currentFrame = child;
-            for (DetailAST methodCall: child.getMethodCalls()) {
-                checkMethodCall(methodCall);
-            }
+            child.getMethodCalls().forEach(this::checkMethodCall);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
@@ -138,13 +138,13 @@ public class EqualsHashCodeCheck
 
     @Override
     public void finishTree(DetailAST rootAST) {
-        for (Map.Entry<DetailAST, DetailAST> detailASTDetailASTEntry : objBlockWithEquals
-                .entrySet()) {
-            if (objBlockWithHashCode.remove(detailASTDetailASTEntry.getKey()) == null) {
+        objBlockWithEquals
+            .entrySet().stream().filter(detailASTDetailASTEntry ->
+                objBlockWithHashCode.remove(detailASTDetailASTEntry.getKey()) == null)
+            .forEach(detailASTDetailASTEntry -> {
                 final DetailAST equalsAST = detailASTDetailASTEntry.getValue();
                 log(equalsAST.getLineNo(), equalsAST.getColumnNo(), MSG_KEY_HASHCODE);
-            }
-        }
+            });
         for (Map.Entry<DetailAST, DetailAST> detailASTDetailASTEntry : objBlockWithHashCode
                 .entrySet()) {
             final DetailAST equalsAST = detailASTDetailASTEntry.getValue();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -314,9 +314,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
         final ScopeData scopeData = scopeStack.peek();
         final Deque<DetailAST> prevScopeUnitializedVariableData =
                 new ArrayDeque<>();
-        for (DetailAST variable : scopeData.uninitializedVariables) {
-            prevScopeUnitializedVariableData.push(variable);
-        }
+        scopeData.uninitializedVariables.forEach(prevScopeUnitializedVariableData::push);
         prevScopeUninitializedVariables.push(prevScopeUnitializedVariableData);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -142,9 +142,7 @@ public class IllegalInstantiationCheck
 
     @Override
     public void finishTree(DetailAST rootAST) {
-        for (DetailAST literalNewAST : instantiations) {
-            postProcessLiteralNew(literalNewAST);
-        }
+        instantiations.forEach(this::postProcessLiteralNew);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -375,15 +375,15 @@ public final class ModifiedControlVariableCheck extends AbstractCheck {
         final DetailAST forIteratorAST = ast.findFirstToken(TokenTypes.FOR_ITERATOR);
         final DetailAST forUpdateListAST = forIteratorAST.findFirstToken(TokenTypes.ELIST);
 
-        for (DetailAST iteratingExpressionAST : findChildrenOfExpressionType(forUpdateListAST)) {
-
-            if (MUTATION_OPERATIONS.contains(iteratingExpressionAST.getType())) {
+        findChildrenOfExpressionType(forUpdateListAST).stream()
+            .filter(iteratingExpressionAST ->
+                MUTATION_OPERATIONS.contains(iteratingExpressionAST.getType()))
+            .forEach(iteratingExpressionAST -> {
                 final DetailAST oneVariableOperatorChild = iteratingExpressionAST.getFirstChild();
                 if (oneVariableOperatorChild.getType() == TokenTypes.IDENT) {
                     iteratorVariables.add(oneVariableOperatorChild.getText());
                 }
-            }
-        }
+            });
 
         return iteratorVariables;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import antlr.collections.AST;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -729,13 +728,9 @@ public class VisibilityModifierCheck
      * @return true if all of generic type arguments are immutable.
      */
     private boolean areImmutableTypeArguments(List<String> typeArgsClassNames) {
-        return !Iterables.tryFind(typeArgsClassNames, new Predicate<String>() {
-            @Override
-            public boolean apply(String typeName) {
-                return !immutableClassShortNames.contains(typeName)
-                    && !immutableClassCanonicalNames.contains(typeName);
-            }
-        }).isPresent();
+        return !Iterables.tryFind(typeArgsClassNames,
+            typeName -> !immutableClassShortNames.contains(typeName)
+            && !immutableClassCanonicalNames.contains(typeName)).isPresent();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
@@ -123,13 +123,10 @@ public class RedundantImportCheck
                     imp.getText());
             }
             // Check for a duplicate import
-            for (FullIdent full : imports) {
-                if (imp.getText().equals(full.getText())) {
-                    log(ast.getLineNo(), ast.getColumnNo(),
-                            MSG_DUPLICATE, full.getLineNo(),
-                            imp.getText());
-                }
-            }
+            imports.stream().filter(full -> imp.getText().equals(full.getText()))
+                .forEach(full -> log(ast.getLineNo(), ast.getColumnNo(),
+                    MSG_DUPLICATE, full.getLineNo(),
+                    imp.getText()));
 
             imports.add(imp);
         }
@@ -138,12 +135,9 @@ public class RedundantImportCheck
             final FullIdent imp =
                 FullIdent.createFullIdent(
                     ast.getLastChild().getPreviousSibling());
-            for (FullIdent full : staticImports) {
-                if (imp.getText().equals(full.getText())) {
-                    log(ast.getLineNo(), ast.getColumnNo(),
-                        MSG_DUPLICATE, full.getLineNo(), imp.getText());
-                }
-            }
+            staticImports.stream().filter(full -> imp.getText().equals(full.getText()))
+                .forEach(full -> log(ast.getLineNo(), ast.getColumnNo(),
+                    MSG_DUPLICATE, full.getLineNo(), imp.getText()));
 
             staticImports.add(imp);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -101,13 +101,11 @@ public class UnusedImportsCheck extends AbstractCheck {
     @Override
     public void finishTree(DetailAST rootAST) {
         // loop over all the imports to see if referenced.
-        for (final FullIdent imp : imports) {
-            if (!referenced.contains(CommonUtils.baseClassName(imp.getText()))) {
-                log(imp.getLineNo(),
-                    imp.getColumnNo(),
-                    MSG_KEY, imp.getText());
-            }
-        }
+        imports.stream()
+            .filter(imp -> !referenced.contains(CommonUtils.baseClassName(imp.getText())))
+            .forEach(imp -> log(imp.getLineNo(),
+                imp.getColumnNo(),
+                MSG_KEY, imp.getText()));
     }
 
     @Override
@@ -238,20 +236,13 @@ public class UnusedImportsCheck extends AbstractCheck {
         final Set<String> references = new HashSet<>();
         // process all the @link type tags
         // INLINE tags inside BLOCKs get hidden when using ALL
-        for (final JavadocTag tag
-                : getValidTags(textBlock, JavadocUtils.JavadocTagType.INLINE)) {
-            if (tag.canReferenceImports()) {
-                references.addAll(processJavadocTag(tag));
-            }
-        }
+        getValidTags(textBlock, JavadocUtils.JavadocTagType.INLINE).stream()
+            .filter(JavadocTag::canReferenceImports)
+            .forEach(tag -> references.addAll(processJavadocTag(tag)));
         // process all the @throws type tags
-        for (final JavadocTag tag
-                : getValidTags(textBlock, JavadocUtils.JavadocTagType.BLOCK)) {
-            if (tag.canReferenceImports()) {
-                references.addAll(
-                        matchPattern(tag.getFirstArg(), FIRST_CLASS_NAME));
-            }
-        }
+        getValidTags(textBlock, JavadocUtils.JavadocTagType.BLOCK).stream()
+            .filter(JavadocTag::canReferenceImports)
+            .forEach(tag -> references.addAll(matchPattern(tag.getFirstArg(), FIRST_CLASS_NAME)));
         return references;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -501,11 +501,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
             }
 
             // Dump out all unused tags
-            for (JavadocTag javadocTag : tags) {
-                if (!javadocTag.isSeeOrInheritDocTag()) {
-                    log(javadocTag.getLineNo(), MSG_UNUSED_TAG_GENERAL);
-                }
-            }
+            tags.stream().filter(javadocTag -> !javadocTag.isSeeOrInheritDocTag())
+                .forEach(javadocTag -> log(javadocTag.getLineNo(), MSG_UNUSED_TAG_GENERAL));
         }
     }
 
@@ -914,14 +911,13 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
         // Now dump out all throws without tags :- unless
         // the user has chosen to suppress these problems
         if (!allowMissingThrowsTags && reportExpectedTags) {
-            for (ExceptionInfo exceptionInfo : throwsList) {
-                if (!exceptionInfo.isFound()) {
+            throwsList.stream().filter(exceptionInfo -> !exceptionInfo.isFound())
+                .forEach(exceptionInfo -> {
                     final Token token = exceptionInfo.getName();
                     log(token.getLineNo(), token.getColumnNo(),
-                            MSG_EXPECTED_TAG,
-                            JavadocTagInfo.THROWS.getText(), token.getText());
-                }
-            }
+                        MSG_EXPECTED_TAG,
+                        JavadocTagInfo.THROWS.getText(), token.getText());
+                });
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -205,9 +205,7 @@ public class JavaNCSSCheck extends AbstractCheck {
         //check if token is countable
         if (isCountable(ast)) {
             //increment the stacked counters
-            for (final Counter counter : counters) {
-                counter.increment();
-            }
+            counters.forEach(Counter::increment);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -241,9 +241,7 @@ public class SuppressWithNearbyCommentFilter
         if (checkC) {
             final Collection<List<TextBlock>> cComments =
                 contents.getCComments().values();
-            for (final List<TextBlock> element : cComments) {
-                tagSuppressions(element);
-            }
+            cComments.forEach(this::tagSuppressions);
         }
         Collections.sort(tags);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -236,9 +236,7 @@ public class SuppressionCommentFilter
         if (checkC) {
             final Collection<List<TextBlock>> cComments = contents
                     .getCComments().values();
-            for (List<TextBlock> element : cComments) {
-                tagSuppressions(element);
-            }
+            cComments.forEach(this::tagSuppressions);
         }
         Collections.sort(tags);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java
@@ -20,8 +20,6 @@
 package com.puppycrawl.tools.checkstyle.gui;
 
 import javax.swing.ListSelectionModel;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
 import javax.swing.tree.DefaultTreeSelectionModel;
 import javax.swing.tree.TreePath;
 
@@ -45,12 +43,8 @@ class ListToTreeSelectionModelWrapper extends DefaultTreeSelectionModel {
      */
     ListToTreeSelectionModelWrapper(JTreeTable jTreeTable) {
         treeTable = jTreeTable;
-        getListSelectionModel().addListSelectionListener(new ListSelectionListener() {
-            @Override
-            public void valueChanged(ListSelectionEvent event) {
-                updateSelectedPathsFromSelectedRows();
-            }
-        });
+        getListSelectionModel().addListSelectionListener(event ->
+            updateSelectedPathsFromSelectedRows());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java
@@ -41,19 +41,16 @@ public final class Main {
      * @param args the command line arguments.
      */
     public static void main(final String... args) {
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                final MainFrame mainFrame = new MainFrame();
+        SwingUtilities.invokeLater(() -> {
+            final MainFrame mainFrame = new MainFrame();
 
-                if (args.length > 0) {
-                    final File sourceFile = new File(args[0]);
-                    mainFrame.openFile(sourceFile);
-                }
-                mainFrame.setTitle("Checkstyle GUI");
-                mainFrame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-                mainFrame.setVisible(true);
+            if (args.length > 0) {
+                final File sourceFile = new File(args[0]);
+                mainFrame.openFile(sourceFile);
             }
+            mainFrame.setTitle("Checkstyle GUI");
+            mainFrame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+            mainFrame.setVisible(true);
         });
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModelAdapter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModelAdapter.java
@@ -113,12 +113,7 @@ public class TreeTableModelAdapter extends AbstractTableModel {
      * processed. SwingUtilities.invokeLater is used to handle this.
      */
     private void delayedFireTableDataChanged() {
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                fireTableDataChanged();
-            }
-        });
+        SwingUtilities.invokeLater(this::fireTableDataChanged);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -41,7 +41,6 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.MapDifference.ValueDifference;
@@ -186,12 +185,7 @@ public class BaseCheckTestSupport {
         // process each of the lines
         final Map<String, List<String>> actualViolations = getActualViolations(errs);
         final Map<String, List<String>> realExpectedViolations =
-            Maps.filterValues(expectedViolations, new Predicate<List<String>>() {
-                @Override
-                public boolean apply(List<String> input) {
-                    return !input.isEmpty();
-                }
-            });
+            Maps.filterValues(expectedViolations, input -> !input.isEmpty());
         final MapDifference<String, List<String>> violationDifferences =
             Maps.difference(realExpectedViolations, actualViolations);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -280,7 +280,7 @@ public class CheckerTest extends BaseCheckTestSupport {
         checker.setSeverity("ignore");
 
         final PackageObjectFactory factory = new PackageObjectFactory(
-                new HashSet<String>(), Thread.currentThread().getContextClassLoader());
+            new HashSet<>(), Thread.currentThread().getContextClassLoader());
         checker.setModuleFactory(factory);
 
         checker.setFileExtensions((String[]) null);
@@ -322,7 +322,7 @@ public class CheckerTest extends BaseCheckTestSupport {
         final Checker checker = new Checker();
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         final PackageObjectFactory factory = new PackageObjectFactory(
-                new HashSet<String>(), Thread.currentThread().getContextClassLoader());
+            new HashSet<>(), Thread.currentThread().getContextClassLoader());
         checker.setModuleFactory(factory);
 
         checker.finishLocalSetup();
@@ -332,7 +332,7 @@ public class CheckerTest extends BaseCheckTestSupport {
     public void testSetupChildExceptions() {
         final Checker checker = new Checker();
         final PackageObjectFactory factory = new PackageObjectFactory(
-                new HashSet<String>(), Thread.currentThread().getContextClassLoader());
+            new HashSet<>(), Thread.currentThread().getContextClassLoader());
         checker.setModuleFactory(factory);
 
         final Configuration config = new DefaultConfiguration("java.lang.String");
@@ -349,7 +349,7 @@ public class CheckerTest extends BaseCheckTestSupport {
     public void testSetupChildListener() throws Exception {
         final Checker checker = new Checker();
         final PackageObjectFactory factory = new PackageObjectFactory(
-                new HashSet<String>(), Thread.currentThread().getContextClassLoader());
+            new HashSet<>(), Thread.currentThread().getContextClassLoader());
         checker.setModuleFactory(factory);
 
         final Configuration config = new DefaultConfiguration(
@@ -452,7 +452,7 @@ public class CheckerTest extends BaseCheckTestSupport {
     public void testWithCacheWithNoViolation() throws Exception {
         final Checker checker = new Checker();
         final PackageObjectFactory factory = new PackageObjectFactory(
-            new HashSet<String>(), Thread.currentThread().getContextClassLoader());
+            new HashSet<>(), Thread.currentThread().getContextClassLoader());
         checker.setModuleFactory(factory);
         checker.configure(createCheckConfig(TranslationCheck.class));
         checker.setCacheFile(temporaryFolder.newFile().getPath());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -144,13 +144,10 @@ public class MainTest {
     public void testVersionPrint()
             throws Exception {
 
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals("Checkstyle version: null" + System.lineSeparator(),
-                        systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("Checkstyle version: null" + System.lineSeparator(),
+                    systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-v");
     }
@@ -159,14 +156,11 @@ public class MainTest {
     public void testWrongArgument()
             throws Exception {
         exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                final String usage = String.format(Locale.ROOT, "Unrecognized option: -w%n")
-                        + USAGE;
-                assertEquals(usage, systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            final String usage = String.format(Locale.ROOT, "Unrecognized option: -w%n")
+                    + USAGE;
+            assertEquals(usage, systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-w");
     }
@@ -175,13 +169,10 @@ public class MainTest {
     public void testNoConfigSpecified()
             throws Exception {
         exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals("Must specify a config XML file." + System.lineSeparator(),
-                        systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("Must specify a config XML file." + System.lineSeparator(),
+                    systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main(getPath("InputMain.java"));
     }
@@ -190,13 +181,10 @@ public class MainTest {
     public void testNonExistingTargetFile()
             throws Exception {
         exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals("Files to process must be specified, found 0."
-                    + System.lineSeparator(), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("Files to process must be specified, found 0."
+                + System.lineSeparator(), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-c", "/google_checks.xml", "NonExistingFile.java");
     }
@@ -205,15 +193,12 @@ public class MainTest {
     public void testNonExistingConfigFile()
             throws Exception {
         exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals(String.format(Locale.ROOT,
-                        "Could not find config XML file "
-                            + "'src/main/resources/non_existing_config.xml'.%n"),
-                        systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals(String.format(Locale.ROOT,
+                    "Could not find config XML file "
+                        + "'src/main/resources/non_existing_config.xml'.%n"),
+                    systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-c", "src/main/resources/non_existing_config.xml",
                 getPath("InputMain.java"));
@@ -222,13 +207,10 @@ public class MainTest {
     @Test
     public void testNonExistingOutputFormat() throws Exception {
         exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals(String.format(Locale.ROOT, "Invalid output format. "
-                        + "Found 'xmlp' but expected 'plain' or 'xml'.%n"), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals(String.format(Locale.ROOT, "Invalid output format. "
+                    + "Found 'xmlp' but expected 'plain' or 'xml'.%n"), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-c", "/google_checks.xml", "-f", "xmlp",
                 getPath("InputMain.java"));
@@ -237,17 +219,14 @@ public class MainTest {
     @Test
     public void testNonExistingClass() throws Exception {
         exit.expectSystemExitWithStatus(-2);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                final String expectedExceptionMessage =
-                        String.format(Locale.ROOT, "Checkstyle ends with 1 errors.%n");
-                assertEquals(expectedExceptionMessage, systemOut.getLog());
+        exit.checkAssertionAfterwards(() -> {
+            final String expectedExceptionMessage =
+                    String.format(Locale.ROOT, "Checkstyle ends with 1 errors.%n");
+            assertEquals(expectedExceptionMessage, systemOut.getLog());
 
-                final String cause = "com.puppycrawl.tools.checkstyle.api.CheckstyleException:"
-                        + " cannot initialize module TreeWalker - ";
-                assertTrue(systemErr.getLog().startsWith(cause));
-            }
+            final String cause = "com.puppycrawl.tools.checkstyle.api.CheckstyleException:"
+                    + " cannot initialize module TreeWalker - ";
+            assertTrue(systemErr.getLog().startsWith(cause));
         });
 
         Main.main("-c", getPath("config-non-existing-classname.xml"),
@@ -257,13 +236,10 @@ public class MainTest {
     @Test
     public void testExistingTargetFile() throws Exception {
 
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals(String.format(Locale.ROOT, "Starting audit...%n"
-                        + "Audit done.%n"), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals(String.format(Locale.ROOT, "Starting audit...%n"
+                    + "Audit done.%n"), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-c", getPath("config-classname.xml"),
                 getPath("InputMain.java"));
@@ -272,22 +248,19 @@ public class MainTest {
     @Test
     public void testExistingTargetFileXmlOutput() throws Exception {
 
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() throws IOException {
-                final String expectedPath = getFilePath("InputMain.java");
-                final ResourceBundle compilationProperties =
-                        ResourceBundle.getBundle("checkstylecompilation", Locale.ROOT);
-                final String version = compilationProperties
-                    .getString("checkstyle.compile.version");
-                assertEquals(String.format(Locale.ROOT,
-                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>%n"
-                        + "<checkstyle version=\"%s\">%n"
-                        + "<file name=\"%s\">%n"
-                        + "</file>%n"
-                        + "</checkstyle>%n", version, expectedPath), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            final String expectedPath = getFilePath("InputMain.java");
+            final ResourceBundle compilationProperties =
+                    ResourceBundle.getBundle("checkstylecompilation", Locale.ROOT);
+            final String version = compilationProperties
+                .getString("checkstyle.compile.version");
+            assertEquals(String.format(Locale.ROOT,
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>%n"
+                    + "<checkstyle version=\"%s\">%n"
+                    + "<file name=\"%s\">%n"
+                    + "</file>%n"
+                    + "</checkstyle>%n", version, expectedPath), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-c", getPath("config-classname.xml"),
                 "-f", "xml",
@@ -297,13 +270,10 @@ public class MainTest {
     @Test
     public void testExistingTargetFilePlainOutput() throws Exception {
 
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals(String.format(Locale.ROOT, "Starting audit...%n"
-                        + "Audit done.%n"), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals(String.format(Locale.ROOT, "Starting audit...%n"
+                    + "Audit done.%n"), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-c", getPath("config-classname.xml"),
                 "-f", "plain",
@@ -312,21 +282,18 @@ public class MainTest {
 
     @Test
     public void testExistingTargetFileWithViolations() throws Exception {
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() throws IOException {
-                final String expectedPath = getFilePath("InputMain.java");
-                assertEquals(String.format(Locale.ROOT, "Starting audit...%n"
-                                + "[WARN] %1$s:3:14: "
-                                + "Name 'InputMain' must match pattern"
-                                + " '^[a-z0-9]*$'. [TypeName]%n"
-                                + "[WARN] %1$s:5:7: "
-                                + "Name 'InputMainInner' must match pattern"
-                                + " '^[a-z0-9]*$'. [TypeName]%n"
-                                + "Audit done.%n", expectedPath),
-                        systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            final String expectedPath = getFilePath("InputMain.java");
+            assertEquals(String.format(Locale.ROOT, "Starting audit...%n"
+                            + "[WARN] %1$s:3:14: "
+                            + "Name 'InputMain' must match pattern"
+                            + " '^[a-z0-9]*$'. [TypeName]%n"
+                            + "[WARN] %1$s:5:7: "
+                            + "Name 'InputMainInner' must match pattern"
+                            + " '^[a-z0-9]*$'. [TypeName]%n"
+                            + "Audit done.%n", expectedPath),
+                    systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-c", getPath("config-classname2.xml"),
                 getPath("InputMain.java"));
@@ -336,19 +303,16 @@ public class MainTest {
     public void testExistingTargetFileWithError()
             throws Exception {
         exit.expectSystemExitWithStatus(2);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() throws IOException {
-                final String expectedPath = getFilePath("InputMain.java");
-                assertEquals(String.format(Locale.ROOT, "Starting audit...%n"
-                        + "[ERROR] %1$s:3:14: "
-                        + "Name 'InputMain' must match pattern '^[a-z0-9]*$'. [TypeName]%n"
-                        + "[ERROR] %1$s:5:7: "
-                        + "Name 'InputMainInner' must match pattern '^[a-z0-9]*$'. [TypeName]%n"
-                        + "Audit done.%n"
-                        + "Checkstyle ends with 2 errors.%n", expectedPath), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            final String expectedPath = getFilePath("InputMain.java");
+            assertEquals(String.format(Locale.ROOT, "Starting audit...%n"
+                    + "[ERROR] %1$s:3:14: "
+                    + "Name 'InputMain' must match pattern '^[a-z0-9]*$'. [TypeName]%n"
+                    + "[ERROR] %1$s:5:7: "
+                    + "Name 'InputMainInner' must match pattern '^[a-z0-9]*$'. [TypeName]%n"
+                    + "Audit done.%n"
+                    + "Checkstyle ends with 2 errors.%n", expectedPath), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-c",
                 getPath("config-classname2-error.xml"),
@@ -359,12 +323,9 @@ public class MainTest {
     public void testExistingTargetFilePlainOutputToNonExistingFile()
             throws Exception {
 
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals("", systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("", systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-c", getPath("config-classname.xml"),
                 "-f", "plain",
@@ -376,12 +337,9 @@ public class MainTest {
     public void testExistingTargetFilePlainOutputToFile()
             throws Exception {
         final File file = temporaryFolder.newFile("file.output");
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals("", systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("", systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-c", getPath("config-classname.xml"),
                 "-f", "plain",
@@ -404,13 +362,10 @@ public class MainTest {
     public void testExistingTargetFilePlainOutputProperties()
             throws Exception {
         //exit.expectSystemExitWithStatus(0);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals(String.format(Locale.ROOT, "Starting audit...%n"
-                        + "Audit done.%n"), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals(String.format(Locale.ROOT, "Starting audit...%n"
+                    + "Audit done.%n"), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-c", getPath("config-classname-prop.xml"),
                 "-p", getPath("mycheckstyle.properties"),
@@ -421,13 +376,10 @@ public class MainTest {
     public void testExistingTargetFilePlainOutputNonexistingProperties()
             throws Exception {
         exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals("Could not find file 'nonexisting.properties'."
-                        + System.lineSeparator(), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("Could not find file 'nonexisting.properties'."
+                    + System.lineSeparator(), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-c", getPath("config-classname-prop.xml"),
                 "-p", "nonexisting.properties",
@@ -438,16 +390,13 @@ public class MainTest {
     public void testExistingIncorrectConfigFile()
             throws Exception {
         exit.expectSystemExitWithStatus(-2);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                final String output = String.format(Locale.ROOT,
-                        "Checkstyle ends with 1 errors.%n");
-                assertEquals(output, systemOut.getLog());
-                final String errorOuput = "com.puppycrawl.tools.checkstyle.api."
-                    + "CheckstyleException: unable to parse configuration stream - ";
-                assertTrue(systemErr.getLog().startsWith(errorOuput));
-            }
+        exit.checkAssertionAfterwards(() -> {
+            final String output = String.format(Locale.ROOT,
+                    "Checkstyle ends with 1 errors.%n");
+            assertEquals(output, systemOut.getLog());
+            final String errorOuput = "com.puppycrawl.tools.checkstyle.api."
+                + "CheckstyleException: unable to parse configuration stream - ";
+            assertTrue(systemErr.getLog().startsWith(errorOuput));
         });
         Main.main("-c", getPath("config-Incorrect.xml"),
             getPath("InputMain.java"));
@@ -457,17 +406,14 @@ public class MainTest {
     public void testExistingIncorrectChildrenInConfigFile()
             throws Exception {
         exit.expectSystemExitWithStatus(-2);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                final String output = String.format(Locale.ROOT,
-                        "Checkstyle ends with 1 errors.%n");
-                assertEquals(output, systemOut.getLog());
-                final String errorOuput = "com.puppycrawl.tools.checkstyle.api."
-                        + "CheckstyleException: cannot initialize module RegexpSingleline"
-                        + " - RegexpSingleline is not allowed as a child in RegexpSingleline";
-                assertTrue(systemErr.getLog().startsWith(errorOuput));
-            }
+        exit.checkAssertionAfterwards(() -> {
+            final String output = String.format(Locale.ROOT,
+                    "Checkstyle ends with 1 errors.%n");
+            assertEquals(output, systemOut.getLog());
+            final String errorOuput = "com.puppycrawl.tools.checkstyle.api."
+                    + "CheckstyleException: cannot initialize module RegexpSingleline"
+                    + " - RegexpSingleline is not allowed as a child in RegexpSingleline";
+            assertTrue(systemErr.getLog().startsWith(errorOuput));
         });
         Main.main("-c", getPath("config-incorrectChildren.xml"),
             getPath("InputMain.java"));
@@ -477,17 +423,14 @@ public class MainTest {
     public void testExistingIncorrectChildrenInConfigFile2()
             throws Exception {
         exit.expectSystemExitWithStatus(-2);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                final String output = String.format(Locale.ROOT,
-                        "Checkstyle ends with 1 errors.%n");
-                assertEquals(output, systemOut.getLog());
-                final String errorOuput = "com.puppycrawl.tools.checkstyle.api."
-                        + "CheckstyleException: cannot initialize module TreeWalker"
-                        + " - JavadocVariable is not allowed as a child in JavadocMethod";
-                assertTrue(systemErr.getLog().startsWith(errorOuput));
-            }
+        exit.checkAssertionAfterwards(() -> {
+            final String output = String.format(Locale.ROOT,
+                    "Checkstyle ends with 1 errors.%n");
+            assertEquals(output, systemOut.getLog());
+            final String errorOuput = "com.puppycrawl.tools.checkstyle.api."
+                    + "CheckstyleException: cannot initialize module TreeWalker"
+                    + " - JavadocVariable is not allowed as a child in JavadocMethod";
+            assertTrue(systemErr.getLog().startsWith(errorOuput));
         });
         Main.main("-c", getPath("config-incorrectChildren2.xml"),
             getPath("InputMain.java"));
@@ -631,21 +574,18 @@ public class MainTest {
     @Test
     public void testFileReferenceDuringException() throws Exception {
         exit.expectSystemExitWithStatus(-2);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                final String expectedExceptionMessage =
-                        String.format(Locale.ROOT, "Starting audit...%n"
-                                + "Checkstyle ends with 1 errors.%n");
-                assertEquals(expectedExceptionMessage, systemOut.getLog());
+        exit.checkAssertionAfterwards(() -> {
+            final String expectedExceptionMessage =
+                    String.format(Locale.ROOT, "Starting audit...%n"
+                            + "Checkstyle ends with 1 errors.%n");
+            assertEquals(expectedExceptionMessage, systemOut.getLog());
 
-                final String exceptionFirstLine = String.format(Locale.ROOT,
-                        "com.puppycrawl.tools.checkstyle.api."
-                        + "CheckstyleException: Exception was thrown while processing "
-                        + new File(getNonCompilablePath("InputIncorrectClass.java")).getPath()
-                        + "%n");
-                assertTrue(systemErr.getLog().startsWith(exceptionFirstLine));
-            }
+            final String exceptionFirstLine = String.format(Locale.ROOT,
+                    "com.puppycrawl.tools.checkstyle.api."
+                    + "CheckstyleException: Exception was thrown while processing "
+                    + new File(getNonCompilablePath("InputIncorrectClass.java")).getPath()
+                    + "%n");
+            assertTrue(systemErr.getLog().startsWith(exceptionFirstLine));
         });
 
         // We put xml as source to cause parse excepion
@@ -657,13 +597,10 @@ public class MainTest {
     public void testPrintTreeOnMoreThanOneFile() throws Exception {
 
         exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals("Printing AST is allowed for only one file."
-                    + System.lineSeparator(), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("Printing AST is allowed for only one file."
+                + System.lineSeparator(), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
 
         Main.main("-t", getPath("checks/metrics"));
@@ -697,12 +634,9 @@ public class MainTest {
             + "    |--LCURLY -> { [5:21]%n"
             + "    `--RCURLY -> } [6:0]%n");
 
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals(expected, systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals(expected, systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-t", getPath("InputMain.java"));
     }
@@ -738,12 +672,9 @@ public class MainTest {
             + "    |--LCURLY -> { [5:21]%n"
             + "    `--RCURLY -> } [6:0]%n");
 
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals(expected, systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals(expected, systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-T", getPath("InputMain.java"));
     }
@@ -754,12 +685,9 @@ public class MainTest {
                 getPath("astprinter/expectedInputJavadocComment.txt")), Charsets.UTF_8)
                     .replaceAll("\\\\r\\\\n", "\\\\n");
 
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals(expected, systemOut.getLog().replaceAll("\\\\r\\\\n", "\\\\n"));
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals(expected, systemOut.getLog().replaceAll("\\\\r\\\\n", "\\\\n"));
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-j", getPath("astprinter/InputJavadocComment.javadoc"));
     }
@@ -770,12 +698,9 @@ public class MainTest {
                 getPath("astprinter/expectedInputAstTreeStringPrinterJavadoc.txt")),
                 Charsets.UTF_8).replaceAll("\\\\r\\\\n", "\\\\n");
 
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals(expected, systemOut.getLog().replaceAll("\\\\r\\\\n", "\\\\n"));
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals(expected, systemOut.getLog().replaceAll("\\\\r\\\\n", "\\\\n"));
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-J", getPath("astprinter/InputAstTreeStringPrinterJavadoc.java"));
     }
@@ -784,13 +709,10 @@ public class MainTest {
     public void testConflictingOptionsTvsC() throws Exception {
 
         exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals("Option '-t' cannot be used with other options."
-                    + System.lineSeparator(), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("Option '-t' cannot be used with other options."
+                + System.lineSeparator(), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
 
         Main.main("-c", "/google_checks.xml", "-t", getPath("checks/metrics"));
@@ -800,13 +722,10 @@ public class MainTest {
     public void testConflictingOptionsTvsP() throws Exception {
 
         exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals("Option '-t' cannot be used with other options."
-                    + System.lineSeparator(), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("Option '-t' cannot be used with other options."
+                + System.lineSeparator(), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
 
         Main.main("-p", getPath("mycheckstyle.properties"), "-t", getPath("checks/metrics"));
@@ -816,13 +735,10 @@ public class MainTest {
     public void testConflictingOptionsTvsF() throws Exception {
 
         exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals("Option '-t' cannot be used with other options."
-                    + System.lineSeparator(), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("Option '-t' cannot be used with other options."
+                + System.lineSeparator(), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
 
         Main.main("-f", "plain", "-t", getPath("checks/metrics"));
@@ -833,13 +749,10 @@ public class MainTest {
         final File file = temporaryFolder.newFile("file.output");
 
         exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals("Option '-t' cannot be used with other options."
-                    + System.lineSeparator(), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("Option '-t' cannot be used with other options."
+                + System.lineSeparator(), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
 
         Main.main("-o", file.getCanonicalPath(), "-t", getPath("checks/metrics"));
@@ -847,25 +760,17 @@ public class MainTest {
 
     @Test
     public void testDebugOption() throws Exception {
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertNotEquals("", systemErr.getLog());
-            }
-        });
+        exit.checkAssertionAfterwards(() -> assertNotEquals("", systemErr.getLog()));
         Main.main("-c", "/google_checks.xml", getPath("InputMain.java"), "-d");
     }
 
     @Test
     public void testExcludeOption() throws Exception {
         exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals("Files to process must be specified, found 0."
-                    + System.lineSeparator(), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("Files to process must be specified, found 0."
+                + System.lineSeparator(), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-c", "/google_checks.xml", getFilePath(""), "-e", getFilePath(""));
     }
@@ -873,13 +778,10 @@ public class MainTest {
     @Test
     public void testExcludeRegexpOption() throws Exception {
         exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(new Assertion() {
-            @Override
-            public void checkAssertion() {
-                assertEquals("Files to process must be specified, found 0."
-                    + System.lineSeparator(), systemOut.getLog());
-                assertEquals("", systemErr.getLog());
-            }
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("Files to process must be specified, found 0."
+                + System.lineSeparator(), systemOut.getLog());
+            assertEquals("", systemErr.getLog());
         });
         Main.main("-c", "/google_checks.xml", getFilePath(""), "-x", ".");
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -39,11 +39,11 @@ import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 public class PackageObjectFactoryTest {
 
     private final PackageObjectFactory factory = new PackageObjectFactory(
-            new HashSet<String>(), Thread.currentThread().getContextClassLoader());
+        new HashSet<>(), Thread.currentThread().getContextClassLoader());
 
     @Test(expected = IllegalArgumentException.class)
     public void testCtorException() {
-        new PackageObjectFactory(new HashSet<String>(), null);
+        new PackageObjectFactory(new HashSet<>(), null);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -157,7 +157,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         treeWalker.setTabWidth(1);
         treeWalker.configure(new DefaultConfiguration("default config"));
         final File file = new File("src/main/resources/checkstyle_packages.xml");
-        treeWalker.processFiltered(file, new ArrayList<String>());
+        treeWalker.processFiltered(file, new ArrayList<>());
     }
 
     @Test
@@ -165,7 +165,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         final TreeWalker treeWalker = new TreeWalker();
         treeWalker.configure(createCheckConfig(TypeNameCheck.class));
         final PackageObjectFactory factory = new PackageObjectFactory(
-                new HashSet<String>(), Thread.currentThread().getContextClassLoader());
+            new HashSet<>(), Thread.currentThread().getContextClassLoader());
         treeWalker.setModuleFactory(factory);
         treeWalker.setupChild(createCheckConfig(TypeNameCheck.class));
         final File file = temporaryFolder.newFile("file.java");
@@ -179,7 +179,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         final TreeWalker treeWalker = new TreeWalker();
         treeWalker.configure(createCheckConfig(TypeNameCheck.class));
         final PackageObjectFactory factory = new PackageObjectFactory(
-                new HashSet<String>(), Thread.currentThread().getContextClassLoader());
+            new HashSet<>(), Thread.currentThread().getContextClassLoader());
         treeWalker.setModuleFactory(factory);
         treeWalker.setupChild(createCheckConfig(TypeNameCheck.class));
         final File file = temporaryFolder.newFile("file.java");
@@ -200,7 +200,7 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         final TreeWalker treeWalker = new TreeWalker();
         treeWalker.configure(createCheckConfig(TypeNameCheck.class));
         final PackageObjectFactory factory = new PackageObjectFactory(
-                new HashSet<String>(), Thread.currentThread().getContextClassLoader());
+            new HashSet<>(), Thread.currentThread().getContextClassLoader());
         treeWalker.setModuleFactory(factory);
         treeWalker.setupChild(createCheckConfig(TypeNameCheck.class));
         final File file = temporaryFolder.newFile("file.java");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.lang.reflect.Method;
 import java.text.MessageFormat;
 import java.util.Locale;
@@ -123,14 +122,9 @@ public class DetailASTTest {
     }
 
     private static void checkDir(File dir) throws Exception {
-        final File[] files = dir.listFiles(new FileFilter() {
-                @Override
-                public boolean accept(File file) {
-                    return (file.getName().endsWith(".java")
-                            || file.isDirectory())
-                        && !file.getName().endsWith("InputGrammar.java");
-                }
-            });
+        final File[] files = dir.listFiles(file -> (file.getName().endsWith(".java")
+                || file.isDirectory())
+            && !file.getName().endsWith("InputGrammar.java"));
         for (File file : files) {
             if (file.isFile()) {
                 checkFile(file.getCanonicalPath());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -49,10 +49,7 @@ public class GenericWhitespaceCheckTest
     public void setUp() {
         checkConfig = createCheckConfig(GenericWhitespaceCheck.class);
         final Map<Class<?>, Integer> x = Maps.newHashMap();
-        for (final Map.Entry<Class<?>, Integer> entry : x.entrySet()) {
-            entry.getValue();
-        }
-        //for (final Entry<Class<?>, Integer> entry : entrySet())
+        x.entrySet().forEach(Map.Entry::getValue);
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -31,6 +30,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -151,14 +151,12 @@ public class AllChecksTest extends BaseCheckTestSupport {
         final Set<String> checksReferencedInConfig = CheckUtil.getConfigCheckStyleChecks();
         final Set<String> checksNames = getSimpleNames(CheckUtil.getCheckstyleChecks());
 
-        for (String check : checksNames) {
-            if (!checksReferencedInConfig.contains(check)) {
+        checksNames.stream().filter(check -> !checksReferencedInConfig.contains(check))
+            .forEach(check -> {
                 final String errorMessage = String.format(Locale.ROOT,
-                        "%s is not referenced in checkstyle_checks.xml", check);
+                    "%s is not referenced in checkstyle_checks.xml", check);
                 Assert.fail(errorMessage);
-            }
-        }
-
+            });
     }
 
     @Test
@@ -166,14 +164,14 @@ public class AllChecksTest extends BaseCheckTestSupport {
         final Set<String> checkstyleModulesNames = getSimpleNames(CheckUtil.getCheckstyleModules());
         final Set<String> modulesNamesWhichHaveXdocs = XDocUtil.getModulesNamesWhichHaveXdoc();
 
-        for (String moduleName : checkstyleModulesNames) {
-            if (!modulesNamesWhichHaveXdocs.contains(moduleName)) {
+        checkstyleModulesNames.stream()
+            .filter(moduleName -> !modulesNamesWhichHaveXdocs.contains(moduleName))
+            .forEach(moduleName -> {
                 final String missingModuleMessage = String.format(Locale.ROOT,
                     "Module %s does not have xdoc documentation.",
                     moduleName);
                 Assert.fail(missingModuleMessage);
-            }
-        }
+            });
     }
 
     @Test
@@ -295,10 +293,7 @@ public class AllChecksTest extends BaseCheckTestSupport {
      * @return a set of simple names.
      */
     private static Set<String> getSimpleNames(Set<Class<?>> checks) {
-        final Set<String> checksNames = new HashSet<>();
-        for (Class<?> check : checks) {
-            checksNames.add(check.getSimpleName().replace("Check", ""));
-        }
-        return checksNames;
+        return checks.stream().map(check -> check.getSimpleName().replace("Check", ""))
+            .collect(Collectors.toSet());
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
@@ -408,11 +408,9 @@ public class XDocsPagesTest {
         }
 
         // remove undocumented properties
-        for (String p : new HashSet<>(properties)) {
-            if (UNDOCUMENTED_PROPERTIES.contains(clss.getSimpleName() + "." + p)) {
-                properties.remove(p);
-            }
-        }
+        new HashSet<>(properties).stream()
+            .filter(p -> UNDOCUMENTED_PROPERTIES.contains(clss.getSimpleName() + "." + p))
+            .forEach(properties::remove);
 
         if (AbstractCheck.class.isAssignableFrom(clss)) {
             final AbstractCheck check = (AbstractCheck) instance;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
@@ -198,12 +198,8 @@ public class CommonUtilsTest {
 
     @Test(expected = IllegalStateException.class)
     public void testCloseWithException() {
-        CommonUtils.close(new Closeable() {
-
-            @Override
-            public void close() throws IOException {
-                throw new IOException("Test IOException");
-            }
+        CommonUtils.close(() -> {
+            throw new IOException("Test IOException");
         });
     }
 


### PR DESCRIPTION
Issue #3233 

This change reverts commits 015fa7f and 6c1a0e1 and fixes violations of respective rules.

I got two Checkstyle violations which seemed unrelated to my changes (and caused by legitimate code), so I suppressed them using `SuppressWarnings` syntax. Please let me know if there is a different preferred way to deal with them.