### PR TITLE
Issue #3433: Cut down on Checkstyle's dependencies on Guava (part 3)

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -44,7 +44,8 @@
              com.google.common.base.Preconditions,com.google.common.base.Predicate,
              com.google.common.io.CharSource,com.google.common.annotations.Beta,
              com.google.common.collect.Queues,com.google.common.collect.Sets,
-             com.google.common.collect.Lists"/>
+             com.google.common.collect.Lists,com.google.common.annotations.GwtCompatible,
+             com.google.common.io.Files,com.google.common.collect.TreeTraverser"/>
         </module>
         <module name="ForbidCCommentsInMethods"/>
         <module name="FinalizeImplementationCheck"/>
@@ -111,7 +112,9 @@
             com\.google\.common\.base\.Equivalence|com\.google\.common\.base\.Preconditions|
             com\.google\.common\.base\.Optional|com\.google\.common\.io\.CharSource|
             com\.google\.common\.primitives.*|com\.google\.common\.collect\.Sets|
-            com\.google\.common\.collect\.Queues|com\.google\.common\.collect\.Lists"/>
+            com\.google\.common\.collect\.Queues|com\.google\.common\.collect\.Lists|
+            com\.google\.common\.annotations\.GwtCompatible|com\.google\.common\.io\.Files|
+            com\.google\.common\.collect\.TreeTraverser"/>
             <property name="forbiddenImportsExcludesRegexp" value=""/>
         </module>
         <module name="ForbidCertainImports">

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -70,7 +70,6 @@
   <subpackage name="checks">
     <allow pkg="com.puppycrawl.tools.checkstyle.checks"/>
     <allow class="com.puppycrawl.tools.checkstyle.Definitions"/>
-    <allow class="com.google.common.io.Files" local-only="true"/>
     <allow class="com.google.common.io.Closeables" local-only="true"/>
     <allow class="com.google.common.collect.HashMultiset" local-only="true"/>
     <allow class="com.google.common.collect.HashMultimap" local-only="true"/>
@@ -99,23 +98,15 @@
       <allow pkg="com.puppycrawl.tools.checkstyle.grammars.javadoc"/>
       <allow pkg="java.lang.reflect"/>
       <allow class="com.google.common.base.CharMatcher" local-only="true"/>
-      <allow class="com.google.common.annotations.GwtCompatible" local-only="true"/>
-      <allow class="com.google.common.annotations.GwtIncompatible" local-only="true"/>
       <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
       <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
       <allow class="com.google.common.collect.ImmutableSortedSet" local-only="true"/>
       <allow class="com.google.common.collect.Multiset" local-only="true"/>
     </subpackage>
-    <subpackage name="whitespace">
-      <allow class="com.google.common.annotations.GwtCompatible" local-only="true"/>
-    </subpackage>
     <subpackage name="design">
       <allow class="com.google.common.annotations.VisibleForTesting" local-only="true"/>
       <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
       <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
-    </subpackage>
-    <subpackage name="regexp">
-      <allow class="com.google.common.io.Files" local-only="true"/>
     </subpackage>
     <subpackage name="imports">
       <allow class="com.google.common.collect.HashMultimap" local-only="true"/>
@@ -164,8 +155,6 @@
 
   <subpackage name="internal">
     <allow class="com.google.common.reflect.ClassPath" local-only="true"/>
-    <allow class="com.google.common.io.Files" local-only="true"/>
     <allow class="com.google.common.collect.FluentIterable" local-only="true"/>
-    <allow class="com.google.common.collect.TreeTraverser"/>
   </subpackage>
 </import-control>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -44,7 +44,6 @@ import org.apache.commons.logging.LogFactory;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.io.Closeables;
-import com.google.common.io.Files;
 import com.puppycrawl.tools.checkstyle.Definitions;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
@@ -351,7 +350,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
             final String baseName = extractBaseName(fileName);
             final Matcher baseNameMatcher = baseNameRegexp.matcher(baseName);
             if (baseNameMatcher.matches()) {
-                final String extension = Files.getFileExtension(fileName);
+                final String extension = CommonUtils.getFileExtension(fileName);
                 final String path = getPath(currentFile.getAbsolutePath());
                 final ResourceBundle newBundle = new ResourceBundle(baseName, path, extension);
                 final Optional<ResourceBundle> bundle = findBundle(resourceBundles, newBundle);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import com.google.common.io.Files;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -272,7 +271,7 @@ public class RegexpOnFilenameCheck extends AbstractFileSetCheck {
         String fileName = file.getName();
 
         if (ignoreFileNameExtensions) {
-            fileName = Files.getNameWithoutExtension(fileName);
+            fileName = CommonUtils.getFileNameWithoutExtension(fileName);
         }
 
         return fileName;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
@@ -425,4 +425,46 @@ public final class CommonUtils {
     public static boolean isBlank(String str) {
         return str == null || CharMatcher.WHITESPACE.matchesAllOf(str);
     }
+
+    /**
+     * Returns file name without extension.
+     * We do not use the method from Guava library to reduce Checkstyle's dependencies
+     * on external libraries.
+     * @param fullFilename file name with extension.
+     * @return file name without extension.
+     */
+    public static String getFileNameWithoutExtension(String fullFilename) {
+        final String fileName = new File(fullFilename).getName();
+        final int dotIndex = fileName.lastIndexOf('.');
+        final String fileNameWithoutExtension;
+        if (dotIndex == -1) {
+            fileNameWithoutExtension = fileName;
+        }
+        else {
+            fileNameWithoutExtension = fileName.substring(0, dotIndex);
+        }
+        return fileNameWithoutExtension;
+    }
+
+    /**
+     * Returns file extension for the given file name
+     * or empty string if file does not have an extension.
+     * We do not use the method from Guava library to reduce Checkstyle's dependencies
+     * on external libraries.
+     * @param fileNameWithExtension file name with extension.
+     * @return file extension for the given file name
+     *         or empty string if file does not have an extension.
+     */
+    public static String getFileExtension(String fileNameWithExtension) {
+        final String fileName = Paths.get(fileNameWithExtension).toString();
+        final int dotIndex = fileName.lastIndexOf('.');
+        final String extension;
+        if (dotIndex == -1) {
+            extension = "";
+        }
+        else {
+            extension = fileName.substring(dotIndex + 1);
+        }
+        return extension;
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -91,7 +91,7 @@ public class JavadocMethodCheckTest extends BaseCheckTestSupport {
         config.addAttribute("allowedAnnotations", "MyAnnotation, Override");
         config.addAttribute("minLineCount", "2");
         final String[] expected = {
-            "46:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "44:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verify(config, getPath("InputExtendAnnotation.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
@@ -27,13 +27,13 @@ import static com.puppycrawl.tools.checkstyle.checks.regexp.MultilineDetector.MS
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import com.google.common.io.Files;
 import com.puppycrawl.tools.checkstyle.BaseFileSetCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -121,7 +121,8 @@ public class RegexpMultilineCheckTest extends BaseFileSetCheckTestSupport {
         };
 
         final File file = temporaryFolder.newFile();
-        Files.write("first line \r\n second line \n\r third line", file, StandardCharsets.UTF_8);
+        Files.write(file.toPath(),
+            "first line \r\n second line \n\r third line".getBytes(StandardCharsets.UTF_8));
 
         verify(checkConfig, file.getPath(), expected);
     }
@@ -160,7 +161,7 @@ public class RegexpMultilineCheckTest extends BaseFileSetCheckTestSupport {
         };
 
         final File file = temporaryFolder.newFile();
-        Files.write(makeLargeXyString(), file, StandardCharsets.UTF_8);
+        Files.write(file.toPath(), makeLargeXyString().toString().getBytes(StandardCharsets.UTF_8));
 
         verify(checkConfig, file.getPath(), expected);
     }
@@ -175,7 +176,7 @@ public class RegexpMultilineCheckTest extends BaseFileSetCheckTestSupport {
         };
 
         final File file = temporaryFolder.newFile();
-        Files.write("", file, StandardCharsets.UTF_8);
+        Files.write(file.toPath(), "".getBytes(StandardCharsets.UTF_8));
 
         verify(checkConfig, file.getPath(), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
@@ -204,6 +204,13 @@ public class CommonUtilsTest {
     }
 
     @Test
+    public void testGetFileExtensionForFileNameWithoutExtension() {
+        final String fileNameWithoutExtension = "file";
+        final String extension = CommonUtils.getFileExtension(fileNameWithoutExtension);
+        assertEquals("", extension);
+    }
+
+    @Test
     @PrepareForTest({ CommonUtils.class, CommonUtilsTest.class })
     @SuppressWarnings("unchecked")
     public void testLoadSuppressionsUriSyntaxException() throws Exception {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputExtendAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputExtendAnnotation.java
@@ -16,8 +16,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multiset.Entry;
 
@@ -36,7 +34,7 @@ import java.util.List;
  *
  * @author Chris Povirk
  */
-@GwtCompatible(emulated = true)
+@SuppressWarnings(value = "unchecked")
 public abstract class InputExtendAnnotation<E>
   {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputEmptyTypesAndCycles.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputEmptyTypesAndCycles.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import com.google.common.annotations.GwtCompatible;
+
 
 class myFoo
 {
@@ -56,7 +56,7 @@ class WithEmptyAnonymous
 @Target(
     ElementType.ANNOTATION_TYPE)
 @Documented
-@GwtCompatible
+@Deprecated
 @interface Beta {}
 @interface MapFeature {
 	@interface Require {


### PR DESCRIPTION
#3433 

Got rid of and prohibited usage of:
1) com.google.common.annotations.GwtCompatible
2) com.google.common.annotations.GwtInCompatible
3) com.google.common.collect.TreeTraverser
4) com.google.common.io.Files

Immutable collections from Guava cannot be replaced with Java's Collections.unmodifiable... since unmodifiable collections provide only read-only view of modifiable collections. They are not thread-safe!

The list of the remaining dependencies on Guava: [checkstyle-dependencies](https://github.com/checkstyle/checkstyle/files/484682/checkstyle-dependencies.txt)







