### PR TITLE
Issue: #3398 False positive for ImportOrder for default IntelliJ Idea settings

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -530,4 +530,59 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
             };
         verify(checkConfig, getNonCompilablePath("InputEclipseStaticImportsOrder.java"), expected);
     }
+
+    @Test
+    public void testOnDemandDeclarationFirstInGroups() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("groups", "*,javax");
+        checkConfig.addAttribute("ordered", "true");
+        checkConfig.addAttribute("separated", "false");
+        checkConfig.addAttribute("caseSensitive", "false");
+        checkConfig.addAttribute("option", "bottom");
+        checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
+        checkConfig.addAttribute("onDemandImportLastInGroup", "true");
+
+        final String[] expected = {"4: " + getCheckMessage(MSG_ORDERING, "java.lang.Byte"),
+        };
+        verify(checkConfig, getPath("InputImportOrderOnDemandFirstInGroup.java"),
+                expected);
+    }
+
+    @Test
+    public void testOnDemandDeclaration() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("groups", "*,javax");
+        checkConfig.addAttribute("ordered", "true");
+        checkConfig.addAttribute("separated", "false");
+        checkConfig.addAttribute("caseSensitive", "true");
+        checkConfig.addAttribute("option", "bottom");
+        checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
+        checkConfig.addAttribute("onDemandImportLastInGroup", "true");
+
+        final String[] expected = {
+            "6: " + getCheckMessage(MSG_ORDERING, "org.*"),
+            "8: " + getCheckMessage(MSG_ORDERING, "java.util.Set"),
+        };
+        verify(checkConfig, getPath("InputImportOrderStaticOnDemandGroupOrder.java"),
+                expected);
+    }
+
+    @Test
+    public void testOnDemandDeclarationLastInGroups() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("groups", "*,javax");
+        checkConfig.addAttribute("ordered", "true");
+        checkConfig.addAttribute("separated", "false");
+        checkConfig.addAttribute("caseSensitive", "false");
+        checkConfig.addAttribute("option", "bottom");
+        checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
+        checkConfig.addAttribute("onDemandImportLastInGroup", "true");
+
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputImportOrderOnDemandLastInGroup.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/InputImportOrderOnDemandFirstInGroup.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/InputImportOrderOnDemandFirstInGroup.java
@@ -1,0 +1,8 @@
+package com.puppycrawl.tools.checkstyle.checks.imports;
+
+import java.lang.*;
+import java.lang.Byte;
+import java.lang.Class;
+
+public class InputImportOrderOnDemandFirstInGroup {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/InputImportOrderOnDemandLastInGroup.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/InputImportOrderOnDemandLastInGroup.java
@@ -1,0 +1,8 @@
+package com.puppycrawl.tools.checkstyle.checks.imports;
+
+import java.lang.Byte;
+import java.lang.Class;
+import java.lang.*;
+
+public class InputImportOrderOnDemandLastInGroup {
+}

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -884,6 +884,12 @@ import android.*;
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
           </tr>
+          <tr>
+            <td>onDemandImportLastInGroup</td>
+            <td>whether to use a type-import-on-demand declaration last in group or not</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td>false</td>
+          </tr>
 
           <tr>
             <td>tokens</td>


### PR DESCRIPTION
For fix [issue #3398](https://github.com/checkstyle/checkstyle/issues/3398) added new field: onDemandImportLastInGroup
Config file for example:

```
<module name="Checker">
    <module name="TreeWalker">
        <module name="ImportOrder">
            <property name="groups" value="*,javax"/>
            <property name="ordered" value="true"/>
            <property name="separated" value="false"/>
            <property name="option" value="bottom"/>
            <property name="sortStaticImportsAlphabetically" value="true"/>
	<property name="onDemandImportLastInGroup" value="true"/>
        </module>
    </module>
</module>
```
