### PR TITLE
Issue #3433: Cut down on Checkstyle's dependencies on Guava (part 1)

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -35,7 +35,14 @@
         <module name="ForbidThrowAnonymousExceptionsCheck"/>
         <module name="ForbidReturnInFinallyBlock"/>
         <module name="ForbidInstantiation">
-            <property name="forbiddenClasses" value="java.lang.NullPointerException,java.util.Vector,java.util.Stack"/>
+            <property name="forbiddenClasses" value="java.lang.NullPointerException,
+             java.util.Vector, java.util.Stack,com.google.collect.Iterables,
+             com.google.common.primitives.Ints,com.google.common.base.String,
+             com.google.common.base.Function,com.google.common.base.Supplier,
+             com.google.common.base.Charsets,com.google.common.base.MoreObjects,
+             com.google.common.base.Optional,com.google.common.base.Equivalence,
+             com.google.common.base.Preconditions,com.google.common.base.Predicate,
+             com.google.common.io.CharSource,com.google.common.annotations.Beta"/>
         </module>
         <module name="ForbidCCommentsInMethods"/>
         <module name="FinalizeImplementationCheck"/>
@@ -94,7 +101,14 @@
         </module>
         <module name="ForbidCertainImports">
             <property name="packageNameRegexp" value=".+"/>
-            <property name="forbiddenImportsRegexp" value="java\.util\.Stack|java\.util\.Vector"/>
+            <property name="forbiddenImportsRegexp" value="java\.util\.Stack|java\.util\.Vector|
+            com\.google\.collect\.Iterables|com\.google\.common\.annotations\.Beta|
+            com\.google\.common\.base\.Predicate|com\.google\.common\.base\.String||
+            com\.google\.common\.base\.Function|com\.google\.common\.base\.Supplier|
+            com\.google\.common\.base\.Charsets|com\.google\.common\.base\.MoreObjects|
+            com\.google\.common\.base\.Equivalence|com\.google\.common\.base\.Preconditions|
+            com\.google\.common\.base\.Optional|com\.google\.common\.io\.CharSource|
+            com\.google\.common\.primitives.*"/>
             <property name="forbiddenImportsExcludesRegexp" value=""/>
         </module>
         <module name="ForbidCertainImports">

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -7,7 +7,7 @@
 
   <allow pkg="antlr"/>
   <allow pkg="org.antlr.v4.runtime"/>
-  <allow pkg="com.google.common"/>
+  <allow pkg="com.google.common.collect"/>
   <allow pkg="com.puppycrawl.tools.checkstyle.api"/>
   <allow pkg="com.puppycrawl.tools.checkstyle.checks"/>
   <allow pkg="java.io"/>
@@ -20,6 +20,17 @@
   <allow pkg="org.xml.sax"/>
   <allow pkg="com.puppycrawl.tools.checkstyle"/>
   <allow pkg="java.lang.reflect"/>
+
+  <allow class="com.google.common.annotations.GwtCompatible" />
+  <allow class="com.google.common.annotations.GwtIncompatible"/>
+  <allow class="com.google.common.annotations.VisibleForTesting"/>
+  <allow class="com.google.common.base.Ascii"/>
+  <allow class="com.google.common.base.CaseFormat"/>
+  <allow class="com.google.common.base.CharMatcher"/>
+  <allow class="com.google.common.io.Closeables"/>
+  <allow class="com.google.common.io.Flushables"/>
+  <allow class="com.google.common.io.Files"/>
+  <allow class="com.google.common.reflect.ClassPath"/>
 
   <!-- The local ones -->
   <allow class="java.security.MessageDigest" local-only="true"/>

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/InputNoLineWrapBad.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/InputNoLineWrapBad.java
@@ -1,7 +1,7 @@
 package com.google.checkstyle.test. //warn
               chapter3filestructure.rule332nolinewrap;
 
-import com.google.common.annotations.Beta; //ok
+import com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck; //ok
 
 import javax.accessibility. //warn
     AccessibleAttributeSequence;

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/InputNoLineWrapGood.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/InputNoLineWrapGood.java
@@ -1,6 +1,6 @@
 package com.google.checkstyle.test.chapter3filestructure.rule332nolinewrap; //ok
 
-import com.google.common.annotations.Beta; //ok
+import com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck; //ok
  
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater; //ok
 import javax.accessibility.AccessibleAttributeSequence; //ok

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrderValid.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrderValid.java
@@ -1,11 +1,11 @@
 package com.google.checkstyle.test.chapter3filestructure.rule333orderingandspacing;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.puppycrawl.tools.checkstyle.utils.AnnotationUtility.containsAnnotation;
+import static com.puppycrawl.tools.checkstyle.utils.AnnotationUtility.getAnnotation;
 
-import com.google.common.annotations.Beta;
-import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
+import com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck;
+import com.puppycrawl.tools.checkstyle.checks.design.ThrowsCountCheck;
+import com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck;
 
 import com.sun.accessibility.internal.resources.*;
 import org.apache.commons.beanutils.converters.ArrayConverter;

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3sourcefile/InputEmptyLineSeparator.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3sourcefile/InputEmptyLineSeparator.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.Collections;
-import com.google.common.base.CharMatcher;
-import com.google.common.io.CharSource;
+import com.puppycrawl.tools.checkstyle.Checker;
+import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
 
 import javax.swing.AbstractAction;
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputEmptyLineSeparator.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputEmptyLineSeparator.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.Collections;
-import com.google.common.base.CharMatcher;
-import com.google.common.io.CharSource;
+import com.puppycrawl.tools.checkstyle.Checker;
+import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
 
 import javax.swing.AbstractAction;
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundEmptyTypesAndCycles.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundEmptyTypesAndCycles.java
@@ -1,7 +1,7 @@
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-import com.google.common.base.Function;
-import com.google.common.base.Supplier;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 class myFoo
 {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -40,7 +40,6 @@ import java.util.Set;
 
 import javax.xml.bind.DatatypeConverter;
 
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.io.Closeables;
 import com.google.common.io.Flushables;
@@ -300,7 +299,7 @@ final class PropertyCacheFile {
      * @return true if the contents of external configuration resources were changed.
      */
     private boolean areExternalResourcesChanged(Set<ExternalResource> resources) {
-        return Iterables.tryFind(resources, resource -> {
+        return resources.stream().filter(resource -> {
             boolean changed = false;
             if (isResourceLocationInCache(resource.location)) {
                 final String contentHashSum = resource.contentHashSum;
@@ -313,7 +312,7 @@ final class PropertyCacheFile {
                 changed = true;
             }
             return changed;
-        }).isPresent();
+        }).findFirst().isPresent();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -28,7 +28,6 @@ import java.util.regex.Pattern;
 
 import antlr.collections.AST;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -728,9 +727,9 @@ public class VisibilityModifierCheck
      * @return true if all of generic type arguments are immutable.
      */
     private boolean areImmutableTypeArguments(List<String> typeArgsClassNames) {
-        return !Iterables.tryFind(typeArgsClassNames,
+        return !typeArgsClassNames.stream().filter(
             typeName -> !immutableClassShortNames.contains(typeName)
-            && !immutableClassCanonicalNames.contains(typeName)).isPresent();
+                && !immutableClassCanonicalNames.contains(typeName)).findFirst().isPresent();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -21,8 +21,8 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.IntStream;
 
-import com.google.common.primitives.Ints;
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser;
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseErrorMessage;
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseStatus;
@@ -250,15 +250,15 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
 
         DetailNode curNode = root;
         while (curNode != null) {
-            final boolean waitsFor = Ints.contains(defaultTokenTypes, curNode.getType());
+            final boolean waitsForProcessing = shouldBeProcessed(defaultTokenTypes, curNode);
 
-            if (waitsFor) {
+            if (waitsForProcessing) {
                 visitJavadocToken(curNode);
             }
             DetailNode toVisit = JavadocUtils.getFirstChild(curNode);
             while (curNode != null && toVisit == null) {
 
-                if (waitsFor) {
+                if (waitsForProcessing) {
                     leaveJavadocToken(curNode);
                 }
 
@@ -269,6 +269,16 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
             }
             curNode = toVisit;
         }
+    }
+
+    /**
+     * Checks whether the current node should be processed by the check.
+     * @param defaultTokenTypes default token types.
+     * @param curNode current node.
+     * @return true if the current node should be processed by the check.
+     */
+    private boolean shouldBeProcessed(int[] defaultTokenTypes, DetailNode curNode) {
+        return IntStream.of(defaultTokenTypes).anyMatch(i -> i == curNode.getType());
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
@@ -19,9 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.regexp;
 
+import java.util.Optional;
 import java.util.regex.Pattern;
-
-import com.google.common.base.MoreObjects;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractViolationReporter;
 
@@ -227,8 +226,8 @@ public final class DetectorOptions {
          * @return DetectorOptions instance.
          */
         public DetectorOptions build() {
-            message = MoreObjects.firstNonNull(message, "");
-            suppressor = MoreObjects.firstNonNull(suppressor, NeverSuppress.INSTANCE);
+            message = Optional.ofNullable(message).orElse("");
+            suppressor = Optional.ofNullable(suppressor).orElse(NeverSuppress.INSTANCE);
             return DetectorOptions.this;
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.checks.regexp;
 
 import java.util.regex.Matcher;
 
-import com.google.common.base.Strings;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.LineColumn;
 
@@ -79,7 +78,8 @@ class MultilineDetector {
         text = new FileText(fileText);
         resetState();
 
-        if (Strings.isNullOrEmpty(options.getFormat())) {
+        final String format = options.getFormat();
+        if (format == null || format.isEmpty()) {
             options.getReporter().log(0, MSG_EMPTY);
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
@@ -39,7 +39,6 @@ import javax.swing.table.TableCellEditor;
 import javax.swing.tree.TreePath;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Ints;
 
 /**
  * This example shows how to create a simple JTreeTable component,
@@ -163,7 +162,7 @@ public class JTreeTable extends JTable {
         getColumn("Line").setMaxWidth(widthOfColumnContainingSixCharacterString);
         getColumn("Column").setMaxWidth(widthOfColumnContainingSixCharacterString);
         final int preferredTreeColumnWidth =
-                Ints.checkedCast(Math.round(getPreferredSize().getWidth() * 0.6));
+                Math.toIntExact(Math.round(getPreferredSize().getWidth() * 0.6));
         getColumn("Tree").setPreferredWidth(preferredTreeColumnWidth);
         // Twenty eight character string to contain "Type" column
         final int widthOfTwentyEightCharacterString =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtils.java
@@ -24,7 +24,6 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.primitives.Ints;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
@@ -74,7 +73,7 @@ public final class TokenUtils {
 
         TOKEN_NAME_TO_VALUE = builder.build();
         TOKEN_VALUE_TO_NAME = tempTokenValueToName;
-        TOKEN_IDS = Ints.toArray(TOKEN_NAME_TO_VALUE.values());
+        TOKEN_IDS = TOKEN_NAME_TO_VALUE.values().stream().mapToInt(Integer::intValue).toArray();
     }
 
     /** Stop instances being created. **/

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
@@ -22,12 +22,13 @@ package com.puppycrawl.tools.checkstyle;
 import static com.puppycrawl.tools.checkstyle.internal.TestUtils.assertUtilsClassHasPrivateConstructor;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
 public class AstTreeStringPrinterTest {
@@ -55,8 +56,8 @@ public class AstTreeStringPrinterTest {
     public void testParseFile() throws Exception {
         final String actual = AstTreeStringPrinter.printFileAst(
             new File(getPath("InputAstTreeStringPrinterComments.java")), false);
-        final String expected = Files.toString(new File(
-                getPath("expectedInputAstTreeStringPrinter.txt")), Charsets.UTF_8);
+        final String expected = new String(Files.readAllBytes(Paths.get(
+            getPath("expectedInputAstTreeStringPrinter.txt"))), StandardCharsets.UTF_8);
         Assert.assertEquals(expected, actual);
     }
 
@@ -65,8 +66,8 @@ public class AstTreeStringPrinterTest {
         final String actual = AstTreeStringPrinter.printFileAst(
             new File(getPath("InputAstTreeStringPrinterComments.java")), true)
                 .replaceAll("\\\\r\\\\n", "\\\\n");
-        final String expected = Files.toString(new File(
-                getPath("expectedInputAstTreeStringPrinterComments.txt")), Charsets.UTF_8)
+        final String expected = new String(Files.readAllBytes(Paths.get(
+                getPath("expectedInputAstTreeStringPrinterComments.txt"))), StandardCharsets.UTF_8)
                 .replaceAll("\\\\r\\\\n", "\\\\n");
         Assert.assertEquals(expected, actual);
     }
@@ -76,8 +77,8 @@ public class AstTreeStringPrinterTest {
         final String actual = AstTreeStringPrinter.printJavaAndJavadocTree(
                 new File(getPath("InputAstTreeStringPrinterJavadoc.java")))
                 .replaceAll("\\\\r\\\\n", "\\\\n");
-        final String expected = Files.toString(new File(
-                getPath("expectedInputAstTreeStringPrinterJavadoc.txt")), Charsets.UTF_8)
+        final String expected = new String(Files.readAllBytes(Paths.get(
+                getPath("expectedInputAstTreeStringPrinterJavadoc.txt"))), StandardCharsets.UTF_8)
                 .replaceAll("\\\\r\\\\n", "\\\\n");
         Assert.assertEquals(expected, actual);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,12 +42,10 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.MapDifference.ValueDifference;
 import com.google.common.collect.Maps;
-import com.google.common.io.Files;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class BaseCheckTestSupport {
@@ -108,8 +108,9 @@ public class BaseCheckTestSupport {
 
     protected static void verifyAst(String expectedTextPrintFileName, String actualJavaFileName,
             boolean withComments) throws Exception {
-        final String expectedContents = Files.toString(new File(expectedTextPrintFileName),
-                Charsets.UTF_8).replaceAll("\\\\r\\\\n", "\\\\n");
+        final String expectedContents = new String(Files.readAllBytes(
+            Paths.get(expectedTextPrintFileName)), StandardCharsets.UTF_8)
+            .replaceAll("\\\\r\\\\n", "\\\\n");
         final String actualContents = AstTreeStringPrinter.printFileAst(
                 new File(actualJavaFileName), withComments).replaceAll("\\\\r\\\\n", "\\\\n");
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -44,7 +44,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.powermock.api.mockito.PowerMockito;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
@@ -366,9 +365,8 @@ public class CheckerTest extends BaseCheckTestSupport {
         checker.configure(new DefaultConfiguration("default config"));
         // We set wrong file name length in order to reproduce IOException on OS Linux, OS Windows.
         // The maximum file name length which is allowed in most UNIX, Windows file systems is 255.
-        // See https://en.wikipedia.org/wiki/Filename
-        final int wrongFileNameLength = 300;
-        checker.setCacheFile(Strings.padEnd("fileName", wrongFileNameLength, 'e'));
+        // See https://en.wikipedia.org/wiki/Filename;
+        checker.setCacheFile(String.format(Locale.ENGLISH, "%0300d", 0));
         try {
             checker.destroy();
             fail("Exception did not happen");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -22,12 +22,12 @@ package com.puppycrawl.tools.checkstyle;
 import static com.puppycrawl.tools.checkstyle.internal.TestUtils.assertUtilsClassHasPrivateConstructor;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 
 public class DetailNodeTreeStringPrinterTest {
 
@@ -45,9 +45,9 @@ public class DetailNodeTreeStringPrinterTest {
         final String actual = DetailNodeTreeStringPrinter.printFileAst(
             new File(getPath("InputJavadocComment.javadoc")))
                 .replaceAll("\\\\r\\\\n", "\\\\n");
-        final String expected = Files.toString(new File(
-                getPath("expectedInputJavadocComment.txt")), Charsets.UTF_8)
-                .replaceAll("\\\\r\\\\n", "\\\\n");
+        final String expected = new String(Files.readAllBytes(Paths.get(
+            getPath("expectedInputJavadocComment.txt"))), StandardCharsets.UTF_8)
+            .replaceAll("\\\\r\\\\n", "\\\\n");
         Assert.assertEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -32,6 +32,9 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -52,8 +55,6 @@ import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.rules.TemporaryFolder;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 
@@ -681,9 +682,9 @@ public class MainTest {
 
     @Test
     public void testPrintTreeJavadocOption() throws Exception {
-        final String expected = Files.toString(new File(
-                getPath("astprinter/expectedInputJavadocComment.txt")), Charsets.UTF_8)
-                    .replaceAll("\\\\r\\\\n", "\\\\n");
+        final String expected = new String(Files.readAllBytes(Paths.get(
+            getPath("astprinter/expectedInputJavadocComment.txt"))), StandardCharsets.UTF_8)
+            .replaceAll("\\\\r\\\\n", "\\\\n");
 
         exit.checkAssertionAfterwards(() -> {
             assertEquals(expected, systemOut.getLog().replaceAll("\\\\r\\\\n", "\\\\n"));
@@ -694,9 +695,9 @@ public class MainTest {
 
     @Test
     public void testPrintFullTreeOption() throws Exception {
-        final String expected = Files.toString(new File(
-                getPath("astprinter/expectedInputAstTreeStringPrinterJavadoc.txt")),
-                Charsets.UTF_8).replaceAll("\\\\r\\\\n", "\\\\n");
+        final String expected = new String(Files.readAllBytes(Paths.get(
+            getPath("astprinter/expectedInputAstTreeStringPrinterJavadoc.txt"))),
+            StandardCharsets.UTF_8).replaceAll("\\\\r\\\\n", "\\\\n");
 
         exit.checkAssertionAfterwards(() -> {
             assertEquals(expected, systemOut.getLog().replaceAll("\\\\r\\\\n", "\\\\n"));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -331,8 +331,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
                 "SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STATIC###SPECIAL_IMPORTS");
         final String[] expected = {
-            "11: " + getCheckMessage(MSG_ORDER, THIRD, SPECIAL,
-                "com.google.common.annotations.GwtCompatible"),
+            "11: " + getCheckMessage(MSG_ORDER, THIRD, SPECIAL, "com.google.common.collect.Sets"),
         };
 
         verify(checkConfig, getPath("InputCustomImportOrderThirdPartyAndSpecial.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
@@ -26,13 +26,13 @@ import static com.puppycrawl.tools.checkstyle.checks.regexp.MultilineDetector.MS
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import com.puppycrawl.tools.checkstyle.BaseFileSetCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -121,7 +121,7 @@ public class RegexpMultilineCheckTest extends BaseFileSetCheckTestSupport {
         };
 
         final File file = temporaryFolder.newFile();
-        Files.write("first line \r\n second line \n\r third line", file, Charsets.UTF_8);
+        Files.write("first line \r\n second line \n\r third line", file, StandardCharsets.UTF_8);
 
         verify(checkConfig, file.getPath(), expected);
     }
@@ -133,8 +133,17 @@ public class RegexpMultilineCheckTest extends BaseFileSetCheckTestSupport {
     }
 
     @Test
-    public void testEmptyFormat() throws Exception {
+    public void testNullFormat() throws Exception {
         checkConfig.addAttribute("format", null);
+        final String[] expected = {
+            "0: " + getCheckMessage(MSG_EMPTY),
+        };
+        verify(checkConfig, getPath("InputSemantic.java"), expected);
+    }
+
+    @Test
+    public void testEmptyFormat() throws Exception {
+        checkConfig.addAttribute("format", "");
         final String[] expected = {
             "0: " + getCheckMessage(MSG_EMPTY),
         };
@@ -151,7 +160,7 @@ public class RegexpMultilineCheckTest extends BaseFileSetCheckTestSupport {
         };
 
         final File file = temporaryFolder.newFile();
-        Files.write(makeLargeXyString(), file, Charsets.UTF_8);
+        Files.write(makeLargeXyString(), file, StandardCharsets.UTF_8);
 
         verify(checkConfig, file.getPath(), expected);
     }
@@ -166,7 +175,7 @@ public class RegexpMultilineCheckTest extends BaseFileSetCheckTestSupport {
         };
 
         final File file = temporaryFolder.newFile();
-        Files.write("", file, Charsets.UTF_8);
+        Files.write("", file, StandardCharsets.UTF_8);
 
         verify(checkConfig, file.getPath(), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParseTreeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParseTreeTest.java
@@ -24,6 +24,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.BaseErrorListener;
@@ -33,9 +35,6 @@ import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 
 public class JavadocParseTreeTest {
     private final BaseErrorListener errorListener = new FailOnErrorListener();
@@ -62,7 +61,7 @@ public class JavadocParseTreeTest {
 
     private static String getFileContent(File filename)
             throws IOException {
-        return Files.toString(filename, Charsets.UTF_8);
+        return new String(Files.readAllBytes(filename.toPath()), StandardCharsets.UTF_8);
     }
 
     private static String getPath(String filename) throws IOException {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/InputCustomImportOrderThirdPartyAndSpecial.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/InputCustomImportOrderThirdPartyAndSpecial.java
@@ -1,14 +1,14 @@
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
-import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.Beta;
-import com.google.common.annotations.VisibleForTesting;
+import com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck;
+import com.puppycrawl.tools.checkstyle.checks.design.ThrowsCountCheck;
+import com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck;
 
 import org.apache.commons.io.ByteOrderMark;
 
 import static sun.tools.util.ModifierFilter.ALL_ACCESS;
 
-import com.google.common.annotations.GwtCompatible; //warn, ORDER, should be on THIRD_PARTY_PACKAGE, now SPECIAL_IMPORTS
+import com.google.common.collect.Sets; //warn, ORDER, should be on THIRD_PARTY_PACKAGE, now SPECIAL_IMPORTS
 
 import antlr.*;
 import antlr.CommonASTWithHiddenTokens;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputFromGuava.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputFromGuava.java
@@ -1,12 +1,12 @@
 package com.puppycrawl.tools.checkstyle.checks.indentation; //indent:0 exp:0
 
 import java.util.AbstractMap; //indent:0 exp:0
+import java.util.List; //indent:0 exp:0
 import java.util.Set; //indent:0 exp:0
 import java.util.concurrent.ConcurrentMap; //indent:0 exp:0
 
 import javax.xml.bind.annotation.XmlElement; //indent:0 exp:0
 
-import com.google.common.base.Equivalence; //indent:0 exp:0
 
 /**                                                                           //indent:0 exp:0
  * This test-input is intended to be checked using following configuration:   //indent:1 exp:1
@@ -39,8 +39,8 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
       } //indent:6 exp:6
 
       @Override //indent:6 exp:6
-      Equivalence<Object> defaultEquivalence() { //indent:6 exp:6
-        return Equivalence.equals(); //indent:8 exp:8
+      List<Object> defaultEquivalence() { //indent:6 exp:6
+        return new java.util.ArrayList<>(); //indent:8 exp:8
       } //indent:6 exp:6
 
       @Override //indent:6 exp:6
@@ -60,8 +60,8 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
       } //indent:6 exp:6
 
       @Override //indent:6 exp:6
-      Equivalence<Object> defaultEquivalence() { //indent:6 exp:6
-        return Equivalence.identity(); //indent:8 exp:8
+      List<Object> defaultEquivalence() { //indent:6 exp:6
+        return new java.util.ArrayList<>(); //indent:8 exp:8
       } //indent:6 exp:6
 
       @Override <K, V> Object referenceValue(Segment<K, V> segment, ReferenceEntry<K, V> entry, //indent:6 exp:6
@@ -81,8 +81,8 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
       } //indent:6 exp:6
 
       @Override //indent:6 exp:6
-      Equivalence<Object> defaultEquivalence() { //indent:6 exp:6
-        return Equivalence.identity(); //indent:8 exp:8
+      List<Object> defaultEquivalence() { //indent:6 exp:6
+        return new java.util.ArrayList<>(); //indent:8 exp:8
       } //indent:6 exp:6
     }; //indent:4 exp:4
 
@@ -97,7 +97,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
      * at this strength. This strategy will be used unless the user explicitly specifies an        //indent:5 exp:5
      * alternate strategy.                                                                         //indent:5 exp:5
      */                                                                                            //indent:5 exp:5
-    abstract Equivalence<Object> defaultEquivalence(); //indent:4 exp:4
+    abstract List<Object> defaultEquivalence(); //indent:4 exp:4
   } //indent:2 exp:2
 
   /**                        //indent:2 exp:2

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputGuavaFalsePositive.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputGuavaFalsePositive.java
@@ -1,6 +1,6 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 class Foo5 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputAllowEmptyTypesAndNonEmptyClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputAllowEmptyTypesAndNonEmptyClasses.java
@@ -1,7 +1,7 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
-import com.google.common.base.Function;
-import com.google.common.base.Supplier;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class InputAllowEmptyTypesAndNonEmptyClasses{
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputEmptyLineSeparator.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputEmptyLineSeparator.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.Collections;
 
-import com.google.common.io.CharSource;
+import com.oracle.net.Sdp;
 
 import javax.swing.AbstractAction;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputEmptyTypesAndCycles.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputEmptyTypesAndCycles.java
@@ -9,10 +9,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.base.Function;
-import com.google.common.base.Supplier;
 
 class myFoo
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputNoLineWrapBad.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputNoLineWrapBad.java
@@ -1,7 +1,7 @@
 package com.puppycrawl.tools.
     checkstyle.checks.whitespace;
 
-import com.google.common.annotations.Beta;
+import com.puppycrawl.tools.checkstyle.TreeWalker;
 
 import javax.accessibility.
     AccessibleAttributeSequence;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputNoLineWrapGood.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputNoLineWrapGood.java
@@ -1,6 +1,6 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
-import com.google.common.annotations.Beta;
+import com.puppycrawl.tools.checkstyle.TreeWalker;
 
 import javax.accessibility.AccessibleAttributeSequence;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;


### PR DESCRIPTION
#3433 

Got rid of the following dependencies and prohibited their ussage in code:
1) com.google.collect.Iterables
2) com.google.common.base.String
3) com.google.common.base.Function
4) com.google.common.base.Supplier
5) com.google.common.base.Charsets
6) com.google.common.base.MoreObjects
7) com.google.common.base.Equivalence
8) com.google.common.base.Preconditions
9) com.google.common.base.Optional
10) com.google.common.base.Predicate
11) com.google.common.io.Files (partially)
12) com.google.common.io.CharSource
13) com.google.common.primitives.Ints
14) com.google.common.annotations.Beta

I'll try to reduce the number of usages of the following dependencies in part 2 as it will need more investigation:
1) com.google.common.io.Closables can be replaced with try-with-resources. However, it will be difficult to cover 8 branches with UTs (Cobertura will complain that 8 branches should be covered).
2) com.google.common.io.Flushables. If we get rid of the dependency it will require additional UTs and decrease readibility of the code as we will need to use additional try-catch block.
3) com.google.common.reflect.ClassPath. If we get rid of the dependency it will decrease the readibility.
4) com.google.common.base.CaseFormat and com.google.common.base.CharMatcher are good for their purposes and reduce the amount of code.
5) com.google.common.collect.* should be discussed in seperate PR as it has to many usages in Checkstyle's code.


