### PR TITLE
Issue #3731: expand documentation on METHOD_REF token

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -723,7 +723,24 @@ public final class TokenTypes {
     public static final int METHOD_CALL = GeneratedJavaTokenTypes.METHOD_CALL;
 
     /**
-     * Part of Java 8 syntax. Method or constructor call without arguments.
+     * Part of Java 8 syntax. A reference to a method or constructor without arguments.
+     * The token should be used for subscribing for double colon literal.
+     * {@link #DOUBLE_COLON} token does not appear in the tree.
+     *
+     * <p>For example:</p>
+     * <pre>
+     * String::compareToIgnoreCase
+     * </pre>
+     *
+     * <p>parses as:
+     * <pre>
+     * +--METHOD_REF (::)
+     *     |
+     *     +--IDENT (String)
+     *     +--IDENT (compareToIgnoreCase)
+     * </pre>
+     *
+     * @see #IDENT
      * @see #DOUBLE_COLON
      */
     public static final int METHOD_REF = GeneratedJavaTokenTypes.METHOD_REF;
@@ -1448,6 +1465,8 @@ public final class TokenTypes {
     /**
      * The <code>::</code> (double colon) operator.
      * It is part of Java 8 syntax that is used for method reference.
+     * The token does not appear in tree, {@link #METHOD_REF} should be used instead.
+     *
      * @see #METHOD_REF
      */
     public static final int DOUBLE_COLON = GeneratedJavaTokenTypes.DOUBLE_COLON;


### PR DESCRIPTION
Issue #3731 

@romani 
I ran a GUI to show the AST of my example code successfully by following the [docs](http://checkstyle.sourceforge.net/writingchecks.html#The_Checkstyle_SDK_Gui) and write a example depends on what the tree shown by GUI window.

One thing I am confused is that the I didn't find the `DOUBLE_COLON ` type in the tree which shown by GUI, but there is a `@see #DOUBLE_COLON` in original code. Did I miss anything? Or there should be no `DOUBLE_COLON` actually?