### PR TITLE
Issue #2999: allow regex in importcontrol and subpackage element

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE import-control PUBLIC
-    "-//Puppy Crawl//DTD Import Control 1.1//EN"
-    "http://www.puppycrawl.com/dtds/import_control_1_1.dtd">
+    "-//Puppy Crawl//DTD Import Control 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd">
 
 <import-control pkg="com.puppycrawl.tools.checkstyle">
 
@@ -110,7 +110,7 @@
 
   <subpackage name="doclets">
     <allow pkg="com.sun.javadoc"/>
-    <disallow pkg="com.puppycrawl.tools.checkstyle.(checks|ant|filters|gui)" regex="true"/>
+    <disallow pkg="com\.puppycrawl\.tools\.checkstyle\.(checks|ant|filters|gui)" regex="true"/>
   </subpackage>
 
   <subpackage name="filters">
@@ -119,15 +119,15 @@
     <allow class="com.google.common.base.CaseFormat" local-only="true"/>
     <allow class="com.google.common.collect.ImmutableCollection" local-only="true"/>
     <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
-    <!-- is not possible till pkg is not a regexp -->
-    <!-- <disallow pkg="com.puppycrawl.tools.checkstyle.checks.*"/> -->
-    <disallow pkg="com.puppycrawl.tools.checkstyle.(ant|doclets|gui)" regex="true"/>
+    <!-- check's subpackages -->
+    <disallow pkg="com\.puppycrawl\.tools\.checkstyle\.checks\.[^.]+" regex="true"/>
+    <disallow pkg="com\.puppycrawl\.tools\.checkstyle\.(ant|doclets|gui)" regex="true"/>
   </subpackage>
 
   <subpackage name="gui">
     <allow pkg="java.awt"/>
     <allow pkg="javax.swing"/>
-    <disallow pkg="com.puppycrawl.tools.checkstyle.(checks|ant|doclets|filters)" regex="true"/>
+    <disallow pkg="com\.puppycrawl\.tools\.checkstyle\.(checks|ant|doclets|filters)" regex="true"/>
   </subpackage>
 
   <subpackage name="internal">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -96,11 +96,13 @@ final class ImportControlLoader extends AbstractLoader {
             throws SAXException {
         if ("import-control".equals(qName)) {
             final String pkg = safeGet(attributes, PKG_ATTRIBUTE_NAME);
-            stack.push(new PkgControl(pkg));
+            final boolean regex = containsRegexAttribute(attributes);
+            stack.push(new PkgControl(pkg, regex));
         }
         else if (SUBPACKAGE_ELEMENT_NAME.equals(qName)) {
             final String name = safeGet(attributes, "name");
-            stack.push(new PkgControl(stack.peek(), name));
+            final boolean regex = containsRegexAttribute(attributes);
+            stack.push(new PkgControl(stack.peek(), name, regex));
         }
         else if (ALLOW_ELEMENT_NAME.equals(qName) || "disallow".equals(qName)) {
             // Need to handle either "pkg" or "class" attribute.
@@ -109,7 +111,7 @@ final class ImportControlLoader extends AbstractLoader {
             final boolean isAllow = ALLOW_ELEMENT_NAME.equals(qName);
             final boolean isLocalOnly = attributes.getValue("local-only") != null;
             final String pkg = attributes.getValue(PKG_ATTRIBUTE_NAME);
-            final boolean regex = attributes.getValue("regex") != null;
+            final boolean regex = containsRegexAttribute(attributes);
             final Guard guard;
             if (pkg == null) {
                 // handle class names which can be normal class names or regular
@@ -126,6 +128,15 @@ final class ImportControlLoader extends AbstractLoader {
             final PkgControl pkgControl = stack.peek();
             pkgControl.addGuard(guard);
         }
+    }
+
+    /**
+     * Check if the given attributes contain the regex attribute.
+     * @param attributes the attributes.
+     * @return if the regex attribute is contained.
+     */
+    private static boolean containsRegexAttribute(final Attributes attributes) {
+        return attributes.getValue("regex") != null;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControl.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Represents the a tree of guards for controlling whether packages are allowed
@@ -32,6 +33,12 @@ import java.util.List;
  * @author Oliver Burn
  */
 class PkgControl {
+    /** The package separator: "." */
+    private static final String DOT = ".";
+    /** A pattern matching the package separator: "." */
+    private static final Pattern DOT_PATTERN = Pattern.compile(DOT, Pattern.LITERAL);
+    /** The regex for the package separator: "\\.". */
+    private static final String DOT_REGEX = "\\.";
     /** List of {@link Guard} objects to check. */
     private final Deque<Guard> guards = new LinkedList<>();
     /** List of children {@link PkgControl} objects. */
@@ -40,25 +47,136 @@ class PkgControl {
     private final PkgControl parent;
     /** The full package name for the node. */
     private final String fullPackage;
+    /**
+     * The regex pattern for partial match (exact and for subpackages) - only not
+     * null if regex is true.
+     */
+    private final Pattern patternForPartialMatch;
+    /** The regex pattern for exact matches - only not null if regex is true. */
+    private final Pattern patternForExactMatch;
+    /** If this package represents a regular expression. */
+    private final boolean regex;
 
     /**
      * Construct a root node.
      * @param pkgName the name of the package.
+     * @param regex flags interpretation of pkgName as regex pattern.
      */
-    PkgControl(final String pkgName) {
+    PkgControl(final String pkgName, final boolean regex) {
         parent = null;
-        fullPackage = pkgName;
+        this.regex = regex;
+        if (regex) {
+            // ensure that fullPackage is a self-contained regular expression
+            fullPackage = encloseInGroup(pkgName);
+            patternForPartialMatch = createPatternForPartialMatch(fullPackage);
+            patternForExactMatch = createPatternForExactMatch(fullPackage);
+        }
+        else {
+            fullPackage = pkgName;
+            patternForPartialMatch = null;
+            patternForExactMatch = null;
+        }
     }
 
     /**
-     * Construct a child node.
+     * Construct a child node. The concatenation of regular expressions needs special care:
+     * see {@link #ensureSelfContainedRegex(String, boolean)} for more details.
      * @param parent the parent node.
      * @param subPkg the sub package name.
+     * @param regex flags interpretation of subPkg as regex pattern.
      */
-    PkgControl(final PkgControl parent, final String subPkg) {
+    PkgControl(final PkgControl parent, final String subPkg, final boolean regex) {
         this.parent = parent;
-        fullPackage = parent.fullPackage + "." + subPkg;
+        if (regex || parent.regex) {
+            // regex gets inherited
+            final String parentRegex = ensureSelfContainedRegex(parent.fullPackage, parent.regex);
+            final String thisRegex = ensureSelfContainedRegex(subPkg, regex);
+            fullPackage = parentRegex + DOT_REGEX + thisRegex;
+            patternForPartialMatch = createPatternForPartialMatch(fullPackage);
+            patternForExactMatch = createPatternForExactMatch(fullPackage);
+            this.regex = true;
+        }
+        else {
+            fullPackage = parent.fullPackage + DOT + subPkg;
+            patternForPartialMatch = null;
+            patternForExactMatch = null;
+            this.regex = false;
+        }
         parent.children.add(this);
+    }
+
+    /**
+     * Returns a regex that is suitable for concatenation by 1) either converting a plain string
+     * into a regular expression (handling special characters) or 2) by enclosing {@code input} in
+     * a (non-capturing) group if {@code input} already is a regular expression.
+     *
+     * <p>1) When concatenating a non-regex package component (like "org.google") with a regex
+     * component (like "[^.]+") the other component has to be converted into a regex too, see
+     * {@link #toRegex(String)}.
+     *
+     * <p>2) The grouping is strictly necessary if a) {@code input} is a regular expression that b)
+     * contains the alteration character ('|') and if c) the pattern is not already enclosed in a
+     * group - as you see in this example: {@code parent="com|org", child="common|uncommon"} will
+     * result in the pattern {@code "(?:org|com)\.(?common|uncommon)"} what will match
+     * {@code "com.common"}, {@code "com.uncommon"}, {@code "org.common"}, and {@code
+     * "org.uncommon"}. Without the grouping it would be {@code "com|org.common|uncommon"} which
+     * would match {@code "com"}, {@code "org.common"}, and {@code "uncommon"}, which clearly is
+     * undesirable. Adding the group fixes this.
+     *
+     * <p>For simplicity the grouping is added to regular expressions unconditionally.
+     *
+     * @param input the input string.
+     * @param alreadyRegex signals if input already is a regular expression.
+     * @return a regex string.
+     */
+    private static String ensureSelfContainedRegex(final String input, final boolean alreadyRegex) {
+        final String result;
+        if (alreadyRegex) {
+            result = encloseInGroup(input);
+        }
+        else {
+            result = toRegex(input);
+        }
+        return result;
+    }
+
+    /**
+     * Enclose {@code expression} in a (non-capturing) group.
+     * @param expression the input regular expression
+     * @return a grouped pattern.
+     */
+    private static String encloseInGroup(String expression) {
+        return "(?:" + expression + ")";
+    }
+
+    /**
+     * Converts a normal package name into a regex pattern by escaping all
+     * special characters that may occur in a java package name.
+     * @param input the input string.
+     * @return a regex string.
+     */
+    private static String toRegex(String input) {
+        return DOT_PATTERN.matcher(input).replaceAll(DOT_REGEX);
+    }
+
+    /**
+     * Creates a Pattern from {@code expression} that matches exactly and child packages.
+     * @param expression a self-contained regular expression matching the full package exactly.
+     * @return a Pattern.
+     */
+    private static Pattern createPatternForPartialMatch(String expression) {
+        // javadoc of encloseInGroup() explains how to concatenate regular expressions
+        // no grouping needs to be added to fullPackage since this already have been done.
+        return Pattern.compile(expression + "(?:\\..*)?");
+    }
+
+    /**
+     * Creates a Pattern from {@code expression}.
+     * @param expression a self-contained regular expression matching the full package exactly.
+     * @return a Pattern.
+     */
+    private static Pattern createPatternForExactMatch(String expression) {
+        return Pattern.compile(expression);
     }
 
     /**
@@ -77,9 +195,7 @@ class PkgControl {
     public PkgControl locateFinest(final String forPkg) {
         PkgControl finestMatch = null;
         // Check if we are a match.
-        // This algorithm should be improved to check for a trailing "."
-        // or nothing following.
-        if (forPkg.startsWith(fullPackage)) {
+        if (matchesAtFront(forPkg)) {
             // If there won't be match so I am the best there is.
             finestMatch = this;
             // Check if any of the children match.
@@ -92,6 +208,34 @@ class PkgControl {
             }
         }
         return finestMatch;
+    }
+
+    /**
+     * Matches other package name exactly or partially at front.
+     * @param pkg the package to compare with.
+     * @return if it matches.
+     */
+    private boolean matchesAtFront(final String pkg) {
+        final boolean result;
+        if (regex) {
+            result = patternForPartialMatch.matcher(pkg).matches();
+        }
+        else {
+            result = matchesAtFrontNoRegex(pkg);
+        }
+        return result;
+    }
+
+    /**
+     * Non-regex case. Ensure a trailing dot for subpackages, i.e. "com.puppy"
+     * will match "com.puppy.crawl" but not "com.puppycrawl.tools".
+     * @param pkg the package to compare with.
+     * @return if it matches.
+     */
+    private boolean matchesAtFrontNoRegex(final String pkg) {
+        return pkg.startsWith(fullPackage)
+                && (pkg.length() == fullPackage.length()
+                    || pkg.charAt(fullPackage.length()) == '.');
     }
 
     /**
@@ -131,7 +275,7 @@ class PkgControl {
         final String inPkg) {
         for (Guard g : guards) {
             // Check if a Guard is only meant to be applied locally.
-            if (g.isLocalOnly() && !fullPackage.equals(inPkg)) {
+            if (g.isLocalOnly() && !matchesExactly(inPkg)) {
                 continue;
             }
             final AccessResult result = g.verifyImport(forImport);
@@ -140,5 +284,21 @@ class PkgControl {
             }
         }
         return AccessResult.UNKNOWN;
+    }
+
+    /**
+     * Check for equality of this with pkg
+     * @param pkg the package to compare with.
+     * @return if it matches.
+     */
+    private boolean matchesExactly(final String pkg) {
+        final boolean result;
+        if (regex) {
+            result = patternForExactMatch.matcher(pkg).matches();
+        }
+        else {
+            result = fullPackage.equals(pkg);
+        }
+        return result;
     }
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_2.dtd
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_2.dtd
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Add the following to any file that is to be validated against this DTD:
+
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Import Control 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd">
+-->
+
+<!--
+  The root element of the configuration file.
+-->
+<!ELEMENT import-control ((allow|disallow)*,subpackage*)>
+
+<!--
+  pkg - The root package to be checked. For example "com.puppycrawl".
+-->
+<!ATTLIST import-control
+  pkg CDATA #REQUIRED
+  regex (true) #IMPLIED>
+
+<!--
+  Represents a subpackage of the parent element.
+-->
+<!ELEMENT subpackage ((allow|disallow)*,subpackage*)>
+
+<!--
+  name - The name of the subpackage. For example if the name is "tools"
+  and the pa the parent is "com.puppycrawl", then it corresponds to the
+  package "com.puppycrawl.tools". If the regex attribute is "true" the
+  name is interpreted as a regular expression.
+-->
+<!ATTLIST subpackage
+  name CDATA #REQUIRED
+  regex (true) #IMPLIED>
+
+<!--
+  Represents attributes for a guard which can either allow or disallow
+  access.
+
+  pkg - The fully qualified name of the package to guard. Cannot be
+  specified in conjunction with "class".
+
+  class - The fully qualified name of the class to guard. Cannot be
+  specified in conjunction with "pkg".
+
+  exact-match - Only valid with "pkg". Specifies whether the package
+  name matching should be exact. For example, the pkg
+  "com.puppycrawl.tools" will match the import
+  "com.puppycrawl.tools.checkstyle.api.*" when the option is not set,
+  but will not match is the option is set.
+
+  local-only - Indicates that the guard is to apply only to the current
+  package and not to subpackages.
+
+  regex - Indicates that the class or package name has to be interpreted as
+  regular expression.
+-->
+<!ENTITY % attlist.guard "
+  pkg CDATA #IMPLIED
+  exact-match (true) #IMPLIED
+  class CDATA #IMPLIED
+  local-only (true) #IMPLIED
+  regex (true) #IMPLIED">
+
+<!--
+  Represents a guard that will allow access.
+-->
+<!ELEMENT allow EMPTY>
+<!ATTLIST allow
+  %attlist.guard;>
+
+<!--
+  Represents a guard that will disallow access.
+-->
+<!ELEMENT disallow EMPTY>
+<!ATTLIST disallow
+  %attlist.guard;>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -178,6 +178,30 @@ public class ImportControlCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
+    public void testPkgRegExpInParent() throws Exception {
+        testRegExpInPackage("import-control_pkg-re-in-parent.xml");
+    }
+
+    @Test
+    public void testPkgRegExpInChild() throws Exception {
+        testRegExpInPackage("import-control_pkg-re-in-child.xml");
+    }
+
+    @Test
+    public void testPkgRegExpInBoth() throws Exception {
+        testRegExpInPackage("import-control_pkg-re-in-both.xml");
+    }
+
+    // all import-control_pkg-re* files should be equivalent so use one test for all
+    private void testRegExpInPackage(String file) throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ImportControlCheck.class);
+        checkConfig.addAttribute("file", getPath(file));
+        final String[] expected = {"5:1: " + getCheckMessage(MSG_DISALLOWED, "java.io.File")};
+
+        verify(checkConfig, getPath("InputImportControl.java"), expected);
+    }
+
+    @Test
     public void testGetAcceptableTokens() {
         final ImportControlCheck testCheckObject =
                 new ImportControlCheck();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControlRegExpInPkgTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControlRegExpInPkgTest.java
@@ -1,0 +1,92 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.imports;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class PkgControlRegExpInPkgTest {
+    private final PkgControl pcRoot = new PkgControl("com\\.[^.]+\\.courtlink", true);
+    private final PkgControl pcCommon = new PkgControl(pcRoot, "com+on", true);
+
+    @Test
+    public void testRegExpInRootIsConsidered() {
+        assertNull(pcRoot.locateFinest("com"));
+        assertNull(pcRoot.locateFinest("com/hurz/courtlink"));
+        assertNull(pcRoot.locateFinest("com.hurz.hurz.courtlink"));
+        assertEquals(pcRoot, pcRoot
+                .locateFinest("com.hurz.courtlink.domain"));
+        assertEquals(pcRoot, pcRoot
+                .locateFinest("com.kazgroup.courtlink.domain"));
+    }
+
+    @Test
+    public void testRegExpInSubpackageIsConsidered() {
+        assertEquals(pcCommon, pcRoot
+                .locateFinest("com.kazgroup.courtlink.common.api"));
+        assertEquals(pcCommon, pcRoot
+                .locateFinest("com.kazgroup.courtlink.comon.api"));
+    }
+
+    @Test
+    public void testEnsureTrailingDot() {
+        assertNull(pcRoot.locateFinest("com.kazgroup.courtlinkkk"));
+        assertNull(pcRoot.locateFinest("com.kazgroup.courtlink/common.api"));
+    }
+
+    @Test
+    public void testAlternationInParentIsHandledCorrectly() {
+        // the regular expression has to be adjusted to (com\.foo|com\.bar)
+        final PkgControl root = new PkgControl("com\\.foo|com\\.bar", true);
+        final PkgControl common = new PkgControl(root, "common", false);
+        assertEquals(root, root.locateFinest("com.foo"));
+        assertEquals(common, root.locateFinest("com.foo.common"));
+        assertEquals(root, root.locateFinest("com.bar"));
+        assertEquals(common, root.locateFinest("com.bar.common"));
+    }
+
+    @Test
+    public void testAlternationInParentIfUserCaresForIt() {
+        // the regular expression has to be adjusted to (com\.foo|com\.bar)
+        final PkgControl root = new PkgControl("(com\\.foo|com\\.bar)", true);
+        final PkgControl common = new PkgControl(root, "common", false);
+        assertEquals(root, root.locateFinest("com.foo"));
+        assertEquals(common, root.locateFinest("com.foo.common"));
+        assertEquals(root, root.locateFinest("com.bar"));
+        assertEquals(common, root.locateFinest("com.bar.common"));
+    }
+
+    @Test
+    public void testAlternationInSubpackageIsHandledCorrectly() {
+        final PkgControl root = new PkgControl("org.somewhere", false);
+        // the regular expression has to be adjusted to (foo|bar)
+        final PkgControl subpackages = new PkgControl(root, "foo|bar", true);
+        assertEquals(root, root.locateFinest("org.somewhere"));
+        assertEquals(subpackages, root.locateFinest("org.somewhere.foo"));
+        assertEquals(subpackages, root.locateFinest("org.somewhere.bar"));
+    }
+
+    @Test
+    public void testUnknownPkg() {
+        assertNull(pcRoot.locateFinest("net.another"));
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControlRegExpTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControlRegExpTest.java
@@ -26,8 +26,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class PkgControlRegExpTest {
-    private final PkgControl pcRoot = new PkgControl("com.kazgroup.courtlink");
-    private final PkgControl pcCommon = new PkgControl(pcRoot, "common");
+    private final PkgControl pcRoot = new PkgControl("com.kazgroup.courtlink", false);
+    private final PkgControl pcCommon = new PkgControl(pcRoot, "common", false);
 
     @Before
     public void setUp() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControlTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControlTest.java
@@ -26,8 +26,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class PkgControlTest {
-    private final PkgControl pcRoot = new PkgControl("com.kazgroup.courtlink");
-    private final PkgControl pcCommon = new PkgControl(pcRoot, "common");
+    private final PkgControl pcRoot = new PkgControl("com.kazgroup.courtlink", false);
+    private final PkgControl pcCommon = new PkgControl(pcRoot, "common", false);
 
     @Before
     public void setUp() {
@@ -45,6 +45,12 @@ public class PkgControlTest {
         assertEquals(pcCommon, pcRoot
                 .locateFinest("com.kazgroup.courtlink.common.api"));
         assertNull(pcRoot.locateFinest("com"));
+    }
+
+    @Test
+    public void testEnsureTrailingDot() {
+        assertNull(pcRoot.locateFinest("com.kazgroup.courtlinkkk"));
+        assertNull(pcRoot.locateFinest("com.kazgroup.courtlink/common.api"));
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_pkg-re-in-both.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_pkg-re-in-both.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE import-control PUBLIC
+    "-//Puppy Crawl//DTD Import Control 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd">
+
+<import-control pkg="com\.puppycrawl\.[^.]*\.checkstyle\.[^.]*" regex="true">
+  <allow class="java.awt.Image"/>
+  <allow class="java.awt.Button.ABORT"/>
+  <allow class="java.io.File" local-only="true"/>
+  <subpackage name="imp.rts" regex="true">
+    <allow pkg="javax.swing"/>
+  </subpackage>
+</import-control>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_pkg-re-in-child.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_pkg-re-in-child.xml
@@ -4,10 +4,10 @@
     "http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd">
 
 <import-control pkg="com.puppycrawl.tools.checkstyle.checks">
-  <allow class="java\.awt.Image" regex="true"/>
-  <allow class="java..*.Button.ABORT" regex="true"/>
-  <allow class="java.(io|lui).File" local-only="true" regex="true"/>
-  <subpackage name="imports">
-    <allow pkg="javax.swing" regex="true"/>
+  <allow class="java.awt.Image"/>
+  <allow class="java.awt.Button.ABORT"/>
+  <allow class="java.io.File" local-only="true"/>
+  <subpackage name="imp.rts" regex="true">
+    <allow pkg="javax.swing"/>
   </subpackage>
 </import-control>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_pkg-re-in-parent.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_pkg-re-in-parent.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE import-control PUBLIC
+    "-//Puppy Crawl//DTD Import Control 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd">
+
+<import-control pkg="com\.puppycrawl\.[^.]*\.checkstyle\.[^.]*" regex="true">
+  <allow class="java.awt.Image"/>
+  <allow class="java.awt.Button.ABORT"/>
+  <allow class="java.io.File" local-only="true"/>
+  <subpackage name="imports">
+    <allow pkg="javax.swing"/>
+  </subpackage>
+</import-control>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_two-re.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_two-re.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE import-control PUBLIC
-    "-//Puppy Crawl//DTD Import Control 1.1//EN"
-    "http://www.puppycrawl.com/dtds/import_control_1_1.dtd">
+    "-//Puppy Crawl//DTD Import Control 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd">
 
 <import-control pkg="com.puppycrawl.tools.checkstyle.checks">
   <allow class="java\.awt\.Image" regex="true"/>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -677,8 +677,8 @@ import android.*;
 
         <p>
           The DTD for a import control XML document is at <a
-          href="http://www.puppycrawl.com/dtds/import_control_1_1.dtd">
-          http://www.puppycrawl.com/dtds/import_control_1_1.dtd</a>. It
+          href="http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd">
+          http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd</a>. It
           contains documentation on each of the elements and attributes.
         </p>
 
@@ -690,8 +690,8 @@ import android.*;
 
         <pre>
 &lt;!DOCTYPE import-control PUBLIC
-    &quot;-//Puppy Crawl//DTD Import Control 1.1//EN&quot;
-    &quot;http://www.puppycrawl.com/dtds/import_control_1_1.dtd&quot;&gt;
+    &quot;-//Puppy Crawl//DTD Import Control 1.2//EN&quot;
+    &quot;http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd&quot;&gt;
         </pre>
       </subsection>
 
@@ -735,25 +735,107 @@ import android.*;
         </source>
 
         <p>
-          In the example below, all classes beginning with an I in the package
-          java.awt are allowed. In the package java.io only the classes File
-          and InputStream are allowed.
+            In the example below access to package
+            <code>com.puppycrawl.tools.checkstyle.checks</code> and its subpackages is
+            allowed from anywhere in <code>com.puppycrawl.tools.checkstyle</code> except
+            from the <code>filters</code> subpackage where access to all
+            <code>check</code>'s subpackages is disallowed. Two <code>java.lang.ref</code>
+            classes are allowed by virtue of one regular expression instead of listing
+            them in two separate allow rules (as it is done with the <code>Files</code>
+            and <code>ClassPath</code> classes).
         </p>
 
         <source>
 &lt;import-control pkg=&quot;com.puppycrawl.tools.checkstyle&quot;&gt;
-    &lt;allow class=&quot;java\.awt\.I.*&quot; regex=&quot;true&quot;/&gt;
-    &lt;allow class=&quot;java\.io\.(File|InputStream)&quot; local-only=&quot;true&quot;
-        regex=&quot;true&quot;/&gt;
+    &lt;allow pkg=&quot;com.puppycrawl.tools.checkstyle.api&quot;/&gt;
+    &lt;allow pkg=&quot;com.puppycrawl.tools.checkstyle.checks&quot;/&gt;
+    &lt;allow class=&quot;com.google.common.io.Files&quot;/&gt;
+    &lt;allow class=&quot;com.google.common.reflect.ClassPath&quot;/&gt;
+    &lt;subpackage name=&quot;filters&quot;&gt;
+        &lt;allow class=&quot;java\.lang\.ref\.(Weak|Soft)Reference&quot;
+            regex=&quot;true&quot;/&gt;
+        &lt;disallow pkg=&quot;com\.puppycrawl\.tools\.checkstyle\.checks\.[^.]+&quot;
+            regex=&quot;true&quot;/&gt;
+        &lt;disallow pkg=&quot;com.puppycrawl.tools.checkstyle.ant&quot;/&gt;
+        &lt;disallow pkg=&quot;com.puppycrawl.tools.checkstyle.doclets&quot;/&gt;
+        &lt;disallow pkg=&quot;com.puppycrawl.tools.checkstyle.gui&quot;/&gt;
+    &lt;/subpackage&gt;
 &lt;/import-control&gt;
         </source>
 
         <p>
-          For an example import control file, look at the file called <a
+          In the next example regular expressions are used to enforce a layering rule: In all
+          <code>dao</code> packages it is not allowed to access UI layer code (<code>ui</code>,
+          <code>awt</code>, and <code>swing</code>). On the other hand it is not allowed to directly
+          access <code>dao</code> and <code>service</code> layer from <code>ui</code> packages. The
+          root package is also a regular expression that is used to handle old and new domain name
+          with the same rules.
+        </p>
+
+        <source>
+&lt;import-control pkg=&quot;(de.olddomain|de.newdomain)\..*&quot; regex=&quot;true&quot;&gt;
+    &lt;subpackage pkg=&quot;[^.]+\.dao&quot; regex=&quot;true&quot;&gt;
+        &lt;disallow pkg=&quot;.*\.ui&quot; regex=&quot;true&quot;/&gt;
+        &lt;disallow pkg=&quot;.*\.(awt|swing).\.*&quot; regex=&quot;true&quot;/&gt;
+    &lt;/subpackage&gt;
+    &lt;subpackage pkg=&quot;[^.]+\.ui&quot; regex=&quot;true&quot;&gt;
+        &lt;disallow pkg=&quot;.*\.(dao|service)&quot; regex=&quot;true&quot;/&gt;
+    &lt;/subpackage&gt;
+&lt;/import-control&gt;
+        </source>
+
+        <p>
+          For a real-life import control file look at the file called <a
           href="https://github.com/checkstyle/checkstyle/blob/master/config/import-control.xml">
           import-control.xml</a>
           which is part of the Checkstyle distribution.
         </p>
+
+        <h4 id="regex-notes">Notes on regular expressions</h4>
+        <p>
+          Regular expressions in import rules have to match either Java packages or
+          classes. The language rules for packages and class names can be described by the
+          following complicated regular expression that takes into account that Java names may
+          contain any unicode letter, numbers, underscores, and dollar signs (see section 3.8
+          in the <a href="http://docs.oracle.com/javase/specs/">Java specs</a>):
+        </p>
+        <ul>
+          <li>
+            <code>[\p{Letter}_$][\p{Letter}\p{Number}_$]*</code> or short
+            <code>[\p{L}_$][\p{L}\p{N}_$]*</code> for a class name or package component.
+          </li>
+          <li>
+            <code>([\p{L}_$][\p{L}\p{N}_$]*\.)*[\p{L}_$][\p{L}\p{N}_$]*</code>
+            for a fully qualified name.
+          </li>
+        </ul>
+        <p>
+          But it is not necessary to use these complicated expressions since no validation is
+          required. Differentiating between package separator '.' and others is
+          sufficient. Unfortunately '.' has a special meaning in regular expressions so one has
+          to write <code>\.</code> to match an actual dot.
+        </p>
+        <ul>
+          <li>
+            Use <code>[^.]+</code> (one or more "not a dot" characters) for a class name or
+            package component.
+          </li>
+          <li>
+            Use <code>com\.google\.common\.[^.]+</code> to match any subpackage of
+            <code>com.google.common</code>.
+          </li>
+          <li>
+            When matching concrete packages like <code>com.google.common</code> omitting the
+            backslash before the dots may improve readability and may be just exact enough:
+            <code>com.google.common\.[^.]+</code> matches not only subpackages of
+            <code>com.google.common</code> but e.g. also of <code>com.googleecommon</code> but
+            you may not care for that.
+          </li>
+          <li>
+            Do not use <code>.*</code> unless you really do not care for what is matched. Often
+            you want to match only a certain package level instead.
+          </li>
+        </ul>
       </subsection>
 
       <subsection name="Example of Usage">


### PR DESCRIPTION
This pull request fixes Issue #2999. Notes:
* I have added the possibility to define packages not only to the `subpackage` element but also to the root element `importcontrol`.
* The travis will continue to fail until the new DTD [import_control_1_2.dtd](https://github.com/vboerchers/checkstyle/blob/master/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_2.dtd) is available as http://www.puppycrawl.com/dtds/import_control_1_2.dtd