### PR TITLE
config: fixed issue with appveyor and corrupted maven cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ init:
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
-      if (!(Test-Path -Path "C:\maven" )) {
+      if (!(Test-Path -Path "C:\maven\apache-maven-3.2.5" )) {
         (new-object System.Net.WebClient).DownloadFile(
           'http://www.us.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip',
           'C:\maven-bin.zip'
@@ -27,7 +27,7 @@ install:
   - cmd: '%CYG_BIN% -qnNdO -R %CYG_ROOT% -s %CYG_MIRROR% -l %CYG_CACHE% -P hg'
 
 cache:
-  - C:\maven\
+  - C:\maven\apache-maven-3.2.5
   - C:\Users\appveyor\.m2
   - C:\cygwin\var\cache\setup
 


### PR DESCRIPTION
Fixing appveyor failure:
````
M2_HOME = "C:\maven\apache-maven-3.2.5" 
Please set the M2_HOME variable in your environment to match the 
location of the Maven installation 
Command exited with code 1
````

Maven was somehow installed into `C:\maven\maven`. Since we cache the directory, it stuck with future runs and we were skipping new install because of directory check.
This fixes verifying the install directory and that only it is cached.