### PR TITLE
Issue #2427: added customizable javadoc tokens

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -24,6 +24,9 @@ import org.antlr.v4.runtime.Recognizer;
 import com.puppycrawl.tools.checkstyle.grammars.javadoc.JavadocParser;
 
 /**
+ * Contains the constants for all the tokens contained in the Abstract
+ * Syntax Tree for the javadoc grammar.
+ *
  * @author Baratali Izmailov
  * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html">
  * javadoc - The Java API Documentation Generator</a>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -131,6 +131,11 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
     }
 
     @Override
+    public int[] getRequiredJavadocTokens() {
+        return getAcceptableJavadocTokens();
+    }
+
+    @Override
     public int[] getAcceptableTokens() {
         return new int[] {TokenTypes.BLOCK_COMMENT_BEGIN};
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -120,6 +120,11 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
     }
 
     @Override
+    public int[] getRequiredJavadocTokens() {
+        return getAcceptableJavadocTokens();
+    }
+
+    @Override
     public int[] getAcceptableTokens() {
         return new int[] {TokenTypes.BLOCK_COMMENT_BEGIN};
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -73,6 +73,11 @@ public class JavadocTagContinuationIndentationCheck extends AbstractJavadocCheck
     }
 
     @Override
+    public int[] getRequiredJavadocTokens() {
+        return getAcceptableJavadocTokens();
+    }
+
+    @Override
     public int[] getAcceptableTokens() {
         return new int[] {TokenTypes.BLOCK_COMMENT_BEGIN };
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -101,6 +101,11 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
     }
 
     @Override
+    public int[] getRequiredJavadocTokens() {
+        return getAcceptableJavadocTokens();
+    }
+
+    @Override
     public int[] getAcceptableTokens() {
         return new int[] {TokenTypes.BLOCK_COMMENT_BEGIN };
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -117,6 +117,11 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
     }
 
     @Override
+    public int[] getRequiredJavadocTokens() {
+        return getAcceptableJavadocTokens();
+    }
+
+    @Override
     public int[] getAcceptableTokens() {
         return new int[] {TokenTypes.BLOCK_COMMENT_BEGIN };
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CheckUtil.java
@@ -46,6 +46,7 @@ import com.puppycrawl.tools.checkstyle.api.Filter;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck;
+import com.puppycrawl.tools.checkstyle.utils.JavadocUtils;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
 
 public final class CheckUtil {
@@ -334,5 +335,43 @@ public final class CheckUtil {
 
             return result.toString();
         }
+    }
+
+    public static String getJavadocTokenText(int[] tokens, int... subtractions) {
+        final StringBuilder result = new StringBuilder();
+        boolean first = true;
+
+        for (int token : tokens) {
+            boolean found = false;
+
+            for (int subtraction : subtractions) {
+                if (subtraction == token) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (found) {
+                continue;
+            }
+
+            if (first) {
+                first = false;
+            }
+            else {
+                result.append(", ");
+            }
+
+            result.append(JavadocUtils.getTokenName(token));
+        }
+
+        if (result.length() == 0) {
+            result.append("empty");
+        }
+        else {
+            result.append(".");
+        }
+
+        return result.toString();
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputMain.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputMain.java
@@ -1,0 +1,4 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+/** Javadoc */
+public class InputMain {
+}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1372,6 +1372,33 @@ public boolean isSomething()
         </p>
       </subsection>
 
+      <subsection name="Properties">
+        <table>
+          <tr>
+            <th>name</th>
+            <th>description</th>
+            <th>type</th>
+            <th>default value</th>
+          </tr>
+          <tr>
+            <td>javadocTokens</td>
+            <td>javadoc tokens to check</td>
+            <td>subset of javadoc tokens
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#PARAM_LITERAL">PARAM_LITERAL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#RETURN_LITERAL">RETURN_LITERAL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#THROWS_LITERAL">THROWS_LITERAL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#DEPRECATED_LITERAL">DEPRECATED_LITERAL</a>.
+            </td>
+            <td>
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#PARAM_LITERAL">PARAM_LITERAL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#RETURN_LITERAL">RETURN_LITERAL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#THROWS_LITERAL">THROWS_LITERAL</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#DEPRECATED_LITERAL">DEPRECATED_LITERAL</a>.
+            </td>
+          </tr>
+        </table>
+      </subsection>
+
       <subsection name="Examples">
         <p>
           Default configuration that will check <code>@param</code>, <code>@return</code>,

--- a/src/xdocs/writingjavadocchecks.xml.vm
+++ b/src/xdocs/writingjavadocchecks.xml.vm
@@ -532,7 +532,43 @@ JAVADOC -> <p> First </p>\r\n<p> Second </p><EOF> [0:0]
     </section>
 
     <section name="Customize token types in Javadoc Checks">
-      Not implemented yet. See <a href="https://github.com/checkstyle/checkstyle/issues/2427">Github Issue #2427</a>.
+      <p>
+        There are four methods in AbstractJavadocCheck class to control the processed
+        <a href="apidocs/index.html">JavadocTokenTypes</a> -
+        one setter
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html#setJavadocTokens-java.lang.String...-">
+        setTokens()</a>, which is used to define a custom set (which is different
+        from the default one) of the processed JavadocTokenTypes via config file and
+        three getters, which have to be overridden:
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html#getDefaultJavadocTokens--">
+        getDefaultJavadocTokens()</a>,
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html#getAcceptableJavadocTokens--">
+        getAcceptableJavadocTokens()</a>,
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html#getRequiredJavadocTokens--">
+        getRequiredJavadocTokens()</a>.
+      </p>
+
+      <ul>
+
+        <li>
+          getDefaultJavadocTokens() - returns a set of JavadocTokenTypes which are processed in
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html#visitToken-com.puppycrawl.tools.checkstyle.api.DetailAST-">
+          visitToken()</a> method by default.
+        </li>
+
+        <li>
+          getRequiredJavadocTokens() - returns a set of JavadocTokenTypes which Check must be subscribed to for
+          a valid execution. If the user wants to specify a custom set of JavadocTokenTypes then
+          this set must contain all the JavadocTokenTypes from RequiredJavadocTokens.
+        </li>
+
+        <li>
+          getAcceptableJavadocTokens() - returns a set, which contains all the JavadocTokenTypes that
+          can be processed by the check. Both DefaultJavadocTokens and RequiredJavadocTokens and any custom
+          set of JavadocTokenTypes are subsets of AcceptableJavadocTokens.
+        </li>
+    
+      </ul>
     </section>
 
     <section name="Integrating new Javadoc Check">


### PR DESCRIPTION
Issue #2427.

Added acceptable and required javadoc tokens. Code was mostly copied from `TreeWalker` which this class is mimicking.
All javadoc checks required `getRequiredJavadocTokens` to be added.

Questions:
1)
The issue made note of an [area that had documentation on this already but was removed](https://github.com/checkstyle/checkstyle/blob/fff24e89001ce2ad9c30d1f573639cd640183669/src/xdocs/config_javadoc.xml#L978).
Was that documentation valid that the 2 tokens are optional?
Are there any other optional tokens for the javadoc checks? I didn't see anything jump out when glancing over.

Some things to note:
1)
We needed some place to validate that the javadoc tokens set for the check are correct and require us to be able to throw a `CheckstyleException`. I did this in `init` and so had to add the exception to the throws clause, and this is why there is an update in `FallThroughCheck`. I don't see any other place we can do this.
I brought this up before where [none of the `AbstractCheck` methods allow throwing an exception](https://github.com/checkstyle/checkstyle/blob/25a37e5049b7816b34c552899841a978efc37a63/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java#L126-L169), even `CheckstyleException` and I don't think we should use runtime exceptions.
If your ok with it, I think we should change all the methods to be able to throw `CheckstyleException`s.

2)
Javadoc's `walk` method changed slightly because I think there is a bug with `waitsForProcessing` and when we loop `while (curNode != null && toVisit == null) {` more than once since the value isn't updated.
I will try to find a test to show this and add it.

3)
`AtClauseOrderCheck` changed slightly to not loop through the children, but to use the visit token's power. This would be helpful if the token appears in other places than a child of the root.
