### PR TITLE
Issue #3803: fixed catch indentation wrapping

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CatchHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CatchHandler.java
@@ -52,7 +52,7 @@ public class CatchHandler extends BlockParentHandler {
     private void checkCondExpr() {
         final DetailAST condAst = getMainAst().findFirstToken(TokenTypes.LPAREN)
             .getNextSibling();
-        checkExpressionSubtree(condAst, getIndent(), false, false);
+        checkExpressionSubtree(condAst, getIndent(), true, false);
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -839,6 +839,14 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
             "74: " + getCheckMessage(MSG_ERROR, "catch lcurly", 6, 8),
             "77: " + getCheckMessage(MSG_ERROR, "catch rcurly", 10, 8),
             "80: " + getCheckMessage(MSG_CHILD_ERROR, "catch", 10, 12),
+            "86: " + getCheckMessage(MSG_ERROR, "try", 0, 8),
+            "87: " + getCheckMessage(MSG_ERROR, "try rcurly", 0, 8),
+            "88: " + getCheckMessage(MSG_CHILD_ERROR, "catch", 0, 12),
+            "89: " + getCheckMessage(MSG_ERROR, "catch rcurly", 0, 8),
+            "91: " + getCheckMessage(MSG_ERROR, "try", 0, 8),
+            "92: " + getCheckMessage(MSG_ERROR, "try rcurly", 0, 8),
+            "93: " + getCheckMessage(MSG_CHILD_ERROR, "catch", 0, 12),
+            "94: " + getCheckMessage(MSG_ERROR, "catch rcurly", 0, 8),
         };
         verifyWarns(checkConfig, fileName, expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidTryIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputInvalidTryIndent.java
@@ -83,6 +83,14 @@ public class InputInvalidTryIndent { //indent:0 exp:0
         { //indent:8 exp:8
         } //indent:8 exp:8
 
+try { //indent:0 exp:8 warn
+} catch (NullPointerException //indent:0 exp:8 warn
+| IllegalArgumentException t) { //indent:0 exp:12 warn
+} //indent:0 exp:8 warn
 
+try { //indent:0 exp:8 warn
+} catch (NullPointerException | //indent:0 exp:8 warn
+IllegalArgumentException t) { //indent:0 exp:12 warn
+} //indent:0 exp:8 warn
     } //indent:4 exp:4
 } //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputValidTryIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputValidTryIndent.java
@@ -82,7 +82,31 @@ public class InputValidTryIndent { //indent:0 exp:0
         { //indent:8 exp:8
         } //indent:8 exp:8
 
+        try  //indent:8 exp:8
+        { //indent:8 exp:8
+        }  //indent:8 exp:8
+        catch (NullPointerException | IllegalArgumentException t)  //indent:8 exp:8
+        { //indent:8 exp:8
+            System.identityHashCode("err"); //indent:12 exp:12
+        } //indent:8 exp:8
 
+        try  //indent:8 exp:8
+        { //indent:8 exp:8
+        }  //indent:8 exp:8
+        catch (NullPointerException //indent:8 exp:8
+            | IllegalArgumentException t)  //indent:12 exp:12
+        { //indent:8 exp:8
+            System.identityHashCode("err"); //indent:12 exp:12
+        } //indent:8 exp:8
+
+        try  //indent:8 exp:8
+        { //indent:8 exp:8
+        }  //indent:8 exp:8
+        catch (NullPointerException | //indent:8 exp:8
+            IllegalArgumentException t)  //indent:12 exp:12
+        { //indent:8 exp:8
+            System.identityHashCode("err"); //indent:12 exp:12
+        } //indent:8 exp:8
     } //indent:4 exp:4
 
 } //indent:0 exp:0


### PR DESCRIPTION
Issue #3803 

The `true`/`false` change tells the method if indentation should be increased because of line wrapping.

Regression: http://rveach.no-ip.org/checkstyle/regression/reports/190/

Only one difference in openjdk9, which I assume the reason it is there is because the `try` in not indented correct from the lambda.