### PR TITLE
Issue #3612: Fix LCurly on nl in Annon Inner Class Wrapped

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
@@ -87,14 +87,22 @@ public class ObjectBlockHandler extends BlockParentHandler {
     }
 
     @Override
+    protected void checkLCurly() {
+        checkCurly(getLCurly(), "lcurly");
+    }
+
+    @Override
     protected void checkRCurly() {
-        final DetailAST rcurly = getRCurly();
-        final int rcurlyPos = expandedTabsColumnNo(rcurly);
+        checkCurly(getRCurly(), "rcurly");
+    }
+
+    private void checkCurly(final DetailAST curly, final String subtypeName) {
+        final int curlyPos = expandedTabsColumnNo(curly);
         final IndentLevel level = curlyIndent();
         level.addAcceptedIndent(level.getFirstIndentLevel() + getLineWrappingIndentation());
 
-        if (!level.isAcceptable(rcurlyPos) && isOnStartOfLine(rcurly)) {
-            logError(rcurly, "rcurly", rcurlyPos, level);
+        if (!level.isAcceptable(curlyPos) && isOnStartOfLine(curly)) {
+            logError(curly, subtypeName, curlyPos, level);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1568,7 +1568,8 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("tabWidth", "4");
         checkConfig.addAttribute("throwsIndent", "8");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
-        verifyWarns(checkConfig, getPath("InputSynchronizedMethod.java"), expected);
+        verifyWarns(checkConfig, getPath("InputSynchronizedMethod.java"),
+                expected);
     }
 
     @Test
@@ -1590,6 +1591,20 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
             "26: " + getCheckMessage(MSG_ERROR, "method def rcurly", 8, 2),
         };
         verifyWarns(checkConfig, getPath("InputAnonymousClassInMethod.java"), expected);
+    }
+
+    @Test
+    public void testAnonymousClassInMethodWithCurlyOnNewLine() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+        checkConfig.addAttribute("tabWidth", "4");
+        checkConfig.addAttribute("basicOffset", "4");
+        checkConfig.addAttribute("braceAdjustment", "0");
+        checkConfig.addAttribute("caseIndent", "4");
+        checkConfig.addAttribute("lineWrappingIndentation", "8");
+        checkConfig.addAttribute("throwsIndent", "4");
+        checkConfig.addAttribute("arrayInitIndent", "4");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, getPath("InputAnonymousClassInMethodCurlyOnNewLine.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputAnonymousClassInMethodCurlyOnNewLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputAnonymousClassInMethodCurlyOnNewLine.java
@@ -1,0 +1,42 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation; //indent:0 exp:0
+
+import java.util.List; //indent:0 exp:0
+import java.util.Map; //indent:0 exp:0
+import java.util.function.Supplier; //indent:0 exp:0
+
+/**                                                                         //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration: //indent:1 exp:1
+ *                                                                          //indent:1 exp:1
+ * arrayInitIndent = 4                                                      //indent:1 exp:1
+ * basicOffset = 4                                                          //indent:1 exp:1
+ * braceAdjustment = 0                                                      //indent:1 exp:1
+ * caseIndent = 4                                                           //indent:1 exp:1
+ * forceStrictCondition = false                                             //indent:1 exp:1
+ * lineWrappingIndentation = 8                                              //indent:1 exp:1
+ * tabWidth = 4                                                             //indent:1 exp:1
+ * throwsIndent = 4                                                         //indent:1 exp:1
+ */                                                                         //indent:1 exp:1
+public class InputAnonymousClassInMethodCurlyOnNewLine //indent:0 exp:0
+{ //indent:0 exp:0
+    private void aMethod() //indent:4 exp:4
+    { //indent:4 exp:4
+        final Supplier<Map<String, List<AbstractExpressionHandler>>> sup1 = //indent:8 exp:8
+                new Supplier<Map<String, List<com.puppycrawl.tools.checkstyle.checks.indentation.AbstractExpressionHandler>>>() { //indent:16 exp:16
+                    @Override //indent:20 exp:20
+                    public Map<String, List<AbstractExpressionHandler>> get() //indent:20 exp:20
+                    { //indent:20 exp:20
+                        return null; //indent:24 exp:24
+                    } //indent:20 exp:20
+                }; //indent:16 exp:16
+        final Supplier<Map<String, List<AbstractExpressionHandler>>> sup2 = //indent:8 exp:8
+                new Supplier<Map<String, List<com.puppycrawl.tools.checkstyle.checks.indentation.AbstractExpressionHandler>>>() //indent:16 exp:16
+                { //indent:16 exp:16
+                    @Override //indent:20 exp:20
+                    public Map<String, List<AbstractExpressionHandler>> get() //indent:20 exp:20
+                    { //indent:20 exp:20
+                        return null; //indent:24 exp:24
+                    } //indent:20 exp:20
+                }; //indent:16 exp:16
+    } //indent:4 exp:4
+} //indent:0 exp:0
+


### PR DESCRIPTION
The location of the `LCURLY` when wrapped was not being added as an acceptable indent location.

This prevented this rule from being combined with:

```xml
<module name="LeftCurly">
  <property name="option" value="nl"/>
</module>
```

This solve this (I think) by adding the indentation for the `LCURLY` as valid the same way that it is done for the `RCURLY`.

This should close: #3612