### PR TITLE
Issue #3900: Split and Organize Checkstyle inputs by Test for TypecastParenPad

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheckTest.java
@@ -40,7 +40,9 @@ public class TypecastParenPadCheckTest
     @Override
     protected String getPath(String filename) throws IOException {
         return super.getPath("checks" + File.separator
-                + "whitespace" + File.separator + filename);
+                + "whitespace" + File.separator
+                + "typecastparenpad" + File.separator
+                + filename);
     }
 
     @Test
@@ -52,7 +54,7 @@ public class TypecastParenPadCheckTest
             "89:14: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
             "89:21: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
         };
-        verify(checkConfig, getPath("InputWhitespace.java"), expected);
+        verify(checkConfig, getPath("InputTypecastParenPadWhitespace.java"), expected);
     }
 
     @Test
@@ -71,7 +73,7 @@ public class TypecastParenPadCheckTest
             "241:18: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
             "241:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
         };
-        verify(checkConfig, getPath("InputWhitespace.java"), expected);
+        verify(checkConfig, getPath("InputTypecastParenPadWhitespace.java"), expected);
     }
 
     @Test
@@ -80,7 +82,7 @@ public class TypecastParenPadCheckTest
             createCheckConfig(TypecastParenPadCheck.class);
         checkConfig.addAttribute("option", PadOption.SPACE.toString());
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("InputWhitespaceAround.java"),
+        verify(checkConfig, getPath("InputTypecastParenPadWhitespaceAround.java"),
                expected);
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/InputTypecastParenPadWhitespace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/InputTypecastParenPadWhitespace.java
@@ -1,0 +1,289 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for checkstyle.
+// Created: 2001
+////////////////////////////////////////////////////////////////////////////////
+package com . puppycrawl
+    .tools.
+    checkstyle.checks.whitespace.typecastparenpad;
+
+/**
+ * Class for testing whitespace issues.
+ * error missing author tag
+ **/
+class InputTypecastParenPadWhitespace
+{
+    /** ignore assignment **/
+    private int mVar1=1;
+    /** ignore assignment **/
+    private int mVar2 =1;
+    /** Should be ok **/
+    private int mVar3 = 1;
+
+    /** method **/
+    void method1()
+    {
+        final int a = 1;
+        int b= 1; // Ignore 1
+        b=1; // Ignore 1
+        b+=1; // Ignore 1
+        b -=- 1 + (+ b); // Ignore 2
+        b = b ++ + b --; // Ignore 1
+        b = ++ b - -- b; // Ignore 1
+    }
+
+    /** method **/
+    void method2()
+    {
+        synchronized(this) {
+        }
+        try{
+        }
+        catch(RuntimeException e){
+        }
+    }
+
+    /**
+       skip blank lines between comment and code,
+       should be ok
+    **/
+
+
+    private int mVar4 = 1;
+
+
+    /** test WS after void return */
+    private void fastExit()
+    {
+        boolean complicatedStuffNeeded = true;
+        if( !complicatedStuffNeeded )
+        {
+            return; // should not complain about missing WS after return
+        }
+        else
+        {
+            // do complicated stuff
+        }
+    }
+
+
+    /** test WS after non void return
+     @return 2
+    */
+    private int nonVoid()
+    {
+        if ( true )
+        {
+            return(2); // should complain about missing WS after return
+        }
+        else
+        {
+            return 2; // this is ok
+        }
+    }
+
+    /** test casts **/
+    private void testCasts()
+    {
+        Object o = (Object) new Object(); // ok
+        o = (Object)o; // error
+        o = ( Object ) o; // ok
+        o = (Object)
+            o; // ok
+    }
+
+    /** test questions **/
+    private void testQuestions()
+    {
+        boolean b = (1 == 2)?true:false;
+        b = (1==2) ? false : true;
+    }
+
+    /** star test **/
+    private void starTest()
+    {
+        int x = 2 *3* 4;
+    }
+
+    /** boolean test **/
+    private void boolTest()
+    {
+        boolean a = true;
+        boolean x = ! a;
+        int z = ~1 + ~ 2;
+    }
+
+    /** division test **/
+    private void divTest()
+    {
+        int a = 4 % 2;
+        int b = 4% 2;
+        int c = 4 %2;
+        int d = 4%2;
+        int e = 4 / 2;
+        int f = 4/ 2;
+        int g = 4 /2;
+        int h = 4/2;
+    }
+
+    /** @return dot test **/
+    private java .lang.  String dotTest()
+    {
+        Object o = new java.lang.Object();
+        o.
+            toString();
+        o
+            .toString();
+        o . toString();
+        return o.toString();
+    }
+
+    /** assert statement test */
+    public void assertTest()
+    {
+        // OK
+        assert true;
+
+        // OK
+        assert true : "Whups";
+
+        // evil colons, should be OK
+        assert "OK".equals(null) ? false : true : "Whups";
+
+        // missing WS around assert
+        assert(true);
+
+        // missing WS around colon
+        assert true:"Whups";
+    }
+
+    /** another check */
+    void donBradman(Runnable aRun)
+    {
+        donBradman(new Runnable() {
+            public void run() {
+            }
+        });
+
+        final Runnable r = new Runnable() {
+            public void run() {
+            }
+        };
+    }
+
+    /** rfe 521323, detect whitespace before ';' */
+    void rfe521323()
+    {
+        doStuff() ;
+        //       ^ whitespace
+        for (int i = 0 ; i < 5; i++) {
+            //        ^ whitespace
+        }
+    }
+
+
+    /** bug 806243 (NoWhitespaceBeforeCheck error for anonymous inner class) */
+    private int i ;
+    //           ^ whitespace
+    private int i1, i2, i3 ;
+    //                    ^ whitespace
+    private int i4, i5, i6;
+
+    /** bug 806243 (NoWhitespaceBeforeCheck error for anonymous inner class) */
+    void bug806243()
+    {
+        Object o = new InputTypecastParenPadWhitespace() {
+            private int j ;
+            //           ^ whitespace
+        };
+    }
+
+    void doStuff() {
+    }
+}
+
+/**
+ * Bug 806242 (NoWhitespaceBeforeCheck error with an interface).
+ * @author o_sukhodolsky
+ * @version 1.0
+ */
+interface IFoo_TypecastParenPad
+{
+    void foo() ;
+    //        ^ whitespace
+}
+
+/**
+ * Avoid Whitespace errors in for loop.
+ * @author lkuehne
+ * @version 1.0
+ */
+class SpecialCasesInForLoop_TypecastParenPad
+{
+    void forIterator()
+    {
+        // avoid conflict between WhiteSpaceAfter ';' and ParenPad(nospace)
+        for (int i = 0; i++ < 5;) {
+	    //                  ^ no whitespace
+	}
+
+        // bug 895072
+	// avoid confilct between ParenPad(space) and NoWhiteSpace before ';'
+	int i = 0;
+	for ( ; i < 5; i++ ) {
+	//   ^ whitespace
+	}
+        for (int anInt : getSomeInts()) {
+            //Should be ignored
+        }
+    }
+
+    int[] getSomeInts() {
+        int i = (int) ( 2 / 3 );
+        return null;
+    }
+
+    public void myMethod() {
+        new Thread() {
+            public void run() {
+            }
+        }.start();
+    }
+
+    public void foo(java.util.List<? extends String[]> bar, Comparable<? super Object[]> baz) { }
+
+    public void mySuperMethod() {
+        Runnable[] runs = new Runnable[] {new Runnable() {
+                public void run() {
+                }
+            },
+            new Runnable() {
+                public void run() {
+                }
+            }};
+        runs[0]
+.
+ run()
+;
+    }
+
+    public void testNullSemi() {
+        return ;
+    }
+
+    public void register(Object obj) { }
+
+    public void doSomething(String args[]) {
+        register(boolean[].class);
+        register( args );
+    }
+
+    public void parentheses() {
+        testNullSemi
+(
+)
+;
+    }
+
+    public static void testNoWhitespaceBeforeEllipses(String ... args) {
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/InputTypecastParenPadWhitespaceAround.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/InputTypecastParenPadWhitespaceAround.java
@@ -1,0 +1,31 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.typecastparenpad;
+
+@SuppressWarnings({"this", "that"})
+class InputTypecastParenPadWhitespaceAround
+{
+    protected InputTypecastParenPadWhitespaceAround ( int i )
+    {
+        this (); //whitespace
+        toString ();
+    }
+    protected InputTypecastParenPadWhitespaceAround ()
+    {
+        super ();
+    }
+    
+    public void enhancedFor ()
+    {
+        int[] i = new int[2];
+        for ( int j: i ) {
+            System.identityHashCode ( j );
+        }
+    }
+}
+
+@interface CronExpression_TypecastParenPad {
+	Class<?>[] groups() default {}; 
+}
+
+@interface CronExpression1_TypecastParenPad {
+	Class<?>[] groups() default { }; // extra space
+}


### PR DESCRIPTION
Issue #3900 : Modified TypecastParenPadCheckTest.java to accommodate for the change in the location of test-resources the corresponding tests depend upon. The test-resources for those tests now reside at src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPad. Also the corresponding test-resources had to be modified accordingly to overcome having duplicate classes
