### PR TITLE
Pull #3841: add allowEmptyCatches parameter to WhitespaceAroundCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -187,6 +187,8 @@ public class WhitespaceAroundCheck extends AbstractCheck {
     private boolean allowEmptyLoops;
     /** Whether or not empty lambda blocks are allowed. */
     private boolean allowEmptyLambdas;
+    /** Whether or not empty catch blocks are allowed. */
+    private boolean allowEmptyCatches;
     /** Whether or not to ignore a colon in a enhanced for loop. */
     private boolean ignoreEnhancedForColon = true;
 
@@ -362,6 +364,14 @@ public class WhitespaceAroundCheck extends AbstractCheck {
         allowEmptyLambdas = allow;
     }
 
+    /**
+     * Sets whether or not empty catch blocks are allowed.
+     * @param allow {@code true} to allow empty catch blocks.
+     */
+    public void setAllowEmptyCatches(boolean allow) {
+        allowEmptyCatches = allow;
+    }
+
     @Override
     public void visitToken(DetailAST ast) {
         final int currentType = ast.getType();
@@ -478,7 +488,8 @@ public class WhitespaceAroundCheck extends AbstractCheck {
         return isEmptyMethodBlock(ast, parentType)
                 || isEmptyCtorBlock(ast, parentType)
                 || isEmptyLoop(ast, parentType)
-                || isEmptyLambda(ast, parentType);
+                || isEmptyLambda(ast, parentType)
+                || isEmptyCatch(ast, parentType);
     }
 
     /**
@@ -597,6 +608,18 @@ public class WhitespaceAroundCheck extends AbstractCheck {
      */
     private boolean isEmptyLambda(DetailAST ast, int parentType) {
         return allowEmptyLambdas && isEmptyBlock(ast, parentType, TokenTypes.LAMBDA);
+    }
+
+    /**
+     * Tests if the given {@code DetailAst} is part of an allowed empty
+     * catch block.
+     * @param ast the {@code DetailAst} to test.
+     * @param parentType the token type of {@code ast}'s parent
+     * @return {@code true} if {@code ast} makes up part of an
+     *         allowed empty catch block.
+     */
+    private boolean isEmptyCatch(DetailAST ast, int parentType) {
+        return allowEmptyCatches && isEmptyBlock(ast, parentType, TokenTypes.LITERAL_CATCH);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java
@@ -405,4 +405,12 @@ public class WhitespaceAroundCheckTest
         };
         verify(checkConfig, getPath("InputWhitespaceAroundLambda.java"), expected);
     }
+
+    @Test
+    public void testWhitespaceAroundEmptyCatchBlock() throws Exception {
+        checkConfig.addAttribute("allowEmptyCatches", "true");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputWhitespaceAroundCatch.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputWhitespaceAroundCatch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputWhitespaceAroundCatch.java
@@ -1,0 +1,39 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace;
+
+public class InputWhitespaceAroundCatch {
+    public int case1(int i) {
+        int k = 1;
+        try {
+            k = 5 / i;
+        } catch (ArithmeticException ex) {}
+        return k;
+    }
+
+    public int case2(int i) {
+        int k = 1;
+        try {
+            k = 10 / i;
+        } catch (ArithmeticException ex) {   }
+        return k;
+    }
+
+    public int case3(int i) {
+        int k = 1;
+        try {
+            k = 15 / i;
+        } catch (ArithmeticException ex) {
+
+        }
+        return k;
+    }
+
+    public int case4(int i) {
+        int k = 1;
+        try {
+            k = 20 / i;
+        } catch (ArithmeticException ex) {
+            // This is expected
+        }
+        return k;
+    }
+}

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -2018,8 +2018,9 @@ public @interface Beta {} // empty annotation type
         <p>
         may optionally be exempted from the policy using the <code>
         allowEmptyMethods</code>, <code>allowEmptyConstructors
-        </code>, <code>allowEmptyTypes</code>, <code>allowEmptyLoops</code> and
-        <code>allowEmptyLambdas</code> properties.
+        </code>, <code>allowEmptyTypes</code>, <code>allowEmptyLoops</code>
+        <code>allowEmptyLambdas</code> and <code>allowEmptyCatches</code>
+        properties.
         </p>
         <p>This check does not flag as violation double brace initialization like:</p>
         <pre><code>
@@ -2027,6 +2028,17 @@ new Properties() {{
     setProperty("key", "value");
 }};
         </code></pre>
+        <p>Parameter allowEmptyCatches allows to suppress violations when token
+        list contains SLIST to check if beginning of block is surrounded by
+        whitespace and catch block is empty, for example:</p>
+        <pre><code>
+try {
+    k = 5 / i;
+} catch (ArithmeticException ex) {}
+        </code></pre>
+        With this property turned off, this raises violation because the beginning of the
+        catch block (left curly bracket) is not separated from the end of the catch
+        block (right curly bracket).
       </subsection>
 
       <subsection name="Properties">
@@ -2064,6 +2076,12 @@ new Properties() {{
           <tr>
             <td>allowEmptyLambdas</td>
             <td>allow empty lambda bodies</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>false</code></td>
+          </tr>
+          <tr>
+            <td>allowEmptyCatches</td>
+            <td>allow empty catch bodies</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
           </tr>


### PR DESCRIPTION
It should be an option to disable checking whitespace around empty catch block because:

```java
try {
 sth....
} catch (RuntimeException ex) {}
```

is a common pattern to explicitly suppress exceptions.

