### PR TITLE
Issue #3720: verify all tokens are used in checkstyle config

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -135,7 +135,13 @@
 
     <!-- Annotations -->
     <module name="AnnotationLocation">
+      <property name="tokens" value="ANNOTATION_DEF"/>
+      <property name="tokens" value="ANNOTATION_FIELD_DEF"/>
       <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="tokens" value="PARAMETER_DEF"/>
+      <property name="allowSamelineMultipleAnnotations" value="true"/>
     </module>
     <module name="AnnotationUseStyle"/>
     <module name="MissingDeprecated"/>
@@ -151,6 +157,10 @@
       <property name="allowInSwitchCase" value="true"/>
     </module>
     <module name="EmptyBlock">
+      <property name="tokens" value="LITERAL_CATCH"/>
+      <property name="tokens" value="ARRAY_INIT"/>
+      <property name="tokens" value="LITERAL_DEFAULT"/>
+      <property name="tokens" value="LITERAL_CASE"/>
       <property name="option" value="text"/>
     </module>
     <module name="EmptyCatchBlock"/>
@@ -159,7 +169,18 @@
     </module>
     <module name="NeedBraces"/>
     <module name="RightCurly">
+      <property name="tokens" value="METHOD_DEF"/>
+      <property name="tokens" value="CTOR_DEF"/>
+      <property name="tokens" value="CLASS_DEF"/>
+      <property name="tokens" value="INSTANCE_INIT"/>
+      <property name="tokens" value="LITERAL_FOR"/>
+      <property name="tokens" value="STATIC_INIT"/>
+      <property name="tokens" value="LITERAL_WHILE"/>
       <property name="option" value="alone"/>
+    </module>
+    <module name="RightCurly">
+      <property name="tokens" value="LITERAL_DO"/>
+      <property name="option" value="same"/>
     </module>
 
     <!-- Class Design -->
@@ -199,7 +220,10 @@
     </module>
     <module name="IllegalInstantiation"/>
     <module name="IllegalThrows"/>
-    <module name="IllegalToken"/>
+    <module name="IllegalToken">
+        <property name="tokens" value="LITERAL_NATIVE"/>
+        <property name="tokens" value="LITERAL_VOLATILE"/>
+    </module>
     <module name="IllegalTokenText"/>
     <module name="IllegalType"/>
     <module name="InnerAssignment"/>
@@ -425,7 +449,33 @@
       <property name="tokens" value="DOT"/>
       <property name="allowLineBreaks" value="true"/>
     </module>
-    <module name="OperatorWrap"/>
+    <module name="OperatorWrap">
+      <property name="tokens" value="QUESTION"/>
+      <property name="tokens" value="COLON"/>
+      <property name="tokens" value="EQUAL"/>
+      <property name="tokens" value="NOT_EQUAL"/>
+      <property name="tokens" value="DIV"/>
+      <property name="tokens" value="PLUS"/>
+      <property name="tokens" value="MINUS"/>
+      <property name="tokens" value="STAR"/>
+      <property name="tokens" value="MOD"/>
+      <property name="tokens" value="SR"/>
+      <property name="tokens" value="BSR"/>
+      <property name="tokens" value="GE"/>
+      <property name="tokens" value="GT"/>
+      <property name="tokens" value="SL"/>
+      <property name="tokens" value="LE"/>
+      <property name="tokens" value="LT"/>
+      <property name="tokens" value="BXOR"/>
+      <property name="tokens" value="BOR"/>
+      <property name="tokens" value="LOR"/>
+      <property name="tokens" value="BAND"/>
+      <property name="tokens" value="LAND"/>
+      <property name="tokens" value="TYPE_EXTENSION_AND"/>
+      <property name="tokens" value="LITERAL_INSTANCEOF"/>
+      <property name="tokens" value="METHOD_REF"/>
+      <property name="option" value="nl"/>
+    </module>
     <module name="OperatorWrap">
       <property name="tokens" value="ASSIGN"/>
       <property name="tokens" value="DIV_ASSIGN"/>
@@ -444,10 +494,15 @@
     <module name="ParenPad"/>
     <module name="SeparatorWrap">
       <property name="tokens" value="DOT"/>
+      <property name="tokens" value="AT"/>
       <property name="option" value="nl"/>
     </module>
     <module name="SeparatorWrap">
       <property name="tokens" value="COMMA"/>
+      <property name="tokens" value="RBRACK"/>
+      <property name="tokens" value="ARRAY_DECLARATOR"/>
+      <property name="tokens" value="ELLIPSIS"/>
+      <property name="tokens" value="SEMI"/>
       <property name="option" value="EOL"/>
     </module>
     <module name="SingleSpaceSeparator">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
@@ -192,8 +192,7 @@ public class ModifierOrderCheck
         DetailAST modifier;
         do {
             modifier = modifierIterator.next();
-        }
-        while (modifierIterator.hasNext() && modifier.getType() == TokenTypes.ANNOTATION);
+        } while (modifierIterator.hasNext() && modifier.getType() == TokenTypes.ANNOTATION);
         return modifier;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CheckUtil.java
@@ -379,6 +379,16 @@ public final class CheckUtil {
         }
     }
 
+    public static Set<String> getTokenTextSet(int... tokens) {
+        final Set<String> result = new HashSet<>();
+
+        for (int token : tokens) {
+            result.add(TokenUtils.getTokenName(token));
+        }
+
+        return result;
+    }
+
     public static String getJavadocTokenText(int[] tokens, int... subtractions) {
         final StringBuilder result = new StringBuilder();
         boolean first = true;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/ConfigurationUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/ConfigurationUtil.java
@@ -1,0 +1,79 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.internal;
+
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
+import com.puppycrawl.tools.checkstyle.PropertiesExpander;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+
+public final class ConfigurationUtil {
+    private ConfigurationUtil() {
+    }
+
+    public static Configuration loadConfiguration(String path) throws CheckstyleException {
+        final Properties props = new Properties();
+
+        props.setProperty("checkstyle.basedir", "basedir");
+        props.setProperty("checkstyle.cache.file", "file");
+        props.setProperty("checkstyle.suppressions.file", "file");
+        props.setProperty("checkstyle.header.file", "file");
+        props.setProperty("checkstyle.regexp.header.file", "file");
+        props.setProperty("checkstyle.importcontrol.file", "file");
+
+        return loadConfiguration(path, props);
+    }
+
+    public static Configuration loadConfiguration(String path, Properties props)
+            throws CheckstyleException {
+        return ConfigurationLoader.loadConfiguration(path, new PropertiesExpander(props));
+    }
+
+    public static Set<Configuration> getModules(Configuration config) {
+        final Set<Configuration> result = new HashSet<>();
+
+        for (Configuration child : config.getChildren()) {
+            if ("TreeWalker".equals(child.getName())) {
+                result.addAll(getModules(child));
+            }
+            else {
+                result.add(child);
+            }
+        }
+
+        return result;
+    }
+
+    public static Set<Configuration> getChecks(Configuration config) {
+        final Set<Configuration> result = new HashSet<>();
+
+        for (Configuration child : config.getChildren()) {
+            if ("TreeWalker".equals(child.getName())) {
+                result.addAll(getModules(child));
+            }
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
Issue #3720 

@romani 
Issue is not approved so code is more a demonstration. Since there was also some reservation about a UT of this kind, I didn't add all overrides.
Please approve issue if you want me to finish this.

The test uses our configuration loader to read and process the configuration file.

`TOKENS_IN_CONFIG_TO_IGNORE` will specify all tokens that we do not want defined directly in our config. `NoWhitespaceBefore` was added for demonstration but it's value is valid as we don't have those used in our config.

If we want, we can add this to all configurations (google and sun).

Eventually I think we should add more support to the configurations to allow writing these back to files for fully dynamic testing in PRs. Sevntu's CI has a perfect example of where that could be used.