### PR TITLE
Issue #3376: Ignore pattern for MethodLength

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
@@ -86,4 +86,31 @@ public class MethodLengthCheckTest extends BaseCheckTestSupport {
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputModifier.java"), expected);
     }
+
+    @Test
+    public void testWithoutIgnorePattern()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(MethodLengthCheck.class);
+        checkConfig.addAttribute("max", "18");
+        final String[] expected = {
+            "79:5: " + getCheckMessage(MSG_KEY, 20, 18),
+            "115:5: " + getCheckMessage(MSG_KEY, 19, 18),
+            "170:5: " + getCheckMessage(MSG_KEY, 19, 18),
+        };
+        verify(checkConfig, getPath("InputSimple.java"), expected);
+    }
+
+    @Test
+    public void testWithIgnorePattern()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(MethodLengthCheck.class);
+        checkConfig.addAttribute("max", "18");
+        checkConfig.addAttribute("ignorePattern", "(veryLong|localVariables)");
+        final String[] expected = {
+            "79:5: " + getCheckMessage(MSG_KEY, 20, 18),
+        };
+        verify(checkConfig, getPath("InputSimple.java"), expected);
+    }
 }

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -560,6 +560,12 @@
             <th>type</th>
             <th>default value</th>
           </tr>
+           <tr>
+            <td>ignorePattern</td>
+            <td>pattern for methods to ignore</td>
+            <td><a href="property_types.html#regexp">regular expression</a></td>
+            <td>^$</td>
+          </tr>
           <tr>
             <td>max</td>
             <td>maximum allowable number of lines</td>


### PR DESCRIPTION
- Code copied from LineLengthCheck
- I wrote the commit only in the Github editor, but I hope it gets this issue going. Would be handy to have an ignore pattern especially when dealing with legacy code where some methods just might be too long (for instance meta data descriptors) and they all have the same name.  Putting a suppress filter or a suppress annotation is not viable in such cases.