### PR TITLE
config: enforce strict version of htmlunit code to prevent build fail…

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -71,7 +71,7 @@ build:
         && CS_POM_VERSION=$(mvn -q -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
         && echo CS_version: ${CS_POM_VERSION}
         && echo "checkouting project sources ..."
-        && svn -q export https://svn.code.sf.net/p/htmlunit/code/trunk/htmlunit htmlunit
+        && svn -q export https://svn.code.sf.net/p/htmlunit/code/trunk/htmlunit@13524 htmlunit
         && cd htmlunit
         && echo "Running checkstyle validation ..."
         && mvn compile checkstyle:check -Dcheckstyle.version=${CS_POM_VERSION}

--- a/wercker.yml
+++ b/wercker.yml
@@ -71,9 +71,8 @@ build:
         && CS_POM_VERSION=$(mvn -q -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
         && echo CS_version: ${CS_POM_VERSION}
         && echo "checkouting project sources ..."
-        && svn -q export https://svn.code.sf.net/p/htmlunit/code/trunk/htmlunit@13524 htmlunit
+        && svn -q export https://svn.code.sf.net/p/htmlunit/code/trunk/htmlunit@13543 htmlunit
         && cd htmlunit
-        && sed -i'' "s/<includeTestSourceDirectory>true/<includeTestSourceDirectory>false/" pom.xml
         && echo "Running checkstyle validation ..."
         && mvn compile checkstyle:check -Dcheckstyle.version=${CS_POM_VERSION}
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -73,6 +73,7 @@ build:
         && echo "checkouting project sources ..."
         && svn -q export https://svn.code.sf.net/p/htmlunit/code/trunk/htmlunit@13524 htmlunit
         && cd htmlunit
+        && sed -i'' "s/<includeTestSourceDirectory>true/<includeTestSourceDirectory>false/" pom.xml
         && echo "Running checkstyle validation ..."
         && mvn compile checkstyle:check -Dcheckstyle.version=${CS_POM_VERSION}
 


### PR DESCRIPTION
…ures in our CI while htmlunit  have build failures

failure build on our side: 
https://app.wercker.com/checkstyle/checkstyle/runs/build/5892509b7062f40100fb5a60?step=589250abe3159e000111bb93

failure on htmlunit side:
https://ci.canoo.com/teamcity/viewLog.html?buildId=256892&tab=buildResultsDiv&buildTypeId=HtmlUnit_FastBuild

stable build: https://ci.canoo.com/teamcity/viewLog.html?buildId=256893&buildTypeId=HtmlUnit_FastBuild&tab=buildChangesDiv

issue with project : https://sourceforge.net/p/htmlunit/feature-requests/244/

so we will use strict revision for checkout
