### PR TITLE
Issue #3271: add profile with pitest plugin for checks.sizes package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1470,5 +1470,30 @@
       </build>
     </profile>
 
+    <profile>
+      <id>pitest-checks-sizes</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-maven</artifactId>
+            <version>1.1.10</version>
+            <configuration>
+              <targetClasses>
+                <param>com.puppycrawl.tools.checkstyle.checks.sizes.*</param>
+              </targetClasses>
+              <targetTests>
+                <param>com.puppycrawl.tools.checkstyle.checks.sizes.*</param>
+              </targetTests>
+              <mutationThreshold>88</mutationThreshold>
+              <timeoutFactor>10</timeoutFactor>
+              <timeoutConstant>50000</timeoutConstant>
+              <threads>4</threads>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
   </profiles>
 </project>

--- a/shippable.yml
+++ b/shippable.yml
@@ -10,4 +10,4 @@ build:
     - /root/.m2
 
   ci:
-    - mvn clean verify
+    - mvn clean verify -Ppitest-checks-sizes org.pitest:pitest-maven:mutationCoverage


### PR DESCRIPTION
Issue #3271.

Due to the fact that pitest works for a long time, and CI will perceive it as an timeout error, we need to split pitest testing packages on maven profiles. At first I added the sizes package of checks to separate profile. I added pitest testing of this package in shippable CI.