### PR TITLE
Issue #3830: Fix bug in DesignForExtension when order of annotations changes violation

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -183,9 +183,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
         final DetailAST methodImplOpenBrace = ast.findFirstToken(TokenTypes.SLIST);
         final DetailAST methodImplCloseBrace = methodImplOpenBrace.getLastChild();
         final Predicate<DetailAST> predicate = currentNode -> {
-            return currentNode != null
-                && currentNode != methodImplCloseBrace
-                && currentNode.getLineNo() <= methodImplCloseBrace.getLineNo()
+            return currentNode != methodImplCloseBrace
                 && !TokenUtils.isCommentType(currentNode.getType());
         };
         final Optional<DetailAST> methodBody =
@@ -220,31 +218,19 @@ public class DesignForExtensionCheck extends AbstractCheck {
      * @return true if a method has any of ignored annotations.
      */
     private static boolean hasIgnoredAnnotation(DetailAST methodDef, Set<String> annotations) {
-        return annotations.stream().filter(annotation -> hasAnnotation(methodDef, annotation))
-            .findAny().isPresent();
-    }
-
-    /**
-     * Check if a method has specific annotation.
-     * @param methodDef method definition token.
-     * @param annotationName annotation name.
-     * @return true, if a method has a specific annotation.
-     */
-    private static boolean hasAnnotation(DetailAST methodDef, String annotationName) {
         final DetailAST modifiers = methodDef.findFirstToken(TokenTypes.MODIFIERS);
-        boolean containsAnnotation = false;
+        boolean hasIgnoredAnnotation = false;
         if (modifiers.branchContains(TokenTypes.ANNOTATION)) {
             final Optional<DetailAST> annotation = TokenUtils.findFirstTokenByPredicate(modifiers,
                 currentToken -> {
-                    return currentToken != null
-                        && currentToken.getType() == TokenTypes.ANNOTATION
-                        && annotationName.equals(getAnnotationName(currentToken));
+                    return currentToken.getType() == TokenTypes.ANNOTATION
+                        && annotations.contains(getAnnotationName(currentToken));
                 });
             if (annotation.isPresent()) {
-                containsAnnotation = true;
+                hasIgnoredAnnotation = true;
             }
         }
-        return containsAnnotation;
+        return hasIgnoredAnnotation;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtils.java
@@ -191,7 +191,8 @@ public final class TokenUtils {
     }
 
     /**
-     * Finds the first node {@link Optional} of {@link DetailAST} which matches the predicate.
+     * Finds the first {@link Optional} child token of {@link DetailAST} root node
+     * which matches the given predicate.
      * @param root root node.
      * @param predicate predicate.
      * @return {@link Optional} of {@link DetailAST} node which matches the predicate.
@@ -199,20 +200,11 @@ public final class TokenUtils {
     public static Optional<DetailAST> findFirstTokenByPredicate(DetailAST root,
                                                                 Predicate<DetailAST> predicate) {
         Optional<DetailAST> result = Optional.empty();
-        DetailAST rootNode = root;
-        while (rootNode != null) {
-            DetailAST toVisit = rootNode.getFirstChild();
-            if (predicate.test(toVisit)) {
-                result = Optional.of(toVisit);
+        for (DetailAST ast = root.getFirstChild(); ast != null; ast = ast.getNextSibling()) {
+            if (predicate.test(ast)) {
+                result = Optional.of(ast);
                 break;
             }
-            while (rootNode != null && toVisit == null) {
-                toVisit = rootNode.getNextSibling();
-                if (toVisit == null) {
-                    rootNode = rootNode.getParent();
-                }
-            }
-            rootNode = toVisit;
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class DesignForExtensionCheckTest
     extends BaseCheckTestSupport {
@@ -88,14 +89,27 @@ public class DesignForExtensionCheckTest
     @Test
     public void testIgnoredAnnotationsOption() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(DesignForExtensionCheck.class);
-        checkConfig.addAttribute("ignoredAnnotations", "Override, Deprecated");
+        checkConfig.addAttribute("ignoredAnnotations", "Override, Deprecated, MyAnnotation");
         final String[] expected = {
             "31:5: "
                 + getCheckMessage(MSG_KEY, "InputDesignForExtensionIgnoredAnnotations", "foo1"),
             "141:5: "
                 + getCheckMessage(MSG_KEY, "InputDesignForExtensionIgnoredAnnotations", "foo21"),
+            "146:5: "
+                + getCheckMessage(MSG_KEY, "InputDesignForExtensionIgnoredAnnotations", "setAge"),
+            "161:5: "
+                + getCheckMessage(MSG_KEY, "InputDesignForExtensionIgnoredAnnotations", "foo24"),
         };
         verify(checkConfig, getPath("InputDesignForExtensionIgnoredAnnotations.java"), expected);
+    }
+
+    @Test
+    public void testIgnoreAnnotationsOptionWithMultipleAnnotations() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(DesignForExtensionCheck.class);
+        checkConfig.addAttribute("ignoredAnnotations",
+            "Override, Deprecated, Before, After, BeforeClass, AfterClass");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputDesignForExtensionMultipleAnnotations.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputDesignForExtensionIgnoredAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputDesignForExtensionIgnoredAnnotations.java
@@ -138,6 +138,29 @@ public class InputDesignForExtensionIgnoredAnnotations {
     @InputLocalAnnotations.ClassRule
     public void foo20() { return; }
 
-    @InputLocalAnnotations.ClassRule
-    public void foo21() { return; } // violation
+    @InputLocalAnnotations.ClassRule // violation
+    public void foo21() { return; }
+
+    private int age;
+
+    @Inject // violation
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public @interface Inject { }
+
+    public @MyAnnotation void foo22() {
+        foo1();
+    }
+
+    @MyAnnotation public void foo23() {
+        foo1();
+    }
+
+    public void foo24(@MyAnnotation int a) { // violation
+        foo1();
+    }
+
+    public @interface MyAnnotation { }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputDesignForExtensionMultipleAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputDesignForExtensionMultipleAnnotations.java
@@ -1,0 +1,84 @@
+package com.puppycrawl.tools.checkstyle.checks.design;
+
+import java.util.List;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class InputDesignForExtensionMultipleAnnotations {
+
+    @Ignore
+    @Deprecated
+    public void foo1() {
+        foo3();
+    }
+
+    @Deprecated
+    @Ignore
+    public void foo2() {
+        foo3();
+    }
+
+    @Ignore
+    // comment
+    @Deprecated
+    public void foo4() {
+        foo3();
+    }
+
+    @Deprecated
+    // comment
+    @Ignore
+    public void foo5() {
+        foo3();
+    }
+
+
+    @Ignore
+    /**
+     * comment
+     */
+    @Deprecated
+    public void foo6() {
+        foo3();
+    }
+
+    @Deprecated
+    /**
+     * comment
+     */
+    @Ignore
+    public void foo7() {
+        foo3();
+    }
+
+    @Ignore
+    /* comment */
+    @Deprecated
+    public void foo8() {
+        foo3();
+    }
+
+    @Deprecated
+    /* comment */
+    @Ignore
+    public void foo9() {
+        foo3();
+    }
+
+    /* comment */
+    @Ignore
+    @Deprecated
+    public void foo10() {
+        foo3();
+    }
+
+    /* comment */
+    @Deprecated
+    @Ignore
+    public void foo11() {
+        foo3();
+    }
+
+    private void foo3() {}
+}


### PR DESCRIPTION
#3830 

> @rnveach 
 As shown in the debug output above, do you know why DesignForExtensionCheck.hasAnnotation has to examine the contents of the method? Won't this lead to false positives for this method?
@romani 
it should not review content of method. modificators and annotations is enough for decision.

Fixed. 

```findFirstTokenByPredicate``` was reimplemented. The idea was taken from DetailAST#findFirstToken .

There is no need in looping through all ignored annotations and invoking of  ```hasAnnotation``` inside ```hasIgnoredAnnotation```  each time, that is why I decided to check whether ignored annotations set contains any of method annotations.

Diff reports:
http://mezk.github.io/i3830-DesignForExtension/diff

As you can see from the reports there are both false positives and false negatives in previous implementation of DesignForExtensionCheck. From my point of view, all of them are due to incorrect implementation of tree traversing algorithm in TokenUtils#findFirstTokenByPredicate.
