### PR TITLE
Pull #3820: Rename method in CheckUtil

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -432,9 +432,9 @@ public class AllChecksTest extends BaseCheckTestSupport {
                         configTokens.addAll(overrideTokens);
                     }
 
-                    configTokens.addAll(CheckUtil.getTokenTextSet(check.getDefaultTokens()));
+                    configTokens.addAll(CheckUtil.getTokenNameSet(check.getDefaultTokens()));
                     checkTokens.put(checkName,
-                            CheckUtil.getTokenTextSet(check.getAcceptableTokens()));
+                            CheckUtil.getTokenNameSet(check.getAcceptableTokens()));
                 }
 
                 try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CheckUtil.java
@@ -379,7 +379,7 @@ public final class CheckUtil {
         }
     }
 
-    public static Set<String> getTokenTextSet(int... tokens) {
+    public static Set<String> getTokenNameSet(int... tokens) {
         final Set<String> result = new HashSet<>();
 
         for (int token : tokens) {


### PR DESCRIPTION
The method returns token names, not text.