### PR TITLE
Issue #3664: verified all types of checks are on checks.xml

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -30,7 +30,6 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -149,7 +148,7 @@ public class AllChecksTest extends BaseCheckTestSupport {
     @Test
     public void testAllModulesAreReferencedInConfigFile() throws Exception {
         final Set<String> modulesReferencedInConfig = CheckUtil.getConfigCheckStyleModules();
-        final Set<String> moduleNames = getSimpleNames(CheckUtil.getCheckstyleModules());
+        final Set<String> moduleNames = CheckUtil.getSimpleNames(CheckUtil.getCheckstyleModules());
 
         moduleNames.stream().filter(check -> !modulesReferencedInConfig.contains(check))
             .forEach(check -> {
@@ -161,7 +160,8 @@ public class AllChecksTest extends BaseCheckTestSupport {
 
     @Test
     public void testAllCheckstyleModulesHaveXdocDocumentation() throws Exception {
-        final Set<String> checkstyleModulesNames = getSimpleNames(CheckUtil.getCheckstyleModules());
+        final Set<String> checkstyleModulesNames = CheckUtil.getSimpleNames(CheckUtil
+                .getCheckstyleModules());
         final Set<String> modulesNamesWhichHaveXdocs = XDocUtil.getModulesNamesWhichHaveXdoc();
 
         // these are documented on non-'config_' pages
@@ -182,7 +182,7 @@ public class AllChecksTest extends BaseCheckTestSupport {
     public void testAllCheckstyleModulesInCheckstyleConfig() throws Exception {
         final Set<String> configChecks = CheckUtil.getConfigCheckStyleModules();
 
-        for (String moduleName : getSimpleNames(CheckUtil.getCheckstyleModules())) {
+        for (String moduleName : CheckUtil.getSimpleNames(CheckUtil.getCheckstyleModules())) {
             Assert.assertTrue("checkstyle_checks.xml is missing module: " + moduleName,
                     configChecks.contains(moduleName));
         }
@@ -298,23 +298,5 @@ public class AllChecksTest extends BaseCheckTestSupport {
             }
         }
         return true;
-    }
-
-    /**
-     * Retrieves a list of class names, removing 'Check' from the end if the class is
-     * a checkstyle check.
-     * @param checks class instances.
-     * @return a set of simple names.
-     */
-    private static Set<String> getSimpleNames(Set<Class<?>> checks) {
-        return checks.stream().map(check -> {
-            String name = check.getSimpleName();
-
-            if (name.endsWith("Check")) {
-                name = name.substring(0, name.length() - 5);
-            }
-
-            return name;
-        }).collect(Collectors.toSet());
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CheckUtil.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -66,6 +67,24 @@ public final class CheckUtil {
 
     public static Set<String> getConfigGoogleStyleModules() {
         return getCheckStyleModulesReferencedInConfig("src/main/resources/google_checks.xml");
+    }
+
+    /**
+     * Retrieves a list of class names, removing 'Check' from the end if the class is
+     * a checkstyle check.
+     * @param checks class instances.
+     * @return a set of simple names.
+     */
+    public static Set<String> getSimpleNames(Set<Class<?>> checks) {
+        return checks.stream().map(check -> {
+            String name = check.getSimpleName();
+
+            if (name.endsWith("Check")) {
+                name = name.substring(0, name.length() - 5);
+            }
+
+            return name;
+        }).collect(Collectors.toSet());
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XDocsPagesTest.java
@@ -66,33 +66,9 @@ import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck;
 
 public class XDocsPagesTest {
-    private static final Path JAVA_SOURCES_DIRECTORY = Paths.get("src/main/java");
     private static final Path AVAILABLE_CHECKS_PATH = Paths.get("src/xdocs/checks.xml");
-    private static final String CHECK_FILE_NAME = ".+Check.java$";
-    private static final String CHECK_SUFFIX = "Check.java";
     private static final String LINK_TEMPLATE =
             "(?s).*<a href=\"config_\\w+\\.html#%1$s\">%1$s</a>.*";
-
-    private static final List<String> MODULES_ON_PAGE_IGNORE_LIST = Arrays.asList(
-            "AbstractAccessControlNameCheck.java",
-            "AbstractCheck.java",
-            "AbstractClassCouplingCheck.java",
-            "AbstractComplexityCheck.java",
-            "AbstractFileSetCheck.java",
-            "AbstractFormatCheck.java",
-            "AbstractHeaderCheck.java",
-            "AbstractIllegalCheck.java",
-            "AbstractIllegalMethodCheck.java",
-            "AbstractJavadocCheck.java",
-            "AbstractNameCheck.java",
-            "AbstractNestedDepthCheck.java",
-            "AbstractOptionCheck.java",
-            "AbstractParenPadCheck.java",
-            "AbstractSuperCheck.java",
-            "AbstractTypeAwareCheck.java",
-            "AbstractTypeParameterNameCheck.java",
-            "FileSetCheck.java"
-    );
 
     private static final List<String> XML_FILESET_LIST = Arrays.asList(
             "TreeWalker",
@@ -140,19 +116,16 @@ public class XDocsPagesTest {
         new HashSet<>(CheckUtil.getConfigGoogleStyleModules()));
 
     @Test
-    public void testAllChecksPresentOnAvailableChecksPage() throws IOException {
+    public void testAllChecksPresentOnAvailableChecksPage() throws Exception {
         final String availableChecks = new String(Files.readAllBytes(AVAILABLE_CHECKS_PATH), UTF_8);
-        Files.walk(JAVA_SOURCES_DIRECTORY).forEach(filePath -> {
-            final String fileName = filePath.getFileName().toString();
-            if (fileName.matches(CHECK_FILE_NAME)
-                    && !MODULES_ON_PAGE_IGNORE_LIST.contains(fileName)) {
-                final String checkName = fileName.replace(CHECK_SUFFIX, "");
+
+        CheckUtil.getSimpleNames(CheckUtil.getCheckstyleChecks())
+            .forEach(checkName -> {
                 if (!isPresent(availableChecks, checkName)) {
                     Assert.fail(checkName + " is not correctly listed on Available Checks page"
                         + " - add it to " + AVAILABLE_CHECKS_PATH);
                 }
-            }
-        });
+            });
     }
 
     private static boolean isPresent(String availableChecks, String checkName) {

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -5,7 +5,7 @@
   xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 http://maven.apache.org/xsd/xdoc-2.0.xsd">
 
   <head>
-    <title>Standard Checks</title>
+    <title>Checks</title>
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"/>
     <script type="text/javascript" src="js/anchors.js"/>
     <script type="text/javascript" src="js/google-analytics.js"/>
@@ -14,7 +14,7 @@
   </head>
 
   <body>
-    <section name="Checks">
+    <section name="Standard Checks">
     <p>
       The Standard Checkstyle Checks are applicable to general Java coding style
       and require no external libraries. The standard checks are included in
@@ -721,12 +721,6 @@
         </td>
       </tr>
       <tr>
-        <td><a href="config_annotation.html#SuppressWarningsHolder">SuppressWarningsHolder</a></td>
-        <td>
-          This check allows for finding code that should not be reported by Checkstyle
-        </td>
-      </tr>
-      <tr>
         <td><a href="config_design.html#ThrowsCount">ThrowsCount</a></td>
         <td>
         Restricts throws statements to a specified count (default = 4).</td>
@@ -802,6 +796,27 @@
         <td><a href="config_javadoc.html#WriteTag">WriteTag</a></td>
         <td>
         Outputs a JavaDoc tag as information.</td>
+      </tr>
+    </table>
+    </section>
+
+    <section name="Holder Checks">
+    <p>
+      These checks aren't normal checks and are usually associated with a specialized filter
+      to gather information the filter can't get on it's own.
+    </p>
+
+    <table>
+      <tr>
+        <td><a href="config_misc.html#FileContentsHolder">FileContentsHolder</a></td>
+        <td>Holds the current file contents for global access when configured as a
+        TreeWalker sub-module.</td>
+      </tr>
+      <tr>
+        <td><a href="config_annotation.html#SuppressWarningsHolder">SuppressWarningsHolder</a></td>
+        <td>
+          Maintains a set of check suppressions from <code>SuppressWarnings</code> annotations.
+        </td>
       </tr>
     </table>
     </section>


### PR DESCRIPTION
Issue #3664

Test was re-written from scratch. Original test scanned files and folders, new test uses the common utility that scans the classpath and checks class inheritance.
`getSimpleNames` was moved to utility class so multiple classes could make use of it.

New section is called `Non-Standard Checks`. 2 known non-standard checks were added to this section. One was already listed in standard section so it was just moved.