### PR TITLE
Issue #2143: Check that import groups aren't separated internally

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java
@@ -26,7 +26,6 @@ import java.util.regex.Pattern;
 
 import antlr.RecognitionException;
 import antlr.TokenStreamException;
-
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Set;
 
 import antlr.collections.AST;
-
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -23,7 +23,6 @@ import java.util.Deque;
 import java.util.LinkedList;
 
 import antlr.collections.AST;
-
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import antlr.collections.AST;
-
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import java.util.Arrays;
 
 import antlr.collections.AST;
-
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import antlr.collections.AST;
-
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import antlr.collections.AST;
-
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -27,7 +27,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import antlr.collections.ASTEnumeration;
-
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePModel.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import antlr.ASTFactory;
 import antlr.collections.AST;
-
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtils.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.utils;
 
 import antlr.collections.AST;
-
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages.properties
@@ -10,6 +10,7 @@ import.separation=''{0}'' should be separated from previous imports.
 import.control.missing.file=Missing an import control file.
 import.control.disallowed=Disallowed import - {0}.
 import.control.unknown.pkg=Import control file does not handle this package.
+import.groups.separated.internally=Extra separation in import group before ''{0}''
 custom.import.order=Import statement for ''{2}'' is in the wrong order. Should be in the ''{0}'' group, expecting group ''{1}'' on this line.
 custom.import.order.line.separator=''{0}'' should be separated from previous import group.
 custom.import.order.lex=Wrong lexicographical order for ''{0}'' import. Should be before ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_de.properties
@@ -16,3 +16,4 @@ custom.import.order.lex=Falsche lexikographische Reihenfolge des Imports von ''{
 custom.import.order.nonGroup.import=Importe ohne Gruppe sollten an Ende der Import-Liste stehen: ''{0}''.
 custom.import.order.nonGroup.expected=Import-Anweisung für ''{1}'' ist an der falschen Stelle. Sollte in der Import-Gruppe ''{0}'' Gruppe stehen. \
     Erwartet wird in dieser Zeile ein Import, der keiner Import-Gruppe entspricht.
+import.groups.separated.internally=Zusätzliche Trennung in der Importgruppe vor ''{0}''

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_es.properties
@@ -15,3 +15,4 @@ custom.import.order.line.separator = ''{0}'' debe ser separado del grupo de impo
 custom.import.order.lex = Orden lexicográfico incorrecto de ''{0}'' importación. En caso de ser antes de ''{1}''.
 custom.import.order.nonGroup.import = Las importaciones sin grupos deben colocarse al final de la lista de importación: ''{0}''.
 custom.import.order.nonGroup.expected = Declaración de importación de ''{1}'' es en el orden equivocado. En caso de estar en el ''{0}'' del grupo, esperando que las importaciones no asignadas en esta línea.
+import.groups.separated.internally=Separación extra en el grupo de importación antes ''{0}''

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_fi.properties
@@ -15,3 +15,4 @@ custom.import.order.line.separator = ''{0}'' olisi erotettava edellisestä tuont
 custom.import.order.lex = Väärä leksikografisessa jotta ''{0}'' tuonnilla. Pitäisi olla ennen ''{1}''.
 custom.import.order.nonGroup.import = Tuonti ilman ryhmät olisi sijoitettava loppuun tuonti lista: ''{0}''.
 custom.import.order.nonGroup.expected = Tuo lausuman ''{1}'' on väärässä järjestyksessä. Pitäisi olla ''{0}'' ryhmä, odottaa ei osoitettu tuontia tätä linjaa.
+import.groups.separated.internally=Extra erottaminen tuonti ryhmässä ennen ''{0}''

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_fr.properties
@@ -15,3 +15,4 @@ custom.import.order.line.separator=''{0}'' doit être séparé du groupe d'impor
 custom.import.order.lex=Mauvais ordre lexicographique pour l''import ''{0}''. Il devrait être avant ''{1}''.
 custom.import.order.nonGroup.import=Les imports sans groupes doivent être placés à la fin de la liste : ''{0}''.
 custom.import.order.nonGroup.expected=L''import pour ''{1}'' est dans le mauvais ordre. Il devrait être dans le groupe ''{0}''.
+import.groups.separated.internally=Séparation supplémentaire dans le groupe d'importation avant ''{0}''

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_ja.properties
@@ -15,3 +15,4 @@ custom.import.order.line.separator = ''{0}'' 前のインポート・グルー�
 custom.import.order.lex = のための間違った辞書式順序 ''{0}'' インポート。の前にすべきである ''{1}'' 。
 custom.import.order.nonGroup.import = グループのない輸入はインポートリストの末尾に配置する必要があります： ''{0}''。
 custom.import.order.nonGroup.expected = のインポート文 ''{1}'' は、間違った順序です。 にする必要があります ''{0}'' この行に割り当てられていない輸入を期待して、グループ。
+import.groups.separated.internally=輸入グループの余分な分離 ''{0}''

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_pt.properties
@@ -15,3 +15,4 @@ custom.import.order.line.separator = ''{0}'' deve ser separado do grupo importa�
 custom.import.order.lex = Errado ordem lexicográfica para ''{0}'' importação. Deve ser antes ''{1}''.
 custom.import.order.nonGroup.import = Importações sem grupos devem ser colocados no final da lista de importação: ''{0}''.
 custom.import.order.nonGroup.expected = Declaração de importação para ''{1}'' está na ordem errada. Deve estar no ''{0}'' grupo, esperando que as importações não atribuídos nesta linha.
+import.groups.separated.internally=Separação extra no grupo de importação antes ''{0}''

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_tr.properties
@@ -18,3 +18,4 @@ custom.import.order.line.separator = {0} önceki ithalat grubundan ayrılmalıd�
 custom.import.order.lex = Için yanlış lexicographical sipariş {0} ithal. Önce olmalı ''{1}''.
 custom.import.order.nonGroup.import = Gruplar olmadan İthalat İthalat listenin en sonunda yer almalıdır: {0}
 custom.import.order.nonGroup.expected = İthalat deyimi ''{1}'' yanlış sırayla yer almaktadır. Olmalıdır ''{0}'' bu hat üzerinde değil atanmış ithalatı bekliyor grubuna.
+import.groups.separated.internally=Daha önce ithalat grubunda fazladan ayrılma ''{0}''

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/messages_zh.properties
@@ -15,3 +15,4 @@ custom.import.order.line.separator=''{0}'' 应与之前的导入组分开。
 custom.import.order.lex=导入语句''{0}'' 字典顺序错误。应在''{1}''之前。
 custom.import.order.nonGroup.import=未分组导入应位于导入列表的最后： ''{0}''。
 custom.import.order.nonGroup.expected=导入语句''{1}''位置错误。应位于 ''{0}'' 组，此行不应导入。
+import.groups.separated.internally=進口組以前的額外分離 ''{0}''。

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
@@ -30,7 +30,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import antlr.NoViableAltException;
-
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
 public class AstTreeStringPrinterTest {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
@@ -29,7 +29,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
-
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
-
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
-
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
-
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
 import static com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck.MSG_ORDERING;
+import static com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck.MSG_SEPARATED_IN_GROUP;
 import static com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck.MSG_SEPARATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -550,5 +551,19 @@ public class ImportOrderCheckTest extends BaseCheckTestSupport {
                 "io.netty.handler.codec.http.HttpHeaders.Names.DATE"),
             };
         verify(checkConfig, getNonCompilablePath("InputEclipseStaticImportsOrder.java"), expected);
+    }
+
+    @Test
+    public void testImportGroupsRedundantSeparatedInternally() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("groups", "/^javax\\./,com");
+        checkConfig.addAttribute("ordered", "true");
+        checkConfig.addAttribute("separated", "true");
+        checkConfig.addAttribute("option", "bottom");
+        final String[] expected = {
+            "5: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
+        };
+        verify(checkConfig, getNonCompilablePath("InputImportOrder_MultiplePatternMatches.java"),
+                expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
-
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
-
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -28,7 +28,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
-
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
-
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -36,7 +36,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
-
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
@@ -30,7 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
-
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -47,7 +47,6 @@ import com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class SuppressWithNearbyCommentFilterTest

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -47,7 +47,6 @@ import com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class SuppressionCommentFilterTest

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
@@ -34,10 +34,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-
 import org.mockito.BDDMockito;
 import org.mockito.Mockito;
-
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -50,7 +48,6 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/AstRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/AstRegressionTest.java
@@ -37,7 +37,6 @@ import antlr.NoViableAltForCharException;
 import antlr.ParserSharedInputState;
 import antlr.SemanticException;
 import antlr.TokenBuffer;
-
 import com.puppycrawl.tools.checkstyle.AstTreeStringPrinter;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.api.FileText;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPModelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPModelTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
-
 import com.puppycrawl.tools.checkstyle.gui.MainFrameModel.ParseMode;
 
 public class CodeSelectorPModelTest {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePModelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePModelTest.java
@@ -26,16 +26,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import antlr.collections.AST;
-
 import com.puppycrawl.tools.checkstyle.TreeWalker;
-
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-
 import com.puppycrawl.tools.checkstyle.gui.MainFrameModel.ParseMode;
 
 public class ParseTreeTablePModelTest {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
@@ -42,7 +42,6 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -890,6 +890,8 @@ import android.*;
           then everything else)</li>
           <li>adds a separation between groups : ensures that a blank
           line sit between each group</li>
+          <li>import groups aren't separated internally: ensures that
+          each group aren't separated internally by blank line or comment</li>
           <li>sorts imports inside each group: ensures that imports
           within each group are in lexicographic order</li>
           <li>sorts according to case: ensures that the comparison
@@ -939,7 +941,7 @@ import android.*;
             <td>separated</td>
             <td>
               whether imports groups should be separated by, at least, one
-              blank line
+              blank line and aren't separated internally
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
@@ -991,7 +993,7 @@ import android.*;
           <li>groups of non-static imports: &quot;java&quot; and &quot;javax&quot; packages first,
               then &quot;org&quot; and then all other imports</li>
           <li>imports will be sorted in the groups</li>
-          <li>groups are separated by, at least, one blank line</li>
+          <li>groups are separated by, at least, one blank line and aren't separated internally</li>
         </ul>
         <p>Notes:</p>
         <ul>
@@ -1003,7 +1005,7 @@ import android.*;
 
         <source>
 &lt;module name=&quot;ImportOrder&quot;&gt;
-    &lt;property name=&quot;groups&quot; value=&quot;/^javax?\./,org&quot;/&gt;
+    &lt;property name=&quot;groups&quot; value=&quot;/^java\./,javax,org&quot;/&gt;
     &lt;property name=&quot;ordered&quot; value=&quot;true&quot;/&gt;
     &lt;property name=&quot;separated&quot; value=&quot;true&quot;/&gt;
     &lt;property name=&quot;option&quot; value=&quot;above&quot;/&gt;
@@ -1018,12 +1020,12 @@ import android.*;
           <li>groups of non-static imports: &quot;java&quot; and &quot;javax&quot; packages first,
               then &quot;org&quot; and &quot;com&quot;, then all other imports as one group</li>
           <li>imports will be sorted in the groups</li>
-          <li>groups are separated by, at least, one blank line</li>
+          <li>groups are separated by, at least, one blank line and aren't separated internally</li>
         </ul>
 
         <source>
 &lt;module name=&quot;ImportOrder&quot;&gt;
-    &lt;property name=&quot;groups&quot; value=&quot;/^javax?\./,org,com&quot;/&gt;
+    &lt;property name=&quot;groups&quot; value=&quot;/^java\./,javax,org,com&quot;/&gt;
     &lt;property name=&quot;ordered&quot; value=&quot;true&quot;/&gt;
     &lt;property name=&quot;separated&quot; value=&quot;true&quot;/&gt;
     &lt;property name=&quot;option&quot; value=&quot;above&quot;/&gt;
@@ -1038,7 +1040,7 @@ import android.*;
           <li>groups of non-static imports: all imports except of &quot;javax&quot;
               and &quot;java&quot;, then &quot;javax&quot; and &quot;java&quot;</li>
           <li>imports will be sorted in the groups</li>
-          <li>groups are separated by, at least, one blank line</li>
+          <li>groups are separated by, at least, one blank line and aren't separated internally</li>
         </ul>
 
         <p>
@@ -1158,6 +1160,10 @@ public class InputEclipseStaticImportsOrder { }
 
       <subsection name="Error Messages">
         <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.groups.separated.internally%22">
+            import.groups.separated.internally</a>
+          </li>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.ordering%22">
             import.ordering</a>


### PR DESCRIPTION
Issue: [#2143](https://github.com/checkstyle/checkstyle/issues/2143)

Add new check, and it give a lot of "Redundant separation" errors, fixed.

