### PR TITLE
Issue #3486: DetailAST cache and child counting with comments

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -80,8 +80,8 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
 
     @Override
     public void setFirstChild(AST ast) {
-        clearBranchTokenTypesCache();
-        childCount = NOT_INITIALIZED;
+        clearBranchTokenTypes();
+        clearChildCountCache(this);
         super.setFirstChild(ast);
         if (ast != null) {
             ((DetailAST) ast).setParent(this);
@@ -90,7 +90,8 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
 
     @Override
     public void setNextSibling(AST ast) {
-        clearBranchTokenTypesCache();
+        clearBranchTokenTypes();
+        clearChildCountCache(parent);
         super.setNextSibling(ast);
         if (ast != null && parent != null) {
             ((DetailAST) ast).setParent(parent);
@@ -106,7 +107,8 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
      *        DetailAST object.
      */
     public void addPreviousSibling(DetailAST ast) {
-        clearBranchTokenTypesCache();
+        clearBranchTokenTypes();
+        clearChildCountCache(parent);
         if (ast != null) {
             ast.setParent(parent);
             final DetailAST previousSiblingNode = previousSibling;
@@ -130,7 +132,8 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
      *        DetailAST object.
      */
     public void addNextSibling(DetailAST ast) {
-        clearBranchTokenTypesCache();
+        clearBranchTokenTypes();
+        clearChildCountCache(parent);
         if (ast != null) {
             ast.setParent(parent);
             final DetailAST nextSibling = getNextSibling();
@@ -147,7 +150,8 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
 
     @Override
     public void addChild(AST ast) {
-        clearBranchTokenTypesCache();
+        clearBranchTokenTypes();
+        clearChildCountCache(this);
         super.addChild(ast);
         if (ast != null) {
             ((DetailAST) ast).setParent(this);
@@ -194,7 +198,7 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
      * @param parent the parent token
      */
     private void setParent(DetailAST parent) {
-        clearBranchTokenTypesCache();
+        clearBranchTokenTypes();
         this.parent = parent;
         final DetailAST nextSibling = getNextSibling();
         if (nextSibling != null) {
@@ -402,9 +406,20 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
     }
 
     /**
-     * Clears branchTokenTypes cache for all parents of the current DetailAST instance.
+     * Clears the child count for the ast instance.
+     * @param ast The ast to clear.
      */
-    private void clearBranchTokenTypesCache() {
+    private static void clearChildCountCache(DetailAST ast) {
+        if (ast != null) {
+            ast.childCount = NOT_INITIALIZED;
+        }
+    }
+
+    /**
+     * Clears branchTokenTypes cache for all parents of the current DetailAST instance, and the
+     * child count for the current DetailAST instance.
+     */
+    private void clearBranchTokenTypes() {
         DetailAST prevParent = getParent();
         while (prevParent != null) {
             prevParent.branchTokenTypes = null;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -818,8 +818,23 @@ public class CheckerTest extends BaseCheckTestSupport {
             final int childCount = ast.getChildCount();
             if (childCount != METHOD_DEF_CHILD_COUNT) {
                 final String msg = String.format(Locale.getDefault(),
-                    "AST node has wrong number of children. Expected is %d but was %d",
+                    "AST node in no comment tree has wrong number of children. "
+                            + "Expected is %d but was %d",
                     METHOD_DEF_CHILD_COUNT, childCount);
+                log(ast, msg);
+            }
+            // count children where comment lives
+            int actualChildCount = 0;
+            for (DetailAST child = ast.getFirstChild().getFirstChild(); child != null; child =
+                    child.getNextSibling()) {
+                actualChildCount++;
+            }
+            final int cacheChildCount = ast.getFirstChild().getChildCount();
+            if (cacheChildCount != actualChildCount) {
+                final String msg = String.format(Locale.getDefault(),
+                        "AST node with no comment has wrong number of children. "
+                                + "Expected is %d but was %d",
+                        cacheChildCount, actualChildCount);
                 log(ast, msg);
             }
         }
@@ -858,8 +873,23 @@ public class CheckerTest extends BaseCheckTestSupport {
             final int childCount = ast.getChildCount();
             if (childCount != METHOD_DEF_CHILD_COUNT) {
                 final String msg = String.format(Locale.getDefault(),
-                    "AST node has wrong number of children. Expected is %d but was %d",
+                    "AST node in comment tree has wrong number of children. "
+                            + "Expected is %d but was %d",
                     METHOD_DEF_CHILD_COUNT, childCount);
+                log(ast, msg);
+            }
+            // count children where comment lives
+            int actualChildCount = 0;
+            for (DetailAST child = ast.getFirstChild().getFirstChild(); child != null; child =
+                    child.getNextSibling()) {
+                actualChildCount++;
+            }
+            final int cacheChildCount = ast.getFirstChild().getChildCount();
+            if (cacheChildCount != actualChildCount) {
+                final String msg = String.format(Locale.getDefault(),
+                        "AST node with comment has wrong number of children. "
+                                + "Expected is %d but was %d",
+                        cacheChildCount, actualChildCount);
                 log(ast, msg);
             }
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/api/InputClearDetailAstLazyLoadCache.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/api/InputClearDetailAstLazyLoadCache.java
@@ -2,10 +2,11 @@ package com.puppycrawl.tools.checkstyle.api;
 
 public class InputClearDetailAstLazyLoadCache {
 
-    /**
+    public
+    /*
      * Javadoc comment
      */
-    public void foo() {
+    static void foo() {
         return;
     }
 }


### PR DESCRIPTION
Issue #3486

@romani This is the showcase of https://github.com/checkstyle/checkstyle/issues/3466#issuecomment-250868051 . I will make a issue and fix the code in this same PR.

Test works by testing actual child count versus cached child count. Both should always be equal. AST tree with comment fails this test.