### PR TITLE
Issue #2803: added synchronized to NoWhitespaceAfterCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -112,6 +112,7 @@ public class NoWhitespaceAfterCheck extends AbstractCheck {
             TokenTypes.TYPECAST,
             TokenTypes.ARRAY_DECLARATOR,
             TokenTypes.INDEX_OP,
+            TokenTypes.LITERAL_SYNCHRONIZED,
         };
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
@@ -174,6 +174,15 @@ public class NoWhitespaceAfterCheckTest
     }
 
     @Test
+    public void testSynchronized() throws Exception {
+        checkConfig.addAttribute("tokens", "LITERAL_SYNCHRONIZED");
+        final String[] expected = {
+            "14:21: " + getCheckMessage(MSG_KEY, "synchronized"),
+        };
+        verify(checkConfig, getPath("InputNoWhitespaceAfterSynchronized.java"), expected);
+    }
+
+    @Test
     public void testNpe() throws Exception {
         verify(checkConfig, getPath("InputNoWhiteSpaceAfterFormerNpe.java"));
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputNoWhitespaceAfterSynchronized.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputNoWhitespaceAfterSynchronized.java
@@ -1,0 +1,16 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace;
+
+class InputNoWhitespaceAfterSynchronized {
+    void method2()
+    {
+        synchronized(this) {
+        }
+    }
+
+    public void synchronzed() {
+        synchronized(this) {}
+        synchronized
+            (this) {}
+        synchronized (this) {}
+    }
+}

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -970,7 +970,9 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR">ARRAY_DECLARATOR</a>,
               <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP">INDEX_OP</a>.
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP">INDEX_OP</a>,
+              <a
+              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">LITERAL_SYNCHRONIZED</a>.
             </td>
 
             <td>


### PR DESCRIPTION
Issue #2803 

Regression: http://rveach.no-ip.org/checkstyle/regression/reports/166/
````
<module name="NoWhitespaceAfterCheck">
    <property name="tokens" value="LITERAL_SYNCHRONIZED"/>
</module>
````

I did not add this to google_config. As regression shows, every single `synchronized` written in guava and android have a space after it.
Even though google style doesn't specify this token specifically I believe the following text covers that it should have this space:
http://checkstyle.sourceforge.net/reports/google-java-style-20160712.html#s4.6.2-horizontal-whitespace
> a single ASCII space also appears in the following places
> Separating any reserved word ... from an open parenthesis (() that follows it on that line

If you still think I should ask them about this, please direct me to the place where I can post the question.