### PR TITLE
Issue #3843: Fix coverage problem for DesignForExtension

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputDesignForExtensionOverridableMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputDesignForExtensionOverridableMethods.java
@@ -218,4 +218,8 @@ public class InputDesignForExtensionOverridableMethods {
 
         protected final int foo4(int a, int b) {return a + b;}
     }
+
+    public abstract class C {
+        public abstract void foo1(int a);
+    }
 }


### PR DESCRIPTION
#3843 

1) Replaced Stream.of(...) with Arrays.stream(...) to avoid problem with cobertura.
2) Removed null-check (``` if (methodImplOpenBrace != null)```) from ```hasEmptyImplementation``` as ```methodImplOpenBrace``` can be null only if the method is native or abstract, or its signature is declared in interface. All the cases mentioned are checked by ```canBeOverriden``` which is more verbose that is why I decided to rely on it. Since I change the check logic a bit I decided to regenerate diff reports with default configuration.
3) Added test input to increase branch coverage rate up to 100%.

Diff reports:
http://mezk.github.io/i3843-coverage/diff
Cobertura report:
http://mezk.github.io/i3843-coverage/cobertura

@rnveach 
Feel free to review and share your thoughts.

This PR blocks  https://github.com/checkstyle/checkstyle/pull/3842