### PR TITLE
Issue #1254: Fix JavadocVariableCheck when assigning a lambda as a field

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtils.java
@@ -193,7 +193,7 @@ public final class ScopeUtils {
 
     /**
      * Returns whether the scope of a node is restricted to a code block.
-     * A code block is a method or constructor body, or a initializer block.
+     * A code block is a method or constructor body, an initializer block, or lambda body.
      *
      * @param node the node to check
      * @return a {@code boolean} value
@@ -207,9 +207,10 @@ public final class ScopeUtils {
              token = token.getParent()) {
             final int type = token.getType();
             if (type == TokenTypes.METHOD_DEF
-                || type == TokenTypes.CTOR_DEF
-                || type == TokenTypes.INSTANCE_INIT
-                || type == TokenTypes.STATIC_INIT) {
+                    || type == TokenTypes.CTOR_DEF
+                    || type == TokenTypes.INSTANCE_INIT
+                    || type == TokenTypes.STATIC_INIT
+                    || type == TokenTypes.LAMBDA) {
                 returnValue = true;
                 break;
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
@@ -338,4 +338,13 @@ public class JavadocVariableCheckTest
                 getPath("InputNoJavadoc.java"),
                 expected);
     }
+
+    @Test
+    public void testLambdaLocalVariablesDoNotNeedJavadoc() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(JavadocVariableCheck.class);
+        final String[] expected = {
+            "6:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig, getPath("InputNoJavadocNeededInLambda.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputNoJavadocNeededInLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/InputNoJavadocNeededInLambda.java
@@ -1,0 +1,21 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+import java.util.function.Function;
+
+public class InputNoJavadocNeededInLambda {
+    private static final Function<String, String> FUNCTION1 = (String it) -> {
+        String stuff = it;
+        return stuff + it;
+    };
+
+    /** */
+    private static final Function<String, String> FUNCTION2 = (String it) -> {
+        String stuff = it;
+        return stuff + it;
+    };
+
+    /** Runnable. */
+    private Runnable r = () -> {
+        String str = "Hello world";
+    };
+}


### PR DESCRIPTION
#1254

Diff reoports were generated against the following projects:
1. openjdk8
2. pmd
3. lombok-ast
4. spring-framework
5. elasticsearch
6. java-design-patterns
7. MaterialDesignLibrary
8. Hbase
9. Orekit
10. apache-ant
11. apache-jsecurity
12. android-launcher
13. apache-struts
14. infinispan
15. protonpack
16. jOOL
17. RxJava
18. checkstyle-with-excludes
19. sevntu-checkstyle-with-excludes
20. findbugs
21. hibernate-orm-with-excludes
22. guava-mvnstyle

http://mezk.github.io/i1254-JavadocVariable/index.html
