### PR TITLE
Forbid Windows End of Line (EOL)

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -74,6 +74,10 @@
   <!-- Regexp -->
   <module name="RegexpMultiline"/>
   <module name="RegexpMultiline">
+    <property name="format" value="(\r\n|\r)"/>
+    <property name="message" value="Line has Windows line delimiter."/>
+  </module>
+  <module name="RegexpMultiline">
     <property name="format" value="\r?\n[\t ]*\r?\n[\t ]*\r?\n"/>
     <property name="fileExtensions" value="java,xml,properties"/>
     <property name="message" value="Unnecessary consecutive lines"/>


### PR DESCRIPTION
This automatically detects, and would prevent future fallback,
of what I fixed one off in https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/479,
but which without this will come back, of course.

If it's "too late" to do this enforcement in this file, then perhaps..
the same shold be done just for sevntu?  I don't see how.

Signed-off-by: Michael Vorburger <mike@vorburger.ch>