### PR TITLE
doc: added links to cs backport jre6

### DIFF
--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -99,6 +99,23 @@
 
     </section>
 
+    <section name="Backport">
+      <p>
+        Since Checkstyle 7, some users have been unable to continue upgrading to newer versions
+        of the utility because of the new JDK 1.8 compile requirement. The development team doesn't
+        have the resources to keep updating the utility for older JDKs for those that can't
+        work with the latest version.
+      </p>
+      <p>
+        However, some members of the community have created an unofficial backport of the latest
+        Checkstyle releases to be run with JDKs as old as 1.6. If you wish to continue using new
+        Checkstyle versions on older JDKs, we recommend you either checkout the
+        <a href="https://github.com/rnveach/checkstyle-backport-jre6">github site</a> or the 
+        <a href="https://rnveach.github.io/checkstyle-backport-jre6">documentation site</a> on how
+        to use the backport version of the utility, in place of the official Checkstyle version.
+      </p>
+    </section>
+
     <section name="Related Tools">
       <p>
         Checkstyle is most useful if you integrate it in your build process or


### PR DESCRIPTION
Added text and link to CS backport on main index.
I put in some explanation why we can't support older JDKS and emphasized that backport is community/unofficially controlled.

Feel free to make any corrections/additions you see fit.