### PR TITLE
Issue #3567: added ForbidAnnotationElementValueCheck

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -174,5 +174,6 @@
         <module name="SingleBreakOrContinueCheck"/>
         <module name="NumericLiteralNeedsUnderscoreCheck"/>
         <module name="UniformEnumConstantNameCheck" />
+        <module name="ForbidAnnotationElementValueCheck" />
     </module>
 </module>

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/SingleLineJavadocTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/SingleLineJavadocTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 
 import com.google.checkstyle.test.base.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.SingleLineJavadocCheck;
 
 public class SingleLineJavadocTest extends BaseCheckTestSupport {
@@ -55,21 +54,6 @@ public class SingleLineJavadocTest extends BaseCheckTestSupport {
         final DefaultConfiguration checkConfig = createCheckConfig(SingleLineJavadocCheck.class);
         checkConfig.addAttribute("ignoreInlineTags", "false");
         final String filePath = getPath("InputSingleLineJavadocCheck.java");
-
-        final Integer[] warnList = getLinesWithWarn(filePath);
-        verify(checkConfig, filePath, expected, warnList);
-    }
-
-    @Test(expected = Exception.class)
-    public void customInlineTagTest() throws Exception {
-        final String msg = getCheckMessage(SingleLineJavadocCheck.class, "singleline.javadoc");
-
-        final Configuration checkConfig = getCheckConfig("SingleLineJavadocCheck");
-        final String filePath = getPath("InputSingleLineJavadocCheckError.java");
-
-        final String[] expected = {
-            "4: " + msg,
-        };
 
         final Integer[] warnList = getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputSingleLineJavadocCheckError.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputSingleLineJavadocCheckError.java
@@ -1,6 +1,0 @@
-package com.google.checkstyle.test.chapter7javadoc.rule711generalform;
-
-public class InputSingleLineJavadocCheckError {
-    /** {@customTag} */ //warn
-    void bar() {}
-}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
@@ -29,6 +29,8 @@ import java.nio.file.Paths;
 import org.junit.Assert;
 import org.junit.Test;
 
+import antlr.NoViableAltException;
+
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
 public class AstTreeStringPrinterTest {
@@ -46,10 +48,17 @@ public class AstTreeStringPrinterTest {
         assertUtilsClassHasPrivateConstructor(AstTreeStringPrinter.class);
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testParseFileThrowable() throws Exception {
-        AstTreeStringPrinter.printFileAst(
-            new File(getNonCompilablePath("InputAstTreeStringPrinter.java")), false);
+        try {
+            AstTreeStringPrinter.printFileAst(
+                new File(getNonCompilablePath("InputAstTreeStringPrinter.java")), false);
+            Assert.fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            Assert.assertSame(NoViableAltException.class, ex.getCause().getClass());
+            Assert.assertEquals("unexpected token: classD", ex.getCause().getMessage());
+        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertiesExpanderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertiesExpanderTest.java
@@ -26,9 +26,15 @@ import org.junit.Test;
 
 public class PropertiesExpanderTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCtorException() {
-        new PropertiesExpander(null);
+        try {
+            new PropertiesExpander(null);
+            Assert.fail("exception expected");
+        }
+        catch (IllegalArgumentException ex) {
+            Assert.assertEquals("cannot pass null", ex.getMessage());
+        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.lang.reflect.Method;
 import java.util.SortedSet;
@@ -100,7 +101,7 @@ public class AbstractViolationReporterTest extends BaseCheckTestSupport {
                 messages.first().getMessage());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCustomMessageWithParametersNegative() throws Exception {
         final DefaultConfiguration config = createCheckConfig(emptyCheck.getClass());
         config.addMessage("msgKey", "This is a custom message {0.");
@@ -109,14 +110,13 @@ public class AbstractViolationReporterTest extends BaseCheckTestSupport {
         final LocalizedMessages collector = new LocalizedMessages();
         emptyCheck.setMessages(collector);
 
-        emptyCheck.log(0, "msgKey", "TestParam");
-
-        final SortedSet<LocalizedMessage> messages = collector.getMessages();
-        assertEquals(1, messages.size());
-
-        //we expect an exception here because of the bogus custom message
-        //format
-        messages.first().getMessage();
+        try {
+            emptyCheck.log(0, "msgKey", "TestParam");
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException ex) {
+            assertEquals("Unmatched braces in the pattern.", ex.getMessage());
+        }
     }
 
     private static class EmptyCheck extends AbstractCheck {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -118,12 +118,18 @@ public class AutomaticBeanTest {
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testTestBean() {
         final TestBean testBean = new TestBean();
         testBean.setVal(0);
         testBean.setWrong("wrongVal");
-        testBean.setExceptionalMethod("someValue");
+        try {
+            testBean.setExceptionalMethod("someValue");
+            fail("exception expected");
+        }
+        catch (IllegalStateException ex) {
+            assertEquals("null,wrongVal,0,someValue", ex.getMessage());
+        }
     }
 
     private static class TestBean extends AutomaticBean {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ScopeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ScopeTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Locale;
 
@@ -44,15 +45,21 @@ public class ScopeTest {
         assertEquals(Scope.PRIVATE, scope);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMisc() {
         final Scope o = Scope.getInstance("public");
         assertNotNull(o);
         assertEquals("public", o.toString());
         assertEquals("public", o.getName());
 
-        // will fail
-        Scope.getInstance("unknown");
+        try {
+            Scope.getInstance("unknown");
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException ex) {
+            assertEquals("No enum constant com.puppycrawl.tools.checkstyle.api.Scope.UNKNOWN",
+                    ex.getMessage());
+        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelCounterTest.java
@@ -20,14 +20,21 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
 public class SeverityLevelCounterTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCtorException() {
-        new SeverityLevelCounter(null);
+        try {
+            new SeverityLevelCounter(null);
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException ex) {
+            assertEquals("'level' cannot be null", ex.getMessage());
+        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.api;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import java.util.Locale;
 
@@ -42,15 +43,22 @@ public class SeverityLevelTest {
         assertEquals(SeverityLevel.INFO, level);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMisc() {
         final SeverityLevel o = SeverityLevel.getInstance("info");
         assertNotNull(o);
         assertEquals("info", o.toString());
         assertEquals("info", o.getName());
 
-        // will fail
-        SeverityLevel.getInstance("unknown");
+        try {
+            SeverityLevel.getInstance("unknown");
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException ex) {
+            assertEquals(
+                    "No enum constant com.puppycrawl.tools.checkstyle.api.SeverityLevel.UNKNOWN",
+                    ex.getMessage());
+        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -23,6 +23,7 @@ import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG
 import static java.util.Locale.ENGLISH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -144,13 +145,22 @@ public class NewlineAtEndOfFileCheckTest
             expected);
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testSetLineSeparatorFailure()
             throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(NewlineAtEndOfFileCheck.class);
         checkConfig.addAttribute("lineSeparator", "ct");
-        createChecker(checkConfig);
+        try {
+            createChecker(checkConfig);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle."
+                            + "checks.NewlineAtEndOfFileCheck - "
+                            + "Cannot set property 'lineSeparator' to 'ct' in module"));
+        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
@@ -22,6 +22,8 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 import static com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck.MSG_KEY_BLOCK_EMPTY;
 import static com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck.MSG_KEY_BLOCK_NO_STMT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -138,12 +140,21 @@ public class EmptyBlockCheckTest
         verify(checkConfig, getPath("InputSemantic2.java"), expected);
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testInvalidOption() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyBlockCheck.class);
         checkConfig.addAttribute("option", "invalid_option");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputSemantic.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputSemantic.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'option' to 'invalid_option' in module"));
+        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -24,6 +24,8 @@ import static com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck.MSG_K
 import static com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck.MSG_KEY_LINE_PREVIOUS;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -361,11 +363,20 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
         verify(checkConfig, getPath("InputScopeInnerInterfaces2.java"), expected);
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testInvalidOption() throws Exception {
         checkConfig.addAttribute("option", "invalid_option");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputScopeInnerInterfaces.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputScopeInnerInterfaces.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'option' to 'invalid_option' in module"));
+        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -24,6 +24,8 @@ import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_
 import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_NEW;
 import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_SAME;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -275,12 +277,21 @@ public class RightCurlyCheckTest extends BaseCheckTestSupport {
         verify(checkConfig, getPath("InputRightCurly.java"), expected);
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testInvalidOption() throws Exception {
         checkConfig.addAttribute("option", "invalid_option");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputRightCurly.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputRightCurly.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'option' to 'invalid_option' in module"));
+        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -21,6 +21,8 @@ package com.puppycrawl.tools.checkstyle.checks.design;
 
 import static com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck.MSG_KEY;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,6 +30,7 @@ import java.io.IOException;
 import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
+
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -370,12 +373,18 @@ public class VisibilityModifierCheckTest
         verify(checkConfig, getPath("InputEnumIsSealed.java"), expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWrongTokenType() {
         final VisibilityModifierCheck obj = new VisibilityModifierCheck();
         final DetailAST ast = new DetailAST();
         ast.initialize(new CommonHiddenStreamToken(TokenTypes.CLASS_DEF, "class"));
-        obj.visitToken(ast);
+        try {
+            obj.visitToken(ast);
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException ex) {
+            assertEquals("Unexpected token type: class", ex.getMessage());
+        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -26,6 +26,8 @@ import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCh
 import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.MSG_ORDER;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -462,7 +464,7 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
                 expected);
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testSamePackageDepthNegative() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(CustomImportOrderCheck.class);
@@ -470,12 +472,22 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("separateLineBetweenGroups", "false");
         checkConfig.addAttribute("customImportOrderRules",
                 "SAME_PACKAGE(-1)");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputCustomImportOrder.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputCustomImportOrder.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'customImportOrderRules' to "
+                            + "'SAME_PACKAGE(-1)' in module"));
+        }
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testSamePackageDepthZero() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(CustomImportOrderCheck.class);
@@ -483,32 +495,62 @@ public class CustomImportOrderCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("separateLineBetweenGroups", "false");
         checkConfig.addAttribute("customImportOrderRules",
                 "SAME_PACKAGE(0)");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputCustomImportOrder.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputCustomImportOrder.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'customImportOrderRules' to "
+                            + "'SAME_PACKAGE(0)' in module"));
+        }
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testUnsupportedRule() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(CustomImportOrderCheck.class);
         // #AAA##BBBB###CCCC####DDDD
         checkConfig.addAttribute("customImportOrderRules", "SAME_PACKAGE(3)###UNSUPPORTED_RULE");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputCustomImportOrder.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputCustomImportOrder.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'customImportOrderRules' to "
+                            + "'SAME_PACKAGE(3)###UNSUPPORTED_RULE' in module"));
+        }
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testSamePackageDepthNotInt() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(CustomImportOrderCheck.class);
         checkConfig.addAttribute("customImportOrderRules", "SAME_PACKAGE(INT_IS_REQUIRED_HERE)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputCustomImportOrder.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputCustomImportOrder.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'customImportOrderRules' to "
+                            + "'SAME_PACKAGE(INT_IS_REQUIRED_HERE)' in module"));
+        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -22,6 +22,8 @@ package com.puppycrawl.tools.checkstyle.checks.imports;
 import static com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck.MSG_ORDERING;
 import static com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck.MSG_SEPARATION;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -131,14 +133,23 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
         verify(checkConfig, getPath("InputImportOrderCaseInsensitive.java"), expected);
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testInvalidOption() throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(ImportOrderCheck.class);
         checkConfig.addAttribute("option", "invalid_option");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputImportOrder_Top.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputImportOrder_Top.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'option' to 'invalid_option' in module"));
+        }
     }
 
     @Test
@@ -384,13 +395,22 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
             expected);
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testGroupWithSlashes() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(ImportOrderCheck.class);
         checkConfig.addAttribute("groups", "/^javax");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputImportOrder.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputImportOrder.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'groups' to '/^javax' in module"));
+        }
     }
 
     @Test
@@ -413,6 +433,7 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
             expected);
     }
 
+    // -@cs[ForbidAnnotationElementValue] Will examine turkish failure
     @Test(expected = IllegalStateException.class)
     public void testVisitTokenSwitchReflection() {
         // Create mock ast

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
@@ -20,6 +20,8 @@
 package com.puppycrawl.tools.checkstyle.checks.metrics;
 
 import static com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck.MSG_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -78,12 +80,18 @@ public class BooleanExpressionComplexityCheckTest extends BaseCheckTestSupport {
         verify(checkConfig, getPath("InputBooleanExpressionComplexityNPE.java"), expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWrongToken() {
         final BooleanExpressionComplexityCheck booleanExpressionComplexityCheckObj =
             new BooleanExpressionComplexityCheck();
         final DetailAST ast = new DetailAST();
         ast.initialize(new CommonHiddenStreamToken(TokenTypes.INTERFACE_DEF, "interface"));
-        booleanExpressionComplexityCheckObj.visitToken(ast);
+        try {
+            booleanExpressionComplexityCheckObj.visitToken(ast);
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException ex) {
+            assertEquals("Unknown type: interface[0x-1]", ex.getMessage());
+        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
@@ -20,6 +20,8 @@
 package com.puppycrawl.tools.checkstyle.checks.metrics;
 
 import static com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck.MSG_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -68,12 +70,18 @@ public class ClassDataAbstractionCouplingCheckTest extends BaseCheckTestSupport 
         verify(checkConfig, getPath("InputClassCoupling.java"), expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWrongToken() {
         final ClassDataAbstractionCouplingCheck classDataAbstractionCouplingCheckObj =
             new ClassDataAbstractionCouplingCheck();
         final DetailAST ast = new DetailAST();
         ast.initialize(new CommonHiddenStreamToken(TokenTypes.CTOR_DEF, "ctor"));
-        classDataAbstractionCouplingCheckObj.visitToken(ast);
+        try {
+            classDataAbstractionCouplingCheckObj.visitToken(ast);
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException ex) {
+            assertEquals("Unknown type: ctor[0x-1]", ex.getMessage());
+        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
@@ -20,6 +20,8 @@
 package com.puppycrawl.tools.checkstyle.checks.sizes;
 
 import static com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck.MSG_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -131,24 +133,36 @@ public class ExecutableStatementCountCheckTest
         verify(checkConfig, getPath("InputExecutableStatementCount.java"), expected);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testVisitTokenWithWrongTokenType() {
         final ExecutableStatementCountCheck checkObj =
             new ExecutableStatementCountCheck();
         final DetailAST ast = new DetailAST();
         ast.initialize(
             new CommonHiddenStreamToken(TokenTypes.ENUM, "ENUM"));
-        checkObj.visitToken(ast);
+        try {
+            checkObj.visitToken(ast);
+            fail("exception expected");
+        }
+        catch (IllegalStateException ex) {
+            assertEquals("ENUM[0x-1]", ex.getMessage());
+        }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testLeaveTokenWithWrongTokenType() {
         final ExecutableStatementCountCheck checkObj =
             new ExecutableStatementCountCheck();
         final DetailAST ast = new DetailAST();
         ast.initialize(
             new CommonHiddenStreamToken(TokenTypes.ENUM, "ENUM"));
-        checkObj.leaveToken(ast);
+        try {
+            checkObj.leaveToken(ast);
+            fail("exception expected");
+        }
+        catch (IllegalStateException ex) {
+            assertEquals("ENUM[0x-1]", ex.getMessage());
+        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
@@ -23,6 +23,8 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitiali
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck.MSG_PRECEDED;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -106,11 +108,20 @@ public class EmptyForInitializerPadCheckTest
         assertEquals(WrapOption.EOL, option);
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testInvalidOption() throws Exception {
         checkConfig.addAttribute("option", "invalid_option");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputForWhitespace.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputForWhitespace.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'option' to 'invalid_option' in module"));
+        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
@@ -22,6 +22,8 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck.MSG_WS_FOLLOWED;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck.MSG_WS_NOT_FOLLOWED;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -86,11 +88,20 @@ public class EmptyForIteratorPadCheckTest
         assertArrayEquals(expected, actual);
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testInvalidOption() throws Exception {
         checkConfig.addAttribute("option", "invalid_option");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputForWhitespace.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputForWhitespace.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'option' to 'invalid_option' in module"));
+        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -24,6 +24,8 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespac
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck.MSG_WS_NOT_PRECEDED;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck.MSG_WS_PRECEDED;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -150,11 +152,17 @@ public class GenericWhitespaceCheckTest
         assertArrayEquals(expected, actual);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWrongTokenType() {
         final GenericWhitespaceCheck genericWhitespaceCheckObj = new GenericWhitespaceCheck();
         final DetailAST ast = new DetailAST();
         ast.initialize(new CommonHiddenStreamToken(TokenTypes.INTERFACE_DEF, "interface"));
-        genericWhitespaceCheckObj.visitToken(ast);
+        try {
+            genericWhitespaceCheckObj.visitToken(ast);
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException ex) {
+            assertEquals("Unknown type interface[0x-1]", ex.getMessage());
+        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
@@ -23,6 +23,8 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCh
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck.MSG_WS_NOT_PRECEDED;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck.MSG_WS_PRECEDED;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -152,11 +154,20 @@ public class MethodParamPadCheckTest
         assertArrayEquals(expected, actual);
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testInvalidOption() throws Exception {
         checkConfig.addAttribute("option", "invalid_option");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputMethodParamPad.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputMethodParamPad.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'option' to 'invalid_option' in module"));
+        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheckTest.java
@@ -21,6 +21,8 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck.MSG_LINE_NEW;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck.MSG_LINE_PREVIOUS;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -106,11 +108,20 @@ public class OperatorWrapCheckTest
         verify(checkConfig, getPath("InputOpWrap.java"), expected);
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testInvalidOption() throws Exception {
         checkConfig.addAttribute("option", "invalid_option");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputOpWrap.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputOpWrap.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'option' to 'invalid_option' in module"));
+        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
@@ -23,6 +23,8 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPad
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck.MSG_WS_NOT_FOLLOWED;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck.MSG_WS_NOT_PRECEDED;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck.MSG_WS_PRECEDED;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -241,12 +243,21 @@ public class ParenPadCheckTest
         verify(checkConfig, getPath("InputParenPad.java"), expected);
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testInvalidOption() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(ParenPadCheck.class);
         checkConfig.addAttribute("option", "invalid_option");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputParenPad.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputParenPad.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'option' to 'invalid_option' in module"));
+        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
@@ -21,6 +21,8 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck.MSG_LINE_NEW;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck.MSG_LINE_PREVIOUS;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -82,11 +84,20 @@ public class SeparatorWrapCheckTest
         Assert.assertArrayEquals(expected, actual);
     }
 
-    @Test(expected = CheckstyleException.class)
+    @Test
     public void testInvalidOption() throws Exception {
         checkConfig.addAttribute("option", "invalid_option");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputSeparatorWrap.java"), expected);
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+            verify(checkConfig, getPath("InputSeparatorWrap.java"), expected);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                            + "Cannot set property 'option' to 'invalid_option' in module"));
+        }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -88,14 +89,26 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
         }
     }
 
-    @Test(expected = CheckstyleException.class)
-    public void testLoadFromMalformedUrl() throws CheckstyleException {
-        SuppressionsLoader.loadSuppressions("http");
+    @Test
+    public void testLoadFromMalformedUrl() {
+        try {
+            SuppressionsLoader.loadSuppressions("http");
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertEquals("Unable to find: http", ex.getMessage());
+        }
     }
 
-    @Test(expected = CheckstyleException.class)
-    public void testLoadFromNonExistingUrl() throws CheckstyleException {
-        SuppressionsLoader.loadSuppressions("http://^%$^* %&% %^&");
+    @Test
+    public void testLoadFromNonExistingUrl() {
+        try {
+            SuppressionsLoader.loadSuppressions("http://^%$^* %&% %^&");
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertEquals("Unable to find: http://^%$^* %&% %^&", ex.getMessage());
+        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
@@ -81,14 +81,26 @@ public class CommonUtilsTest {
         assertEquals(3, CommonUtils.lengthMinusTrailingWhitespace(" 23 \t "));
     }
 
-    @Test(expected = ConversionException.class)
+    @Test
     public void testBadRegex() {
-        CommonUtils.createPattern("[");
+        try {
+            CommonUtils.createPattern("[");
+            fail("exception expected");
+        }
+        catch (ConversionException ex) {
+            assertEquals("Failed to initialise regular expression [", ex.getMessage());
+        }
     }
 
-    @Test(expected = ConversionException.class)
+    @Test
     public void testBadRegex2() {
-        CommonUtils.createPattern("[", Pattern.MULTILINE);
+        try {
+            CommonUtils.createPattern("[", Pattern.MULTILINE);
+            fail("exception expected");
+        }
+        catch (ConversionException ex) {
+            assertEquals("Failed to initialise regular expression [", ex.getMessage());
+        }
     }
 
     @Test
@@ -196,11 +208,17 @@ public class CommonUtilsTest {
         assertTrue(closeable.closed);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testCloseWithException() {
-        CommonUtils.close(() -> {
-            throw new IOException("Test IOException");
-        });
+        try {
+            CommonUtils.close(() -> {
+                throw new IOException("Test IOException");
+            });
+            fail("exception expected");
+        }
+        catch (IllegalStateException ex) {
+            assertEquals("Cannot close the stream", ex.getMessage());
+        }
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java
@@ -215,18 +215,36 @@ public class JavadocUtilsTest {
         assertEquals("EOF", JavadocUtils.getTokenName(JavadocTokenTypes.EOF));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetTokenNameForLargeId() {
-        JavadocUtils.getTokenName(20074);
+        try {
+            JavadocUtils.getTokenName(20074);
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException ex) {
+            assertEquals("Unknown javadoc token id. Given id: 20074", ex.getMessage());
+        }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetTokenNameForInvalidId() {
-        JavadocUtils.getTokenName(100);
+        try {
+            JavadocUtils.getTokenName(100);
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException ex) {
+            assertEquals("Unknown javadoc token id. Given id: 100", ex.getMessage());
+        }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetTokenIdThatIsUnknown() {
-        JavadocUtils.getTokenId("");
+        try {
+            JavadocUtils.getTokenId("");
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException ex) {
+            assertEquals("Unknown javadoc token name. Given name ", ex.getMessage());
+        }
     }
 }


### PR DESCRIPTION
Issue #3567 

Only 2 surprises when working on this.
* `SingleLineJavadocTest` was hiding a NPE that was not in the check. Even fixing the NPE, the input file didn't produce any violations, so I just removed the test.
* `AbstractViolationReporterTest` looks like the exception moved based on the comments.

I didn't try to regress to see how any original tests worked.