### PR TITLE
Issue #3848: Increase code coverage of RequireThisCheck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1437,12 +1437,6 @@
                     <branchRate>79</branchRate>
                     <lineRate>97</lineRate>
                   </regex>
-                  <!--Until https://github.com/checkstyle/checkstyle/issues/3848-->
-                  <regex>
-                    <pattern>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</pattern>
-                    <branchRate>99</branchRate>
-                    <lineRate>100</lineRate>
-                  </regex>
                 </regexes>
               </check>
               <instrumentation>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -428,7 +428,8 @@ public class RequireThisCheck extends AbstractCheck {
      */
     private static boolean isAnonymousClassDef(DetailAST ast) {
         final DetailAST lastChild = ast.getLastChild();
-        return lastChild != null && lastChild.getType() == TokenTypes.OBJBLOCK;
+        return lastChild != null
+            && lastChild.getType() == TokenTypes.OBJBLOCK;
     }
 
     /**
@@ -800,8 +801,7 @@ public class RequireThisCheck extends AbstractCheck {
     private AbstractFrame getMethodWithoutThis(DetailAST ast) {
         AbstractFrame result = null;
         final AbstractFrame frame = findFrame(ast, true);
-        if (frame != null
-                && !validateOnlyOverlapping
+        if (!validateOnlyOverlapping
                 && ((ClassFrame) frame).hasInstanceMethod(ast)
                 && !((ClassFrame) frame).hasStaticMethod(ast)) {
             result = frame;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -252,4 +252,13 @@ public class RequireThisCheckTest extends BaseCheckTestSupport {
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputRequireThisStatic.java"), expected);
     }
+
+    @Test
+    public void testMethodReferencess() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(RequireThisCheck.class);
+        final String[] expected = {
+            "15:9: " + getCheckMessage(MSG_VARIABLE, "tags", ""),
+        };
+        verify(checkConfig, getPath("InputRequireThisMetodReferences.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputRequireThisMetodReferences.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputRequireThisMetodReferences.java
@@ -1,0 +1,23 @@
+package com.puppycrawl.tools.checkstyle.checks.coding;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+public class InputRequireThisMetodReferences {
+    private Set<String> tags = Collections.unmodifiableSortedSet(
+        Arrays.stream(new String[] {"br", "li", "dt", "dd", "hr", "img", "p", "td", "tr", "th",})
+            .collect(Collectors.toCollection(TreeSet::new)));
+
+    public InputRequireThisMetodReferences(Set<String> tags) {
+        tags = tags; // violation
+    }
+
+    public InputRequireThisMetodReferences() {
+        this.tags = Arrays.stream(
+            new String[] {"br", "li", "dt", "dd", "hr", "img", "p", "td", "tr", "th",})
+            .collect(Collectors.toCollection(TreeSet::new));
+    }
+}


### PR DESCRIPTION
#3848 

1) Added UT for method references.
2) Removed unnecessary null check as [method call](https://github.com/MEZk/checkstyle/blob/242cfe3ac366cb270fdbdd1425c96dff812f4bd0/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java#L259) always refers to specific frame. And it means that we do not need to check whether [the frame](https://github.com/checkstyle/checkstyle/compare/master...MEZk:i3848-RequireThichCheck-coverage?expand=1#diff-110729384f4c9d098bd29eafab295062R803) is null.
3) Coverage is 100%.

Diff report:
http://mezk.github.io/i3848-RiquireThisCheck/diff