### PR TITLE
Issue #3584: Deprecate 'url' property of ImportControlCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -187,7 +187,9 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
      * configuration. It will cause the url to be loaded.
      * @param url the url of the file to load.
      * @throws ConversionException on error loading the file.
+     * @deprecated use {@link #setFile(String name)} to load URLs instead
      */
+    @Deprecated
     public void setUrl(final String url) {
         // Handle empty param
         if (!CommonUtils.isBlank(url)) {

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -717,6 +717,8 @@ import android.*;
             <td>url</td>
             <td>
               URL of the file containing the import control configuration.
+              This property is deprecated. Please use the file property to load configurations
+              from URLs.
             </td>
             <td><a href="property_types.html#string">string</a></td>
             <td><code>null</code></td>


### PR DESCRIPTION
Issue #3584 

I wasn't sure about how to mark the property as deprecated in xdocs, so I put it in the description.

I think it would be nice if we could put it in the title of the property table as well but this would require a change in XDocsPagesTest.

For example:

```html
<tr>
  <td>url (deprecated)</td>
  <td>
    URL of the file containing the import control configuration.
    This property is deprecated. Please use the file property to load configurations
    from URLs.
  </td>
  <td><a href="property_types.html#string">string</a></td>
  <td><code>null</code></td>
</tr>
```

Another option would be to give it a CSS class and use CSS to generate the `(deprecated)` after the property name.

If you like these ideas I can open an issue for this.