### PR TITLE
doc: Fix typo in config_imports.xml

### DIFF
--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -728,7 +728,7 @@ import android.*;
 
       <subsection name="Examples">
         <p>
-          To configure the check using a import control file called
+          To configure the check using an import control file called
           &quot;config/import-control.xml&quot;, then have the following:
         </p>
 


### PR DESCRIPTION
Small typo I spotted while adding documentation for the new attribute.