### PR TITLE
Issue #3843: Disallow import of interfaces from java.util.stream due to coverage problem

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -126,6 +126,17 @@
             <property name="forbiddenImportsExcludesRegexp"
                       value="^com.puppycrawl.tools.checkstyle.checks.naming.AccessModifier$"/>
         </module>
+        <module name="ForbidCertainImports">
+            <property name="packageNameRegexp" value=".+"/>
+            <property name="id" value="ForbidInterfacesImportFromJavaUtilStream"/>
+            <!--Disallowed till https://github.com/mojohaus/cobertura-maven-plugin/issues/29-->
+            <property name="forbiddenImportsRegexp" value="java\.util\.stream\.Stream|
+            java\.util\.stream\.Stream\.Builder|java\.util\.stream\.DoubleStream|
+            java\.util\.stream\.DoubleStream\.Builder|java\.util\.stream\.IntStream|
+            java\.util\.stream\.IntStream\.Builder|java\.util\.stream\.LongStream|
+            java\.util\.stream\.LongStream\.Builder|java\.util\.stream\.BaseStream|
+            java\.util\.stream\.Collector"/>
+        </module>
         <module name="LineLengthExtended">
             <property name="max" value="100"/>
             <property name="ignoreClass" value="true"/>

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -16,6 +16,18 @@
   <allow pkg="org.apache.commons.logging"/>
   <allow pkg="org.xml.sax"/>
 
+  <!--Disallowed till https://github.com/mojohaus/cobertura-maven-plugin/issues/29-->
+  <disallow class="java.util.stream.Stream"/>
+  <disallow class="java.util.stream.Stream.Builder"/>
+  <disallow class="java.util.stream.DoubleStream"/>
+  <disallow class="java.util.stream.DoubleStream.Builder"/>
+  <disallow class="java.util.stream.IntStream"/>
+  <disallow class="java.util.stream.IntStream.Builder"/>
+  <disallow class="java.util.stream.LongStream"/>
+  <disallow class="java.util.stream.LongStream.Builder"/>
+  <disallow class="java.util.stream.BaseStream"/>
+  <disallow class="java.util.stream.Collector"/>
+
   <!-- The local ones -->
   <allow pkg="java.lang.reflect" local-only="true" />
   <allow pkg="java.nio" local-only="true" />

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -26,4 +26,9 @@
     JavadocUtils.java and JavadocUtilsTest.java. -->
     <suppress checks="ForbidCertainImports"
               files="JavadocUtils\.java|JavadocUtilsTest\.java"/>
+
+    <!--ITs and UTs are not included in Cobertura coverage report
+    and do not have coverage problems due to imports from java.util.stream. -->
+    <suppress id="ForbidInterfacesImportFromJavaUtilStream"
+              files=".*[\\/]src[\\/](test|it)[\\/]"/>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -1463,6 +1463,8 @@
                   <exclude>com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.class</exclude>
+                  <!--Until https://github.com/checkstyle/checkstyle/issues/3848-->
+                  <exclude>com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.class</exclude>
                 </excludes>
               </instrumentation>
             </configuration>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
@@ -19,10 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -68,7 +68,7 @@ public class FinalParametersCheck extends AbstractCheck {
      * primitive datatypes</a>.
      */
     private final Set<Integer> primitiveDataTypes = Collections.unmodifiableSet(
-        Stream.of(
+        Arrays.stream(new Integer[] {
             TokenTypes.LITERAL_BYTE,
             TokenTypes.LITERAL_SHORT,
             TokenTypes.LITERAL_INT,
@@ -76,7 +76,7 @@ public class FinalParametersCheck extends AbstractCheck {
             TokenTypes.LITERAL_FLOAT,
             TokenTypes.LITERAL_DOUBLE,
             TokenTypes.LITERAL_BOOLEAN,
-            TokenTypes.LITERAL_CHAR)
+            TokenTypes.LITERAL_CHAR, })
         .collect(Collectors.toSet()));
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -19,11 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -45,9 +45,9 @@ public final class IllegalCatchCheck extends AbstractCheck {
     public static final String MSG_KEY = "illegal.catch";
 
     /** Illegal class names. */
-    private final Set<String> illegalClassNames = Stream.of("Exception", "Error",
-            "RuntimeException", "Throwable", "java.lang.Error", "java.lang.Exception",
-            "java.lang.RuntimeException", "java.lang.Throwable").collect(Collectors.toSet());
+    private final Set<String> illegalClassNames = Arrays.stream(new String[] {"Exception", "Error",
+        "RuntimeException", "Throwable", "java.lang.Error", "java.lang.Exception",
+        "java.lang.RuntimeException", "java.lang.Throwable", }).collect(Collectors.toSet());
 
     /**
      * Set the list of illegal classes.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
@@ -19,10 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -61,11 +61,12 @@ public final class IllegalThrowsCheck extends AbstractCheck {
 
     /** Methods which should be ignored. */
     private final Set<String> ignoredMethodNames =
-        Stream.of("finalize").collect(Collectors.toSet());
+        Arrays.stream(new String[] {"finalize", }).collect(Collectors.toSet());
 
     /** Illegal class names. */
-    private final Set<String> illegalClassNames = Stream.of("Error", "RuntimeException",
-        "Throwable", "java.lang.Error", "java.lang.RuntimeException", "java.lang.Throwable")
+    private final Set<String> illegalClassNames = Arrays.stream(
+        new String[] {"Error", "RuntimeException", "Throwable", "java.lang.Error",
+                      "java.lang.RuntimeException", "java.lang.Throwable", })
         .collect(Collectors.toSet());
 
     /** Property for ignoring overridden methods. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -20,13 +20,13 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -109,9 +109,14 @@ public final class ModifiedControlVariableCheck extends AbstractCheck {
     private static final String ILLEGAL_TYPE_OF_TOKEN = "Illegal type of token: ";
 
     /** Operations which can change control variable in update part of the loop. */
-    private static final Set<Integer> MUTATION_OPERATIONS = Stream.of(TokenTypes.POST_INC,
-        TokenTypes.POST_DEC, TokenTypes.DEC, TokenTypes.INC, TokenTypes.ASSIGN)
-        .collect(Collectors.toSet());
+    private static final Set<Integer> MUTATION_OPERATIONS =
+        Arrays.stream(new Integer[] {
+            TokenTypes.POST_INC,
+            TokenTypes.POST_DEC,
+            TokenTypes.DEC,
+            TokenTypes.INC,
+            TokenTypes.ASSIGN,
+        }).collect(Collectors.toSet());
 
     /** Stack of block parameters. */
     private final Deque<Deque<String>> variableStack = new ArrayDeque<>();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
@@ -29,7 +30,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -103,32 +103,21 @@ public class RequireThisCheck extends AbstractCheck {
     public static final String MSG_VARIABLE = "require.this.variable";
 
     /** Set of all declaration tokens. */
-    private static final Set<Integer> DECLARATION_TOKENS = Collections.unmodifiableSet(Stream.of(
-        TokenTypes.VARIABLE_DEF,
-        TokenTypes.CTOR_DEF,
-        TokenTypes.METHOD_DEF,
-        TokenTypes.CLASS_DEF,
-        TokenTypes.ENUM_DEF,
-        TokenTypes.INTERFACE_DEF,
-        TokenTypes.PARAMETER_DEF,
-        TokenTypes.TYPE_ARGUMENT
-    ).collect(Collectors.toSet()));
+    private static final Set<Integer> DECLARATION_TOKENS = Collections.unmodifiableSet(
+        Arrays.stream(new Integer[] {
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.PARAMETER_DEF,
+            TokenTypes.TYPE_ARGUMENT,
+        }).collect(Collectors.toSet()));
     /** Set of all assign tokens. */
-    private static final Set<Integer> ASSIGN_TOKENS = Collections.unmodifiableSet(Stream.of(
-        TokenTypes.ASSIGN,
-        TokenTypes.PLUS_ASSIGN,
-        TokenTypes.STAR_ASSIGN,
-        TokenTypes.DIV_ASSIGN,
-        TokenTypes.MOD_ASSIGN,
-        TokenTypes.SR_ASSIGN,
-        TokenTypes.BSR_ASSIGN,
-        TokenTypes.SL_ASSIGN,
-        TokenTypes.BAND_ASSIGN,
-        TokenTypes.BXOR_ASSIGN
-    ).collect(Collectors.toSet()));
-    /** Set of all compound assign tokens. */
-    private static final Set<Integer> COMPOUND_ASSIGN_TOKENS = Collections.unmodifiableSet(
-        Stream.of(
+    private static final Set<Integer> ASSIGN_TOKENS = Collections.unmodifiableSet(
+        Arrays.stream(new Integer[] {
+            TokenTypes.ASSIGN,
             TokenTypes.PLUS_ASSIGN,
             TokenTypes.STAR_ASSIGN,
             TokenTypes.DIV_ASSIGN,
@@ -137,8 +126,21 @@ public class RequireThisCheck extends AbstractCheck {
             TokenTypes.BSR_ASSIGN,
             TokenTypes.SL_ASSIGN,
             TokenTypes.BAND_ASSIGN,
-            TokenTypes.BXOR_ASSIGN
-        ).collect(Collectors.toSet()));
+            TokenTypes.BXOR_ASSIGN,
+        }).collect(Collectors.toSet()));
+    /** Set of all compound assign tokens. */
+    private static final Set<Integer> COMPOUND_ASSIGN_TOKENS = Collections.unmodifiableSet(
+        Arrays.stream(new Integer[] {
+            TokenTypes.PLUS_ASSIGN,
+            TokenTypes.STAR_ASSIGN,
+            TokenTypes.DIV_ASSIGN,
+            TokenTypes.MOD_ASSIGN,
+            TokenTypes.SR_ASSIGN,
+            TokenTypes.BSR_ASSIGN,
+            TokenTypes.SL_ASSIGN,
+            TokenTypes.BAND_ASSIGN,
+            TokenTypes.BXOR_ASSIGN,
+        }).collect(Collectors.toSet()));
 
     /** Tree of all the parsed frames. */
     private Map<DetailAST, AbstractFrame> frames;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -248,7 +247,7 @@ public class VisibilityModifierCheck
 
     /** Default immutable types canonical names. */
     private static final List<String> DEFAULT_IMMUTABLE_TYPES = Collections.unmodifiableList(
-        Stream.of(
+        Arrays.stream(new String[] {
             "java.lang.String",
             "java.lang.Integer",
             "java.lang.Byte",
@@ -268,16 +267,16 @@ public class VisibilityModifierCheck
             "java.net.URI",
             "java.net.Inet4Address",
             "java.net.Inet6Address",
-            "java.net.InetSocketAddress"
-        ).collect(Collectors.toList()));
+            "java.net.InetSocketAddress",
+        }).collect(Collectors.toList()));
 
     /** Default ignore annotations canonical names. */
     private static final List<String> DEFAULT_IGNORE_ANNOTATIONS = Collections.unmodifiableList(
-        Stream.of(
+        Arrays.stream(new String[] {
             "org.junit.Rule",
             "org.junit.ClassRule",
-            "com.google.common.annotations.VisibleForTesting"
-        ).collect(Collectors.toList()));
+            "com.google.common.annotations.VisibleForTesting",
+        }).collect(Collectors.toList()));
 
     /** Name for 'public' access modifier. */
     private static final String PUBLIC_ACCESS_MODIFIER = "public";

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
@@ -28,7 +29,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -69,22 +69,23 @@ public class JavadocStyleCheck
     public static final String MSG_EXTRA_HTML = "javadoc.extraHtml";
 
     /** HTML tags that do not require a close tag. */
-    private static final Set<String> SINGLE_TAGS = Collections.unmodifiableSortedSet(Stream.of(
-        "br", "li", "dt", "dd", "hr", "img", "p", "td", "tr", "th")
-        .collect(Collectors.toCollection(TreeSet::new)));
+    private static final Set<String> SINGLE_TAGS = Collections.unmodifiableSortedSet(
+        Arrays.stream(new String[] {"br", "li", "dt", "dd", "hr", "img", "p", "td", "tr", "th", })
+            .collect(Collectors.toCollection(TreeSet::new)));
 
     /** HTML tags that are allowed in java docs.
      * From https://www.w3schools.com/tags/default.asp
      * The forms and structure tags are not allowed
      */
-    private static final Set<String> ALLOWED_TAGS = Collections.unmodifiableSortedSet(Stream.of(
-        "a", "abbr", "acronym", "address", "area", "b", "bdo", "big",
-        "blockquote", "br", "caption", "cite", "code", "colgroup", "dd",
-        "del", "div", "dfn", "dl", "dt", "em", "fieldset", "font", "h1",
-        "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd",
-        "li", "ol", "p", "pre", "q", "samp", "small", "span", "strong",
-        "style", "sub", "sup", "table", "tbody", "td", "tfoot", "th",
-        "thead", "tr", "tt", "u", "ul", "var")
+    private static final Set<String> ALLOWED_TAGS = Collections.unmodifiableSortedSet(
+        Arrays.stream(new String[] {
+            "a", "abbr", "acronym", "address", "area", "b", "bdo", "big",
+            "blockquote", "br", "caption", "cite", "code", "colgroup", "dd",
+            "del", "div", "dfn", "dl", "dt", "em", "fieldset", "font", "h1",
+            "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd",
+            "li", "ol", "p", "pre", "q", "samp", "small", "span", "strong",
+            "style", "sub", "sup", "table", "tbody", "td", "tfoot", "th",
+            "thead", "tr", "tt", "u", "ul", "var", })
         .collect(Collectors.toCollection(TreeSet::new)));
 
     /** The scope to check. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -26,7 +26,6 @@ import java.util.Deque;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -43,7 +42,7 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
 public abstract class AbstractClassCouplingCheck extends AbstractCheck {
     /** Class names to ignore. */
     private static final Set<String> DEFAULT_EXCLUDED_CLASSES = Collections.unmodifiableSet(
-        Stream.of(
+        Arrays.stream(new String[] {
             // primitives
             "boolean", "byte", "char", "double", "float", "int",
             "long", "short", "void",
@@ -62,8 +61,8 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
             // java.util.*
             "List", "ArrayList", "Deque", "Queue", "LinkedList",
             "Set", "HashSet", "SortedSet", "TreeSet",
-            "Map", "HashMap", "SortedMap", "TreeMap"
-        ).collect(Collectors.toSet()));
+            "Map", "HashMap", "SortedMap", "TreeMap",
+        }).collect(Collectors.toSet()));
 
     /** Stack of contexts. */
     private final Deque<Context> contextStack = new ArrayDeque<>();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.checks.naming;
 
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -75,9 +74,12 @@ public class ParameterNameCheck extends AbstractNameCheck {
     private boolean ignoreOverridden;
 
     /** Access modifiers of methods which should be checked. */
-    private AccessModifier[] accessModifiers = Stream.of(AccessModifier.PUBLIC,
-        AccessModifier.PROTECTED, AccessModifier.PACKAGE, AccessModifier.PRIVATE)
-        .toArray(AccessModifier[]::new);
+    private AccessModifier[] accessModifiers = {
+        AccessModifier.PUBLIC,
+        AccessModifier.PROTECTED,
+        AccessModifier.PACKAGE,
+        AccessModifier.PRIVATE,
+    };
 
     /**
      * Creates a new {@code ParameterNameCheck} instance.


### PR DESCRIPTION
#3843 

I did not use ForbitCertainImports as it cannot exclude test classes where usage of java.util.stream should be allowed.
