### PR TITLE
Issue #3848: Remove unnecessary if-block to increase code coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1437,6 +1437,12 @@
                     <branchRate>79</branchRate>
                     <lineRate>97</lineRate>
                   </regex>
+                  <!--Until https://github.com/checkstyle/checkstyle/issues/3848-->
+                  <regex>
+                    <pattern>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</pattern>
+                    <branchRate>99</branchRate>
+                    <lineRate>100</lineRate>
+                  </regex>
                 </regexes>
               </check>
               <instrumentation>
@@ -1463,8 +1469,6 @@
                   <exclude>com/puppycrawl/tools/checkstyle/checks/coding/AbstractNestedDepthCheck.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/checks/metrics/AbstractComplexityCheck.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/checks/naming/AbstractTypeParameterNameCheck.class</exclude>
-                  <!--Until https://github.com/checkstyle/checkstyle/issues/3848-->
-                  <exclude>com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.class</exclude>
                 </excludes>
               </instrumentation>
             </configuration>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -348,14 +348,12 @@ public class RequireThisCheck extends AbstractCheck {
                 break;
             case TokenTypes.METHOD_DEF :
                 final DetailAST methodFrameNameIdent = ast.findFirstToken(TokenTypes.IDENT);
-                if (frame.getType() == FrameType.CLASS_FRAME) {
-                    final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
-                    if (mods.branchContains(TokenTypes.LITERAL_STATIC)) {
-                        ((ClassFrame) frame).addStaticMethod(methodFrameNameIdent);
-                    }
-                    else {
-                        ((ClassFrame) frame).addInstanceMethod(methodFrameNameIdent);
-                    }
+                final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
+                if (mods.branchContains(TokenTypes.LITERAL_STATIC)) {
+                    ((ClassFrame) frame).addStaticMethod(methodFrameNameIdent);
+                }
+                else {
+                    ((ClassFrame) frame).addInstanceMethod(methodFrameNameIdent);
                 }
                 frameStack.addFirst(new MethodFrame(frame, methodFrameNameIdent));
                 break;


### PR DESCRIPTION
#3848 

Method can be defined only in class, interface, enum, annotation interface, annonymous class. For CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF tokens we create new ClassFrame with type CLASS_FRAME. For annonymous class we create AnonymousClassFrame which extends ClassFrame and also has the type CLASS_FRAME. Thus, when we collect declarations in ```collectDeclarations```, METHOD_DEF token in always related to the frame with type CLASS_FRAME. It means that there is no need in checking the frame type.

Reports:
1) Diff http://mezk.github.io/i3848-RiquireThisCheck/diff
2) Coverage  http://mezk.github.io/i3848-RiquireThisCheck/cobertura/