### PR TITLE
Issue #3255: changed module setters for pattern

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.StringTokenizer;
+import java.util.regex.Pattern;
 
 import org.apache.commons.beanutils.BeanUtilsBean;
 import org.apache.commons.beanutils.ConversionException;
@@ -42,6 +43,8 @@ import org.apache.commons.beanutils.converters.FloatConverter;
 import org.apache.commons.beanutils.converters.IntegerConverter;
 import org.apache.commons.beanutils.converters.LongConverter;
 import org.apache.commons.beanutils.converters.ShortConverter;
+
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * A Java Bean that implements the component lifecycle interfaces by
@@ -96,6 +99,7 @@ public class AutomaticBean
         cub.register(new ShortConverter(), Short.class);
         cub.register(new ArrayConverter(short[].class, new ShortConverter()),
             short[].class);
+        cub.register(new PatternConverter(), Pattern.class);
         cub.register(new RelaxedStringArrayConverter(), String[].class);
 
         // BigDecimal, BigInteger, Class, Date, String, Time, TimeStamp
@@ -238,6 +242,15 @@ public class AutomaticBean
         if (childConf != null) {
             throw new CheckstyleException(childConf.getName() + " is not allowed as a child in "
                     + getConfiguration().getName());
+        }
+    }
+
+    /** A converter that converts strings to patterns. */
+    private static class PatternConverter implements Converter {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        @Override
+        public Object convert(Class type, Object value) {
+            return CommonUtils.createPattern(value.toString());
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheck.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * <p>
@@ -76,15 +75,13 @@ public class TodoCommentCheck
     }
 
     /**
-     * Setter for 'todo' comment format.
-     * @param format
-     *        format of 'todo' comment.
-     * @throws org.apache.commons.beanutils.ConversionException
-     *         if unable to create Pattern object.
+     * Setter for 'todo' comment pattern.
+     * @param pattern
+     *        pattern of 'todo' comment.
      */
-    public void setFormat(String format) {
-        this.format = format;
-        regexp = CommonUtils.createPattern(format);
+    public void setFormat(Pattern pattern) {
+        format = pattern.pattern();
+        regexp = pattern;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -116,20 +116,19 @@ public class TrailingCommentCheck extends AbstractCheck {
 
     /**
      * Sets patter for legal trailing comments.
-     * @param legalComment format to set.
+     * @param legalComment pattern to set.
      */
-    public void setLegalComment(final String legalComment) {
-        this.legalComment = CommonUtils.createPattern(legalComment);
+    public void setLegalComment(final Pattern legalComment) {
+        this.legalComment = legalComment;
     }
 
     /**
-     * Set the format to the specified regular expression.
-     * @param format a {@code String} value
-     * @throws org.apache.commons.beanutils.ConversionException unable to parse format
+     * Set the format for the specified regular expression.
+     * @param pattern a pattern
      */
-    public final void setFormat(String format) {
-        this.format = format;
-        regexp = CommonUtils.createPattern(format);
+    public final void setFormat(Pattern pattern) {
+        format = pattern.pattern();
+        regexp = pattern;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -169,7 +169,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
     private final Set<File> filesToProcess = new HashSet<>();
 
     /** The base name regexp pattern. */
-    private Pattern baseNamePattern;
+    private Pattern baseName;
 
     /**
      * Language codes of required translations for the check (de, pt, ja, etc).
@@ -181,15 +181,15 @@ public class TranslationCheck extends AbstractFileSetCheck {
      */
     public TranslationCheck() {
         setFileExtensions("properties");
-        baseNamePattern = CommonUtils.createPattern("^messages.*$");
+        baseName = CommonUtils.createPattern("^messages.*$");
     }
 
     /**
      * Sets the base name regexp pattern.
      * @param baseName base name regexp.
      */
-    public void setBaseName(String baseName) {
-        baseNamePattern = CommonUtils.createPattern(baseName);
+    public void setBaseName(Pattern baseName) {
+        this.baseName = baseName;
     }
 
     /**
@@ -250,7 +250,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
     public void finishProcessing() {
         super.finishProcessing();
 
-        final Set<ResourceBundle> bundles = groupFilesIntoBundles(filesToProcess, baseNamePattern);
+        final Set<ResourceBundle> bundles = groupFilesIntoBundles(filesToProcess, baseName);
         for (ResourceBundle currentBundle : bundles) {
             checkExistenceOfDefaultTranslation(currentBundle);
             checkExistenceOfRequiredTranslations(currentBundle);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -63,11 +63,11 @@ public class UncommentedMainCheck
 
     /**
      * Set the excluded classes pattern.
-     * @param excludedClasses a {@code String} value
+     * @param excludedClasses a pattern
      */
-    public void setExcludedClasses(String excludedClasses) {
-        this.excludedClasses = excludedClasses;
-        excludedClassesPattern = CommonUtils.createPattern(excludedClasses);
+    public void setExcludedClasses(Pattern excludedClasses) {
+        this.excludedClasses = excludedClasses.pattern();
+        excludedClassesPattern = excludedClasses;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -114,13 +114,12 @@ public class SuppressWarningsCheck extends AbstractCheck {
     private Pattern regexp = Pattern.compile(format);
 
     /**
-     * Set the format to the specified regular expression.
-     * @param format a {@code String} value
-     * @throws org.apache.commons.beanutils.ConversionException unable to parse format
+     * Set the format for the specified regular expression.
+     * @param pattern the new pattern
      */
-    public final void setFormat(String format) {
-        this.format = format;
-        regexp = CommonUtils.createPattern(format);
+    public final void setFormat(Pattern pattern) {
+        format = pattern.pattern();
+        regexp = pattern;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -84,11 +84,8 @@ public class FallThroughCheck extends AbstractCheck {
     /** Do we need to check last case group. */
     private boolean checkLastCaseGroup;
 
-    /** Relief pattern to allow fall through to the next case branch. */
-    private String reliefPattern = "fallthru|falls? ?through";
-
-    /** Relief regexp. */
-    private Pattern regExp;
+    /** Relief regexp to allow fall through to the next case branch. */
+    private Pattern reliefPattern = Pattern.compile("fallthru|falls? ?through");
 
     @Override
     public int[] getDefaultTokens() {
@@ -111,7 +108,7 @@ public class FallThroughCheck extends AbstractCheck {
      * @param pattern
      *            The regular expression pattern.
      */
-    public void setReliefPattern(String pattern) {
+    public void setReliefPattern(Pattern pattern) {
         reliefPattern = pattern;
     }
 
@@ -121,12 +118,6 @@ public class FallThroughCheck extends AbstractCheck {
      */
     public void setCheckLastCaseGroup(boolean value) {
         checkLastCaseGroup = value;
-    }
-
-    @Override
-    public void init() {
-        super.init();
-        regExp = Pattern.compile(reliefPattern);
     }
 
     @Override
@@ -339,7 +330,7 @@ public class FallThroughCheck extends AbstractCheck {
         //    /+ FALLTHRU +/}
         //
         final String linePart = lines[endLineNo - 1].substring(0, endColNo);
-        if (matchesComment(regExp, linePart, endLineNo)) {
+        if (matchesComment(reliefPattern, linePart, endLineNo)) {
             allThroughComment = true;
         }
         else {
@@ -357,7 +348,7 @@ public class FallThroughCheck extends AbstractCheck {
             final int startLineNo = currentCase.getLineNo();
             for (int i = endLineNo - 2; i > startLineNo - 1; i--) {
                 if (!lines[i].trim().isEmpty()) {
-                    allThroughComment = matchesComment(regExp, lines[i], i + 1);
+                    allThroughComment = matchesComment(reliefPattern, lines[i], i + 1);
                     break;
                 }
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -30,7 +30,6 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtils;
 
 /**
@@ -143,7 +142,7 @@ public class HiddenFieldCheck
     private FieldFrame frame;
 
     /** Pattern for names of variables and parameters to ignore. */
-    private Pattern regexp;
+    private Pattern ignoreFormat;
 
     /** Controls whether to check the parameter of a property setter method. */
     private boolean ignoreSetter;
@@ -356,7 +355,7 @@ public class HiddenFieldCheck
      * @return true is regexp is matching
      */
     private boolean isMatchingRegexp(String name) {
-        return regexp != null && regexp.matcher(name).find();
+        return ignoreFormat != null && ignoreFormat.matcher(name).find();
     }
 
     /**
@@ -511,11 +510,11 @@ public class HiddenFieldCheck
     }
 
     /**
-     * Set the ignore format to the specified regular expression.
-     * @param format a {@code String} value
+     * Set the ignore format for the specified regular expression.
+     * @param pattern a pattern.
      */
-    public void setIgnoreFormat(String format) {
-        regexp = CommonUtils.createPattern(format);
+    public void setIgnoreFormat(Pattern pattern) {
+        ignoreFormat = pattern;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -31,7 +31,6 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
 
 /**
@@ -151,13 +150,12 @@ public final class IllegalTypeCheck extends AbstractCheck {
     }
 
     /**
-     * Set the format to the specified regular expression.
-     * @param format a {@code String} value
-     * @throws org.apache.commons.beanutils.ConversionException unable to parse format
+     * Set the format for the specified regular expression.
+     * @param pattern a pattern.
      */
-    public void setFormat(String format) {
-        this.format = format;
-        regexp = CommonUtils.createPattern(format);
+    public void setFormat(Pattern pattern) {
+        format = pattern.pattern();
+        regexp = pattern;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -29,7 +29,6 @@ import java.util.regex.Pattern;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
 
 /**
@@ -67,13 +66,13 @@ public class MultipleStringLiteralsCheck extends AbstractCheck {
     /**
      * Pattern for matching ignored strings.
      */
-    private Pattern pattern;
+    private Pattern ignoreStringsRegexp;
 
     /**
      * Construct an instance with default values.
      */
     public MultipleStringLiteralsCheck() {
-        setIgnoreStringsRegexp("^\"\"$");
+        setIgnoreStringsRegexp(Pattern.compile("^\"\"$"));
         ignoreOccurrenceContext.set(TokenTypes.ANNOTATION);
     }
 
@@ -89,15 +88,13 @@ public class MultipleStringLiteralsCheck extends AbstractCheck {
      * Sets regular expression pattern for ignored strings.
      * @param ignoreStringsRegexp
      *        regular expression pattern for ignored strings
-     * @throws org.apache.commons.beanutils.ConversionException
-     *         if unable to create Pattern object
      */
-    public final void setIgnoreStringsRegexp(String ignoreStringsRegexp) {
-        if (ignoreStringsRegexp == null || ignoreStringsRegexp.isEmpty()) {
-            pattern = null;
+    public final void setIgnoreStringsRegexp(Pattern ignoreStringsRegexp) {
+        if (ignoreStringsRegexp == null || ignoreStringsRegexp.pattern().isEmpty()) {
+            this.ignoreStringsRegexp = null;
         }
         else {
-            pattern = CommonUtils.createPattern(ignoreStringsRegexp);
+            this.ignoreStringsRegexp = ignoreStringsRegexp;
         }
     }
 
@@ -132,7 +129,7 @@ public class MultipleStringLiteralsCheck extends AbstractCheck {
     public void visitToken(DetailAST ast) {
         if (!isInIgnoreOccurrenceContext(ast)) {
             final String currentString = ast.getText();
-            if (pattern == null || !pattern.matcher(currentString).find()) {
+            if (ignoreStringsRegexp == null || !ignoreStringsRegexp.matcher(currentString).find()) {
                 List<StringInfo> hitList = stringMap.get(currentString);
                 if (hitList == null) {
                     hitList = new ArrayList<>();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
@@ -26,7 +26,6 @@ import java.util.regex.Pattern;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * <p>
@@ -101,13 +100,12 @@ public final class ReturnCountCheck extends AbstractCheck {
     }
 
     /**
-     * Set the format to the specified regular expression.
-     * @param format a {@code String} value
-     * @throws org.apache.commons.beanutils.ConversionException unable to parse format
+     * Set the format for the specified regular expression.
+     * @param pattern a pattern.
      */
-    public void setFormat(String format) {
-        this.format = format;
-        regexp = CommonUtils.createPattern(format);
+    public void setFormat(Pattern pattern) {
+        format = pattern.pattern();
+        regexp = pattern;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -32,7 +32,6 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * <p>
@@ -213,13 +212,10 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
 
     /**
      * Sets RegExp pattern to ignore distance calculation for variables listed in this pattern.
-     * @param ignorePattern
-     *        Pattern contains ignored variables.
-     * @throws org.apache.commons.beanutils.ConversionException
-     *         if unable to create Pattern object.
+     * @param pattern a pattern.
      */
-    public void setIgnoreVariablePattern(String ignorePattern) {
-        ignoreVariablePattern = CommonUtils.createPattern(ignorePattern);
+    public void setIgnoreVariablePattern(Pattern pattern) {
+        ignoreVariablePattern = pattern;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
@@ -26,7 +26,6 @@ import java.util.regex.Pattern;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * <p> Ensures that exceptions (classes with names conforming to some regular
@@ -54,7 +53,7 @@ public final class MutableExceptionCheck extends AbstractCheck {
     /** Stack of checking information for classes. */
     private final Deque<Boolean> checkingStack = new ArrayDeque<>();
     /** Pattern for class name that is being extended. */
-    private String extendedClassNameFormat = DEFAULT_FORMAT;
+    private Pattern extendedClassNameFormat = Pattern.compile(DEFAULT_FORMAT);
     /** Should we check current class or not. */
     private boolean checking;
     /** The format string of the regexp. */
@@ -66,18 +65,17 @@ public final class MutableExceptionCheck extends AbstractCheck {
      * Sets the format of extended class name to the specified regular expression.
      * @param extendedClassNameFormat a {@code String} value
      */
-    public void setExtendedClassNameFormat(String extendedClassNameFormat) {
+    public void setExtendedClassNameFormat(Pattern extendedClassNameFormat) {
         this.extendedClassNameFormat = extendedClassNameFormat;
     }
 
     /**
-     * Set the format to the specified regular expression.
-     * @param format a {@code String} value
-     * @throws org.apache.commons.beanutils.ConversionException unable to parse format
+     * Set the format for the specified regular expression.
+     * @param pattern the new pattern
      */
-    public void setFormat(String format) {
-        this.format = format;
-        regexp = CommonUtils.createPattern(format);
+    public void setFormat(Pattern pattern) {
+        format = pattern.pattern();
+        regexp = pattern;
     }
 
     @Override
@@ -169,7 +167,7 @@ public final class MutableExceptionCheck extends AbstractCheck {
                 currentNode = currentNode.getLastChild();
             }
             final String extendedClassName = currentNode.getText();
-            return extendedClassName.matches(extendedClassNameFormat);
+            return extendedClassNameFormat.matcher(extendedClassName).matches();
         }
         return false;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -35,7 +35,6 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.AnnotationUtility;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtils;
 
 /**
@@ -372,12 +371,10 @@ public class VisibilityModifierCheck
      * Set the pattern for public members to ignore.
      * @param pattern
      *        pattern for public members to ignore.
-     * @throws org.apache.commons.beanutils.ConversionException
-     *         if unable to create Pattern object
      */
-    public void setPublicMemberPattern(String pattern) {
-        publicMemberPattern = CommonUtils.createPattern(pattern);
-        publicMemberFormat = pattern;
+    public void setPublicMemberPattern(Pattern pattern) {
+        publicMemberPattern = pattern;
+        publicMemberFormat = pattern.pattern();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -29,7 +29,6 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * <p>
@@ -386,33 +385,27 @@ public class CustomImportOrderCheck extends AbstractCheck {
      * Sets standardRegExp specified by user.
      * @param regexp
      *        user value.
-     * @throws org.apache.commons.beanutils.ConversionException
-     *         if unable to create Pattern object.
      */
-    public final void setStandardPackageRegExp(String regexp) {
-        standardPackageRegExp = CommonUtils.createPattern(regexp);
+    public final void setStandardPackageRegExp(Pattern regexp) {
+        standardPackageRegExp = regexp;
     }
 
     /**
      * Sets thirdPartyRegExp specified by user.
      * @param regexp
      *        user value.
-     * @throws org.apache.commons.beanutils.ConversionException
-     *         if unable to create Pattern object.
      */
-    public final void setThirdPartyPackageRegExp(String regexp) {
-        thirdPartyPackageRegExp = CommonUtils.createPattern(regexp);
+    public final void setThirdPartyPackageRegExp(Pattern regexp) {
+        thirdPartyPackageRegExp = regexp;
     }
 
     /**
      * Sets specialImportsRegExp specified by user.
      * @param regexp
      *        user value.
-     * @throws org.apache.commons.beanutils.ConversionException
-     *         if unable to create Pattern object.
      */
-    public final void setSpecialImportsRegExp(String regexp) {
-        specialImportsRegExp = CommonUtils.createPattern(regexp);
+    public final void setSpecialImportsRegExp(Pattern regexp) {
+        specialImportsRegExp = regexp;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -196,10 +196,10 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
 
     /**
      * Set regex for matching method names to ignore.
-     * @param regex regex for matching method names.
+     * @param pattern a pattern.
      */
-    public void setIgnoreMethodNamesRegex(String regex) {
-        ignoreMethodNamesRegex = CommonUtils.createPattern(regex);
+    public void setIgnoreMethodNamesRegex(Pattern pattern) {
+        ignoreMethodNamesRegex = pattern;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -94,10 +94,7 @@ public class JavadocStyleCheck
     private Scope excludeScope;
 
     /** Format for matching the end of a sentence. */
-    private String endOfSentenceFormat = "([.?!][ \t\n\r\f<])|([.?!]$)";
-
-    /** Regular expression for matching the end of a sentence. */
-    private Pattern endOfSentencePattern;
+    private Pattern endOfSentenceFormat = Pattern.compile("([.?!][ \t\n\r\f<])|([.?!]$)");
 
     /**
      * Indicates if the first sentence should be checked for proper end of
@@ -236,7 +233,7 @@ public class JavadocStyleCheck
         final String commentText = getCommentText(comment.getText());
 
         if (!commentText.isEmpty()
-            && !getEndOfSentencePattern().matcher(commentText).find()
+            && !endOfSentenceFormat.matcher(commentText).find()
             && !(commentText.startsWith("{@inheritDoc}")
             && JavadocTagInfo.INHERIT_DOC.isValidOn(ast))) {
             log(comment.getStartLineNo(), MSG_NO_PERIOD);
@@ -508,22 +505,10 @@ public class JavadocStyleCheck
 
     /**
      * Set the format for matching the end of a sentence.
-     * @param format format for matching the end of a sentence.
+     * @param pattern a pattern.
      */
-    public void setEndOfSentenceFormat(String format) {
-        endOfSentenceFormat = format;
-    }
-
-    /**
-     * Returns a regular expression for matching the end of a sentence.
-     *
-     * @return a regular expression for matching the end of a sentence.
-     */
-    private Pattern getEndOfSentencePattern() {
-        if (endOfSentencePattern == null) {
-            endOfSentencePattern = Pattern.compile(endOfSentenceFormat);
-        }
-        return endOfSentencePattern;
+    public void setEndOfSentenceFormat(Pattern pattern) {
+        endOfSentenceFormat = pattern;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -134,20 +134,20 @@ public class JavadocTypeCheck
 
     /**
      * Set the author tag pattern.
-     * @param format a {@code String} value
+     * @param pattern a pattern.
      */
-    public void setAuthorFormat(String format) {
-        authorFormat = format;
-        authorFormatPattern = CommonUtils.createPattern(format);
+    public void setAuthorFormat(Pattern pattern) {
+        authorFormat = pattern.pattern();
+        authorFormatPattern = pattern;
     }
 
     /**
      * Set the version format pattern.
-     * @param format a {@code String} value
+     * @param pattern a pattern.
      */
-    public void setVersionFormat(String format) {
-        versionFormat = format;
-        versionFormatPattern = CommonUtils.createPattern(format);
+    public void setVersionFormat(Pattern pattern) {
+        versionFormat = pattern.pattern();
+        versionFormatPattern = pattern;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -27,7 +27,6 @@ import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtils;
 
 /**
@@ -71,11 +70,10 @@ public class JavadocVariableCheck
 
     /**
      * Sets the variable names to ignore in the check.
-     * @param regexp regular expression to define variable names to ignore.
-     * @throws org.apache.commons.beanutils.ConversionException if unable to create Pattern object.
+     * @param pattern a pattern.
      */
-    public void setIgnoreNamePattern(String regexp) {
-        ignoreNamePattern = CommonUtils.createPattern(regexp);
+    public void setIgnoreNamePattern(Pattern pattern) {
+        ignoreNamePattern = pattern;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -95,10 +95,10 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
 
     /**
      * Sets custom value of regular expression for forbidden summary fragments.
-     * @param pattern user's value.
+     * @param pattern a pattern.
      */
-    public void setForbiddenSummaryFragments(String pattern) {
-        forbiddenSummaryFragments = CommonUtils.createPattern(pattern);
+    public void setForbiddenSummaryFragments(Pattern pattern) {
+        forbiddenSummaryFragments = pattern;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
@@ -107,11 +107,11 @@ public class WriteTagCheck
 
     /**
      * Set the tag format.
-     * @param format a {@code String} value
+     * @param pattern a {@code String} value
      */
-    public void setTagFormat(String format) {
-        tagFormat = format;
-        tagFormatRegExp = CommonUtils.createPattern(format);
+    public void setTagFormat(Pattern pattern) {
+        tagFormat = pattern.pattern();
+        tagFormatRegExp = pattern;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * <p>
@@ -85,13 +84,12 @@ public final class AbstractClassNameCheck extends AbstractCheck {
     }
 
     /**
-     * Set the format to the specified regular expression.
-     * @param format a {@code String} value
-     * @throws org.apache.commons.beanutils.ConversionException unable to parse format
+     * Set the format for the specified regular expression.
+     * @param pattern the new pattern
      */
-    public void setFormat(String format) {
-        this.format = format;
-        regexp = CommonUtils.createPattern(format);
+    public void setFormat(Pattern pattern) {
+        format = pattern.pattern();
+        regexp = pattern;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractNameCheck.java
@@ -49,7 +49,7 @@ public abstract class AbstractNameCheck
      * @param format format to check with
      */
     protected AbstractNameCheck(String format) {
-        setFormat(format);
+        setFormat(CommonUtils.createPattern(format));
     }
 
     /**
@@ -62,13 +62,12 @@ public abstract class AbstractNameCheck
     protected abstract boolean mustCheckName(DetailAST ast);
 
     /**
-     * Set the format to the specified regular expression.
-     * @param format a {@code String} value
-     * @throws org.apache.commons.beanutils.ConversionException unable to parse format
+     * Set the format for the specified regular expression.
+     * @param pattern the new pattern
      */
-    public final void setFormat(String format) {
-        this.format = format;
-        regexp = CommonUtils.createPattern(format);
+    public final void setFormat(Pattern pattern) {
+        format = pattern.pattern();
+        regexp = pattern;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
@@ -25,7 +25,6 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * <p>
@@ -80,13 +79,12 @@ public class PackageNameCheck
     private Pattern regexp = Pattern.compile(format);
 
     /**
-     * Set the format to the specified regular expression.
-     * @param format a {@code String} value
-     * @throws org.apache.commons.beanutils.ConversionException unable to parse format
+     * Set the format for the specified regular expression.
+     * @param pattern the new pattern
      */
-    public final void setFormat(String format) {
-        this.format = format;
-        regexp = CommonUtils.createPattern(format);
+    public void setFormat(Pattern pattern) {
+        format = pattern.pattern();
+        regexp = pattern;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
@@ -166,11 +166,11 @@ public class RegexpCheck extends AbstractCheck {
 
     /**
      * Set the format to the specified regular expression.
-     * @param format a {@code String} value
+     * @param pattern the new pattern
      * @throws org.apache.commons.beanutils.ConversionException unable to parse format
      */
-    public final void setFormat(String format) {
-        this.format = format;
+    public final void setFormat(Pattern pattern) {
+        format = pattern.pattern();
         regexp = CommonUtils.createPattern(format, Pattern.MULTILINE);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
@@ -208,22 +208,18 @@ public class RegexpOnFilenameCheck extends AbstractFileSetCheck {
      * Setter for folder format.
      *
      * @param folderPattern format of folder.
-     * @throws org.apache.commons.beanutils.ConversionException if unable to
-     *         create Pattern object.
      */
-    public void setFolderPattern(String folderPattern) {
-        this.folderPattern = CommonUtils.createPattern(folderPattern);
+    public void setFolderPattern(Pattern folderPattern) {
+        this.folderPattern = folderPattern;
     }
 
     /**
      * Setter for file name format.
      *
      * @param fileNamePattern format of file.
-     * @throws org.apache.commons.beanutils.ConversionException if unable to
-     *         create Pattern object.
      */
-    public void setFileNamePattern(String fileNamePattern) {
-        this.fileNamePattern = CommonUtils.createPattern(fileNamePattern);
+    public void setFileNamePattern(Pattern fileNamePattern) {
+        this.fileNamePattern = fileNamePattern;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
@@ -90,14 +90,7 @@ public class LineLengthCheck extends AbstractCheck {
     private int max = DEFAULT_MAX_COLUMNS;
 
     /** The regexp when long lines are ignored. */
-    private Pattern ignorePattern;
-
-    /**
-     * Creates a new {@code LineLengthCheck} instance.
-     */
-    public LineLengthCheck() {
-        setIgnorePattern("^$");
-    }
+    private Pattern ignorePattern = Pattern.compile("^$");
 
     @Override
     public int[] getDefaultTokens() {
@@ -140,9 +133,9 @@ public class LineLengthCheck extends AbstractCheck {
 
     /**
      * Set the ignore pattern.
-     * @param format a {@code String} value
+     * @param pattern a pattern.
      */
-    public final void setIgnorePattern(String format) {
-        ignorePattern = CommonUtils.createPattern(format);
+    public final void setIgnorePattern(Pattern pattern) {
+        ignorePattern = pattern;
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilter.java
@@ -23,7 +23,6 @@ import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.BeforeExecutionFileFilter;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * <p>
@@ -78,11 +77,9 @@ public final class BeforeExecutionExclusionFileFilter extends AutomaticBean
      * Sets regular expression of the file to exclude.
      *
      * @param fileNamePattern regular expression of the excluded file.
-     * @throws org.apache.commons.beanutils.ConversionException if unable to
-     *         create Pattern object.
      */
-    public void setFileNamePattern(String fileNamePattern) {
-        this.fileNamePattern = CommonUtils.createPattern(fileNamePattern);
+    public void setFileNamePattern(Pattern fileNamePattern) {
+        this.fileNamePattern = fileNamePattern;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -99,16 +99,16 @@ public class SuppressWithNearbyCommentFilter
     private boolean checkCPP = true;
 
     /** Parsed comment regexp that marks checkstyle suppression region. */
-    private Pattern commentRegexp;
+    private Pattern commentFormat = Pattern.compile(DEFAULT_COMMENT_FORMAT);
 
     /** The comment pattern that triggers suppression. */
-    private String checkFormat;
+    private String checkFormat = DEFAULT_CHECK_FORMAT;
 
     /** The message format to suppress. */
     private String messageFormat;
 
     /** The influence of the suppression comment. */
-    private String influenceFormat;
+    private String influenceFormat = DEFAULT_INFLUENCE_FORMAT;
 
     /**
      * References the current FileContents for this filter.
@@ -120,23 +120,11 @@ public class SuppressWithNearbyCommentFilter
     private WeakReference<FileContents> fileContentsReference = new WeakReference<>(null);
 
     /**
-     * Constructs a SuppressionCommentFilter.
-     * Initializes comment on, comment off, and check formats
-     * to defaults.
-     */
-    public SuppressWithNearbyCommentFilter() {
-        setCommentFormat(DEFAULT_COMMENT_FORMAT);
-        checkFormat = DEFAULT_CHECK_FORMAT;
-        influenceFormat = DEFAULT_INFLUENCE_FORMAT;
-    }
-
-    /**
      * Set the format for a comment that turns off reporting.
-     * @param format a {@code String} value.
-     * @throws ConversionException if unable to create Pattern object.
+     * @param pattern a pattern.
      */
-    public final void setCommentFormat(String format) {
-        commentRegexp = CommonUtils.createPattern(format);
+    public final void setCommentFormat(Pattern pattern) {
+        commentFormat = pattern;
     }
 
     /**
@@ -273,7 +261,7 @@ public class SuppressWithNearbyCommentFilter
      * @param line the line number of text.
      */
     private void tagCommentLine(String text, int line) {
-        final Matcher matcher = commentRegexp.matcher(text);
+        final Matcher matcher = commentFormat.matcher(text);
         if (matcher.find()) {
             addTag(matcher.group(0), line);
         }
@@ -323,18 +311,18 @@ public class SuppressWithNearbyCommentFilter
             String format = "";
             try {
                 format = CommonUtils.fillTemplateWithStringsByRegexp(
-                        filter.checkFormat, text, filter.commentRegexp);
+                        filter.checkFormat, text, filter.commentFormat);
                 tagCheckRegexp = Pattern.compile(format);
                 if (filter.messageFormat == null) {
                     tagMessageRegexp = null;
                 }
                 else {
                     format = CommonUtils.fillTemplateWithStringsByRegexp(
-                            filter.messageFormat, text, filter.commentRegexp);
+                            filter.messageFormat, text, filter.commentFormat);
                     tagMessageRegexp = Pattern.compile(format);
                 }
                 format = CommonUtils.fillTemplateWithStringsByRegexp(
-                        filter.influenceFormat, text, filter.commentRegexp);
+                        filter.influenceFormat, text, filter.commentFormat);
                 final int influence;
                 try {
                     if (CommonUtils.startsWithChar(format, '+')) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -67,10 +67,10 @@ public class SuppressionCommentFilter
     implements Filter {
 
     /** Turns checkstyle reporting off. */
-    private static final String DEFAULT_OFF_FORMAT = "CHECKSTYLE\\:OFF";
+    private static final String DEFAULT_OFF_FORMAT = "CHECKSTYLE:OFF";
 
     /** Turns checkstyle reporting on. */
-    private static final String DEFAULT_ON_FORMAT = "CHECKSTYLE\\:ON";
+    private static final String DEFAULT_ON_FORMAT = "CHECKSTYLE:ON";
 
     /** Control all checks. */
     private static final String DEFAULT_CHECK_FORMAT = ".*";
@@ -87,13 +87,13 @@ public class SuppressionCommentFilter
     private boolean checkCPP = true;
 
     /** Parsed comment regexp that turns checkstyle reporting off. */
-    private Pattern offRegexp;
+    private Pattern offCommentFormat = Pattern.compile(DEFAULT_OFF_FORMAT);
 
     /** Parsed comment regexp that turns checkstyle reporting on. */
-    private Pattern onRegexp;
+    private Pattern onCommentFormat = Pattern.compile(DEFAULT_ON_FORMAT);
 
     /** The check format to suppress. */
-    private String checkFormat;
+    private String checkFormat = DEFAULT_CHECK_FORMAT;
 
     /** The message format to suppress. */
     private String messageFormat;
@@ -108,32 +108,19 @@ public class SuppressionCommentFilter
     private WeakReference<FileContents> fileContentsReference = new WeakReference<>(null);
 
     /**
-     * Constructs a SuppressionCommentFilter.
-     * Initializes comment on, comment off, and check formats
-     * to defaults.
-     */
-    public SuppressionCommentFilter() {
-        setOnCommentFormat(DEFAULT_ON_FORMAT);
-        setOffCommentFormat(DEFAULT_OFF_FORMAT);
-        checkFormat = DEFAULT_CHECK_FORMAT;
-    }
-
-    /**
      * Set the format for a comment that turns off reporting.
-     * @param format a {@code String} value.
-     * @throws ConversionException if unable to create Pattern object.
+     * @param pattern a pattern.
      */
-    public final void setOffCommentFormat(String format) {
-        offRegexp = CommonUtils.createPattern(format);
+    public final void setOffCommentFormat(Pattern pattern) {
+        offCommentFormat = pattern;
     }
 
     /**
      * Set the format for a comment that turns on reporting.
-     * @param format a {@code String} value
-     * @throws ConversionException if unable to create Pattern object.
+     * @param pattern a pattern.
      */
-    public final void setOnCommentFormat(String format) {
-        onRegexp = CommonUtils.createPattern(format);
+    public final void setOnCommentFormat(Pattern pattern) {
+        onCommentFormat = pattern;
     }
 
     /**
@@ -269,12 +256,12 @@ public class SuppressionCommentFilter
      * @param column the column number of text.
      */
     private void tagCommentLine(String text, int line, int column) {
-        final Matcher offMatcher = offRegexp.matcher(text);
+        final Matcher offMatcher = offCommentFormat.matcher(text);
         if (offMatcher.find()) {
             addTag(offMatcher.group(0), line, column, false);
         }
         else {
-            final Matcher onMatcher = onRegexp.matcher(text);
+            final Matcher onMatcher = onCommentFormat.matcher(text);
             if (onMatcher.find()) {
                 addTag(onMatcher.group(0), line, column, true);
             }
@@ -340,27 +327,27 @@ public class SuppressionCommentFilter
             try {
                 if (reportingOn) {
                     format = CommonUtils.fillTemplateWithStringsByRegexp(
-                            filter.checkFormat, text, filter.onRegexp);
+                            filter.checkFormat, text, filter.onCommentFormat);
                     tagCheckRegexp = Pattern.compile(format);
                     if (filter.messageFormat == null) {
                         tagMessageRegexp = null;
                     }
                     else {
                         format = CommonUtils.fillTemplateWithStringsByRegexp(
-                                filter.messageFormat, text, filter.onRegexp);
+                                filter.messageFormat, text, filter.onCommentFormat);
                         tagMessageRegexp = Pattern.compile(format);
                     }
                 }
                 else {
                     format = CommonUtils.fillTemplateWithStringsByRegexp(
-                            filter.checkFormat, text, filter.offRegexp);
+                            filter.checkFormat, text, filter.offCommentFormat);
                     tagCheckRegexp = Pattern.compile(format);
                     if (filter.messageFormat == null) {
                         tagMessageRegexp = null;
                     }
                     else {
                         format = CommonUtils.fillTemplateWithStringsByRegexp(
-                                filter.messageFormat, text, filter.offRegexp);
+                                filter.messageFormat, text, filter.offCommentFormat);
                         tagMessageRegexp = Pattern.compile(format);
                     }
                 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
@@ -69,8 +69,8 @@ public class ConstantNameCheckTest
         }
         catch (CheckstyleException ex) {
             assertEquals("cannot initialize module"
-                    + " com.puppycrawl.tools.checkstyle.TreeWalker - Cannot set property"
-                    + " 'format' to '\\' in module"
+                    + " com.puppycrawl.tools.checkstyle.TreeWalker - illegal value"
+                    + " '\\' for property 'format' of module"
                     + " com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck",
                     ex.getMessage());
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheckTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.regex.Pattern;
 
 import org.junit.Test;
 
@@ -229,7 +230,7 @@ public class RegexpOnFilenameCheckTest extends BaseFileSetCheckTestSupport {
         final File file = new File(getPath("") + "\u0000" + File.separatorChar + "Test");
         try {
             final RegexpOnFilenameCheck check = new RegexpOnFilenameCheck();
-            check.setFileNamePattern("BAD");
+            check.setFileNamePattern(Pattern.compile("BAD"));
             check.process(file, null);
             fail("CheckstyleException expected");
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filefilters/ExclusionBeforeExecutionFileFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filefilters/ExclusionBeforeExecutionFileFilterTest.java
@@ -22,6 +22,8 @@ package com.puppycrawl.tools.checkstyle.filefilters;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.regex.Pattern;
+
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
@@ -73,7 +75,7 @@ public class ExclusionBeforeExecutionFileFilterTest extends BaseCheckTestSupport
         final BeforeExecutionExclusionFileFilter exclusionBeforeExecutionFileFilter =
                 new BeforeExecutionExclusionFileFilter();
         if (fileName != null) {
-            exclusionBeforeExecutionFileFilter.setFileNamePattern(fileName);
+            exclusionBeforeExecutionFileFilter.setFileNamePattern(Pattern.compile(fileName));
         }
         return exclusionBeforeExecutionFileFilter;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/BeforeExecutionFileFilterSetTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/BeforeExecutionFileFilterSetTest.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.regex.Pattern;
+
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.api.BeforeExecutionFileFilterSet;
@@ -34,7 +36,7 @@ public class BeforeExecutionFileFilterSetTest {
     public void testAccept() {
         final String fileName = "BAD";
         final BeforeExecutionExclusionFileFilter filter = new BeforeExecutionExclusionFileFilter();
-        filter.setFileNamePattern(fileName);
+        filter.setFileNamePattern(Pattern.compile(fileName));
         final BeforeExecutionFileFilterSet set = new BeforeExecutionFileFilterSet();
         set.addBeforeExecutionFileFilter(filter);
 
@@ -45,7 +47,7 @@ public class BeforeExecutionFileFilterSetTest {
     public void testReject() {
         final String fileName = "Test";
         final BeforeExecutionExclusionFileFilter filter = new BeforeExecutionExclusionFileFilter();
-        filter.setFileNamePattern(fileName);
+        filter.setFileNamePattern(Pattern.compile(fileName));
         final BeforeExecutionFileFilterSet set = new BeforeExecutionFileFilterSet();
         set.addBeforeExecutionFileFilter(filter);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
@@ -40,6 +40,7 @@ import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -602,6 +603,9 @@ public class XDocsPagesTest {
                 result = "String Set";
             }
         }
+        else if (clss == Pattern.class) {
+            result = "Regular Expression";
+        }
         else if (clss != String.class) {
             Assert.fail("Unknown property type: " + clss.getSimpleName());
         }
@@ -644,6 +648,16 @@ public class XDocsPagesTest {
                         .replace(".0", "");
                 if (result.isEmpty()) {
                     result = "{}";
+                }
+            }
+            else if (clss == Pattern.class) {
+                if (value != null) {
+                    result = '"' + value.toString().replace("\n", "\\n").replace("\t", "\\t")
+                            .replace("\r", "\\r").replace("\f", "\\f") + '"';
+                }
+
+                if ("\"$^\"".equals(result)) {
+                    result += " (empty)";
                 }
             }
 

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -609,10 +609,10 @@ public static final int COUNTER = 10; // violation as javadoc exists
                being suppressed matching this pattern will be flagged.
             </td>
             <td>
-              <a href="property_types.html#regexp">regexp</a>
+              <a href="property_types.html#regexp">Regular Expression</a>
             </td>
             <td>
-              <code>^$|^\s+$</code>
+              <code>"^$|^\s+$"</code>
             </td>
           </tr>
 

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -844,8 +844,8 @@ case 5:
               Regular expression to match the relief comment that suppresses
               the warning about a fall through.
             </td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>fallthru|falls? ?through</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"fallthru|falls? ?through"</code></td>
           </tr>
         </table>
       </subsection>
@@ -1063,8 +1063,8 @@ case 5:
           <tr>
             <td>ignoreFormat</td>
             <td>pattern for names of variables and parameters to ignore</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td>(not applied)</td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>null</code></td>
           </tr>
 
           <tr>
@@ -1665,8 +1665,8 @@ class SomeClass
           <tr>
             <td>format</td>
             <td>illegal pattern</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^$</code> (empty)</td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>&quot;$^&quot; (empty)</code></td>
           </tr>
           <tr>
             <td>ignoreCase</td>
@@ -1805,8 +1805,8 @@ class SomeClass
           <tr>
             <td>format</td>
             <td>Pattern for illegal class names.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^(.*[\\.])?Abstract.*$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^(.*[.])?Abstract.*$"</code></td>
           </tr>
           <tr>
             <td>memberModifiers</td>
@@ -2458,8 +2458,8 @@ class MyClass {
             <td>
               Regular expression pattern for ignored strings (with quotation marks)
             </td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^""$</code> (ignore empty strings)</td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^""$"</code></td>
           </tr>
           <tr>
             <td>ignoreOccurrenceContext</td>
@@ -3503,8 +3503,8 @@ public static class B {
           <tr>
             <td>format</td>
             <td>method names to ignore</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^equals$</code> (empty)</td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^equals$"</code></td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -4103,8 +4103,8 @@ if (&quot;something&quot;.equals(x))
           <tr>
             <td>ignoreVariablePattern</td>
             <td>pattern for ignoring the distance calculation</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td>(not applied)</td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>""</code></td>
           </tr>
 
           <tr>

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -572,14 +572,14 @@ public class StringUtils // not final to allow subclassing
           <tr>
             <td>format</td>
             <td>pattern for exception class names</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^.*Exception$|^.*Error$|^.*Throwable$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^.*Exception$|^.*Error$|^.*Throwable$"</code></td>
           </tr>
           <tr>
             <td>extendedClassNameFormat</td>
             <td>pattern for extended class names</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^.*Exception$|^.*Error$|^.*Throwable$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^.*Exception$|^.*Error$|^.*Throwable$"</code></td>
           </tr>
         </table>
       </subsection>
@@ -922,8 +922,8 @@ public class Foo{
           <tr>
             <td>publicMemberPattern</td>
             <td>pattern for public members that should be ignored</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^serialVersionUID$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^serialVersionUID$"</code></td>
           </tr>
           <tr>
             <td>allowPublicFinalFields</td>

--- a/src/xdocs/config_filefilters.xml
+++ b/src/xdocs/config_filefilters.xml
@@ -54,7 +54,7 @@
           <tr>
             <td>fileNamePattern</td>
             <td>Regular expression to match the file name against.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>null</code></td>
           </tr>
         </table>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -123,26 +123,26 @@
               <tr>
                   <td>offCommentFormat</td>
                   <td>comment pattern to trigger filter to begin suppression</td>
-                  <td><a href="property_types.html#regexp">regular expression</a></td>
-                  <td><code>CHECKSTYLE\:OFF</code></td>
+                  <td><a href="property_types.html#regexp">Regular Expression</a></td>
+                  <td><code>"CHECKSTYLE:OFF"</code></td>
               </tr>
               <tr>
                   <td>onCommentFormat</td>
                   <td>comment pattern to trigger filter to end suppression</td>
-                  <td><a href="property_types.html#regexp">regular expression</a></td>
-                  <td><code>CHECKSTYLE\:ON</code></td>
+                  <td><a href="property_types.html#regexp">Regular Expression</a></td>
+                  <td><code>"CHECKSTYLE:ON"</code></td>
               </tr>
               <tr>
                   <td>checkFormat</td>
                   <td>check pattern to suppress</td>
-                  <td><a href="property_types.html#regexp">regular expression</a></td>
-                  <td><code>.*</code> (all checks)</td>
+                  <td><a href="property_types.html#regexp">Regular Expression</a></td>
+                  <td><code>".*"</code></td>
               </tr>
               <tr>
                   <td>messageFormat</td>
                   <td>message pattern to suppress</td>
-                  <td><a href="property_types.html#regexp">regular expression</a></td>
-                  <td>none</td>
+                  <td><a href="property_types.html#regexp">Regular Expression</a></td>
+                  <td><code>null</code></td>
               </tr>
               <tr>
                   <td>checkCPP</td>
@@ -478,13 +478,13 @@ public class UserService {
           <ul>
               <li>
                   <code>files</code> -
-                  a <a href="property_types.html#regexp">regular expression</a>
+                  a <a href="property_types.html#regexp">Regular Expression</a>
                   matched against the file name associated with an audit
                   event. It is mandatory.
               </li>
               <li>
                   <code>checks</code> -
-                  a <a href="property_types.html#regexp">regular expression</a>
+                  a <a href="property_types.html#regexp">Regular Expression</a>
                   matched against the name of the check associated with an audit
                   event. Optional if <code>id</code> is specified.
               </li>
@@ -768,27 +768,27 @@ public static void foo() {
                 <tr>
                     <td>commentFormat</td>
                     <td>comment pattern to trigger filter to begin suppression</td>
-                    <td><a href="property_types.html#regexp">regular expression</a></td>
-                    <td><code>SUPPRESS CHECKSTYLE (\w+)</code></td>
+                    <td><a href="property_types.html#regexp">Regular Expression</a></td>
+                    <td><code>"SUPPRESS CHECKSTYLE (\w+)"</code></td>
                 </tr>
                 <tr>
                     <td>checkFormat</td>
                     <td>check pattern to suppress</td>
-                    <td><a href="property_types.html#regexp">regular expression</a></td>
-                    <td><code>.*</code></td>
+                    <td><a href="property_types.html#regexp">Regular Expression</a></td>
+                    <td><code>".*"</code></td>
                 </tr>
                 <tr>
                     <td>messageFormat</td>
                     <td>message pattern to suppress</td>
-                    <td><a href="property_types.html#regexp">regular expression</a></td>
-                    <td>none</td>
+                    <td><a href="property_types.html#regexp">Regular Expression</a></td>
+                    <td><code>null</code></td>
                 </tr>
                 <tr>
                     <td>influenceFormat</td>
                     <td>a negative/zero/positive value that defines the number of
                         lines preceding/at/following the suppression comment</td>
-                    <td><a href="property_types.html#regexp">regular expression</a></td>
-                    <td><code>0</code> (the line containing the comment)</td>
+                    <td><a href="property_types.html#regexp">Regular Expression</a></td>
+                    <td><code>"0"</code></td>
                 </tr>
                 <tr>
                     <td>checkCPP</td>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -338,20 +338,20 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
           <tr>
             <td>standardPackageRegExp</td>
             <td>RegExp for STANDARD_JAVA_PACKAGE group imports.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^(java|javax)\.</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^(java|javax)\."</code></td>
           </tr>
           <tr>
             <td>thirdPartyPackageRegExp</td>
             <td>RegExp for THIRDPARTY_PACKAGE group imports.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>.*</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>".*"</code></td>
           </tr>
           <tr>
             <td>specialImportsRegExp</td>
             <td>RegExp for SPECIAL_IMPORTS group imports.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^$"</code></td>
           </tr>
           <tr>
             <td>separateLineBetweenGroups</td>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -335,8 +335,8 @@ public boolean isSomething()
           <tr>
             <td>ignoreMethodNamesRegex</td>
             <td>ignore method whose names are matching specified regex</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>null</code> (tag not required)</td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>null</code></td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -800,8 +800,8 @@ public boolean isSomething()
             <td>
               Format for matching the end of a sentence.
             </td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>([.?!][ \t\n\r\f&lt;])|([.?!]$)</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"([.?!][ \t\n\r\f&lt;])|([.?!]$)"</code></td>
           </tr>
           <tr>
             <td>checkEmptyJavadoc</td>
@@ -1091,14 +1091,14 @@ public boolean isSomething()
           <tr>
             <td>authorFormat</td>
             <td>pattern for @author tag</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>null</code> (tag not required)</td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>null</code></td>
           </tr>
           <tr>
             <td>versionFormat</td>
             <td>pattern for @version tag</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>null</code> (tag not required)</td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>null</code></td>
           </tr>
           <tr>
             <td>allowMissingParamTags</td>
@@ -1269,7 +1269,7 @@ public boolean isSomething()
           <tr>
               <td>ignoreNamePattern</td>
               <td>regexp to define variable names to ignore</td>
-              <td><a href="property_types.html#regexp">regular expression</a></td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
               <td><code>null</code></td>
           </tr>
           <tr>
@@ -1596,8 +1596,8 @@ public boolean isSomething()
           <tr>
             <td>forbiddenSummaryFragments</td>
             <td>forbidden summary fragments</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^$"</code></td>
           </tr>
           <tr>
             <td>period</td>
@@ -1726,7 +1726,7 @@ public boolean isSomething()
           <tr>
             <td>tagFormat</td>
             <td>Format of tag</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>null</code></td>
           </tr>
           <tr>

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -1343,8 +1343,8 @@ void foo(String aFooString,
           <tr>
             <td>format</td>
             <td>Pattern to match comments against</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>TODO:</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"TODO:"</code></td>
           </tr>
         </table>
       </subsection>
@@ -1490,16 +1490,16 @@ d = e / f;        // Another comment for this line
           <tr>
             <td>format</td>
             <td>pattern for strings allowed before the comment</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^[\\s\\}\\);]*$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^[\s\});]*$"</code></td>
           </tr>
           <tr>
             <td>legalComment</td>
             <td>pattern for text allowed in trailing comments. (This
                 pattern will not be applied to multiline comments and the text of the
                 comment will be trimmed before matching.)</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td>(not set)</td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>null</code></td>
           </tr>
         </table>
       </subsection>
@@ -1618,8 +1618,8 @@ messages.properties: Key 'ok' missing.
             <td><a href="https://docs.oracle.com/javase/7/docs/api/java/util/ResourceBundle.html">
               Base name</a> of resource bundles which contain message resources. It helps
               the check to distinguish config and localization resources.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^messages.*$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^messages.*$"</code></td>
           </tr>
           <tr>
             <td>requiredTranslations</td>
@@ -1772,8 +1772,8 @@ messages_home_fr_CA_UNIX.properties
             <td>excludedClasses</td>
             <td>Pattern for qualified names of classes which are allowed
             to have a main method.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^$"</code></td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -186,8 +186,8 @@
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^Abstract.+$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^Abstract.+$"</code></td>
           </tr>
           <tr>
             <td>ignoreModifier</td>
@@ -291,10 +291,10 @@
             <td>format</td>
             <td>Specifies valid identifiers.</td>
             <td>
-              <a href="property_types.html#regexp">regular expression</a>
+              <a href="property_types.html#regexp">Regular Expression</a>
             </td>
             <td>
-              <code>^(e|t|ex|[a-z][a-z][a-zA-Z]+)$</code>
+              <code>"^(e|t|ex|[a-z][a-z][a-zA-Z]+)$"</code>
             </td>
           </tr>
         </table>
@@ -373,8 +373,8 @@
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^[A-Z]$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^[A-Z]$"</code></td>
           </tr>
         </table>
       </subsection>
@@ -442,8 +442,8 @@
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"</code></td>
           </tr>
           <tr>
             <td>applyToPublic</td>
@@ -543,8 +543,8 @@
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^[A-Z]$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^[A-Z]$"</code></td>
           </tr>
         </table>
       </subsection>
@@ -608,8 +608,8 @@
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^[a-z][a-zA-Z0-9]*$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
           </tr>
           <tr>
           <td>tokens</td>
@@ -690,8 +690,8 @@
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^[a-z][a-zA-Z0-9]*$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
           </tr>
           <tr>
             <td>allowOneCharVarInForLoop</td>
@@ -785,8 +785,8 @@ for (int i = 1; i &lt; 10; i++) {}
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^[a-z][a-zA-Z0-9]*$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
           </tr>
           <tr>
             <td>applyToPublic</td>
@@ -890,8 +890,8 @@ for (int i = 1; i &lt; 10; i++) {}
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^[a-z][a-zA-Z0-9]*$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
           </tr>
           <tr>
             <td>allowClassName</td>
@@ -1010,8 +1010,8 @@ class MyClass {
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^[A-Z]$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^[A-Z]$"</code></td>
           </tr>
         </table>
       </subsection>
@@ -1078,8 +1078,8 @@ class MyClass {
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^[a-z]+(\.[a-zA-Z_][a-zA-Z0-9_]*)*$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^[a-z]+(\.[a-zA-Z_][a-zA-Z0-9_]*)*$"</code></td>
           </tr>
         </table>
       </subsection>
@@ -1160,8 +1160,8 @@ class MyClass {
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^[a-z][a-zA-Z0-9]*$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
           </tr>
           <tr>
             <td>ignoreOverridden</td>
@@ -1266,8 +1266,8 @@ public boolean equals(Object o) {
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^[a-z][a-zA-Z0-9]*$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
           </tr>
           <tr>
             <td>applyToPublic</td>
@@ -1360,8 +1360,8 @@ public boolean equals(Object o) {
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^[A-Z][a-zA-Z0-9]*$</code></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"^[A-Z][a-zA-Z0-9]*$"</code></td>
           </tr>
           <tr>
             <td>applyToPublic</td>

--- a/src/xdocs/config_regexp.xml
+++ b/src/xdocs/config_regexp.xml
@@ -80,8 +80,8 @@
           <tr>
             <td>format</td>
             <td>pattern</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>$^</code> (empty)</td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>"$^"</code> (empty)</td>
           </tr>
           <tr>
             <td>message</td>
@@ -504,8 +504,8 @@
           <tr>
             <td>format</td>
             <td>illegal pattern</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^$</code> (empty)</td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>&quot;$.&quot;</code></td>
           </tr>
           <tr>
             <td>message</td>
@@ -653,13 +653,13 @@
           <tr>
             <td>folderPattern</td>
             <td>Regular expression to match the folder path against.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>null</code></td>
           </tr>
           <tr>
             <td>fileNamePattern</td>
             <td>Regular expression to match the file name against.</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>null</code></td>
           </tr>
           <tr>
@@ -817,8 +817,8 @@
           <tr>
             <td>format</td>
             <td>illegal pattern</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^$</code> (empty)</td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>&quot;$.&quot;</code></td>
           </tr>
           <tr>
             <td>message</td>
@@ -959,8 +959,8 @@
           <tr>
             <td>format</td>
             <td>illegal pattern</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td><code>^$</code> (empty)</td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td><code>&quot;$.&quot;</code></td>
           </tr>
           <tr>
             <td>message</td>

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -306,8 +306,8 @@
           <tr>
             <td>ignorePattern</td>
             <td>pattern for lines to ignore</td>
-            <td><a href="property_types.html#regexp">regular expression</a></td>
-            <td>^$</td>
+            <td><a href="property_types.html#regexp">Regular Expression</a></td>
+            <td>"^$"</td>
           </tr>
           <tr>
             <td>max</td>


### PR DESCRIPTION
Issue #3255

Added pattern recognition to `AutomaticBean`.
Modules were changed so setter takes `Pattern` and field is same name as setter.
XDocs were validated and corrected for type and default value.

2 modules required a slight override.
`MultipleStringLiteralsCheck` converts null and empty strings to null pattern.
`RegexpCheck` needs multi-line parameter.