### PR TITLE
Issue #2226: Replace line-based suppressions with inline ones

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -38,14 +38,9 @@
   </module>
   <module name="SuppressWarningsFilter"/>
   <module name="SuppressWithNearbyCommentFilter">
-    <!--
-      Use suppressions.xml for suppressions, this is only example.
-      checkFormat will prevent suppression comments from being valid.
-    -->
-    <property name="checkFormat" value="IGNORETHIS"/>
-    <property name="commentFormat" value="SUPPRESS CHECKSTYLE, (\w+)"/>
-    <property name="messageFormat" value="$1"/>
-    <property name="influenceFormat" value="-1"/>
+    <property name="commentFormat" value="-@cs\[(\w{8,})\] \w[\(\)\-\.\'\`\,\:\;\w ]{10,}"/>
+    <property name="checkFormat" value="$1"/>
+    <property name="influenceFormat" value="3"/>
   </module>
 
   <!-- Headers -->

--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -11,8 +11,14 @@
     <module name="SuppressionFilter">
         <property name="file" value="${project.basedir}/config/sevntu_suppressions.xml"/>
     </module>
+    <module name="SuppressWithNearbyCommentFilter">
+        <property name="commentFormat" value="-@cs\[(\w{8,})\] \w[\(\)\-\.\'\`\,\:\;\w ]{10,}"/>
+        <property name="checkFormat" value="$1"/>
+        <property name="influenceFormat" value="3"/>
+    </module>
 
     <module name="TreeWalker">
+        <module name="FileContentsHolder"/>
         <module name="StaticMethodCandidate"/>
         <module name="UselessSingleCatchCheck"/>
         <module name="NestedSwitchCheck"/>

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -15,47 +15,10 @@
     <suppress checks="LineLengthExtended"
               files="ParseTreeBuilder\.java"/>
 
-    <!-- Override methods from base class.
-    Issue: https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/166-->
-    <suppress checks="SimpleAccessorNameNotation"
-              files="ClassDataAbstractionCouplingCheck\.java"
-              lines="71"/>
-    <suppress checks="SimpleAccessorNameNotation"
-              files="ClassFanOutComplexityCheck\.java"
-              lines="76"/>
-    <suppress checks="SimpleAccessorNameNotation"
-              files="SingleSpaceSeparatorCheck\.java"
-              lines="110"/>
-
-    <!-- These classes are deprecated and will be removed soon. -->
-    <suppress checks="ForbidWildcardAsReturnType"
-              files="AbstractTypeAwareCheck\.java"
-              lines="230,246,409"/>
-    <suppress checks="ForbidWildcardAsReturnType"
-              files="ClassResolver\.java"
-              lines="72,184"/>
-    <!-- We need to satisfy javax.swing.table.AbstractTableModel
-    public Class<?> getColumnClass(int columnIndex) { -->
-    <suppress checks="ForbidWildcardAsReturnType"
-              files="ParseTreeTableModel\.java"
-              lines="92"/>
-    <suppress checks="ForbidWildcardAsReturnType"
-              files="ParseTreeTablePModel\.java"
-              lines="109"/>
     <!-- If we change declaration order, Illegal forward reference will appear.
     See https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/415-->
     <suppress checks="CustomDeclarationOrder"
               files="JavadocTokenTypes.java"/>
-    <!--CustomDeclarationOrder does not treat groups of overloaded methods.
-    See https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/414-->
-    <suppress checks="CustomDeclarationOrder"
-              files="AbstractViolationReporter.java"
-              lines="152,164"/>
-
-    <!-- testing for catch Error is part of 100% coverage -->
-    <suppress checks="IllegalCatchExtended"
-              files="CheckerTest\.java"
-              lines="543"/>
 
     <!--JavadocTagInfo.java, JavadocTags.java, InvalidJavadocTag.java, JavadocTag.java will be
     deprecated as we completely switch to ANTLR parser for javadoc. All of the mentioned classes

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -9,57 +9,6 @@
               files="TokenTypes.java"
               lines="1"/>
 
-    <!-- There is no other way to deliver filename that was under processing.
-         See https://github.com/checkstyle/checkstyle/issues/2285-->
-    <suppress checks="IllegalCatch"
-              files="Checker.java"
-              lines="272"/>
-    <!--Test to reproduce error catching in Checker and satisfy coverage rate. -->
-    <suppress checks="IllegalCatch"
-              files="CheckerTest.java"
-              lines="576"/>
-
-    <!-- we can not change it as, Check name is part of API (used in configurations) -->
-    <suppress checks="AbbreviationAsWordInName"
-              files="JavaNCSSCheck.java"
-              lines="41"/>
-    <!-- test should be named as their main class -->
-    <suppress checks="AbbreviationAsWordInName"
-              files="JavaNCSSCheckTest.java"
-              lines="42"/>
-
-    <!-- we can not change it as, Check name is part of API (used in configurations) -->
-    <suppress checks="AbbreviationAsWordInName"
-              files="XMLLogger.java"
-              lines="44"/>
-    <!-- test should be named as their main class -->
-    <suppress checks="AbbreviationAsWordInName"
-              files="XMLLoggerTest.java"
-              lines="48"/>
-
-    <!-- we can not change it as, Check property is part of API (used in configurations) -->
-    <suppress checks="AbbreviationAsWordInName"
-              files="JavadocMethodCheck.java"
-              lines="146,252"/>
-    <!-- we can not change it as, Check property is part of API (used in configurations) -->
-    <suppress checks="AbbreviationAsWordInName"
-              files="SuppressWithNearbyCommentFilter.java"
-              lines="97,183"/>
-    <!-- we can not change it as, Check property is part of API (used in configurations) -->
-    <suppress checks="AbbreviationAsWordInName"
-              files="SuppressionCommentFilter.java"
-              lines="85,172"/>
-
-    <!-- should be removed at 7.0 version, we keep for some time to avoid braking compatibiilty -->
-    <suppress checks="AbbreviationAsWordInName"
-              files="CheckstyleAntTask.java"
-              lines="230"/>
-
-    <!-- should be removed at 7.0 version, we keep for some time to avoid braking compatibiilty -->
-    <suppress checks="AbbreviationAsWordInName"
-              files="AbstractComplexityCheck.java"
-              lines="65"/>
-
     <!-- illegal words are part of Javadoc -->
     <suppress checks="TodoComment" files=".*TodoCommentCheck\.java"/>
 
@@ -123,10 +72,6 @@
     <!--VisibilityModifierCheck has 7 options which require 7 additional methods (setters)-->
     <suppress checks="MethodCount" files="[\\/]VisibilityModifierCheck.java$"/>
 
-    <!-- getDetails() method - huge Switch, it has to be monolithic -->
-    <suppress checks="ExecutableStatementCount" files="RightCurlyCheck\.java" lines="313"/>
-    <suppress checks="JavaNCSS" files="RightCurlyCheck\.java" lines="313"/>
-
     <!-- we need that set of converters -->
     <suppress checks="ClassDataAbstractionCoupling" files="AutomaticBean\.java"/>
     <!-- they are aggregators of logic, usage a several of classes are ok -->
@@ -139,36 +84,10 @@
     <!-- Should be fixed after moving https://github.com/sevntu-checkstyle/sevntu.checkstyle/blob/master/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ReturnCountExtendedCheck.java into the main repo -->
     <suppress checks="ReturnCount" files="(ClassResolver|ConfigurationLoader|IndentationCheckTest)\.java"/>
 
-    <!--Method getClassFrameWhereViolationIsFound already have too much abstract methods that fully
-    explain a logic, additional abstraction will not make logic/algorithm more readable.-->
-    <suppress checks="CyclomaticComplexity" files="RequireThisCheck\.java" lines="416"/>
-    <!--The only optimization which can be there is to move CASE-block expressions to separate method,
-    but that will not increase readability.-->
-    <suppress checks="CyclomaticComplexity" files="FinalLocalVariableCheck\.java" lines="176, 326"/>
-
     <!-- Suppressions from PMD configuration-->
-    <!-- validateCli is not reasonable to split as encapsulation of logic will be damaged -->
-    <suppress checks="CyclomaticComplexity" files="Main\.java"  lines="247"/>
     <!-- JavadocMethodCheck, JavadocStyleCheck, JavadocUtils.getJavadocTags() - deprecated -->
     <suppress checks="CyclomaticComplexity" files="JavadocMethodCheck\.java"/>
     <suppress checks="CyclomaticComplexity" files="JavadocStyleCheck\.java"/>
     <suppress checks="CyclomaticComplexity" files="CustomImportOrderCheck\.java"/>
 
-    <!-- equals() - a lot of fields to check -->
-    <suppress checks="CyclomaticComplexity" files="LocalizedMessage\.java" lines="210"/>
-    <!-- SWITCH was transformed into IF-ELSE -->
-    <suppress checks="CyclomaticComplexity" files="ImportOrderCheck\.java" lines="357"/>
-
-    <!-- LocalizedMessage class is immutable, we need that amount of arguments. -->
-    <suppress checks="ParameterNumber"
-              files="LocalizedMessage.java"
-              lines="105, 143, 174"/>
-
-    <!-- Not reasonable to split as encapsulation of logic will be damaged. -->
-    <suppress checks="ExecutableStatementCount" files="Main\.java" lines="128"/>
-    <suppress checks="JavaNCSS" files="Main\.java"  lines="128"/>
-
-    <!-- too complex to break apart -->
-    <suppress checks="CyclomaticComplexity" files="MissingOverrideCheck\.java"  lines="144"/>
-    <suppress checks="ReturnCount" files="JavadocStyleCheck\.java"  lines="342"/>
 </suppressions>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -269,6 +269,8 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
                     cache.put(fileName, timestamp);
                 }
             }
+            // -@cs[IllegalCatch] There is no other way to deliver filename that was under
+            // processing. See https://github.com/checkstyle/checkstyle/issues/2285
             catch (Exception ex) {
                 // We need to catch all exceptions to put a reason failure (file name) in exception
                 throw new CheckstyleException("Exception was thrown while processing "

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -244,6 +244,7 @@ public final class Main {
      * @param filesToProcess List of files to process found from the command line.
      * @return list of violations
      */
+    // -@cs[CyclomaticComplexity] Breaking apart will damage encapsulation
     private static List<String> validateCli(CommandLine cmdLine, List<File> filesToProcess) {
         final List<String> result = new ArrayList<>();
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -41,6 +41,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
  * @author <a href="mailto:stephane.bailliez@wanadoo.fr">Stephane Bailliez</a>
  */
+// -@cs[AbbreviationAsWordInName] We can not change it as,
+// check's name is part of API (used in configurations).
 public class XMLLogger
     extends AutomaticBean
     implements AuditListener {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -226,6 +226,8 @@ public class CheckstyleAntTask extends Task {
      * @param url the URL of the configuration to use
      * @deprecated please use setConfigUrl instead
      */
+    // -@cs[AbbreviationAsWordInName] Should be removed at 7.0 version,
+    // we keep for some time to avoid braking compatibility.
     @Deprecated
     public void setConfigURL(URL url) {
         setConfigUrl(url);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
@@ -149,6 +149,8 @@ public abstract class AbstractViolationReporter
      *
      * @see java.text.MessageFormat
      */
+    // -@cs[CustomDeclarationOrder] CustomDeclarationOrder does not treat groups of
+    // overloaded methods. See https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/414
     public abstract void log(int line, String key, Object... args);
 
     /**
@@ -161,6 +163,8 @@ public abstract class AbstractViolationReporter
      *
      * @see java.text.MessageFormat
      */
+    // -@cs[CustomDeclarationOrder] CustomDeclarationOrder does not treat groups of
+    // overloaded methods. See https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/414
     public abstract void log(int line, int col, String key,
             Object... args);
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -102,6 +102,7 @@ public final class LocalizedMessage
      * @param sourceClass the Class that is the source of the message
      * @param customMessage optional custom message overriding the default
      */
+    // -@cs[ParameterNumber] Class is immutable, we need that amount of arguments.
     public LocalizedMessage(int lineNo,
                             int columnNo,
                             String bundle,
@@ -140,6 +141,7 @@ public final class LocalizedMessage
      * @param sourceClass the Class that is the source of the message
      * @param customMessage optional custom message overriding the default
      */
+    // -@cs[ParameterNumber] Class is immutable, we need that amount of arguments.
     public LocalizedMessage(int lineNo,
                             int columnNo,
                             String bundle,
@@ -171,6 +173,7 @@ public final class LocalizedMessage
      * @param sourceClass the source class for the message
      * @param customMessage optional custom message overriding the default
      */
+    // -@cs[ParameterNumber] Class is immutable, we need that amount of arguments.
     public LocalizedMessage(int lineNo,
                             String bundle,
                             String key,
@@ -207,6 +210,7 @@ public final class LocalizedMessage
                 sourceClass, customMessage);
     }
 
+    // -@cs[CyclomaticComplexity] equals - a lot of fields to check.
     @Override
     public boolean equals(Object object) {
         if (this == object) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -227,6 +227,7 @@ public abstract class AbstractTypeAwareCheck extends AbstractCheck {
      * @return the resolved class or {@code null}
      *          if unable to resolve the class.
      */
+    // -@cs[ForbidWildcardAsReturnType] The class is deprecated and will be removed soon.
     protected final Class<?> resolveClass(String resolvableClassName,
             String className) {
         try {
@@ -243,6 +244,7 @@ public abstract class AbstractTypeAwareCheck extends AbstractCheck {
      * @param className name of surrounding class.
      * @return {@code Class} for a ident.
      */
+    // -@cs[ForbidWildcardAsReturnType] The class is deprecated and will be removed soon.
     protected final Class<?> tryLoadClass(Token ident, String className) {
         final Class<?> clazz = resolveClass(ident.getText(), className);
         if (clazz == null) {
@@ -406,6 +408,7 @@ public abstract class AbstractTypeAwareCheck extends AbstractCheck {
         /**
          * @return {@code Class} associated with an object.
          */
+        // -@cs[ForbidWildcardAsReturnType] The class is deprecated and will be removed soon.
         public abstract Class<?> getClazz();
 
         /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ClassResolver.java
@@ -69,6 +69,7 @@ public class ClassResolver {
      * @return the resolved class
      * @throws ClassNotFoundException if unable to resolve the class
      */
+    // -@cs[ForbidWildcardAsReturnType] The class is deprecated and will be removed soon.
     public Class<?> resolve(String name, String currentClass)
             throws ClassNotFoundException {
         // See if the class is full qualified
@@ -182,6 +183,7 @@ public class ClassResolver {
      * @throws ClassNotFoundException if an error occurs
      * @throws NoClassDefFoundError if an error occurs
      */
+    // -@cs[ForbidWildcardAsReturnType] The class is deprecated and will be removed soon.
     private Class<?> safeLoad(String name) throws ClassNotFoundException, NoClassDefFoundError {
         // The next line will load the class using the specified class
         // loader. The magic is having the "false" parameter. This means the

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
@@ -141,6 +141,7 @@ public final class MissingOverrideCheck extends AbstractCheck {
         {TokenTypes.METHOD_DEF, };
     }
 
+    // -@cs[CyclomaticComplexity] Too complex to break apart.
     @Override
     public void visitToken(final DetailAST ast) {
         final TextBlock javadoc =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -310,6 +310,8 @@ public class RightCurlyCheck extends AbstractCheck {
      * @param ast detail ast.
      * @return object that contain all details to make a validation.
      */
+    // -@cs[JavaNCSS] getDetails() method is a huge SWITCH, it has to be monolithic
+    // -@cs[ExecutableStatementCount] getDetails() method is a huge SWITCH, it has to be monolithic
     private static Details getDetails(DetailAST ast) {
         // Attempt to locate the tokens to do the check
         boolean shouldCheckLastRcurly = false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -173,6 +173,8 @@ public class FinalLocalVariableCheck extends AbstractCheck {
         };
     }
 
+    // -@cs[CyclomaticComplexity] The only optimization which can be done here is moving CASE-block
+    // expressions to separate methods, but that will not increase readability.
     @Override
     public void visitToken(DetailAST ast) {
         switch (ast.getType()) {
@@ -323,6 +325,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
      * @param prevScopeUnitializedVariableData variable for previous stack of uninitialized
      *     variables
      */
+    // -@cs[CyclomaticComplexity] Breaking apart will damage encapsulation.
     private void updateUninitializedVariables(Deque<DetailAST> prevScopeUnitializedVariableData) {
         // Check for only previous scope
         for (DetailAST variable : prevScopeUnitializedVariableData) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -413,6 +413,8 @@ public class RequireThisCheck extends AbstractCheck {
      * @param ast IDENT ast to check.
      * @return the class frame where violation is found or null otherwise.
      */
+    // -@cs[CyclomaticComplexity] Method already invokes too many methods that fully explain
+    // a logic, additional abstraction will not make logic/algorithm more readable.
     private AbstractFrame getClassFrameWhereViolationIsFound(DetailAST ast) {
         AbstractFrame frameWhereViolationIsFound = null;
         final AbstractFrame variableDeclarationFrame = findFrame(ast, false);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -354,6 +354,7 @@ public class ImportOrderCheck
         beforeFirstImport = true;
     }
 
+    // -@cs[CyclomaticComplexity] SWITCH was transformed into IF-ELSE.
     @Override
     public void visitToken(DetailAST ast) {
         final FullIdent ident;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -143,6 +143,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * Controls whether to allow documented exceptions that are not declared if
      * they are a subclass of java.lang.RuntimeException.
      */
+    // -@cs[AbbreviationAsWordInName] We can not change it as,
+    // check's property is part of API (used in configurations).
     private boolean allowUndeclaredRTE;
 
     /**
@@ -249,6 +251,8 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      *
      * @param flag a {@code Boolean} value
      */
+    // -@cs[AbbreviationAsWordInName] We can not change it as,
+    // check's property is part of API (used in configurations).
     public void setAllowUndeclaredRTE(boolean flag) {
         allowUndeclaredRTE = flag;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -339,6 +339,7 @@ public class JavadocStyleCheck
      * @param comment the {@code TextBlock} which represents
      *                 the Javadoc comment.
      */
+    // -@cs[ReturnCount] Too complex to break apart.
     private void checkHtmlTags(final DetailAST ast, final TextBlock comment) {
         final int lineNo = comment.getStartLineNo();
         final Deque<HtmlTag> htmlStack = new ArrayDeque<>();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.java
@@ -62,6 +62,8 @@ public abstract class AbstractComplexityCheck
      * Gets the message ID to log violations with.
      * @return the message ID to log violations with
      */
+    // -@cs[AbbreviationAsWordInName] Should be removed at 7.0 version,
+    // we keep for some time to avoid breaking of compatibility
     protected abstract String getMessageID();
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
@@ -68,6 +68,8 @@ public final class ClassDataAbstractionCouplingCheck
         };
     }
 
+    // -@cs[SimpleAccessorNameNotation] Overrides method from the base class.
+    // Issue: https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/166
     @Override
     protected String getLogMessageId() {
         return MSG_KEY;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
@@ -73,6 +73,8 @@ public final class ClassFanOutComplexityCheck extends AbstractClassCouplingCheck
         };
     }
 
+    // -@cs[SimpleAccessorNameNotation] Override methods from base class.
+    // Issue: https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/166
     @Override
     protected String getLogMessageId() {
         return MSG_KEY;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -38,6 +38,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * @author Lars Ködderitzsch
  */
+// -@cs[AbbreviationAsWordInName] We can not change it as,
+// check's name is a part of API (used in configurations).
 public class JavaNCSSCheck extends AbstractCheck {
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
@@ -107,6 +107,8 @@ public class SingleSpaceSeparatorCheck extends AbstractCheck {
         return CommonUtils.EMPTY_INT_ARRAY;
     }
 
+    // -@cs[SimpleAccessorNameNotation] Overrides method from base class.
+    // Issue: https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/166
     @Override
     public boolean isCommentNodesRequired() {
         return validateComments;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -94,6 +94,8 @@ public class SuppressWithNearbyCommentFilter
     private boolean checkC = true;
 
     /** Whether to look for trigger in C++-style comments. */
+    // -@cs[AbbreviationAsWordInName] We can not change it as,
+    // check's property is a part of API (used in configurations).
     private boolean checkCPP = true;
 
     /** Parsed comment regexp that marks checkstyle suppression region. */
@@ -180,6 +182,8 @@ public class SuppressWithNearbyCommentFilter
      * Set whether to look in C++ comments.
      * @param checkCpp {@code true} if C++ comments are checked.
      */
+    // -@cs[AbbreviationAsWordInName] We can not change it as,
+    // check's property is a part of API (used in configurations).
     public void setCheckCPP(boolean checkCpp) {
         checkCPP = checkCpp;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -82,6 +82,8 @@ public class SuppressionCommentFilter
     private boolean checkC = true;
 
     /** Whether to look in comments of the C++ type. */
+    // -@cs[AbbreviationAsWordInName] we can not change it as,
+    // Check property is a part of API (used in configurations)
     private boolean checkCPP = true;
 
     /** Parsed comment regexp that turns checkstyle reporting off. */
@@ -169,6 +171,8 @@ public class SuppressionCommentFilter
      * Set whether to look in C++ comments.
      * @param checkCpp {@code true} if C++ comments are checked.
      */
+    // -@cs[AbbreviationAsWordInName] We can not change it as,
+    // check's property is a part of API (used in configurations).
     public void setCheckCPP(boolean checkCpp) {
         checkCPP = checkCpp;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModel.java
@@ -89,6 +89,8 @@ public class ParseTreeTableModel implements TreeModel {
      * @param column the column number
      * @return the type for column number {@code column}.
      */
+    // -@cs[ForbidWildcardAsReturnType] We need to satisfy javax.swing.table.AbstractTableModel
+    // public Class<?> getColumnClass(int columnIndex) {...}
     public Class<?> getColumnClass(int column) {
         return pModel.getColumnClass(column);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePModel.java
@@ -106,6 +106,8 @@ public class ParseTreeTablePModel {
      * @param column the column number
      * @return the type for column number {@code column}.
      */
+    // -@cs[ForbidWildcardAsReturnType] We need to satisfy javax.swing.table.AbstractTableModel
+    // public Class<?> getColumnClass(int columnIndex) {...}
     public Class<?> getColumnClass(int column) {
         final Class<?> columnClass;
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -540,6 +540,7 @@ public class CheckerTest extends BaseCheckTestSupport {
             checker.process(filesToProcess);
             fail("IOError is expected!");
         }
+        // -@cs[IllegalCatchExtended] Testing for catch Error is part of 100% coverage.
         catch (Error error) {
             assertThat(error.getCause(), instanceOf(IOError.class));
             assertThat(error.getCause().getCause(), instanceOf(InternalError.class));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -45,6 +45,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * Enter a description of class XMLLoggerTest.java.
  * @author Rick Giles
  */
+// -@cs[AbbreviationAsWordInName] Test should be named as its main class.
 public class XMLLoggerTest {
     private final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckTest.java
@@ -39,6 +39,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *
  * @author Lars Ködderitzsch
  */
+// -@cs[AbbreviationAsWordInName] Test should be named as its main class.
 public class JavaNCSSCheckTest extends BaseCheckTestSupport {
     @Override
     protected String getPath(String filename) throws IOException {


### PR DESCRIPTION
#2226 
**Deprecated** and should have been removed in 7.0 release.
1) CheckstyleAntTask#setConfigURL
2) AbstractComplexityCheck#getMessageID

**Problem:**
Suppression comment should be placed on line 1. It is contrary to the model HeaderCheck rules as we need to have licence header on line 1. This is not possible to replace with inline-based suppressions:
```xml
<suppress checks="FileLength" files="TokenTypes.java" lines="1"/>
```

Travic CI is red due to connection problem
https://travis-ci.org/checkstyle/checkstyle/jobs/159947382#L799