### PR TITLE
doc: added missing slash to backport documentation url

### DIFF
--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -111,7 +111,7 @@
         Checkstyle releases to be run with JDKs as old as 1.6. If you wish to continue using new
         Checkstyle versions on older JDKs, we recommend you either checkout the
         <a href="https://github.com/rnveach/checkstyle-backport-jre6">github site</a> or the 
-        <a href="https://rnveach.github.io/checkstyle-backport-jre6">documentation site</a> on how
+        <a href="https://rnveach.github.io/checkstyle-backport-jre6/">documentation site</a> on how
         to use the backport version of the utility, in place of the official Checkstyle version.
       </p>
     </section>


### PR DESCRIPTION
Fixed missing slash in URL to backport documentation.
