### PR TITLE
Issue #3487: turned on checkstyle cache for developers

### DIFF
--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -12,8 +12,6 @@
              classpath="${mvn.runtime_classpath}"
              />
 
-    <delete file="${mvn.project.build.directory}/cachefile" />
-
     <property name="checkstyle.pattern.todo" value="NOTHingWillMatCH_-"/>
     <property name="check.config" location="config/checkstyle_checks.xml"/>
 

--- a/config/build.xml
+++ b/config/build.xml
@@ -20,7 +20,6 @@
              classname="com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask">
       <classpath refid="run.classpath"/>
     </taskdef>
-    <delete file="${target.dir}/cachefile" />
 
     <property name="checkstyle.pattern.todo" value="NOTHingWillMatCH_-"/>
     <property name="check.config" location="config/checkstyle_checks.xml"/>

--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -14,6 +14,8 @@
 
   <metadata name="com.atlas-sw.eclipse" value="I like Sydney"/>
 
+  <property name="cacheFile" value="${checkstyle.cache.file}"/>
+
   <property name="severity" value="error"/>
 
   <property name="fileExtensions" value="java, properties, xml, vm, g, g4"/>

--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -7,6 +7,8 @@
 <module name="Checker">
     <!-- All checks are from https://github.com/sevntu-checkstyle/sevntu.checkstyle project -->
 
+    <property name="cacheFile" value="target/cachefile-sevntu"/>
+
     <!-- Filters -->
     <module name="SuppressionFilter">
         <property name="file" value="${project.basedir}/config/sevntu_suppressions.xml"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
@@ -177,7 +177,9 @@ public class XDocsPagesTest {
     private static void buildAndValidateXml(String fileName, String unserializedSource)
             throws IOException, ParserConfigurationException, CheckstyleException {
         // not all examples come with the full xml structure
-        String code = unserializedSource;
+        String code = unserializedSource
+            // don't corrupt our own cachefile
+            .replace("target/cachefile", "target/cachefile-test");
 
         if (!hasFileSetClass(code)) {
             code = "<module name=\"TreeWalker\">\n" + code + "\n</module>";


### PR DESCRIPTION
Issue #3487

Cache turned on for Checkstyle and sevntu.

* Changes in `XDocPagesTest` is because instantiating the examples caused our own cachefile to be corrupted.
* Sevntu cachefile couldn't be enabled in the pom, that I could figure out. `<cacheFile>${project.build.directory}/cachefile-sevntu</cacheFile>` caused no cache file to be created.
* Removed the delete cachefiles as we don't really need them and will defeat the purpose of the cache. CI will always be clean, so it will only matter locally. Cache is deleted on clean, and will reset for files/configs that change. Deleting the file will just put us back without cache each time we run verify.