### PR TITLE
Issue #3488: save files into cache with no un-suppressed violations

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -201,6 +201,14 @@ final class PropertyCacheFile {
     }
 
     /**
+     * Removed a specific file from the cache.
+     * @param checkedFileName The name of the file to remove.
+     */
+    public void remove(String checkedFileName) {
+        details.remove(checkedFileName);
+    }
+
+    /**
      * Calculates the hashcode for the serializable object based on its content.
      * @param object serializable object.
      * @return the hashcode for serializable object.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/suppress_all.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/suppress_all.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <suppress checks="." files="."/>
+</suppressions>


### PR DESCRIPTION
Issue #3488

Since we can call `fireErrors` in `AbstractFileSetCheck` during `finishProcessing` (`TranslationCheck`), we have to add all files to the cache, and then remove them if errors get fired that are not suppressed.
