### PR TITLE
Fixed style listings for checks

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
@@ -883,6 +883,15 @@ public class XDocsPagesTest {
             final String input = new String(Files.readAllBytes(path), UTF_8);
             final Document document = XmlUtil.getRawXml(fileName, input, input);
             final NodeList sources = document.getElementsByTagName("tr");
+            Set<String> styleChecks = null;
+
+            if (path.toFile().getName().contains("google")) {
+                styleChecks = new HashSet<>(GOOGLE_CHECKS);
+            }
+            else if (path.toFile().getName().contains("sun")) {
+                styleChecks = new HashSet<>();
+            }
+
             String lastRuleName = null;
 
             for (int position = 0; position < sources.getLength(); position++) {
@@ -910,10 +919,14 @@ public class XDocsPagesTest {
                 }
 
                 validateStyleChecks(XmlUtil.findChildElementsByTag(columns.get(2), "a"),
-                        XmlUtil.findChildElementsByTag(columns.get(3), "a"), fileName, ruleName);
+                        XmlUtil.findChildElementsByTag(columns.get(3), "a"), styleChecks, fileName,
+                        ruleName);
 
                 lastRuleName = ruleName;
             }
+
+            Assert.assertTrue(fileName + " requires the following check(s) to appear: "
+                    + styleChecks, styleChecks.isEmpty());
         }
     }
 
@@ -950,8 +963,8 @@ public class XDocsPagesTest {
         }
     }
 
-    private static void validateStyleChecks(Set<Node> checks, Set<Node> configs, String fileName,
-            String ruleName) {
+    private static void validateStyleChecks(Set<Node> checks, Set<Node> configs,
+            Set<String> styleChecks, String fileName, String ruleName) {
         final Iterator<Node> itrChecks = checks.iterator();
         final Iterator<Node> itrConfigs = configs.iterator();
 
@@ -966,6 +979,8 @@ public class XDocsPagesTest {
 
             Assert.assertTrue(fileName + " rule '" + ruleName + "' check '" + checkName
                     + "' shouldn't end with 'Check'", !checkName.endsWith("Check"));
+
+            styleChecks.remove(checkName);
 
             for (String configName : new String[] {"config", "test"}) {
                 Node config = null;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
@@ -773,17 +773,23 @@ public class XDocsPagesTest {
         Assert.assertTrue(fileName + " section '" + sectionName
                 + "' has unknown text in 'Example of Usage': " + text, text.isEmpty());
 
+        boolean hasCheckstyle = false;
+        boolean hasGoogle = false;
+        boolean hasSun = false;
+
         for (Node node : XmlUtil.findChildElementsByTag(subSection, "a")) {
             final String url = node.getAttributes().getNamedItem("href").getTextContent();
             final String linkText = node.getTextContent().trim();
             String expectedUrl = null;
 
             if ("Checkstyle Style".equals(linkText)) {
+                hasCheckstyle = true;
                 expectedUrl = "https://github.com/search?q="
                         + "path%3Aconfig+filename%3Acheckstyle_checks.xml+"
                         + "repo%3Acheckstyle%2Fcheckstyle+" + sectionName;
             }
             else if ("Google Style".equals(linkText)) {
+                hasGoogle = true;
                 expectedUrl = "https://github.com/search?q="
                         + "path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+"
                         + "repo%3Acheckstyle%2Fcheckstyle+"
@@ -794,6 +800,7 @@ public class XDocsPagesTest {
                         GOOGLE_CHECKS.contains(sectionName));
             }
             else if ("Sun Style".equals(linkText)) {
+                hasSun = true;
                 expectedUrl = "https://github.com/search?q="
                         + "path%3Asrc%2Fmain%2Fresources+filename%3Asun_checks.xml+"
                         + "repo%3Acheckstyle%2Fcheckstyle+"
@@ -807,6 +814,15 @@ public class XDocsPagesTest {
             Assert.assertEquals(fileName + " section '" + sectionName
                     + "' should have matching url", expectedUrl, url);
         }
+
+        Assert.assertTrue(fileName + " section '" + sectionName
+                + "' should have a checkstyle section", hasCheckstyle);
+        Assert.assertTrue(fileName + " section '" + sectionName
+                + "' should have a google section since it is in it's config", hasGoogle
+                || !GOOGLE_CHECKS.contains(sectionName));
+        Assert.assertTrue(fileName + " section '" + sectionName
+                + "' should have a sun section since it is in it's config",
+                hasSun || !SUN_CHECKS.contains(sectionName));
     }
 
     private static void validatePackageSection(String fileName, String sectionName,

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -121,6 +121,10 @@ String b = (a==null || a.length&lt;1) ? null : a.substring(1);
       <subsection name="Example of Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Asun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidInlineConditionals">
+            Sun Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidInlineConditionals">
             Checkstyle Style</a>
           </li>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -561,6 +561,10 @@
       <subsection name="Example of Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InterfaceTypeParameterName">
+            Google Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InterfaceTypeParameterName">
             Checkstyle Style</a>
           </li>

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -616,6 +616,12 @@
                                     src="images/ok_green.png"
                                     alt="" />
                                 <a href="config_whitespace.html#SeparatorWrap">SeparatorWrap</a>
+                                <br />
+                                <br />
+                                <img
+                                    src="images/ok_green.png"
+                                    alt="" />
+                                <a href="config_whitespace.html#MethodParamPad">MethodParamPad</a>
                             </td>
                             <td>
                                 <a
@@ -629,6 +635,12 @@
                                 <br />
                                 <a
                                     href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/SeparatorWrapTest.java">test</a>
+                                <br />
+                                <a
+                                    href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodParamPad">config</a>
+                                <br />
+                                <a
+                                    href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/MethodParamPadTest.java">test</a>
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
All checks should have their styles listed if they are in those configs.
All checks that are in style configs should be listed in their style xdocs. Note: Sun is disabled since Sun has no proper xdoc.