### PR TITLE
config: exclude JUnit4TestShouldUseTestAnnotation from pmd.xml

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -210,12 +210,6 @@
   </rule>
 
   <rule ref="rulesets/java/migrating.xml"/>
-  <rule ref="rulesets/java/migrating.xml/JUnit4TestShouldUseTestAnnotation">
-    <properties>
-      <!-- False positive of PMD. Non-test methods can be named as 'test' -->
-      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='PackageObjectFactory']"/>
-    </properties>
-  </rule>
 
   <rule ref="rulesets/java/naming.xml">
     <!-- we use CheckstyleCustomShortVariable, to control lenght (will be fixed in PMD 5.4) and skip Override methods -->


### PR DESCRIPTION
#3499

JUnit4TestShouldUseTestAnnotation is suppressed as it is a PMD bug: pmd treats test method from Predicate interface as UT and rises violation.

Since we use lambda instead of Predicate in PackageObjectFactory, we do not need to suppress JUnit4TestShouldUseTestAnnotation.