### PR TITLE
Issue #3433: Cut down on Checkstyle's dependencies on Guava (part 2)

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -42,7 +42,9 @@
              com.google.common.base.Charsets,com.google.common.base.MoreObjects,
              com.google.common.base.Optional,com.google.common.base.Equivalence,
              com.google.common.base.Preconditions,com.google.common.base.Predicate,
-             com.google.common.io.CharSource,com.google.common.annotations.Beta"/>
+             com.google.common.io.CharSource,com.google.common.annotations.Beta,
+             com.google.common.collect.Queues,com.google.common.collect.Sets,
+             com.google.common.collect.Lists"/>
         </module>
         <module name="ForbidCCommentsInMethods"/>
         <module name="FinalizeImplementationCheck"/>
@@ -108,7 +110,8 @@
             com\.google\.common\.base\.Charsets|com\.google\.common\.base\.MoreObjects|
             com\.google\.common\.base\.Equivalence|com\.google\.common\.base\.Preconditions|
             com\.google\.common\.base\.Optional|com\.google\.common\.io\.CharSource|
-            com\.google\.common\.primitives.*"/>
+            com\.google\.common\.primitives.*|com\.google\.common\.collect\.Sets|
+            com\.google\.common\.collect\.Queues|com\.google\.common\.collect\.Lists"/>
             <property name="forbiddenImportsExcludesRegexp" value=""/>
         </module>
         <module name="ForbidCertainImports">

--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -89,6 +89,8 @@
         <!-- beginProcessing() is kind of c-tor -->
         <Class name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck" />
         <Class name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck" />
+        <!--Uses setters to set fields values-->
+        <Class name="com.puppycrawl.tools.checkstyle.api.AbstractCheck" />
       </Or>
       <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
     </Match>

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -7,7 +7,6 @@
 
   <allow pkg="antlr"/>
   <allow pkg="org.antlr.v4.runtime"/>
-  <allow pkg="com.google.common.collect"/>
   <allow pkg="com.puppycrawl.tools.checkstyle.api"/>
   <allow pkg="com.puppycrawl.tools.checkstyle.checks"/>
   <allow pkg="java.io"/>
@@ -21,25 +20,31 @@
   <allow pkg="com.puppycrawl.tools.checkstyle"/>
   <allow pkg="java.lang.reflect"/>
 
-  <allow class="com.google.common.annotations.GwtCompatible" />
-  <allow class="com.google.common.annotations.GwtIncompatible"/>
-  <allow class="com.google.common.annotations.VisibleForTesting"/>
-  <allow class="com.google.common.base.Ascii"/>
-  <allow class="com.google.common.base.CaseFormat"/>
-  <allow class="com.google.common.base.CharMatcher"/>
-  <allow class="com.google.common.io.Closeables"/>
-  <allow class="com.google.common.io.Flushables"/>
-  <allow class="com.google.common.io.Files"/>
-  <allow class="com.google.common.reflect.ClassPath"/>
-
   <!-- The local ones -->
   <allow class="java.security.MessageDigest" local-only="true"/>
   <allow class="java.security.NoSuchAlgorithmException" local-only="true"/>
   <allow class="javax.xml.bind.DatatypeConverter" local-only="true"/>
+  <allow class="com.google.common.base.CaseFormat" local-only="true"/>
+  <allow class="com.google.common.io.Closeables" local-only="true"/>
+  <allow class="com.google.common.io.Flushables" local-only="true"/>
+  <allow class="com.google.common.collect.HashMultimap" local-only="true"/>
+  <allow class="com.google.common.collect.ImmutableCollection" local-only="true"/>
+  <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
+  <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
+  <allow class="com.google.common.collect.MapDifference" local-only="true"/>
+  <allow class="com.google.common.collect.Maps" local-only="true"/>
+  <allow class="com.google.common.collect.Multimap" local-only="true"/>
   <allow pkg="com.puppycrawl.tools.checkstyle.grammars" local-only="true"/>
   <allow pkg="org.apache.commons.cli" local-only="true"/>
 
+  <subpackage name="utils">
+    <allow class="com.google.common.base.CharMatcher" local-only="true"/>
+    <allow class="com.google.common.collect.ImmutableCollection" local-only="true"/>
+    <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
+  </subpackage>
+
   <subpackage name="ant">
+    <allow class="com.google.common.io.Closeables" local-only="true"/>
     <allow pkg="org.apache.tools.ant" local-only="true"/>
     <disallow pkg="com.puppycrawl.tools.checkstyle.checks"/>
     <disallow pkg="com.puppycrawl.tools.checkstyle.filters"/>
@@ -57,22 +62,71 @@
            local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.Utils"
            local-only="true"/>
+    <allow class="com.google.common.io.Closeables" local-only="true"/>
+    <allow class="com.google.common.collect.ImmutableCollection" local-only="true"/>
+    <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
   </subpackage>
 
   <subpackage name="checks">
     <allow pkg="com.puppycrawl.tools.checkstyle.checks"/>
     <allow class="com.puppycrawl.tools.checkstyle.Definitions"/>
+    <allow class="com.google.common.io.Files" local-only="true"/>
+    <allow class="com.google.common.io.Closeables" local-only="true"/>
+    <allow class="com.google.common.collect.HashMultiset" local-only="true"/>
+    <allow class="com.google.common.collect.HashMultimap" local-only="true"/>
+    <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
+    <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
+    <allow class="com.google.common.collect.ImmutableMultiset" local-only="true"/>
+    <allow class="com.google.common.collect.ImmutableSet" local-only="true"/>
+    <allow class="com.google.common.collect.Multimap" local-only="true"/>
+    <allow class="com.google.common.collect.Multiset" local-only="true"/>
+    <allow class="com.google.common.collect.Multiset.Entry" local-only="true"/>
+    <allow class="com.google.common.collect.SetMultimap" local-only="true"/>
     <allow pkg="java.math"/>
 
     <subpackage name="indentation">
       <allow pkg="java.lang.reflect"/>
+      <allow class="com.google.common.collect.Range" local-only="true"/>
+      <allow class="com.google.common.collect.RangeMap" local-only="true"/>
     </subpackage>
     <subpackage name="header">
       <allow class="java.nio.charset.Charset" local-only="true"/>
+      <allow class="com.google.common.io.Closeables" local-only="true"/>
+      <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
+      <allow class="com.google.common.collect.ImmutableSet" local-only="true"/>
     </subpackage>
     <subpackage name="javadoc">
       <allow pkg="com.puppycrawl.tools.checkstyle.grammars.javadoc"/>
       <allow pkg="java.lang.reflect"/>
+      <allow class="com.google.common.base.CharMatcher" local-only="true"/>
+      <allow class="com.google.common.annotations.GwtCompatible" local-only="true"/>
+      <allow class="com.google.common.annotations.GwtIncompatible" local-only="true"/>
+      <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
+      <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
+      <allow class="com.google.common.collect.ImmutableSortedSet" local-only="true"/>
+      <allow class="com.google.common.collect.Multiset" local-only="true"/>
+    </subpackage>
+    <subpackage name="whitespace">
+      <allow class="com.google.common.annotations.GwtCompatible" local-only="true"/>
+    </subpackage>
+    <subpackage name="design">
+      <allow class="com.google.common.annotations.VisibleForTesting" local-only="true"/>
+      <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
+      <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
+    </subpackage>
+    <subpackage name="regexp">
+      <allow class="com.google.common.io.Files" local-only="true"/>
+    </subpackage>
+    <subpackage name="imports">
+      <allow class="com.google.common.collect.HashMultimap" local-only="true"/>
+      <allow class="com.google.common.collect.ImmutableSet" local-only="true"/>
+    </subpackage>
+    <subpackage name="coding">
+      <allow class="com.google.common.collect.ImmutableCollection" local-only="true"/>
+      <allow class="com.google.common.collect.ImmutableSet" local-only="true"/>
+    </subpackage>
+    <subpackage name="metrics">
+      <allow class="com.google.common.collect.ImmutableSet" local-only="true"/>
     </subpackage>
   </subpackage>
 
@@ -86,6 +140,11 @@
 
   <subpackage name="filters">
     <allow pkg="java.lang.ref"/>
+    <allow class="com.google.common.io.Closeables" local-only="true"/>
+    <allow class="com.google.common.base.CaseFormat" local-only="true"/>
+    <allow class="com.google.common.collect.ImmutableCollection" local-only="true"/>
+    <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
+    <allow class="com.google.common.collect.ImmutableSet" local-only="true"/>
     <!-- is not possible till pkg is not a regexp -->
     <!-- <disallow pkg="com.puppycrawl.tools.checkstyle.checks.*"/> -->
     <disallow pkg="com.puppycrawl.tools.checkstyle.ant"/>
@@ -96,9 +155,17 @@
   <subpackage name="gui">
     <allow pkg="java.awt"/>
     <allow pkg="javax.swing"/>
+    <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
     <disallow pkg="com.puppycrawl.tools.checkstyle.checks"/>
     <disallow pkg="com.puppycrawl.tools.checkstyle.ant"/>
     <disallow pkg="com.puppycrawl.tools.checkstyle.doclets"/>
     <disallow pkg="com.puppycrawl.tools.checkstyle.filters"/>
+  </subpackage>
+
+  <subpackage name="internal">
+    <allow class="com.google.common.reflect.ClassPath" local-only="true"/>
+    <allow class="com.google.common.io.Files" local-only="true"/>
+    <allow class="com.google.common.collect.FluentIterable" local-only="true"/>
+    <allow class="com.google.common.collect.TreeTraverser"/>
   </subpackage>
 </import-control>

--- a/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/BaseCheckTestSupport.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.BriefUtLogger;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
@@ -120,9 +119,9 @@ public class BaseCheckTestSupport {
             Integer... warnsExpected)
             throws Exception {
         stream.flush();
-        final List<File> theFiles = Lists.newArrayList();
+        final List<File> theFiles = new ArrayList<>();
         Collections.addAll(theFiles, processedFiles);
-        final List<Integer> theWarnings = Lists.newArrayList();
+        final List<Integer> theWarnings = new ArrayList<>();
         Collections.addAll(theWarnings, warnsExpected);
         final int errs = checker.process(theFiles);
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -23,16 +23,17 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
@@ -66,10 +67,10 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
             SeverityLevel.ERROR);
 
     /** Vector of listeners. */
-    private final List<AuditListener> listeners = Lists.newArrayList();
+    private final List<AuditListener> listeners = new ArrayList<>();
 
     /** Vector of fileset checks. */
-    private final List<FileSetCheck> fileSetChecks = Lists.newArrayList();
+    private final List<FileSetCheck> fileSetChecks = new ArrayList<>();
 
     /** The audit event filters. */
     private final FilterSet filters = new FilterSet();
@@ -214,7 +215,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
      *         checks and filters.
      */
     private Set<String> getExternalResourceLocations() {
-        final Set<String> externalResources = Sets.newHashSet();
+        final Set<String> externalResources = new HashSet<>();
         fileSetChecks.stream().filter(check -> check instanceof ExternalResourceHolder)
             .forEach(check -> {
                 final Set<String> locations =
@@ -290,7 +291,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher {
      * @throws CheckstyleException if error condition within Checkstyle occurs.
      */
     private SortedSet<LocalizedMessage> processFile(File file) throws CheckstyleException {
-        final SortedSet<LocalizedMessage> fileMessages = Sets.newTreeSet();
+        final SortedSet<LocalizedMessage> fileMessages = new TreeSet<>();
         try {
             final FileText theText = new FileText(file.getAbsoluteFile(), charset);
             for (final FileSetCheck fsc : fileSetChecks) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -23,7 +23,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -38,8 +40,6 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.puppycrawl.tools.checkstyle.api.AbstractLoader;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
@@ -129,7 +129,7 @@ public final class ConfigurationLoader {
      * @return map between local resources and dtd ids.
      */
     private static Map<String, String> createIdToResourceNameMap() {
-        final Map<String, String> map = Maps.newHashMap();
+        final Map<String, String> map = new HashMap<>();
         map.put(DTD_PUBLIC_ID_1_0, DTD_RESOURCE_NAME_1_0);
         map.put(DTD_PUBLIC_ID_1_1, DTD_RESOURCE_NAME_1_1);
         map.put(DTD_PUBLIC_ID_1_2, DTD_RESOURCE_NAME_1_2);
@@ -270,8 +270,8 @@ public final class ConfigurationLoader {
             return null;
         }
 
-        final List<String> fragments = Lists.newArrayList();
-        final List<String> propertyRefs = Lists.newArrayList();
+        final List<String> fragments = new ArrayList<>();
+        final List<String> propertyRefs = new ArrayList<>();
         parsePropertyString(value, fragments, propertyRefs);
 
         final StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -19,13 +19,13 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 
@@ -40,13 +40,13 @@ public final class DefaultConfiguration implements Configuration {
     private final String name;
 
     /** The list of child Configurations. */
-    private final List<Configuration> children = Lists.newArrayList();
+    private final List<Configuration> children = new ArrayList<>();
 
     /** The map from attribute names to attribute values. */
-    private final Map<String, String> attributeMap = Maps.newHashMap();
+    private final Map<String, String> attributeMap = new HashMap<>();
 
     /** The map containing custom messages. */
-    private final Map<String, String> messages = Maps.newHashMap();
+    private final Map<String, String> messages = new HashMap<>();
 
     /**
      * Instantiates a DefaultConfiguration.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultContext.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultContext.java
@@ -19,11 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import com.puppycrawl.tools.checkstyle.api.Context;
 
 /**
@@ -32,7 +32,7 @@ import com.puppycrawl.tools.checkstyle.api.Context;
  */
 public final class DefaultContext implements Context {
     /** Stores the context entries. */
-    private final Map<String, Object> entries = Maps.newHashMap();
+    private final Map<String, Object> entries = new HashMap<>();
 
     @Override
     public Object get(String key) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.ConsoleHandler;
@@ -44,7 +45,6 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import com.google.common.collect.Lists;
 import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -514,7 +514,7 @@ public final class Main {
      */
     private static List<File> getFilesToProcess(List<Pattern> patternsToExclude,
             String... filesToProcess) {
-        final List<File> files = Lists.newLinkedList();
+        final List<File> files = new LinkedList<>();
         for (String element : filesToProcess) {
             files.addAll(listFiles(new File(element), patternsToExclude));
         }
@@ -533,7 +533,7 @@ public final class Main {
     private static List<File> listFiles(File node, List<Pattern> patternsToExclude) {
         // could be replaced with org.apache.commons.io.FileUtils.list() method
         // if only we add commons-io library
-        final List<File> result = Lists.newLinkedList();
+        final List<File> result = new LinkedList<>();
 
         if (node.canRead()) {
             if (node.isDirectory()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -27,6 +27,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -35,7 +36,6 @@ import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import com.google.common.collect.Sets;
 import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.api.AbstractLoader;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -68,7 +68,7 @@ public final class PackageNamesLoader
     private final Deque<String> packageStack = new ArrayDeque<>();
 
     /** The fully qualified package names. */
-    private final Set<String> packageNames = Sets.newLinkedHashSet();
+    private final Set<String> packageNames = new LinkedHashSet<>();
 
     /**
      * Creates a new {@code PackageNamesLoader} instance.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -20,14 +20,15 @@
 package com.puppycrawl.tools.checkstyle;
 
 import java.lang.reflect.Constructor;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 
@@ -68,7 +69,7 @@ public class PackageObjectFactory implements ModuleFactory {
         }
 
         //create a copy of the given set, but retain ordering
-        packages = Sets.newLinkedHashSet(packageNames);
+        packages = new LinkedHashSet<>(packageNames);
         this.moduleClassLoader = moduleClassLoader;
     }
 
@@ -127,7 +128,7 @@ public class PackageObjectFactory implements ModuleFactory {
      * @return all possible name for a class.
      */
     private Set<String> getAllPossibleNames(String name) {
-        final Set<String> names = Sets.newHashSet();
+        final Set<String> names = new HashSet<>();
         names.addAll(packages.stream().map(packageName -> packageName + name)
             .collect(Collectors.toList()));
         return names;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -35,12 +35,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 
 import javax.xml.bind.DatatypeConverter;
 
-import com.google.common.collect.Sets;
 import com.google.common.io.Closeables;
 import com.google.common.io.Flushables;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -241,7 +241,7 @@ final class PropertyCacheFile {
      * @return a set of {@link ExternalResource}.
      */
     private static Set<ExternalResource> loadExternalResources(Set<String> resourceLocations) {
-        final Set<ExternalResource> resources = Sets.newHashSet();
+        final Set<ExternalResource> resources = new HashSet<>();
         for (String location : resourceLocations) {
             String contentHashSum = null;
             try {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -39,7 +39,6 @@ import antlr.TokenStreamHiddenTokenFilter;
 import antlr.TokenStreamRecognitionException;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -75,10 +74,10 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
             HashMultimap.create();
 
     /** Registered ordinary checks, that don't use comment nodes. */
-    private final Set<AbstractCheck> ordinaryChecks = Sets.newHashSet();
+    private final Set<AbstractCheck> ordinaryChecks = new HashSet<>();
 
     /** Registered comment checks. */
-    private final Set<AbstractCheck> commentChecks = Sets.newHashSet();
+    private final Set<AbstractCheck> commentChecks = new HashSet<>();
 
     /** The distance between tab stops. */
     private int tabWidth = DEFAULT_TAB_WIDTH;
@@ -478,7 +477,7 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
      * @return a set of external configuration resource locations which are used by the checks set.
      */
     private static Set<String> getExternalResourceLocations(Set<AbstractCheck> checks) {
-        final Set<String> externalConfigurationResources = Sets.newHashSet();
+        final Set<String> externalConfigurationResources = new HashSet<>();
         checks.stream().filter(check -> check instanceof ExternalResourceHolder).forEach(check -> {
             final Set<String> checkExternalResources =
                 ((ExternalResourceHolder) check).getExternalResourceLocations();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -42,7 +43,6 @@ import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.types.Path;
 import org.apache.tools.ant.types.Reference;
 
-import com.google.common.collect.Lists;
 import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
@@ -71,13 +71,13 @@ public class CheckstyleAntTask extends Task {
     private static final String TIME_SUFFIX = " ms.";
 
     /** Contains the filesets to process. */
-    private final List<FileSet> fileSets = Lists.newArrayList();
+    private final List<FileSet> fileSets = new ArrayList<>();
 
     /** Contains the formatters to log to. */
-    private final List<Formatter> formatters = Lists.newArrayList();
+    private final List<Formatter> formatters = new ArrayList<>();
 
     /** Contains the Properties to override. */
-    private final List<Property> overrideProps = Lists.newArrayList();
+    private final List<Property> overrideProps = new ArrayList<>();
 
     /** Class path to locate class files. */
     private Path classpath;
@@ -505,7 +505,7 @@ public class CheckstyleAntTask extends Task {
      * @return the list of files included via the filesets.
      */
     protected List<File> scanFileSets() {
-        final List<File> list = Lists.newArrayList();
+        final List<File> list = new ArrayList<>();
         if (fileName != null) {
             // oops we've got an additional one to process, don't
             // forget it. No sweat, it's fully resolved via the setter.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
@@ -20,9 +20,8 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
-
-import com.google.common.collect.Sets;
 
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
@@ -38,7 +37,7 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
     private static final int DEFAULT_TAB_WIDTH = 8;
 
     /** The tokens the check is interested in. */
-    private final Set<String> tokens = Sets.newHashSet();
+    private final Set<String> tokens = new HashSet<>();
 
     /** The current file contents. */
     private FileContents fileContents;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractLoader.java
@@ -33,8 +33,6 @@ import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 
-import com.google.common.collect.Maps;
-
 /**
  * Contains the common implementation of a loader, for loading a configuration
  * from an XML file.
@@ -77,8 +75,7 @@ public abstract class AbstractLoader
      */
     protected AbstractLoader(Map<String, String> publicIdToResourceNameMap)
             throws SAXException, ParserConfigurationException {
-        this.publicIdToResourceNameMap =
-            Maps.newHashMap(publicIdToResourceNameMap);
+        this.publicIdToResourceNameMap = new HashMap<>(publicIdToResourceNameMap);
         final SAXParserFactory factory = SAXParserFactory.newInstance();
         factory.setValidating(true);
         factory.setNamespaceAware(true);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.api;
 
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -41,8 +42,6 @@ import org.apache.commons.beanutils.converters.FloatConverter;
 import org.apache.commons.beanutils.converters.IntegerConverter;
 import org.apache.commons.beanutils.converters.LongConverter;
 import org.apache.commons.beanutils.converters.ShortConverter;
-
-import com.google.common.collect.Lists;
 
 /**
  * A Java Bean that implements the component lifecycle interfaces by
@@ -254,7 +253,7 @@ public class AutomaticBean
             // Convert to a String and trim it for the tokenizer.
             final StringTokenizer tokenizer = new StringTokenizer(
                 value.toString().trim(), ",");
-            final List<String> result = Lists.newArrayList();
+            final List<String> result = new ArrayList<>();
 
             while (tokenizer.hasMoreTokens()) {
                 final String token = tokenizer.nextToken();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -20,15 +20,15 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.puppycrawl.tools.checkstyle.grammars.CommentListener;
 
 /**
@@ -55,16 +55,15 @@ public final class FileContents implements CommentListener {
     /** Map of the Javadoc comments indexed on the last line of the comment.
      * The hack is it assumes that there is only one Javadoc comment per line.
      */
-    private final Map<Integer, TextBlock> javadocComments = Maps.newHashMap();
+    private final Map<Integer, TextBlock> javadocComments = new HashMap<>();
     /** Map of the C++ comments indexed on the first line of the comment. */
-    private final Map<Integer, TextBlock> cppComments =
-        Maps.newHashMap();
+    private final Map<Integer, TextBlock> cppComments = new HashMap<>();
 
     /**
      * Map of the C comments indexed on the first line of the comment to a list
      * of comments on that line.
      */
-    private final Map<Integer, List<TextBlock>> clangComments = Maps.newHashMap();
+    private final Map<Integer, List<TextBlock>> clangComments = new HashMap<>();
 
     /**
      * Creates a new {@code FileContents} instance.
@@ -144,7 +143,7 @@ public final class FileContents implements CommentListener {
             entries.add(comment);
         }
         else {
-            final List<TextBlock> entries = Lists.newArrayList();
+            final List<TextBlock> entries = new ArrayList<>();
             entries.add(comment);
             clangComments.put(startLineNo, entries);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FilterSet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FilterSet.java
@@ -20,10 +20,9 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-
-import com.google.common.collect.Sets;
 
 /**
  * A filter set applies filters to AuditEvents.
@@ -34,7 +33,7 @@ import com.google.common.collect.Sets;
 public class FilterSet
     implements Filter {
     /** Filter set. */
-    private final Set<Filter> filters = Sets.newHashSet();
+    private final Set<Filter> filters = new HashSet<>();
 
     /**
      * Adds a Filter to the set.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessages.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessages.java
@@ -21,8 +21,7 @@ package com.puppycrawl.tools.checkstyle.api;
 
 import java.util.Set;
 import java.util.SortedSet;
-
-import com.google.common.collect.Sets;
+import java.util.TreeSet;
 
 /**
  * Collection of messages.
@@ -30,14 +29,14 @@ import com.google.common.collect.Sets;
  */
 public final class LocalizedMessages {
     /** Contains the messages logged. **/
-    private final Set<LocalizedMessage> messages = Sets.newTreeSet();
+    private final Set<LocalizedMessage> messages = new TreeSet<>();
 
     /**
      * Gets the logged messages.
      * @return the logged messages
      */
     public SortedSet<LocalizedMessage> getMessages() {
-        return Sets.newTreeSet(messages);
+        return new TreeSet<>(messages);
     }
 
     /** Reset the object. **/

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
@@ -20,13 +20,13 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -54,10 +54,10 @@ public abstract class AbstractDeclarationCollector extends AbstractCheck {
 
     @Override
     public void beginTree(DetailAST rootAST) {
-        final Deque<LexicalFrame> frameStack = Lists.newLinkedList();
+        final Deque<LexicalFrame> frameStack = new LinkedList<>();
         frameStack.add(new GlobalFrame());
 
-        frames = Maps.newHashMap();
+        frames = new HashMap<>();
 
         DetailAST curNode = rootAST;
         while (curNode != null) {
@@ -243,7 +243,7 @@ public abstract class AbstractDeclarationCollector extends AbstractCheck {
          */
         protected LexicalFrame(LexicalFrame parent) {
             this.parent = parent;
-            varNames = Sets.newHashSet();
+            varNames = new HashSet<>();
         }
 
         /** Add a name to the frame.
@@ -328,10 +328,10 @@ public abstract class AbstractDeclarationCollector extends AbstractCheck {
          */
         ClassFrame(LexicalFrame parent) {
             super(parent);
-            instanceMembers = Sets.newHashSet();
-            instanceMethods = Sets.newHashSet();
-            staticMembers = Sets.newHashSet();
-            staticMethods = Sets.newHashSet();
+            instanceMembers = new HashSet<>();
+            instanceMethods = new HashSet<>();
+            staticMembers = new HashSet<>();
+            staticMethods = new HashSet<>();
         }
 
         /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -21,12 +21,12 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -48,7 +48,7 @@ public abstract class AbstractTypeAwareCheck extends AbstractCheck {
     private final Deque<Map<String, AbstractClassInfo>> typeParams = new ArrayDeque<>();
 
     /** Imports details. **/
-    private final Set<String> imports = Sets.newHashSet();
+    private final Set<String> imports = new HashSet<>();
 
     /** Full identifier for package of the method. **/
     private FullIdent packageFullIdent;
@@ -306,7 +306,7 @@ public abstract class AbstractTypeAwareCheck extends AbstractCheck {
         final DetailAST params =
             ast.findFirstToken(TokenTypes.TYPE_PARAMETERS);
 
-        final Map<String, AbstractClassInfo> paramsMap = Maps.newHashMap();
+        final Map<String, AbstractClassInfo> paramsMap = new HashMap<>();
         typeParams.push(paramsMap);
 
         if (params != null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import org.apache.commons.beanutils.ConversionException;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -478,7 +477,7 @@ public class SuppressWarningsHolder
      * @return list of expressions in strings
      */
     private static List<String> findAllExpressionsInChildren(DetailAST parent) {
-        final List<String> valueList = Lists.newLinkedList();
+        final List<String> valueList = new LinkedList<>();
         DetailAST childAST = parent.getFirstChild();
         while (childAST != null) {
             if (childAST.getType() == TokenTypes.EXPR) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -19,12 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
@@ -158,7 +158,7 @@ public class TrailingCommentCheck extends AbstractCheck {
                 .getCppComments();
         final Map<Integer, List<TextBlock>> cComments = getFileContents()
                 .getCComments();
-        final Set<Integer> lines = Sets.newHashSet();
+        final Set<Integer> lines = new HashSet<>();
         lines.addAll(cppComments.keySet());
         lines.addAll(cComments.keySet());
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -24,22 +24,25 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
-import com.google.common.collect.Sets;
 import com.google.common.io.Closeables;
 import com.google.common.io.Files;
 import com.puppycrawl.tools.checkstyle.Definitions;
@@ -164,7 +167,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
     private static final String REGEXP_FORMAT_TO_CHECK_DEFAULT_TRANSLATIONS = "^%s\\.%s$";
 
     /** The files to process. */
-    private final Set<File> filesToProcess = Sets.newHashSet();
+    private final Set<File> filesToProcess = new HashSet<>();
 
     /** The base name regexp pattern. */
     private Pattern baseNamePattern;
@@ -172,7 +175,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
     /**
      * Language codes of required translations for the check (de, pt, ja, etc).
      */
-    private Set<String> requiredTranslations = Sets.newHashSet();
+    private Set<String> requiredTranslations = new HashSet<>();
 
     /**
      * Creates a new {@code TranslationCheck} instance.
@@ -195,7 +198,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
      * @param translationCodes a comma separated list of language codes.
      */
     public void setRequiredTranslations(String... translationCodes) {
-        requiredTranslations = Sets.newHashSet(translationCodes);
+        requiredTranslations = Arrays.stream(translationCodes).collect(Collectors.toSet());
         validateUserSpecifiedLanguageCodes(requiredTranslations);
     }
 
@@ -342,7 +345,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
      */
     private static Set<ResourceBundle> groupFilesIntoBundles(Set<File> files,
                                                              Pattern baseNameRegexp) {
-        final Set<ResourceBundle> resourceBundles = Sets.newHashSet();
+        final Set<ResourceBundle> resourceBundles = new HashSet<>();
         for (File currentFile : files) {
             final String fileName = currentFile.getName();
             final String baseName = extractBaseName(fileName);
@@ -437,7 +440,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
         final Set<File> filesInBundle = bundle.getFiles();
         if (filesInBundle.size() > 1) {
             // build a map from files to the keys they contain
-            final Set<String> allTranslationKeys = Sets.newHashSet();
+            final Set<String> allTranslationKeys = new HashSet<>();
             final SetMultimap<File, String> filesAssociatedWithKeys = HashMultimap.create();
             for (File currentFile : filesInBundle) {
                 final Set<String> keysInCurrentFile = getTranslationKeys(currentFile);
@@ -461,7 +464,8 @@ public class TranslationCheck extends AbstractFileSetCheck {
             final String path = currentFile.getPath();
             dispatcher.fireFileStarted(path);
             final Set<String> currentFileKeys = fileKeys.get(currentFile);
-            final Set<String> missingKeys = Sets.difference(keysThatMustExist, currentFileKeys);
+            final Set<String> missingKeys = keysThatMustExist.stream()
+                .filter(e -> !currentFileKeys.contains(e)).collect(Collectors.toSet());
             if (!missingKeys.isEmpty()) {
                 for (Object key : missingKeys) {
                     log(0, MSG_KEY, key);
@@ -478,7 +482,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
      * @return a Set object which holds the loaded keys.
      */
     private Set<String> getTranslationKeys(File file) {
-        Set<String> keys = Sets.newHashSet();
+        Set<String> keys = new HashSet<>();
         InputStream inStream = null;
         try {
             inStream = new FileInputStream(file);
@@ -515,7 +519,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
                 args,
                 getId(),
                 getClass(), null);
-        final SortedSet<LocalizedMessage> messages = Sets.newTreeSet();
+        final SortedSet<LocalizedMessage> messages = new TreeSet<>();
         messages.add(message);
         getMessageDispatcher().fireErrors(file.getPath(), messages);
         LOG.debug("IOException occurred.", exception);
@@ -542,7 +546,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
             this.baseName = baseName;
             this.path = path;
             this.extension = extension;
-            files = Sets.newHashSet();
+            files = new HashSet<>();
         }
 
         public String getBaseName() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractIllegalCheck.java
@@ -19,9 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import java.util.HashSet;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 
 /**
@@ -34,7 +34,7 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 @Deprecated
 public abstract class AbstractIllegalCheck extends AbstractCheck {
     /** Illegal class names. */
-    private final Set<String> illegalClassNames = Sets.newHashSet();
+    private final Set<String> illegalClassNames = new HashSet<>();
 
     /**
      * Constructs an object.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -20,10 +20,10 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.Deque;
+import java.util.LinkedList;
 
 import antlr.collections.AST;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -46,7 +46,7 @@ public abstract class AbstractSuperCheck
     public static final String MSG_KEY = "missing.super.call";
 
     /** Stack of methods. */
-    private final Deque<MethodNode> methodStack = Lists.newLinkedList();
+    private final Deque<MethodNode> methodStack = new LinkedList<>();
 
     /**
      * Returns the name of the overriding method.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheck.java
@@ -19,9 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import java.util.HashSet;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -51,7 +51,7 @@ public class CovariantEqualsCheck extends AbstractCheck {
     public static final String MSG_KEY = "covariant.equals";
 
     /** Set of equals method definitions. */
-    private final Set<DetailAST> equalsMethods = Sets.newHashSet();
+    private final Set<DetailAST> equalsMethods = new HashSet<>();
 
     @Override
     public int[] getDefaultTokens() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -19,11 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.Set;
 
-import com.google.common.collect.Queues;
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.Scope;
@@ -182,8 +182,8 @@ public class DeclarationOrderCheck extends AbstractCheck {
 
     @Override
     public void beginTree(DetailAST rootAST) {
-        scopeStates = Queues.newArrayDeque();
-        classFieldNames = Sets.newHashSet();
+        scopeStates = new ArrayDeque<>();
+        classFieldNames = new HashSet<>();
     }
 
     @Override
@@ -335,8 +335,8 @@ public class DeclarationOrderCheck extends AbstractCheck {
      */
     private static Set<DetailAST> getAllTokensOfType(DetailAST ast, int tokenType) {
         DetailAST vertex = ast;
-        final Set<DetailAST> result = Sets.newHashSet();
-        final Deque<DetailAST> stack = Queues.newArrayDeque();
+        final Set<DetailAST> result = new HashSet<>();
+        final Deque<DetailAST> stack = new ArrayDeque<>();
         while (vertex != null || !stack.isEmpty()) {
             if (!stack.isEmpty()) {
                 vertex = stack.pop();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -505,13 +505,13 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
         private final FieldFrame parent;
 
         /** Set of frame's children. */
-        private final Set<FieldFrame> children = Sets.newHashSet();
+        private final Set<FieldFrame> children = new HashSet<>();
 
         /** Set of fields. */
-        private final Set<DetailAST> fields = Sets.newHashSet();
+        private final Set<DetailAST> fields = new HashSet<>();
 
         /** Set of equals calls. */
-        private final Set<DetailAST> methodCalls = Sets.newHashSet();
+        private final Set<DetailAST> methodCalls = new HashSet<>();
 
         /** Name of the class, enum or enum constant declaration. */
         private String frameName;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
@@ -19,11 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import antlr.collections.AST;
-
-import com.google.common.collect.Maps;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -64,10 +63,10 @@ public class EqualsHashCodeCheck
     public static final String MSG_KEY_EQUALS = "equals.noEquals";
 
     /** Maps OBJ_BLOCK to the method definition of equals(). */
-    private final Map<DetailAST, DetailAST> objBlockWithEquals = Maps.newHashMap();
+    private final Map<DetailAST, DetailAST> objBlockWithEquals = new HashMap<>();
 
     /** Maps OBJ_BLOCKs to the method definition of hashCode(). */
-    private final Map<DetailAST, DetailAST> objBlockWithHashCode = Maps.newHashMap();
+    private final Map<DetailAST, DetailAST> objBlockWithHashCode = new HashMap<>();
 
     @Override
     public int[] getDefaultTokens() {
@@ -145,11 +144,10 @@ public class EqualsHashCodeCheck
                 final DetailAST equalsAST = detailASTDetailASTEntry.getValue();
                 log(equalsAST.getLineNo(), equalsAST.getColumnNo(), MSG_KEY_HASHCODE);
             });
-        for (Map.Entry<DetailAST, DetailAST> detailASTDetailASTEntry : objBlockWithHashCode
-                .entrySet()) {
+        objBlockWithHashCode.entrySet().forEach(detailASTDetailASTEntry -> {
             final DetailAST equalsAST = detailASTDetailASTEntry.getValue();
             log(equalsAST.getLineNo(), equalsAST.getColumnNo(), MSG_KEY_EQUALS);
-        }
+        });
 
         objBlockWithEquals.clear();
         objBlockWithHashCode.clear();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -19,12 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.Scope;
@@ -577,10 +577,10 @@ public class HiddenFieldCheck
         private final FieldFrame parent;
 
         /** Set of instance field names. */
-        private final Set<String> instanceFields = Sets.newHashSet();
+        private final Set<String> instanceFields = new HashSet<>();
 
         /** Set of static field names. */
-        private final Set<String> staticFields = Sets.newHashSet();
+        private final Set<String> staticFields = new HashSet<>();
 
         /**
          * Creates new frame.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -22,8 +22,9 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -44,9 +45,9 @@ public final class IllegalCatchCheck extends AbstractCheck {
     public static final String MSG_KEY = "illegal.catch";
 
     /** Illegal class names. */
-    private final Set<String> illegalClassNames = Sets.newHashSet("Exception", "Error",
+    private final Set<String> illegalClassNames = Stream.of("Exception", "Error",
             "RuntimeException", "Throwable", "java.lang.Error", "java.lang.Exception",
-            "java.lang.RuntimeException", "java.lang.Throwable");
+            "java.lang.RuntimeException", "java.lang.Throwable").collect(Collectors.toSet());
 
     /**
      * Set the list of illegal classes.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -19,11 +19,13 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import antlr.collections.AST;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -73,16 +75,16 @@ public class IllegalInstantiationCheck
     private static final String JAVA_LANG = "java.lang.";
 
     /** The imports for the file. */
-    private final Set<FullIdent> imports = Sets.newHashSet();
+    private final Set<FullIdent> imports = new HashSet<>();
 
     /** The class names defined in the file. */
-    private final Set<String> classNames = Sets.newHashSet();
+    private final Set<String> classNames = new HashSet<>();
 
     /** The instantiations in the file. */
-    private final Set<DetailAST> instantiations = Sets.newHashSet();
+    private final Set<DetailAST> instantiations = new HashSet<>();
 
     /** Set of fully qualified class names. E.g. "java.lang.Boolean" */
-    private Set<String> illegalClasses = Sets.newHashSet();
+    private Set<String> illegalClasses = new HashSet<>();
 
     /** Name of the package. */
     private String pkgName;
@@ -351,6 +353,6 @@ public class IllegalInstantiationCheck
      * @param names a comma separate list of class names
      */
     public void setClasses(String... names) {
-        illegalClasses = Sets.newHashSet(names);
+        illegalClasses = Arrays.stream(names).collect(Collectors.toSet());
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
@@ -21,8 +21,9 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -59,11 +60,13 @@ public final class IllegalThrowsCheck extends AbstractCheck {
     public static final String MSG_KEY = "illegal.throw";
 
     /** Methods which should be ignored. */
-    private final Set<String> ignoredMethodNames = Sets.newHashSet("finalize");
+    private final Set<String> ignoredMethodNames =
+        Stream.of("finalize").collect(Collectors.toSet());
 
     /** Illegal class names. */
-    private final Set<String> illegalClassNames = Sets.newHashSet("Error", "RuntimeException",
-        "Throwable", "java.lang.Error", "java.lang.RuntimeException", "java.lang.Throwable");
+    private final Set<String> illegalClassNames = Stream.of("Error", "RuntimeException",
+        "Throwable", "java.lang.Error", "java.lang.RuntimeException", "java.lang.Throwable")
+        .collect(Collectors.toSet());
 
     /** Property for ignoring overridden methods. */
     private boolean ignoreOverriddenMethods = true;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -21,11 +21,11 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -124,11 +124,11 @@ public final class IllegalTypeCheck extends AbstractCheck {
     };
 
     /** Illegal classes. */
-    private final Set<String> illegalClassNames = Sets.newHashSet();
+    private final Set<String> illegalClassNames = new HashSet<>();
     /** Legal abstract classes. */
-    private final Set<String> legalAbstractClassNames = Sets.newHashSet();
+    private final Set<String> legalAbstractClassNames = new HashSet<>();
     /** Methods which should be ignored. */
-    private final Set<String> ignoredMethodNames = Sets.newHashSet();
+    private final Set<String> ignoredMethodNames = new HashSet<>();
     /** Check methods and fields with only corresponding modifiers. */
     private List<Integer> memberModifiers;
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -25,8 +25,9 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -108,9 +109,9 @@ public final class ModifiedControlVariableCheck extends AbstractCheck {
     private static final String ILLEGAL_TYPE_OF_TOKEN = "Illegal type of token: ";
 
     /** Operations which can change control variable in update part of the loop. */
-    private static final Set<Integer> MUTATION_OPERATIONS =
-            Sets.newHashSet(TokenTypes.POST_INC, TokenTypes.POST_DEC, TokenTypes.DEC,
-                    TokenTypes.INC, TokenTypes.ASSIGN);
+    private static final Set<Integer> MUTATION_OPERATIONS = Stream.of(TokenTypes.POST_INC,
+        TokenTypes.POST_DEC, TokenTypes.DEC, TokenTypes.INC, TokenTypes.ASSIGN)
+        .collect(Collectors.toSet());
 
     /** Stack of block parameters. */
     private final Deque<Deque<String>> variableStack = new ArrayDeque<>();
@@ -304,8 +305,8 @@ public final class ModifiedControlVariableCheck extends AbstractCheck {
     private static Set<String> getVariablesManagedByForLoop(DetailAST ast) {
         final Set<String> initializedVariables = getForInitVariables(ast);
         final Set<String> iteratingVariables = getForIteratorVariables(ast);
-
-        return Sets.intersection(initializedVariables, iteratingVariables);
+        return initializedVariables.stream().filter(iteratingVariables::contains)
+            .collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -19,13 +19,13 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -51,7 +51,7 @@ public class MultipleStringLiteralsCheck extends AbstractCheck {
      * {@code <String, ArrayList>}, with the ArrayList containing StringInfo
      * objects.
      */
-    private final Map<String, List<StringInfo>> stringMap = Maps.newHashMap();
+    private final Map<String, List<StringInfo>> stringMap = new HashMap<>();
 
     /**
      * Marks the TokenTypes where duplicate strings should be ignored.
@@ -135,7 +135,7 @@ public class MultipleStringLiteralsCheck extends AbstractCheck {
             if (pattern == null || !pattern.matcher(currentString).find()) {
                 List<StringInfo> hitList = stringMap.get(currentString);
                 if (hitList == null) {
-                    hitList = Lists.newArrayList();
+                    hitList = new ArrayList<>();
                     stringMap.put(currentString, hitList);
                 }
                 final int line = ast.getLineNo();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
@@ -22,9 +22,9 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -218,7 +218,7 @@ public final class ParameterAssignmentCheck extends AbstractCheck {
      */
     private void visitMethodDef(DetailAST ast) {
         parameterNamesStack.push(parameterNames);
-        parameterNames = Sets.newHashSet();
+        parameterNames = new HashSet<>();
 
         visitMethodParameters(ast.findFirstToken(TokenTypes.PARAMETERS));
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -19,16 +19,16 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Queues;
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -199,10 +199,10 @@ public class RequireThisCheck extends AbstractCheck {
 
     @Override
     public void beginTree(DetailAST rootAST) {
-        frames = Maps.newHashMap();
+        frames = new HashMap<>();
         current = null;
 
-        final Deque<AbstractFrame> frameStack = Lists.newLinkedList();
+        final Deque<AbstractFrame> frameStack = new LinkedList<>();
         DetailAST curNode = rootAST;
         while (curNode != null) {
             collectDeclarations(frameStack, curNode);
@@ -683,8 +683,8 @@ public class RequireThisCheck extends AbstractCheck {
      */
     private static Set<DetailAST> getAllTokensOfType(DetailAST ast, int tokenType) {
         DetailAST vertex = ast;
-        final Set<DetailAST> result = Sets.newHashSet();
-        final Deque<DetailAST> stack = Queues.newArrayDeque();
+        final Set<DetailAST> result = new HashSet<>();
+        final Deque<DetailAST> stack = new ArrayDeque<>();
         while (vertex != null || !stack.isEmpty()) {
             if (!stack.isEmpty()) {
                 vertex = stack.pop();
@@ -714,8 +714,8 @@ public class RequireThisCheck extends AbstractCheck {
     private static Set<DetailAST> getAllTokensOfType(DetailAST ast, int tokenType,
                                                      int endLineNumber) {
         DetailAST vertex = ast;
-        final Set<DetailAST> result = Sets.newHashSet();
-        final Deque<DetailAST> stack = Queues.newArrayDeque();
+        final Set<DetailAST> result = new HashSet<>();
+        final Deque<DetailAST> stack = new ArrayDeque<>();
         while (vertex != null || !stack.isEmpty()) {
             if (!stack.isEmpty()) {
                 vertex = stack.pop();
@@ -746,8 +746,8 @@ public class RequireThisCheck extends AbstractCheck {
     private static Set<DetailAST> getAllTokensWhichAreEqualToCurrent(DetailAST ast, DetailAST token,
                                                                      int endLineNumber) {
         DetailAST vertex = ast;
-        final Set<DetailAST> result = Sets.newHashSet();
-        final Deque<DetailAST> stack = Queues.newArrayDeque();
+        final Set<DetailAST> result = new HashSet<>();
+        final Deque<DetailAST> stack = new ArrayDeque<>();
         while (vertex != null || !stack.isEmpty()) {
             if (!stack.isEmpty()) {
                 vertex = stack.pop();
@@ -910,7 +910,7 @@ public class RequireThisCheck extends AbstractCheck {
         protected AbstractFrame(AbstractFrame parent, DetailAST ident) {
             this.parent = parent;
             frameNameIdent = ident;
-            varIdents = Sets.newHashSet();
+            varIdents = new HashSet<>();
         }
 
         /**
@@ -1080,10 +1080,10 @@ public class RequireThisCheck extends AbstractCheck {
          */
         ClassFrame(AbstractFrame parent, DetailAST ident) {
             super(parent, ident);
-            instanceMembers = Sets.newHashSet();
-            instanceMethods = Sets.newHashSet();
-            staticMembers = Sets.newHashSet();
-            staticMethods = Sets.newHashSet();
+            instanceMembers = new HashSet<>();
+            instanceMethods = new HashSet<>();
+            staticMembers = new HashSet<>();
+            staticMethods = new HashSet<>();
         }
 
         @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -28,6 +28,7 @@ import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -36,7 +37,6 @@ import org.apache.commons.beanutils.ConversionException;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -54,7 +54,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
     private static final Pattern ESCAPED_LINE_FEED_PATTERN = Pattern.compile("\\\\n");
 
     /** The lines of the header file. */
-    private final List<String> readerLines = Lists.newArrayList();
+    private final List<String> readerLines = new ArrayList<>();
 
     /** The file that contains the header to check against. */
     private String headerFile;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.header;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -27,7 +28,6 @@ import java.util.regex.PatternSyntaxException;
 
 import org.apache.commons.beanutils.ConversionException;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -58,7 +58,7 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck {
     private static final int[] EMPTY_INT_ARRAY = new int[0];
 
     /** The compiled regular expressions. */
-    private final List<Pattern> headerRegexps = Lists.newArrayList();
+    private final List<Pattern> headerRegexps = new ArrayList<>();
 
     /** The header lines to repeat (0 or more) in the check, sorted. */
     private int[] multiLines = EMPTY_INT_ARRAY;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
@@ -19,9 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
+import java.util.ArrayList;
 import java.util.List;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -75,7 +75,7 @@ public class AvoidStarImportCheck
     private static final String STAR_IMPORT_SUFFIX = ".*";
 
     /** The packages/classes to exempt from this check. */
-    private final List<String> excludes = Lists.newArrayList();
+    private final List<String> excludes = new ArrayList<>();
 
     /** Whether to allow all class imports. */
     private boolean allowClassImports;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgControl.java
@@ -19,10 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
+import java.util.ArrayList;
 import java.util.Deque;
+import java.util.LinkedList;
 import java.util.List;
-
-import com.google.common.collect.Lists;
 
 /**
  * Represents the a tree of guards for controlling whether packages are allowed
@@ -33,9 +33,9 @@ import com.google.common.collect.Lists;
  */
 class PkgControl {
     /** List of {@link Guard} objects to check. */
-    private final Deque<Guard> guards = Lists.newLinkedList();
+    private final Deque<Guard> guards = new LinkedList<>();
     /** List of children {@link PkgControl} objects. */
-    private final List<PkgControl> children = Lists.newArrayList();
+    private final List<PkgControl> children = new ArrayList<>();
     /** The parent. Null indicates we are the root node. */
     private final PkgControl parent;
     /** The full package name for the node. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
@@ -19,9 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
+import java.util.HashSet;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -72,9 +72,9 @@ public class RedundantImportCheck
     public static final String MSG_DUPLICATE = "import.duplicate";
 
     /** Set of the imports. */
-    private final Set<FullIdent> imports = Sets.newHashSet();
+    private final Set<FullIdent> imports = new HashSet<>();
     /** Set of static imports. */
-    private final Set<FullIdent> staticImports = Sets.newHashSet();
+    private final Set<FullIdent> staticImports = new HashSet<>();
 
     /** Name of package in file. */
     private String pkgName;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
@@ -72,10 +71,10 @@ public class UnusedImportsCheck extends AbstractCheck {
     private static final String STAR_IMPORT_SUFFIX = ".*";
 
     /** Set of the imports. */
-    private final Set<FullIdent> imports = Sets.newHashSet();
+    private final Set<FullIdent> imports = new HashSet<>();
 
     /** Set of references - possibly to imports or other things. */
-    private final Set<String> referenced = Sets.newHashSet();
+    private final Set<String> referenced = new HashSet<>();
 
     /** Flag to indicate when time to start collecting references. */
     private boolean collect;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
@@ -20,10 +20,10 @@
 package com.puppycrawl.tools.checkstyle.checks.indentation;
 
 import java.lang.reflect.Constructor;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.collect.Maps;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -37,12 +37,10 @@ public class HandlerFactory {
     /**
      * Registered handlers.
      */
-    private final Map<Integer, Constructor<?>> typeHandlers =
-        Maps.newHashMap();
+    private final Map<Integer, Constructor<?>> typeHandlers = new HashMap<>();
 
     /** Cache for created method call handlers. */
-    private final Map<DetailAST, AbstractExpressionHandler> createdHandlers =
-        Maps.newHashMap();
+    private final Map<DetailAST, AbstractExpressionHandler> createdHandlers = new HashMap<>();
 
     /** Creates a HandlerFactory. */
     public HandlerFactory() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineSet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineSet.java
@@ -20,8 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.indentation;
 
 import java.util.SortedMap;
-
-import com.google.common.collect.Maps;
+import java.util.TreeMap;
 
 /**
  * Represents a set of lines.
@@ -32,7 +31,7 @@ public class LineSet {
     /**
      * Maps line numbers to their start column.
      */
-    private final SortedMap<Integer, Integer> lines = Maps.newTreeMap();
+    private final SortedMap<Integer, Integer> lines = new TreeMap<>();
 
     /**
      * Get the starting column for a given line number.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -29,8 +30,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -563,7 +562,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      */
     private static List<JavadocTag> getMethodTags(TextBlock comment) {
         final String[] lines = comment.getText();
-        final List<JavadocTag> tags = Lists.newArrayList();
+        final List<JavadocTag> tags = new ArrayList<>();
         int currentLine = comment.getStartLineNo() - 1;
         final int startColumnNumber = comment.getStartColNo();
 
@@ -689,7 +688,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      */
     private static List<DetailAST> getParameters(DetailAST ast) {
         final DetailAST params = ast.findFirstToken(TokenTypes.PARAMETERS);
-        final List<DetailAST> returnValue = Lists.newArrayList();
+        final List<DetailAST> returnValue = new ArrayList<>();
 
         DetailAST child = params.getFirstChild();
         while (child != null) {
@@ -709,7 +708,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * @return the list of exception nodes for ast.
      */
     private List<ExceptionInfo> getThrows(DetailAST ast) {
-        final List<ExceptionInfo> returnValue = Lists.newArrayList();
+        final List<ExceptionInfo> returnValue = new ArrayList<>();
         final DetailAST throwsAST = ast
                 .findFirstToken(TokenTypes.LITERAL_THROWS);
         if (throwsAST != null) {
@@ -878,7 +877,7 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
             List<ExceptionInfo> throwsList, boolean reportExpectedTags) {
         // Loop over the tags, checking to see they exist in the throws.
         // The foundThrows used for performance only
-        final Set<String> foundThrows = Sets.newHashSet();
+        final Set<String> foundThrows = new HashSet<>();
         final ListIterator<JavadocTag> tagIt = tags.listIterator();
         while (tagIt.hasNext()) {
             final JavadocTag tag = tagIt.next();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
@@ -20,10 +20,10 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 
 /**
@@ -46,7 +46,7 @@ public class JavadocPackageCheck extends AbstractFileSetCheck {
     public static final String MSG_PACKAGE_INFO = "javadoc.packageInfo";
 
     /** The directories checked. */
-    private final Set<File> directoriesChecked = Sets.newHashSet();
+    private final Set<File> directoriesChecked = new HashSet<>();
 
     /** Indicates if allow legacy "package.html" file to be used. */
     private boolean allowLegacy;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -20,9 +20,10 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
@@ -80,7 +81,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
      * @param tags to be ignored by check.
      */
     public void setIgnoredTags(String... tags) {
-        ignoredTags = Lists.newArrayList(tags);
+        ignoredTags = Arrays.stream(tags).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
@@ -19,9 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import java.util.LinkedList;
 import java.util.List;
-
-import com.google.common.collect.Lists;
 
 /**
  * <p>
@@ -47,7 +46,7 @@ import com.google.common.collect.Lists;
  */
 class TagParser {
     /** List of HtmlTags found on the input line of text. */
-    private final List<HtmlTag> tags = Lists.newLinkedList();
+    private final List<HtmlTag> tags = new LinkedList<>();
 
     /**
      * Constructs a TagParser and finds the first tag if any.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -22,9 +22,9 @@ package com.puppycrawl.tools.checkstyle.checks.metrics;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Set;
+import java.util.TreeSet;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -201,7 +201,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
          * Set of referenced classes.
          * Sorted by name for predictable error messages in unit tests.
          */
-        private final Set<String> referencedClassNames = Sets.newTreeSet();
+        private final Set<String> referencedClassNames = new TreeSet<>();
         /** Own class name. */
         private final String className;
         /* Location of own class. (Used to log violations) */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
@@ -19,10 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.checks.modifier;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -105,7 +105,7 @@ public class ModifierOrderCheck
 
     @Override
     public void visitToken(DetailAST ast) {
-        final List<DetailAST> mods = Lists.newArrayList();
+        final List<DetailAST> mods = new ArrayList<>();
         DetailAST modifier = ast.getFirstChild();
         while (modifier != null) {
             mods.add(modifier);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -19,12 +19,13 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -159,7 +160,8 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
      */
     public void setAllowedAbbreviations(String... allowedAbbreviations) {
         if (allowedAbbreviations != null) {
-            this.allowedAbbreviations = Sets.newHashSet(allowedAbbreviations);
+            this.allowedAbbreviations =
+                Arrays.stream(allowedAbbreviations).collect(Collectors.toSet());
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/CsvFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/CsvFilter.java
@@ -20,11 +20,10 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
-
-import com.google.common.collect.Sets;
 
 /**
  * <p>
@@ -36,7 +35,7 @@ import com.google.common.collect.Sets;
  */
 class CsvFilter implements IntFilter {
     /** Filter set. */
-    private final Set<IntFilter> filters = Sets.newHashSet();
+    private final Set<IntFilter> filters = new HashSet<>();
 
     /**
      * Constructs a {@code CsvFilter} from a CSV, Comma-Separated Values,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -30,7 +31,6 @@ import java.util.regex.PatternSyntaxException;
 
 import org.apache.commons.beanutils.ConversionException;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
@@ -88,7 +88,7 @@ public class SuppressWithNearbyCommentFilter
     private static final String DEFAULT_INFLUENCE_FORMAT = "0";
 
     /** Tagged comments. */
-    private final List<Tag> tags = Lists.newArrayList();
+    private final List<Tag> tags = new ArrayList<>();
 
     /** Whether to look for trigger in C-style comments. */
     private boolean checkC = true;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -30,7 +31,6 @@ import java.util.regex.PatternSyntaxException;
 
 import org.apache.commons.beanutils.ConversionException;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
@@ -76,7 +76,7 @@ public class SuppressionCommentFilter
     private static final String DEFAULT_CHECK_FORMAT = ".*";
 
     /** Tagged comments. */
-    private final List<Tag> tags = Lists.newArrayList();
+    private final List<Tag> tags = new ArrayList<>();
 
     /** Whether to look in comments of the C type. */
     private boolean checkC = true;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.PatternSyntaxException;
@@ -32,7 +33,6 @@ import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import com.google.common.collect.Maps;
 import com.puppycrawl.tools.checkstyle.api.AbstractLoader;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FilterSet;
@@ -167,7 +167,7 @@ public final class SuppressionsLoader
      * @return map between local resources and dtd ids.
      */
     private static Map<String, String> createIdToResourceNameMap() {
-        final Map<String, String> map = Maps.newHashMap();
+        final Map<String, String> map = new HashMap<>();
         map.put(DTD_PUBLIC_ID_1_0, DTD_RESOURCE_NAME_1_0);
         map.put(DTD_PUBLIC_ID_1_1, DTD_RESOURCE_NAME_1_1);
         return map;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtils.java
@@ -19,10 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.utils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -272,7 +272,7 @@ public final class CheckUtils {
         final DetailAST typeParameters =
             node.findFirstToken(TokenTypes.TYPE_PARAMETERS);
 
-        final List<String> typeParameterNames = Lists.newArrayList();
+        final List<String> typeParameterNames = new ArrayList<>();
         if (typeParameters != null) {
             final DetailAST typeParam =
                 typeParameters.findFirstToken(TokenTypes.TYPE_PARAMETER);
@@ -301,7 +301,7 @@ public final class CheckUtils {
         final DetailAST typeParameters =
             node.findFirstToken(TokenTypes.TYPE_PARAMETERS);
 
-        final List<DetailAST> typeParams = Lists.newArrayList();
+        final List<DetailAST> typeParams = new ArrayList<>();
         if (typeParameters != null) {
             final DetailAST typeParam =
                 typeParameters.findFirstToken(TokenTypes.TYPE_PARAMETER);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
@@ -21,12 +21,12 @@ package com.puppycrawl.tools.checkstyle.utils;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
@@ -141,8 +141,8 @@ public final class JavadocUtils {
     public static JavadocTags getJavadocTags(TextBlock textBlock,
             JavadocTagType tagType) {
         final String[] text = textBlock.getText();
-        final List<JavadocTag> tags = Lists.newArrayList();
-        final List<InvalidJavadocTag> invalidTags = Lists.newArrayList();
+        final List<JavadocTag> tags = new ArrayList<>();
+        final List<InvalidJavadocTag> invalidTags = new ArrayList<>();
         for (int i = 0; i < text.length; i++) {
             final String textValue = text[i];
             final Matcher blockTagMatcher = getBlockTagPattern(i).matcher(textValue);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -42,7 +42,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.MapDifference.ValueDifference;
 import com.google.common.collect.Maps;
@@ -148,7 +147,7 @@ public class BaseCheckTestSupport {
                           String... expected)
             throws Exception {
         stream.flush();
-        final List<File> theFiles = Lists.newArrayList();
+        final List<File> theFiles = new ArrayList<>();
         Collections.addAll(theFiles, processedFiles);
         final int errs = checker.process(theFiles);
 
@@ -179,7 +178,7 @@ public class BaseCheckTestSupport {
                           Map<String, List<String>> expectedViolations)
             throws Exception {
         stream.flush();
-        final List<File> theFiles = Lists.newArrayList();
+        final List<File> theFiles = new ArrayList<>();
         Collections.addAll(theFiles, processedFiles);
         final int errs = checker.process(theFiles);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -38,14 +38,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.powermock.api.mockito.PowerMockito;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -94,7 +93,7 @@ public class CheckerTest extends BaseCheckTestSupport {
         checker.fireFileStarted("Some File Name");
         checker.fireFileFinished("Some File Name");
 
-        final SortedSet<LocalizedMessage> messages = Sets.newTreeSet();
+        final SortedSet<LocalizedMessage> messages = new TreeSet<>();
         messages.add(new LocalizedMessage(0, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", messages);
@@ -126,7 +125,7 @@ public class CheckerTest extends BaseCheckTestSupport {
         assertTrue("Checker.fireFileFinished() doesn't call listener", auditAdapter.wasCalled());
 
         auditAdapter.resetListener();
-        final SortedSet<LocalizedMessage> messages = Sets.newTreeSet();
+        final SortedSet<LocalizedMessage> messages = new TreeSet<>();
         messages.add(new LocalizedMessage(0, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", messages);
@@ -167,7 +166,7 @@ public class CheckerTest extends BaseCheckTestSupport {
                 auditAdapter.wasCalled());
 
         aa2.resetListener();
-        final SortedSet<LocalizedMessage> messages = Sets.newTreeSet();
+        final SortedSet<LocalizedMessage> messages = new TreeSet<>();
         messages.add(new LocalizedMessage(0, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", messages);
@@ -184,7 +183,7 @@ public class CheckerTest extends BaseCheckTestSupport {
         checker.addFilter(filter);
 
         filter.resetFilter();
-        final SortedSet<LocalizedMessage> messages = Sets.newTreeSet();
+        final SortedSet<LocalizedMessage> messages = new TreeSet<>();
         messages.add(new LocalizedMessage(0, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", messages);
@@ -201,7 +200,7 @@ public class CheckerTest extends BaseCheckTestSupport {
         checker.removeFilter(filter);
 
         f2.resetFilter();
-        final SortedSet<LocalizedMessage> messages = Sets.newTreeSet();
+        final SortedSet<LocalizedMessage> messages = new TreeSet<>();
         messages.add(new LocalizedMessage(0, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", messages);
@@ -532,7 +531,7 @@ public class CheckerTest extends BaseCheckTestSupport {
         final Error expectedError = new IOError(new InternalError(errorMessage));
         when(mock.lastModified()).thenThrow(expectedError);
         final Checker checker = new Checker();
-        final List<File> filesToProcess = Lists.newArrayList();
+        final List<File> filesToProcess = new ArrayList<>();
         filesToProcess.add(mock);
         try {
             checker.process(filesToProcess);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -36,6 +36,7 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Test;
@@ -43,7 +44,6 @@ import org.mockito.Mockito;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
 /**
@@ -85,8 +85,7 @@ public class PackageNamesLoaderTest {
 
         assertEquals("pkgNames.length.", checkstylePackages.length,
             pkgNames.size());
-        final Set<String> checkstylePackagesSet =
-            Sets.newHashSet(Arrays.asList(checkstylePackages));
+        final Set<String> checkstylePackagesSet = new HashSet<>(Arrays.asList(checkstylePackages));
         assertEquals("names set.", checkstylePackagesSet, pkgNames);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -30,12 +30,12 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
@@ -224,7 +224,7 @@ public class XMLLoggerTest {
         final byte[] bytes = outStream.toByteArray();
         final ByteArrayInputStream inStream =
             new ByteArrayInputStream(bytes);
-        final List<String> lineList = Lists.newArrayList();
+        final List<String> lineList = new ArrayList<>();
         try (BufferedReader reader = new BufferedReader(
                 new InputStreamReader(inStream, StandardCharsets.UTF_8))) {
             while (true) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -39,7 +40,6 @@ import org.apache.tools.ant.types.Reference;
 import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultLogger;
 import com.puppycrawl.tools.checkstyle.XMLLogger;
@@ -424,7 +424,7 @@ public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
             // Assume that I/O error is happened when we try to invoke 'lastModified()' method.
             final Exception expectedError = new RuntimeException("");
             when(mock.lastModified()).thenThrow(expectedError);
-            final List<File> list = Lists.newArrayList();
+            final List<File> list = new ArrayList<>();
             list.add(mock);
             return list;
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/ClassResolverTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/ClassResolverTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyObject;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Test;
@@ -34,14 +35,12 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.google.common.collect.Sets;
-
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ ClassResolver.class, ClassResolverTest.class })
 public class ClassResolverTest {
     @Test
     public void testMisc() throws ClassNotFoundException {
-        final Set<String> imports = Sets.newHashSet();
+        final Set<String> imports = new HashSet<>();
         imports.add("java.io.File");
         imports.add("nothing.will.match.*");
         imports.add("java.applet.*");
@@ -87,7 +86,7 @@ public class ClassResolverTest {
 
     @Test
     public void testExistedImportCantBeResolved() {
-        final Set<String> imports = Sets.newHashSet();
+        final Set<String> imports = new HashSet<>();
         imports.add("java.applet.someClass");
         final ClassResolver classResolver = new ClassResolver(
                 Thread.currentThread().getContextClassLoader(),
@@ -105,7 +104,7 @@ public class ClassResolverTest {
 
     @Test
     public void testResolveInnerClass() throws Exception {
-        final Set<String> imports = Sets.newHashSet();
+        final Set<String> imports = new HashSet<>();
         final ClassResolver classResolver = new ClassResolver(
                 Thread.currentThread().getContextClassLoader(),
                 "java.util", imports);
@@ -116,7 +115,7 @@ public class ClassResolverTest {
 
     @Test
     public void testResolveInnerClassWithEmptyPackage() {
-        final Set<String> imports = Sets.newHashSet();
+        final Set<String> imports = new HashSet<>();
         final ClassResolver classResolver = new ClassResolver(
                 Thread.currentThread().getContextClassLoader(),
                 "", imports);
@@ -131,7 +130,7 @@ public class ClassResolverTest {
 
     @Test
     public void testResolveQualifiedNameFails() throws Exception {
-        final Set<String> imports = Sets.newHashSet();
+        final Set<String> imports = new HashSet<>();
         imports.add("java.applet.someClass");
 
         final ClassResolver classResolver = PowerMockito.spy(new ClassResolver(Thread
@@ -161,7 +160,7 @@ public class ClassResolverTest {
      */
     @Test
     public void testIsLoadableWithNoClassDefFoundError() throws Exception {
-        final Set<String> imports = Sets.newHashSet();
+        final Set<String> imports = new HashSet<>();
         imports.add("java.applet.someClass");
 
         final ClassResolver classResolver = PowerMockito.spy(new ClassResolver(Thread

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -31,12 +31,13 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -171,9 +172,10 @@ public class NewlineAtEndOfFileCheckTest
         final DefaultConfiguration checkConfig = createCheckConfig(NewlineAtEndOfFileCheck.class);
         final NewlineAtEndOfFileCheck check = new NewlineAtEndOfFileCheck();
         check.configure(checkConfig);
+        final List<String> lines = new ArrayList<>(1);
+        lines.add("txt");
         final File impossibleFile = new File("");
-        final Set<LocalizedMessage> messages = check.process(impossibleFile,
-            Lists.newArrayList("txt"));
+        final Set<LocalizedMessage> messages = check.process(impossibleFile, lines);
         assertEquals(1, messages.size());
         final Iterator<LocalizedMessage> iterator = messages.iterator();
         assertEquals("Unable to open ''.", iterator.next().getMessage());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -331,7 +331,8 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
                 "SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STATIC###SPECIAL_IMPORTS");
         final String[] expected = {
-            "11: " + getCheckMessage(MSG_ORDER, THIRD, SPECIAL, "com.google.common.collect.Sets"),
+            "11: " + getCheckMessage(MSG_ORDER, THIRD, SPECIAL,
+                "com.google.common.collect.HashMultimap"),
         };
 
         verify(checkConfig, getPath("InputCustomImportOrderThirdPartyAndSpecial.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -31,13 +31,13 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -208,7 +208,7 @@ public class WriteTagCheckTest extends BaseCheckTestSupport {
                           String... expected)
             throws Exception {
         stream.flush();
-        final List<File> theFiles = Lists.newArrayList();
+        final List<File> theFiles = new ArrayList<>();
         Collections.addAll(theFiles, processedFiles);
         final int errs = checker.process(theFiles);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertArrayEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
@@ -34,7 +35,6 @@ import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
 
-import com.google.common.collect.Maps;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -48,7 +48,7 @@ public class GenericWhitespaceCheckTest
     @Before
     public void setUp() {
         checkConfig = createCheckConfig(GenericWhitespaceCheck.class);
-        final Map<Class<?>, Integer> x = Maps.newHashMap();
+        final Map<Class<?>, Integer> x = new HashMap<>();
         x.entrySet().forEach(Map.Entry::getValue);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -24,10 +24,10 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.BriefUtLogger;
 import com.puppycrawl.tools.checkstyle.Checker;
@@ -155,8 +155,7 @@ public class SuppressWarningsFilterTest
     }
 
     private static String[] removeSuppressed(String[] from, String... remove) {
-        final Collection<String> coll =
-            Lists.newArrayList(Arrays.asList(from));
+        final Collection<String> coll = Arrays.stream(from).collect(Collectors.toList());
         coll.removeAll(Arrays.asList(remove));
         return coll.toArray(new String[coll.size()]);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -26,12 +26,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 import org.apache.commons.beanutils.ConversionException;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.BriefUtLogger;
 import com.puppycrawl.tools.checkstyle.Checker;
@@ -240,8 +240,7 @@ public class SuppressWithNearbyCommentFilterTest
     }
 
     private static String[] removeSuppressed(String[] from, String... remove) {
-        final Collection<String> coll =
-            Lists.newArrayList(Arrays.asList(from));
+        final Collection<String> coll = Arrays.stream(from).collect(Collectors.toList());
         coll.removeAll(Arrays.asList(remove));
         return coll.toArray(new String[coll.size()]);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -26,12 +26,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 import org.apache.commons.beanutils.ConversionException;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.BriefUtLogger;
 import com.puppycrawl.tools.checkstyle.Checker;
@@ -240,8 +240,7 @@ public class SuppressionCommentFilterTest
     }
 
     private static String[] removeSuppressed(String[] from, String... remove) {
-        final Collection<String> coll =
-            Lists.newArrayList(Arrays.asList(from));
+        final Collection<String> coll = Arrays.stream(from).collect(Collectors.toList());
         coll.removeAll(Arrays.asList(remove));
         return coll.toArray(new String[coll.size()]);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/AllBlockCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/AllBlockCommentsTest.java
@@ -22,12 +22,12 @@ package com.puppycrawl.tools.checkstyle.grammars.comments;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -36,7 +36,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class AllBlockCommentsTest extends BaseCheckTestSupport {
-    private static final Set<String> ALL_COMMENTS = Sets.newLinkedHashSet();
+    private static final Set<String> ALL_COMMENTS = new LinkedHashSet<>();
 
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/AllSinglelineCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/AllSinglelineCommentsTest.java
@@ -21,12 +21,12 @@ package com.puppycrawl.tools.checkstyle.grammars.comments;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.google.common.collect.Sets;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -35,7 +35,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class AllSinglelineCommentsTest extends BaseCheckTestSupport {
-    private static final Set<String> ALL_COMMENTS = Sets.newLinkedHashSet();
+    private static final Set<String> ALL_COMMENTS = new LinkedHashSet<>();
 
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
@@ -28,7 +28,11 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -41,9 +45,6 @@ import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
 
 /**
  * Validate commit message has proper structure.
@@ -238,8 +239,10 @@ public class CommitValidationTest {
 
     private static List<RevCommit> getCommitsByCounter(
             Iterator<RevCommit> previousCommitsIterator) {
-        return Lists.newArrayList(Iterators.limit(previousCommitsIterator,
-                PREVIOUS_COMMITS_TO_CHECK_COUNT));
+        final Spliterator<RevCommit> spliterator =
+            Spliterators.spliteratorUnknownSize(previousCommitsIterator, Spliterator.ORDERED);
+        return StreamSupport.stream(spliterator, false).limit(PREVIOUS_COMMITS_TO_CHECK_COUNT)
+            .collect(Collectors.toList());
     }
 
     private static List<RevCommit> getCommitsByLastCommitAuthor(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputFinalLocalVariableAssignedMultipleTimes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputFinalLocalVariableAssignedMultipleTimes.java
@@ -3,7 +3,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import java.util.HashMap;
 import java.util.Locale;
 
-import com.google.common.collect.Maps;
+
 
 public class InputFinalLocalVariableAssignedMultipleTimes {
 
@@ -358,7 +358,7 @@ public class InputFinalLocalVariableAssignedMultipleTimes {
     private void foo12(Long start, Long end) {
         HashMap<Object, Object> headMap;
         if (end < Long.MAX_VALUE) {
-            headMap = Maps.newHashMap();
+            headMap = new HashMap<>();
             Long tailEnd = 1L;
             if (tailEnd != null) {
                 end = tailEnd;
@@ -370,7 +370,7 @@ public class InputFinalLocalVariableAssignedMultipleTimes {
                 }
             }
         }
-        headMap = Maps.newHashMap();
+        headMap = new HashMap<>();
         if (!headMap.isEmpty()) {
             final int headStart = headMap.size();
             final Long headEnd = (Long) headMap.get(headStart);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/InputCustomImportOrderThirdPartyAndSpecial.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/InputCustomImportOrderThirdPartyAndSpecial.java
@@ -8,7 +8,7 @@ import org.apache.commons.io.ByteOrderMark;
 
 import static sun.tools.util.ModifierFilter.ALL_ACCESS;
 
-import com.google.common.collect.Sets; //warn, ORDER, should be on THIRD_PARTY_PACKAGE, now SPECIAL_IMPORTS
+import com.google.common.collect.HashMultimap; //warn, ORDER, should be on THIRD_PARTY_PACKAGE, now SPECIAL_IMPORTS
 
 import antlr.*;
 import antlr.CommonASTWithHiddenTokens;


### PR DESCRIPTION
#3433 

Got rid of and prohibited usage of:
1) com.google.common.collect.Queues
2) com.google.common.collect.Sets
3) com.google.common.collect.Lists 
4) com.google.common.collect.Maps (parttially)
5) com.google.common.collect.Iterators

I also restricted usage of  com.google.common.collect.* to certain packages.

Problems:
1) `com.google.common.collect.HashMultimap, com.google.common.collect.HashMultiset, com.google.common.collect.SetMultimap, com.google.common.collect.Multimap, com.google.common.collect.Multiset, com.google.common.collect.MapDifference `
do not have easy to use analogs in Java.

2) `com.google.common.collect.ImmutableCollection and com.google.common.collect.ImmutableMap` are part of Checkstyle's API (See com.puppycrawl.tools.checkstyle.api.Context and com.puppycrawl.tools.checkstyle.api.Configuration).

3) `com.google.common.annotations.VisibleForTesting, com.google.common.annotations.GwtCompatible, com.google.common.annotations.GwtIncompatible` are required for UTs.

4)` com.google.common.collect.ImmutableList , com.google.common.collect.ImmutableSet` have copyOf method which allows to create immutable copy of collection. If we get rid of ImmutableList and ImmutableSet it will require to use Collections.copy and then create unmodifiable list or set view based on mutable copy. I don't think it is reasonable.

5) If we get rid of `com.google.common.collect.ImmutableSortedSet` the code will become too big. For example:
    
```java
private static final Set<String> SINGLE_TAGS = ImmutableSortedSet.of(
        "br", "li", "dt", "dd", "hr", "img", "p", "td", "tr", "th");
```

will become

```java
private static final Set<String> SINGLE_TAGS = Collections.unmodifiableSortedSet(Stream.of(
    "br", "li", "dt", "dd", "hr", "img", "p", "td", "tr", "th")
    .collect(Collectors.toCollection(TreeSet::new)));
```

6) `com.google.common.collect.Maps` has 'difference' method which is a simple way to get the difference between two maps. It will decrease readibility if we try to get rid of the dependency.

I think that is all we can do now.