### PR TITLE
Fix AbstractTypeAwareCheck when dealing with nested interfaces

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -158,6 +158,7 @@ public abstract class AbstractTypeAwareCheck extends AbstractCheck {
     @Override
     public final void leaveToken(DetailAST ast) {
         if (ast.getType() == TokenTypes.CLASS_DEF
+            || ast.getType() == TokenTypes.INTERFACE_DEF
             || ast.getType() == TokenTypes.ENUM_DEF) {
             // perhaps it was inner class
             int dotIdx = currentClassName.lastIndexOf('$');


### PR DESCRIPTION
`AbstractTypeAwareCheck` looks like it could contain a bug when dealing with interfaces, especially nested interfaces.

[When we process `visitToken`, we call `processClass` for classes, interfaces, and enumerations](https://github.com/rnveach/checkstyle/blob/b4a337a599e853cdc44b19a76da28fcfab2956cd/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java#L145-L148).
[`processClass` manipulates `currentClassName` and calls `processTypeParams` to handle the type parameters.](https://github.com/rnveach/checkstyle/blob/b4a337a599e853cdc44b19a76da28fcfab2956cd/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java#L337)
[When we process `leaveToken` for these tokens we do the same as `processClass` but reversing it](https://github.com/rnveach/checkstyle/blob/b4a337a599e853cdc44b19a76da28fcfab2956cd/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java#L159-L175), except we left out interfaces.

This fix just adds interface to the tokens we do this action on. Without it, we won't have correct internal variables in nested interfaces after leaving the interface.