### PR TITLE
Issue #3749: updated reason for google's OperatorWrapCheck config

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -268,8 +268,8 @@ public class AllChecksTest extends BaseCheckTestSupport {
                 "MOD_ASSIGN", "LITERAL_FOR", "SUPER_CTOR_CALL", "ARRAY_DECLARATOR", "LITERAL_CASE")
                 .collect(Collectors.toSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("OperatorWrap", Stream.of(
-                // state of the configuration when test was made until
-                // https://github.com/checkstyle/checkstyle/issues/3749
+                // specifically allowed via '4.5.1 Where to break' because the following are
+                // assignment operators and they are allowed to break before or after the symbol
                 "DIV_ASSIGN", "BOR_ASSIGN", "SL_ASSIGN", "ASSIGN", "BSR_ASSIGN", "BAND_ASSIGN",
                 "PLUS_ASSIGN", "MINUS_ASSIGN", "SR_ASSIGN", "STAR_ASSIGN", "BXOR_ASSIGN",
                 "MOD_ASSIGN").collect(Collectors.toSet()));


### PR DESCRIPTION
Issue #3749

Just updated reason. All examples already existed at https://github.com/checkstyle/checkstyle/blob/e307efd92b98c19c879db9b0ea3d20bc4460a532/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputOperatorWrap.java#L314-L357