### PR TITLE
Issue #3450: Support loading import control configuration from URLs and classpath

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
-import java.io.File;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Set;
@@ -148,7 +147,8 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
 
     /**
      * Set the name for the file containing the import control
-     * configuration. It will cause the file to be loaded.
+     * configuration. It can also be a URL or resource in the classpath.
+     * It will cause the file to be loaded.
      * @param name the name of the file to load.
      * @throws ConversionException on error loading the file.
      */
@@ -156,7 +156,7 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
         // Handle empty param
         if (!CommonUtils.isBlank(name)) {
             try {
-                root = ImportControlLoader.load(new File(name).toURI());
+                root = ImportControlLoader.load(CommonUtils.getUriByFilename(name));
                 fileLocation = name;
             }
             catch (final CheckstyleException ex) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -60,6 +60,10 @@ public class ImportControlCheckTest extends BaseCheckTestSupport {
                 + "imports" + File.separator + filename);
     }
 
+    private static String getResourcePath(String filename) {
+        return "/com/puppycrawl/tools/checkstyle/checks/imports/" + filename;
+    }
+
     @Test
     public void testGetRequiredTokens() {
         final ImportControlCheck checkObj = new ImportControlCheck();
@@ -271,6 +275,56 @@ public class ImportControlCheckTest extends BaseCheckTestSupport {
         catch (final CheckstyleException ex) {
             final String message = getInvocationTargetExceptionMessage(ex);
             assertTrue(message.startsWith("Syntax error in url "));
+        }
+    }
+
+    @Test
+    public void testResource() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ImportControlCheck.class);
+        checkConfig.addAttribute("file", getResourcePath("import-control_one.xml"));
+        final String[] expected = {"5:1: " + getCheckMessage(MSG_DISALLOWED, "java.io.File")};
+
+        verify(checkConfig, getPath("InputImportControl.java"), expected);
+    }
+
+    @Test
+    public void testResourceUnableToLoad() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ImportControlCheck.class);
+        checkConfig.addAttribute("file", getResourcePath("import-control_unknown.xml"));
+
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+            verify(checkConfig, getPath("InputImportControl.java"), expected);
+            fail("Test should fail if exception was not thrown");
+        }
+        catch (final CheckstyleException ex) {
+            final String message = getInvocationTargetExceptionMessage(ex);
+            assertTrue(message.startsWith("Unable to load "));
+        }
+    }
+
+    @Test
+    public void testUrlInFileProperty() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ImportControlCheck.class);
+        checkConfig.addAttribute("file", getUriString("import-control_one.xml"));
+        final String[] expected = {"5:1: " + getCheckMessage(MSG_DISALLOWED, "java.io.File")};
+
+        verify(checkConfig, getPath("InputImportControl.java"), expected);
+    }
+
+    @Test
+    public void testUrlInFilePropertyUnableToLoad() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ImportControlCheck.class);
+        checkConfig.addAttribute("file", "https://UnableToLoadThisURL");
+
+        try {
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+            verify(checkConfig, getPath("InputImportControl.java"), expected);
+            fail("Test should fail if exception was not thrown");
+        }
+        catch (final CheckstyleException ex) {
+            final String message = getInvocationTargetExceptionMessage(ex);
+            assertTrue(message.startsWith("Unable to load "));
         }
     }
 

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -706,7 +706,9 @@ import android.*;
           <tr>
             <td>file</td>
             <td>
-              name of the file containing the import control configuration.
+              The location of the file containing the import control configuration.
+              It can be a regular file, URL or resource path. It will try loading
+              the path as a URL first, then as a file, and finally as a resource.
             </td>
             <td><a href="property_types.html#string">string</a></td>
             <td><code>null</code></td>


### PR DESCRIPTION
Issue #3450

For now, I just copied some unit tests to test loading URLs and resources with the `file` property.

However, in [SuppressionFilterTest](https://github.com/checkstyle/checkstyle/blob/master/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java#L159), `CommonUtils#getUriByFilename(String filename)` is mocked with Mockito.

Should I change the tests to use mocking? If so, they would also have to be changed for testing regular files.

By the way, I have kept tests for `url` property until it will be removed.