### PR TITLE
Add new check WhitespaceAfterLastMemberCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterLastMemberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterLastMemberCheck.java
@@ -1,0 +1,83 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * <p>
+*  This checks enforces whitespace after last member of the class.
+ * </p>
+ * Examples:
+ * This code is valid:
+ *
+ * <pre>
+ * class Employee {
+ *     private String name;
+*
+ * }
+ * </pre>
+ *
+ * This example is valid as well:
+ *
+ * <pre>
+ * interface EmptyInterface {
+ * }
+ * </pre>
+ *
+ * But this violates the check:
+ *
+ * <pre>
+ * class Message {
+ *     public String msg;
+ * }
+ * </pre>
+ *
+ * @author <a href="mailto:piotr.listkiewicz@gmail.com">liscju</a>
+ */
+public class WhitespaceAfterLastMemberCheck extends AbstractCheck {
+
+    /**
+     * A key is pointing to the warning message ws.after.last.member in "messages.properties"
+     * file.
+     */
+    public static final String MSG_WS_AFTER_LAST_MEMBER = "ws.after.last.member";
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getRequiredTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return new int[] {TokenTypes.RCURLY};
+    }
+
+    @Override
+    public void visitToken(DetailAST ast) {
+        if (ast.getParent() != null &&
+            ast.getParent().getType() == TokenTypes.OBJBLOCK &&
+            ast.getParent().getParent().getType() == TokenTypes.CLASS_DEF &&
+            ast.getPreviousSibling().getType() != TokenTypes.LCURLY) {
+            if (!hasEmptyLineBefore(ast)) {
+                DetailAST classDef = ast.getParent().getParent();
+                log(classDef.getLineNo(), MSG_WS_AFTER_LAST_MEMBER);
+            }
+        }
+    }
+
+    /**
+     * Checks if a token has a empty line before.
+     * @param token token.
+     * @return true, if token have empty line before.
+     */
+    private boolean hasEmptyLineBefore(DetailAST token) {
+        final int lineNo = token.getLineNo();
+        if (lineNo == 1) {
+            return false;
+        }
+        //  [lineNo - 2] is the number of the previous line because the numbering starts from zero.
+        final String lineBefore = getLines()[lineNo - 2];
+        return lineBefore.trim().isEmpty();
+    }
+}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/messages.properties
@@ -19,3 +19,5 @@ ws.illegalFollow=''{0}'' is followed by an illegal character.
 ws.typeCast=''typecast'' is not followed by whitespace.
 
 single.space.separator=Use a single space to separate non-whitespace characters.
+
+ws.after.last.member=Class last member should be followed by whitespace

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterLastMemberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterLastMemberCheckTest.java
@@ -1,0 +1,61 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace;
+
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterLastMemberCheck.MSG_WS_AFTER_LAST_MEMBER;
+import static org.junit.Assert.*;
+
+public class WhitespaceAfterLastMemberCheckTest
+        extends BaseCheckTestSupport {
+
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("checks" + File.separator
+                + "whitespace" + File.separator + filename);
+    }
+
+    @Test
+    public void testGetRequiredTokens() {
+        final WhitespaceAfterLastMemberCheck checkObj = new WhitespaceAfterLastMemberCheck();
+        final int[] requiredTokens = {
+            TokenTypes.RCURLY,
+        };
+        assertArrayEquals(requiredTokens, checkObj.getRequiredTokens());
+    }
+
+    @Test
+    public void testAllowNoEmptyLineInEmptyClass() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(WhitespaceAfterLastMemberCheck.class);
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+                getPath("InputWhitespaceAfterLastMemberEmptyClass.java"),
+                expected);
+    }
+
+    @Test
+    public void testNotAllowNoEmptyLineAfterFieldInClassWithOneField() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(WhitespaceAfterLastMemberCheck.class);
+        final String[] expected = {
+                "3: " + getCheckMessage(MSG_WS_AFTER_LAST_MEMBER),
+        };
+        verify(checkConfig,
+                getPath("InputWhitespaceAfterLastMemberOneFieldClass.java"),
+                expected);
+    }
+
+    @Test
+    public void testAllowEmptyLineAfterLastMethod() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(WhitespaceAfterLastMemberCheck.class);
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+                getPath("InputWhitespaceAfterLastMemberWSAfterLastMethod.java"),
+                expected);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputWhitespaceAfterLastMemberEmptyClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputWhitespaceAfterLastMemberEmptyClass.java
@@ -1,0 +1,4 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace;
+
+public class InputWhitespaceAfterLastMemberEmptyClass {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputWhitespaceAfterLastMemberOneFieldClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputWhitespaceAfterLastMemberOneFieldClass.java
@@ -1,0 +1,5 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace;
+
+public class InputWhitespaceAfterLastMemberOneFieldClass {
+    private int i;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputWhitespaceAfterLastMemberWSAfterLastMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputWhitespaceAfterLastMemberWSAfterLastMethod.java
@@ -1,0 +1,12 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace;
+
+public class InputWhitespaceAfterLastMemberWSAfterLastMethod {
+    public static void method1() {
+        // empty
+    }
+
+    public static void method2() {
+        // empty
+    }
+
+}


### PR DESCRIPTION
I need to check if there is a whitespace after last member of the class, is there a way to do this with one of the existing check? Because I did not find a checkstyle check that fulfills my requirements I wrote this check as a proposal of the solution(it is work in progress, it does not adhere to commit rules etc).

Would it be possible to add this kind of check to checkstyle?