### PR TITLE
Issue #3433:  Cut down on Checkstyle's dependencies on Guava (part 4, collections)

### DIFF
--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -105,4 +105,11 @@
         <Method name="apply" />
         <Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE" />
     </Match>
+    <Match>
+        <!-- Temporary disabled. Have to deal with Javadoc nodes as well
+         See https://github.com/checkstyle/checkstyle/issues/3432-->
+        <Class name="com.puppycrawl.tools.checkstyle.gui.JTreeTable" />
+        <Method name="makeCodeSelection"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    </Match>
 </FindBugsFilter>

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -73,10 +73,8 @@
     <allow class="com.google.common.io.Closeables" local-only="true"/>
     <allow class="com.google.common.collect.HashMultiset" local-only="true"/>
     <allow class="com.google.common.collect.HashMultimap" local-only="true"/>
-    <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
     <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
     <allow class="com.google.common.collect.ImmutableMultiset" local-only="true"/>
-    <allow class="com.google.common.collect.ImmutableSet" local-only="true"/>
     <allow class="com.google.common.collect.Multimap" local-only="true"/>
     <allow class="com.google.common.collect.Multiset" local-only="true"/>
     <allow class="com.google.common.collect.Multiset.Entry" local-only="true"/>
@@ -91,33 +89,22 @@
     <subpackage name="header">
       <allow class="java.nio.charset.Charset" local-only="true"/>
       <allow class="com.google.common.io.Closeables" local-only="true"/>
-      <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
-      <allow class="com.google.common.collect.ImmutableSet" local-only="true"/>
     </subpackage>
     <subpackage name="javadoc">
       <allow pkg="com.puppycrawl.tools.checkstyle.grammars.javadoc"/>
       <allow pkg="java.lang.reflect"/>
       <allow class="com.google.common.base.CharMatcher" local-only="true"/>
-      <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
-      <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
-      <allow class="com.google.common.collect.ImmutableSortedSet" local-only="true"/>
       <allow class="com.google.common.collect.Multiset" local-only="true"/>
     </subpackage>
     <subpackage name="design">
       <allow class="com.google.common.annotations.VisibleForTesting" local-only="true"/>
-      <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
       <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
     </subpackage>
     <subpackage name="imports">
       <allow class="com.google.common.collect.HashMultimap" local-only="true"/>
-      <allow class="com.google.common.collect.ImmutableSet" local-only="true"/>
     </subpackage>
     <subpackage name="coding">
       <allow class="com.google.common.collect.ImmutableCollection" local-only="true"/>
-      <allow class="com.google.common.collect.ImmutableSet" local-only="true"/>
-    </subpackage>
-    <subpackage name="metrics">
-      <allow class="com.google.common.collect.ImmutableSet" local-only="true"/>
     </subpackage>
   </subpackage>
 
@@ -132,7 +119,6 @@
     <allow class="com.google.common.base.CaseFormat" local-only="true"/>
     <allow class="com.google.common.collect.ImmutableCollection" local-only="true"/>
     <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
-    <allow class="com.google.common.collect.ImmutableSet" local-only="true"/>
     <!-- is not possible till pkg is not a regexp -->
     <!-- <disallow pkg="com.puppycrawl.tools.checkstyle.checks.*"/> -->
     <disallow pkg="com.puppycrawl.tools.checkstyle.(ant|doclets|gui)" regex="true"/>
@@ -141,7 +127,6 @@
   <subpackage name="gui">
     <allow pkg="java.awt"/>
     <allow pkg="javax.swing"/>
-    <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
     <disallow pkg="com.puppycrawl.tools.checkstyle.(checks|ant|doclets|filters)" regex="true"/>
   </subpackage>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
@@ -19,9 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
+import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -65,7 +67,8 @@ public class FinalParametersCheck extends AbstractCheck {
      * <a href="http://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html">
      * primitive datatypes</a>.
      */
-    private final Set<Integer> primitiveDataTypes = ImmutableSet.of(
+    private final Set<Integer> primitiveDataTypes = Collections.unmodifiableSet(
+        Stream.of(
             TokenTypes.LITERAL_BYTE,
             TokenTypes.LITERAL_SHORT,
             TokenTypes.LITERAL_INT,
@@ -73,7 +76,8 @@ public class FinalParametersCheck extends AbstractCheck {
             TokenTypes.LITERAL_FLOAT,
             TokenTypes.LITERAL_DOUBLE,
             TokenTypes.LITERAL_BOOLEAN,
-            TokenTypes.LITERAL_CHAR);
+            TokenTypes.LITERAL_CHAR)
+        .collect(Collectors.toSet()));
 
     /**
      * Option to ignore primitive types as params.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -27,7 +28,6 @@ import java.util.Map;
 
 import org.apache.commons.beanutils.ConversionException;
 
-import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -460,7 +460,7 @@ public class SuppressWarningsHolder
     private static List<String> getAnnotationValues(DetailAST ast) {
         switch (ast.getType()) {
             case TokenTypes.EXPR:
-                return ImmutableList.of(getStringExpr(ast));
+                return Collections.singletonList(getStringExpr(ast));
 
             case TokenTypes.ANNOTATION_ARRAY_INIT:
                 return findAllExpressionsInChildren(ast);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -27,8 +28,9 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -101,7 +103,7 @@ public class RequireThisCheck extends AbstractCheck {
     public static final String MSG_VARIABLE = "require.this.variable";
 
     /** Set of all declaration tokens. */
-    private static final ImmutableSet<Integer> DECLARATION_TOKENS = ImmutableSet.of(
+    private static final Set<Integer> DECLARATION_TOKENS = Collections.unmodifiableSet(Stream.of(
         TokenTypes.VARIABLE_DEF,
         TokenTypes.CTOR_DEF,
         TokenTypes.METHOD_DEF,
@@ -110,9 +112,9 @@ public class RequireThisCheck extends AbstractCheck {
         TokenTypes.INTERFACE_DEF,
         TokenTypes.PARAMETER_DEF,
         TokenTypes.TYPE_ARGUMENT
-    );
+    ).collect(Collectors.toSet()));
     /** Set of all assign tokens. */
-    private static final ImmutableSet<Integer> ASSIGN_TOKENS = ImmutableSet.of(
+    private static final Set<Integer> ASSIGN_TOKENS = Collections.unmodifiableSet(Stream.of(
         TokenTypes.ASSIGN,
         TokenTypes.PLUS_ASSIGN,
         TokenTypes.STAR_ASSIGN,
@@ -123,19 +125,20 @@ public class RequireThisCheck extends AbstractCheck {
         TokenTypes.SL_ASSIGN,
         TokenTypes.BAND_ASSIGN,
         TokenTypes.BXOR_ASSIGN
-    );
+    ).collect(Collectors.toSet()));
     /** Set of all compound assign tokens. */
-    private static final ImmutableSet<Integer> COMPOUND_ASSIGN_TOKENS = ImmutableSet.of(
-        TokenTypes.PLUS_ASSIGN,
-        TokenTypes.STAR_ASSIGN,
-        TokenTypes.DIV_ASSIGN,
-        TokenTypes.MOD_ASSIGN,
-        TokenTypes.SR_ASSIGN,
-        TokenTypes.BSR_ASSIGN,
-        TokenTypes.SL_ASSIGN,
-        TokenTypes.BAND_ASSIGN,
-        TokenTypes.BXOR_ASSIGN
-    );
+    private static final Set<Integer> COMPOUND_ASSIGN_TOKENS = Collections.unmodifiableSet(
+        Stream.of(
+            TokenTypes.PLUS_ASSIGN,
+            TokenTypes.STAR_ASSIGN,
+            TokenTypes.DIV_ASSIGN,
+            TokenTypes.MOD_ASSIGN,
+            TokenTypes.SR_ASSIGN,
+            TokenTypes.BSR_ASSIGN,
+            TokenTypes.SL_ASSIGN,
+            TokenTypes.BAND_ASSIGN,
+            TokenTypes.BXOR_ASSIGN
+        ).collect(Collectors.toSet()));
 
     /** Tree of all the parsed frames. */
     private Map<DetailAST, AbstractFrame> frames;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -21,13 +21,15 @@ package com.puppycrawl.tools.checkstyle.checks.design;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import antlr.collections.AST;
-import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -246,35 +248,37 @@ public class VisibilityModifierCheck
     public static final String MSG_KEY = "variable.notPrivate";
 
     /** Default immutable types canonical names. */
-    private static final List<String> DEFAULT_IMMUTABLE_TYPES = ImmutableList.of(
-        "java.lang.String",
-        "java.lang.Integer",
-        "java.lang.Byte",
-        "java.lang.Character",
-        "java.lang.Short",
-        "java.lang.Boolean",
-        "java.lang.Long",
-        "java.lang.Double",
-        "java.lang.Float",
-        "java.lang.StackTraceElement",
-        "java.math.BigInteger",
-        "java.math.BigDecimal",
-        "java.io.File",
-        "java.util.Locale",
-        "java.util.UUID",
-        "java.net.URL",
-        "java.net.URI",
-        "java.net.Inet4Address",
-        "java.net.Inet6Address",
-        "java.net.InetSocketAddress"
-    );
+    private static final List<String> DEFAULT_IMMUTABLE_TYPES = Collections.unmodifiableList(
+        Stream.of(
+            "java.lang.String",
+            "java.lang.Integer",
+            "java.lang.Byte",
+            "java.lang.Character",
+            "java.lang.Short",
+            "java.lang.Boolean",
+            "java.lang.Long",
+            "java.lang.Double",
+            "java.lang.Float",
+            "java.lang.StackTraceElement",
+            "java.math.BigInteger",
+            "java.math.BigDecimal",
+            "java.io.File",
+            "java.util.Locale",
+            "java.util.UUID",
+            "java.net.URL",
+            "java.net.URI",
+            "java.net.Inet4Address",
+            "java.net.Inet6Address",
+            "java.net.InetSocketAddress"
+        ).collect(Collectors.toList()));
 
     /** Default ignore annotations canonical names. */
-    private static final List<String> DEFAULT_IGNORE_ANNOTATIONS = ImmutableList.of(
-        "org.junit.Rule",
-        "org.junit.ClassRule",
-        "com.google.common.annotations.VisibleForTesting"
-    );
+    private static final List<String> DEFAULT_IGNORE_ANNOTATIONS = Collections.unmodifiableList(
+        Stream.of(
+            "org.junit.Rule",
+            "org.junit.ClassRule",
+            "com.google.common.annotations.VisibleForTesting"
+        ).collect(Collectors.toList()));
 
     /** Name for 'public' access modifier. */
     private static final String PUBLIC_ACCESS_MODIFIER = "public";

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -29,14 +29,13 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.apache.commons.beanutils.ConversionException;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -72,8 +71,9 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
      * Return the header lines to check against.
      * @return the header lines to check against.
      */
-    protected ImmutableList<String> getHeaderLines() {
-        return ImmutableList.copyOf(readerLines);
+    protected List<String> getHeaderLines() {
+        final List<String> copy = new ArrayList<>(readerLines);
+        return Collections.unmodifiableList(copy);
     }
 
     /**
@@ -194,6 +194,6 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
 
     @Override
     public Set<String> getExternalResourceLocations() {
-        return ImmutableSet.of(headerFile);
+        return Collections.singleton(headerFile);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -21,11 +21,11 @@ package com.puppycrawl.tools.checkstyle.checks.imports;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Collections;
 import java.util.Set;
 
 import org.apache.commons.beanutils.ConversionException;
 
-import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -143,7 +143,7 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
 
     @Override
     public Set<String> getExternalResourceLocations() {
-        return ImmutableSet.of(fileLocation);
+        return Collections.singleton(fileLocation);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -20,13 +20,16 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import com.google.common.collect.ImmutableSortedSet;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
@@ -66,21 +69,23 @@ public class JavadocStyleCheck
     public static final String MSG_EXTRA_HTML = "javadoc.extraHtml";
 
     /** HTML tags that do not require a close tag. */
-    private static final Set<String> SINGLE_TAGS = ImmutableSortedSet.of(
-            "br", "li", "dt", "dd", "hr", "img", "p", "td", "tr", "th");
+    private static final Set<String> SINGLE_TAGS = Collections.unmodifiableSortedSet(Stream.of(
+        "br", "li", "dt", "dd", "hr", "img", "p", "td", "tr", "th")
+        .collect(Collectors.toCollection(TreeSet::new)));
 
     /** HTML tags that are allowed in java docs.
      * From http://www.w3schools.com/tags/default.asp
      * The forms and structure tags are not allowed
      */
-    private static final Set<String> ALLOWED_TAGS = ImmutableSortedSet.of(
-            "a", "abbr", "acronym", "address", "area", "b", "bdo", "big",
-            "blockquote", "br", "caption", "cite", "code", "colgroup", "dd",
-            "del", "div", "dfn", "dl", "dt", "em", "fieldset", "font", "h1",
-            "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd",
-            "li", "ol", "p", "pre", "q", "samp", "small", "span", "strong",
-            "style", "sub", "sup", "table", "tbody", "td", "tfoot", "th",
-            "thead", "tr", "tt", "u", "ul", "var");
+    private static final Set<String> ALLOWED_TAGS = Collections.unmodifiableSortedSet(Stream.of(
+        "a", "abbr", "acronym", "address", "area", "b", "bdo", "big",
+        "blockquote", "br", "caption", "cite", "code", "colgroup", "dd",
+        "del", "div", "dfn", "dl", "dt", "em", "fieldset", "font", "h1",
+        "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd",
+        "li", "ol", "p", "pre", "q", "samp", "small", "span", "strong",
+        "style", "sub", "sup", "table", "tbody", "td", "tfoot", "th",
+        "thead", "tr", "tt", "u", "ul", "var")
+        .collect(Collectors.toCollection(TreeSet::new)));
 
     /** The scope to check. */
     private Scope scope = Scope.PRIVATE;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
@@ -20,9 +20,10 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
+import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -350,19 +351,10 @@ public enum JavadocTagInfo {
     private static final Map<String, JavadocTagInfo> NAME_TO_TAG;
 
     static {
-        final ImmutableMap.Builder<String, JavadocTagInfo> textToTagBuilder =
-            new ImmutableMap.Builder<>();
-
-        final ImmutableMap.Builder<String, JavadocTagInfo> nameToTagBuilder =
-            new ImmutableMap.Builder<>();
-
-        for (final JavadocTagInfo tag : JavadocTagInfo.values()) {
-            textToTagBuilder.put(tag.text, tag);
-            nameToTagBuilder.put(tag.name, tag);
-        }
-
-        TEXT_TO_TAG = textToTagBuilder.build();
-        NAME_TO_TAG = nameToTagBuilder.build();
+        TEXT_TO_TAG = Collections.unmodifiableMap(Arrays.stream(JavadocTagInfo.values())
+            .collect(Collectors.toMap(JavadocTagInfo::getText, tagText -> tagText)));
+        NAME_TO_TAG = Collections.unmodifiableMap(Arrays.stream(JavadocTagInfo.values())
+            .collect(Collectors.toMap(JavadocTagInfo::getName, tagName -> tagName)));
 
         //Arrays sorting for binary search
         Arrays.sort(DEF_TOKEN_TYPES);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTags.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTags.java
@@ -19,10 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import com.google.common.collect.ImmutableList;
 
 /**
  * Value object for combining the list of valid validTags with information
@@ -40,10 +39,11 @@ public final class JavadocTags {
      * @param tags the list of valid tags
      * @param invalidTags the list of invalid tags
      */
-    public JavadocTags(List<JavadocTag> tags,
-            List<InvalidJavadocTag> invalidTags) {
-        validTags = ImmutableList.copyOf(tags);
-        this.invalidTags = ImmutableList.copyOf(invalidTags);
+    public JavadocTags(List<JavadocTag> tags, List<InvalidJavadocTag> invalidTags) {
+        final List<JavadocTag> validTagsCopy = new ArrayList<>(tags);
+        validTags = Collections.unmodifiableList(validTagsCopy);
+        final List<InvalidJavadocTag> invalidTagsCopy = new ArrayList<>(invalidTags);
+        this.invalidTags = Collections.unmodifiableList(invalidTagsCopy);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -20,11 +20,14 @@
 package com.puppycrawl.tools.checkstyle.checks.metrics;
 
 import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -39,28 +42,28 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
  */
 public abstract class AbstractClassCouplingCheck extends AbstractCheck {
     /** Class names to ignore. */
-    private static final Set<String> DEFAULT_EXCLUDED_CLASSES =
-                ImmutableSet.<String>builder()
-                // primitives
-                .add("boolean", "byte", "char", "double", "float", "int")
-                .add("long", "short", "void")
-                // wrappers
-                .add("Boolean", "Byte", "Character", "Double", "Float")
-                .add("Integer", "Long", "Short", "Void")
-                // java.lang.*
-                .add("Object", "Class")
-                .add("String", "StringBuffer", "StringBuilder")
-                // Exceptions
-                .add("ArrayIndexOutOfBoundsException", "Exception")
-                .add("RuntimeException", "IllegalArgumentException")
-                .add("IllegalStateException", "IndexOutOfBoundsException")
-                .add("NullPointerException", "Throwable", "SecurityException")
-                .add("UnsupportedOperationException")
-                // java.util.*
-                .add("List", "ArrayList", "Deque", "Queue", "LinkedList")
-                .add("Set", "HashSet", "SortedSet", "TreeSet")
-                .add("Map", "HashMap", "SortedMap", "TreeMap")
-                .build();
+    private static final Set<String> DEFAULT_EXCLUDED_CLASSES = Collections.unmodifiableSet(
+        Stream.of(
+            // primitives
+            "boolean", "byte", "char", "double", "float", "int",
+            "long", "short", "void",
+            // wrappers
+            "Boolean", "Byte", "Character", "Double", "Float",
+            "Integer", "Long", "Short", "Void",
+            // java.lang.*
+            "Object", "Class",
+            "String", "StringBuffer", "StringBuilder",
+            // Exceptions
+            "ArrayIndexOutOfBoundsException", "Exception",
+            "RuntimeException", "IllegalArgumentException",
+            "IllegalStateException", "IndexOutOfBoundsException",
+            "NullPointerException", "Throwable", "SecurityException",
+            "UnsupportedOperationException",
+            // java.util.*
+            "List", "ArrayList", "Deque", "Queue", "LinkedList",
+            "Set", "HashSet", "SortedSet", "TreeSet",
+            "Map", "HashMap", "SortedMap", "TreeMap"
+        ).collect(Collectors.toSet()));
 
     /** Stack of contexts. */
     private final Deque<Context> contextStack = new ArrayDeque<>();
@@ -113,7 +116,8 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
      * @param excludedClasses the list of classes to ignore.
      */
     public final void setExcludedClasses(String... excludedClasses) {
-        this.excludedClasses = ImmutableSet.copyOf(excludedClasses);
+        this.excludedClasses =
+            Collections.unmodifiableSet(Arrays.stream(excludedClasses).collect(Collectors.toSet()));
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
@@ -23,10 +23,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 
-import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -109,7 +109,7 @@ public class SuppressionFilter extends AutomaticBean implements Filter, External
 
     @Override
     public Set<String> getExternalResourceLocations() {
-        return ImmutableSet.of(file);
+        return Collections.singleton(file);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPModel.java
@@ -19,9 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.gui;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
 
@@ -46,7 +47,8 @@ public class CodeSelectorPModel {
      */
     public CodeSelectorPModel(DetailAST ast, List<Integer> lines2position) {
         this.ast = ast;
-        this.lines2position = ImmutableList.copyOf(lines2position);
+        final List<Integer> copy = new ArrayList<>(lines2position);
+        this.lines2position = Collections.unmodifiableList(copy);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/JTreeTable.java
@@ -25,6 +25,8 @@ import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EventObject;
 import java.util.List;
 
@@ -37,8 +39,6 @@ import javax.swing.KeyStroke;
 import javax.swing.LookAndFeel;
 import javax.swing.table.TableCellEditor;
 import javax.swing.tree.TreePath;
-
-import com.google.common.collect.ImmutableList;
 
 /**
  * This example shows how to create a simple JTreeTable component,
@@ -237,7 +237,8 @@ public class JTreeTable extends JTable {
      * @param linePositionMap Line position map.
      */
     public void setLinePositionMap(List<Integer> linePositionMap) {
-        this.linePositionMap = ImmutableList.copyOf(linePositionMap);
+        final List<Integer> copy = new ArrayList<>(linePositionMap);
+        this.linePositionMap = Collections.unmodifiableList(copy);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java
@@ -22,12 +22,11 @@ package com.puppycrawl.tools.checkstyle.gui;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
 import antlr.ANTLRException;
-
-import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -174,7 +173,8 @@ public class MainFrameModel {
      * @return lines to position map.
      */
     public List<Integer> getLinesToPosition() {
-        return ImmutableList.copyOf(linesToPosition);
+        final List<Integer> copy = new ArrayList<>(linesToPosition);
+        return Collections.unmodifiableList(copy);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -50,7 +51,6 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
-import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
 import com.puppycrawl.tools.checkstyle.ModuleFactory;
@@ -118,10 +118,10 @@ public class XDocsPagesTest {
             "SuppressionCommentFilter.fileContents"
     );
 
-    private static final Set<String> SUN_CHECKS = ImmutableSet.copyOf(CheckUtil
-            .getConfigSunStyleChecks());
-    private static final Set<String> GOOGLE_CHECKS = ImmutableSet.copyOf(CheckUtil
-            .getConfigGoogleStyleChecks());
+    private static final Set<String> SUN_CHECKS = Collections.unmodifiableSet(
+        new HashSet<>(CheckUtil.getConfigSunStyleChecks()));
+    private static final Set<String> GOOGLE_CHECKS = Collections.unmodifiableSet(
+        new HashSet<>(CheckUtil.getConfigGoogleStyleChecks()));
 
     @Test
     public void testAllChecksPresentOnAvailableChecksPage() throws IOException {


### PR DESCRIPTION
#3433 

I tried to get rid of the following dependencies:

1. com.google.common.collect.ImmutableList
2. com.google.common.collect.ImmutableSortedSet
3. com.google.common.collect.ImmutableSet
4. com.google.common.collect.ImmutableMap


## **PROBLEMS**

**ImmutableCollection**

API which uses ImmutableCollection:
1) com.puppycrawl.tools.checkstyle.DefaultContext
2) com.puppycrawl.tools.checkstyle.api.AutomaticBean
3) com.puppycrawl.tools.checkstyle.api.Context

**ImmutableList**

API which uses ImmutableList:
1) com.puppycrawl.tools.checkstyle.DefaultContext

**ImmutableMap**

API which uses ImmutableMap
1) com.puppycrawl.tools.checkstyle.DefaultConfiguration
2) com.puppycrawl.tools.checkstyle.api.AbstractViolationReporter
3) com.puppycrawl.tools.checkstyle.api.Configuration
4)com.puppycrawl.tools.checkstyle.api.FileContents

Uses ImmutableMap by accessing API
1) com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck
2) com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck
3) com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter
4) com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyCommentFilter
5) com.puppycrawl.tools.checkstyle.ConfigurationLoaderTest
6) com.google.checkstyle.test.chapter5naming.rule528typevariablenames.ClassTypeParameterNameTest
7) com.google.checkstyle.test.chapter5naming.rule528typevariablenames.InterfaceTypeParameterNameTest
8) com.google.checkstyle.test.chapter5naming.rule528typevariablenames.MethodTypeParameterNameTest
9) com.google.checkstyle.test.chapter5naming.rule526parameternames.ParameterNameTest
10) com.google.checkstyle.test.chapter5naming.rule525nonconstantfieldnames.MemberNameTest
11) com.google.checkstyle.test.chapter5naming.rule523methodnames.MethodNameTest
12) com.google.checkstyle.test.chapter5naming.rule522typenames.TypeNameTest
13) com.google.checkstyle.test.chapter5naming.rule521packagenames.PackageNameTest
14) com.google.checkstyle.test.chapter5naming.rule51identifiernames.CatchParameterNameTest
15) com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace.GenericWhitespaceTest
16) com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace.WhitespaceAroundTest

Uses ImmutableMap.Builder:
1) com.puppycrawl.tools.checkstyle.utils.TokenUtils uses ImmutableMap builder. If we replace it with unmodifiable map it will not allow to change the content of the map.
2) com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo
3) com.puppycrawl.tools.checkstyle.utils.TokenUtils

**ImmutableSet**

Uses ImmutableSet for testing
1) com.puppycrawl.tools.checkstyle.checks.design.InputImmutable
2) com.puppycrawl.tools.checkstyle.checks.design.InputVisibilityModifierGenerics

Uses Guava's classes which return ImmutableSet
1) com.puppycrawl.tools.checkstyle.internal.CheckUtil

**Creates immutable copy** (replaced with Java native approach):
1) com.puppycrawl.tools.checkstyle.checks.header.AbstractHeaderCheck
2) com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTags
3) com.puppycrawl.tools.checkstyle.gui.CodeSelector
4) com.puppycrawl.tools.checkstyle.checks.metrics.AbstractClassCouplingCheck
5) com.puppycrawl.tools.checkstyle.internal.XDocsPagesTest

@romani 
Please, review the changes very carefully to avoid issues in future. I might miss something.