### PR TITLE
Issue #3309: Added excludedPackages to class coupling checks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
@@ -50,6 +50,7 @@ public final class ClassDataAbstractionCouplingCheck
     public int[] getRequiredTokens() {
         return new int[] {
             TokenTypes.PACKAGE_DEF,
+            TokenTypes.IMPORT,
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
@@ -61,6 +62,7 @@ public final class ClassDataAbstractionCouplingCheck
     public int[] getAcceptableTokens() {
         return new int[] {
             TokenTypes.PACKAGE_DEF,
+            TokenTypes.IMPORT,
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
@@ -49,6 +49,7 @@ public final class ClassFanOutComplexityCheck extends AbstractClassCouplingCheck
     public int[] getRequiredTokens() {
         return new int[] {
             TokenTypes.PACKAGE_DEF,
+            TokenTypes.IMPORT,
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
@@ -63,6 +64,7 @@ public final class ClassFanOutComplexityCheck extends AbstractClassCouplingCheck
     public int[] getAcceptableTokens() {
         return new int[] {
             TokenTypes.PACKAGE_DEF,
+            TokenTypes.IMPORT,
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
@@ -468,4 +468,39 @@ public final class CommonUtils {
         }
         return extension;
     }
+
+    /**
+     * Checks whether the given string is a valid identifier.
+     * @param str A string to check.
+     * @return true when the given string contains valid identifier.
+     */
+    public static boolean isIdentifier(String str) {
+        boolean isIdentifier = !str.isEmpty();
+
+        for (int i = 0; isIdentifier && i < str.length(); i++) {
+            if (i == 0) {
+                isIdentifier = Character.isJavaIdentifierStart(str.charAt(0));
+            } else {
+                isIdentifier = Character.isJavaIdentifierPart(str.charAt(i));
+            }
+        }
+
+        return isIdentifier;
+    }
+
+    /**
+     * Checks whether the given string is a valid name.
+     * @param str A string to check.
+     * @return true when the given string contains valid name.
+     */
+    public static boolean isName(String str) {
+        boolean isName = !str.isEmpty();
+
+        final String[] identifiers = str.split("\\.", -1);
+        for (int i = 0; isName && i < identifiers.length; i++) {
+            isName = isIdentifier(identifiers[i]);
+        }
+
+        return isName;
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.metrics;
 
 import static com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck.MSG_KEY;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -31,6 +32,7 @@ import org.junit.Test;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -57,6 +59,81 @@ public class ClassDataAbstractionCouplingCheckTest extends BaseCheckTestSupport 
         };
 
         verify(checkConfig, getPath("InputClassCoupling.java"), expected);
+    }
+
+    @Test
+    public void testExludedPackageDirectPackages() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ClassDataAbstractionCouplingCheck.class);
+
+        checkConfig.addAttribute("max", "0");
+        checkConfig.addAttribute("excludedPackages",
+            "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c,"
+                + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.b");
+
+        final String[] expected = {
+            "8:1: " + getCheckMessage(MSG_KEY, 2, 0, "[AAClass, ABClass]"),
+        };
+
+        verify(checkConfig,
+            getPath("InputClassCouplingExcludedPackagesDirectPackages.java"), expected);
+    }
+
+    @Test
+    public void testExludedPackageCommonPackages() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ClassDataAbstractionCouplingCheck.class);
+
+        checkConfig.addAttribute("max", "0");
+        checkConfig.addAttribute("excludedPackages",
+            "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a");
+
+        final String[] expected = {
+            "8:1: " + getCheckMessage(MSG_KEY, 2, 0, "[AAClass, ABClass]"),
+            "12:5: " + getCheckMessage(MSG_KEY, 2, 0, "[BClass, CClass]"),
+            "18:1: " + getCheckMessage(MSG_KEY, 1, 0, "[CClass]"),
+        };
+        verify(checkConfig,
+            getPath("InputClassCouplingExcludedPackagesCommonPackage.java"), expected);
+    }
+
+    @Test
+    public void testExludedPackageWithEndingDot() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ClassDataAbstractionCouplingCheck.class);
+
+        checkConfig.addAttribute("max", "0");
+        checkConfig.addAttribute("excludedPackages",
+            "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.");
+
+        try {
+            createChecker(checkConfig);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "Cannot set property 'excludedPackages' to "
+                    + "'com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.' in module "
+                    + "com.puppycrawl.tools.checkstyle.checks.metrics."
+                    + "ClassDataAbstractionCouplingCheck"));
+        }
+    }
+
+    @Test
+    public void testExludedPackageCommonPackagesAllIgnored() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ClassDataAbstractionCouplingCheck.class);
+
+        checkConfig.addAttribute("max", "0");
+        checkConfig.addAttribute("excludedPackages",
+            "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.aa,"
+                + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.ab,"
+                + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.b,"
+                + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c");
+
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputClassCouplingExcludedPackagesAllIgnored.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -20,6 +20,8 @@
 package com.puppycrawl.tools.checkstyle.checks.metrics;
 
 import static com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck.MSG_KEY;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,6 +31,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
@@ -52,6 +55,82 @@ public class ClassFanOutComplexityCheckTest extends BaseCheckTestSupport {
         };
 
         verify(checkConfig, getPath("InputClassCoupling.java"), expected);
+    }
+
+    @Test
+    public void testExcludedPackagesDirectPackages() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ClassFanOutComplexityCheck.class);
+
+        checkConfig.addAttribute("max", "0");
+        checkConfig.addAttribute("excludedPackages",
+            "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c,"
+                + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.b");
+
+        final String[] expected = {
+            "8:1: " + getCheckMessage(MSG_KEY, 2, 0),
+        };
+
+        verify(checkConfig,
+            getPath("InputClassFanOutComplexityExcludedPackagesDirectPackages.java"), expected);
+    }
+
+    @Test
+    public void testExcludedPackagesCommonPackages() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ClassFanOutComplexityCheck.class);
+
+        checkConfig.addAttribute("max", "0");
+        checkConfig.addAttribute("excludedPackages",
+            "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a");
+
+        final String[] expected = {
+            "8:1: " + getCheckMessage(MSG_KEY, 2, 0),
+            "12:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "18:1: " + getCheckMessage(MSG_KEY, 1, 0),
+        };
+        verify(checkConfig,
+            getPath("InputClassFanOutComplexityExcludedPackagesCommonPackage.java"), expected);
+    }
+
+    @Test
+    public void testExcludedPackagesCommonPackagesWithEndingDot() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ClassFanOutComplexityCheck.class);
+
+        checkConfig.addAttribute("max", "0");
+        checkConfig.addAttribute("excludedPackages",
+            "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.");
+
+        try {
+            createChecker(checkConfig);
+            fail("exception expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue(ex.getMessage().startsWith(
+                "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "Cannot set property 'excludedPackages' to "
+                    + "'com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.' in module "
+                    + "com.puppycrawl.tools.checkstyle.checks.metrics."
+                    + "ClassFanOutComplexityCheck"));
+        }
+    }
+
+    @Test
+    public void testExcludedPackagesAllIgnored() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ClassFanOutComplexityCheck.class);
+
+        checkConfig.addAttribute("max", "0");
+        checkConfig.addAttribute("excludedPackages",
+            "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.aa,"
+                + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.ab,"
+                + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.b,"
+                + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c");
+
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+            getPath("InputClassFanOutComplexityExcludedPackagesAllIgnored.java"), expected);
     }
 
     @Test
@@ -83,6 +162,7 @@ public class ClassFanOutComplexityCheckTest extends BaseCheckTestSupport {
         final int[] actual = classFanOutComplexityCheckObj.getAcceptableTokens();
         final int[] expected = {
             TokenTypes.PACKAGE_DEF,
+            TokenTypes.IMPORT,
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
@@ -228,6 +228,56 @@ public class CommonUtilsTest {
     }
 
     @Test
+    public void testIsIdentifier() throws Exception {
+        assertTrue(CommonUtils.isIdentifier("aValidIdentifier"));
+    }
+
+    @Test
+    public void testIsIdentifierEmptyString() throws Exception {
+        assertFalse(CommonUtils.isIdentifier(""));
+    }
+
+    @Test
+    public void testIsIdentifierInvalidFirstSymbol() throws Exception {
+        assertFalse(CommonUtils.isIdentifier("1InvalidIdentifier"));
+    }
+
+    @Test
+    public void testIsIdentifierInvalidSymbols() throws Exception {
+        assertFalse(CommonUtils.isIdentifier("invalid#Identifier"));
+    }
+
+    @Test
+    public void testIsName() throws Exception {
+        assertTrue(CommonUtils.isName("a.valid.Nam3"));
+    }
+
+    @Test
+    public void testIsNameEmptyString() throws Exception {
+        assertFalse(CommonUtils.isName(""));
+    }
+
+    @Test
+    public void testIsNameInvalidFirstSymbol() throws Exception {
+        assertFalse(CommonUtils.isName("1.invalid.name"));
+    }
+
+    @Test
+    public void testIsNameEmptyPart() throws Exception {
+        assertFalse(CommonUtils.isName("invalid..name"));
+    }
+
+    @Test
+    public void testIsNameEmptyLastPart() throws Exception {
+        assertFalse(CommonUtils.isName("invalid.name."));
+    }
+
+    @Test
+    public void testIsNameInvalidSymbol() throws Exception {
+        assertFalse(CommonUtils.isName("invalid.name#42"));
+    }
+
+    @Test
     @PrepareForTest({ CommonUtils.class, CommonUtilsTest.class })
     @SuppressWarnings("unchecked")
     public void testLoadSuppressionsUriSyntaxException() throws Exception {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/InputClassCouplingExcludedPackagesAllIgnored.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/InputClassCouplingExcludedPackagesAllIgnored.java
@@ -1,0 +1,21 @@
+package com.puppycrawl.tools.checkstyle.checks.metrics;
+
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.aa.AAClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.ab.ABClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.b.BClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c.CClass;
+
+public class InputClassCouplingExcludedPackagesAllIgnored { // total: ok
+    public AAClass aa = new AAClass(); // ok
+    public ABClass ab = new ABClass(); // ok
+
+    class Inner { // total: ok
+        public BClass b = new BClass(); // ok
+        public CClass c = new CClass(); // ok
+    }
+}
+
+class InputClassCouplingExcludedPackagesAllIgnoredHidden { // total: ok
+    public CClass c = new CClass(); // ok
+}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/InputClassCouplingExcludedPackagesCommonPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/InputClassCouplingExcludedPackagesCommonPackage.java
@@ -1,0 +1,20 @@
+package com.puppycrawl.tools.checkstyle.checks.metrics;
+
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.aa.AAClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.ab.ABClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.b.BClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c.CClass;
+
+public class InputClassCouplingExcludedPackagesCommonPackage { // total: ok
+    public AAClass aa = new AAClass(); // ok
+    public ABClass ab = new ABClass(); // ok
+
+    class Inner { // total: 2 violations
+        public BClass b = new BClass(); // violation
+        public CClass c = new CClass(); // violation
+    }
+}
+
+class InputClassCouplingExcludedPackagesCommonPackageHidden { // total: 1 violation
+    public CClass c = new CClass(); // violation
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/InputClassCouplingExcludedPackagesDirectPackages.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/InputClassCouplingExcludedPackagesDirectPackages.java
@@ -1,0 +1,20 @@
+package com.puppycrawl.tools.checkstyle.checks.metrics;
+
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.aa.AAClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.ab.ABClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.b.BClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c.CClass;
+
+public class InputClassCouplingExcludedPackagesDirectPackages { // total: 2 violations
+    public AAClass aa = new AAClass(); // violation
+    public ABClass ab = new ABClass(); // violation
+
+    class Inner { // total: ok
+        public BClass b = new BClass(); // ok
+        public CClass c = new CClass(); // ok
+    }
+}
+
+class InputClassCouplingExcludedPackagesDirectPackagesHidden { // total: ok
+    public CClass c = new CClass(); // ok
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/InputClassFanOutComplexityExcludedPackagesAllIgnored.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/InputClassFanOutComplexityExcludedPackagesAllIgnored.java
@@ -1,0 +1,22 @@
+package com.puppycrawl.tools.checkstyle.checks.metrics;
+
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.aa.AAClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.ab.ABClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.b.BClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c.CClass;
+
+public class InputClassFanOutComplexityExcludedPackagesAllIgnored { // total: ok
+    public AAClass aa; // ok
+    public ABClass ab; // ok
+
+    class Inner { // total: ok
+        public BClass b; // ok
+        public CClass c; // ok
+    }
+}
+
+class InputClassFanOutComplexityExcludedPackagesAllIgnoredHidden { // total: ok
+    public CClass c; // ok
+}
+
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/InputClassFanOutComplexityExcludedPackagesCommonPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/InputClassFanOutComplexityExcludedPackagesCommonPackage.java
@@ -1,0 +1,20 @@
+package com.puppycrawl.tools.checkstyle.checks.metrics;
+
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.aa.AAClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.ab.ABClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.b.BClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c.CClass;
+
+public class InputClassFanOutComplexityExcludedPackagesCommonPackage { // total: 2 violations
+    public AAClass aa; // violation
+    public ABClass ab; // violation
+
+    class Inner { // total: 2 violations
+        public BClass b; // violation
+        public CClass c; // violation
+    }
+}
+
+class InputClassFanOutComplexityExcludedPackagesCommonPackageHidden { // total: 1 violation
+    public CClass c; // violation
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/InputClassFanOutComplexityExcludedPackagesDirectPackages.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/InputClassFanOutComplexityExcludedPackagesDirectPackages.java
@@ -1,0 +1,20 @@
+package com.puppycrawl.tools.checkstyle.checks.metrics;
+
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.aa.AAClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.ab.ABClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.b.BClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c.CClass;
+
+public class InputClassFanOutComplexityExcludedPackagesDirectPackages { // total: 2 violations
+    public AAClass aa; // violation
+    public ABClass ab; // violation
+
+    class Inner { // total: ok
+        public BClass b; // ok
+        public CClass c; // ok
+    }
+}
+
+class InputClassFanOutComplexityExcludedPackagesDirectPackagesHidden { // total: ok
+    public CClass c; // ok
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/inputs/a/aa/AAClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/inputs/a/aa/AAClass.java
@@ -1,0 +1,4 @@
+package com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.aa;
+
+public class AAClass {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/inputs/a/ab/ABClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/inputs/a/ab/ABClass.java
@@ -1,0 +1,4 @@
+package com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.ab;
+
+public class ABClass {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/inputs/b/BClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/inputs/b/BClass.java
@@ -1,0 +1,4 @@
+package com.puppycrawl.tools.checkstyle.checks.metrics.inputs.b;
+
+public class BClass {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/inputs/c/CClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/inputs/c/CClass.java
@@ -1,0 +1,4 @@
+package com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c;
+
+public class CClass {
+}

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -164,6 +164,44 @@
           (object) of another class has data abstraction coupling (DAC).
           The higher the DAC, the more complex the structure of the class.
         </p>
+        <p>
+          This check processes files in the following way:
+          <ol>
+            <li>
+              Iterates over the list of tokens (defined below) and counts all mentioned classes.
+              <ul>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">PACKAGE_DEF</a>
+                </li>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">IMPORT</a>
+                </li>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>
+                </li>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>
+                </li>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>
+                </li>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">LITERAL_NEW</a>
+                </li>
+              </ul>
+            </li>
+            <li>
+              If a class was imported with direct import (i.e. <code>import java.math.BigDecimal</code>),
+              or the class was referenced with the package name (i.e. <code>java.math.BigDecimal value</code>)
+              and the package was added to the <code>excludedPackages</code> parameter,
+              the class does not increase complexity.
+            </li>
+            <li>
+              If a class name was added to the <code>excludedClasses</code> parameter,
+              the class does not increase complexity.
+            </li>
+          </ol>
+        </p>
       </subsection>
 
       <subsection name="Properties">
@@ -203,6 +241,12 @@
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>"^$"</code></td>
           </tr>
+          <tr>
+            <td>excludedPackages</td>
+            <td>User-configured packages to ignore</td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
+            <td>{}</td>
+          </tr>
         </table>
       </subsection>
 
@@ -221,6 +265,45 @@
 &lt;module name=&quot;ClassDataAbstractionCoupling&quot;&gt;
     &lt;property name=&quot;max&quot; value=&quot;5&quot;/&gt;
 &lt;/module&gt;
+        </source>
+
+        <p>
+          To configure the check with two excluded classes <code>HashMap</code> and <code>HashSet</code>:
+        </p>
+        <source>
+          &lt;module name=&quot;ClassDataAbstractionCoupling&quot;&gt;
+          &lt;property name=&quot;excludedClasses&quot; value=&quot;HashMap, HashSet&quot;/&gt;
+          &lt;/module&gt;
+        </source>
+
+        <p>
+          To configure the check with two regular expressions <code>^Array.*</code> and <code>.*Exception$</code>:
+        </p>
+        <source>
+          &lt;module name=&quot;ClassDataAbstractionCoupling&quot;&gt;
+          &lt;property name=&quot;excludeClassesRegexps&quot; value=&quot;^Array.*, .*Exception$&quot;/&gt;
+          &lt;/module&gt;
+        </source>
+
+        <p>
+          The following example demonstrates usage of <b>excludedClasses</b> and <b>excludeClassesRegexps</b> properties
+        </p>
+        <p>
+          Expected result is one class <code>Date</code>
+        </p>
+        <source>
+          &lt;module name=&quot;ClassDataAbstractionCoupling&quot;&gt;
+          &lt;property name=&quot;excludedClasses&quot; value=&quot;ArrayList&quot;/&gt;
+          &lt;property name=&quot;excludeClassesRegexps&quot; value=&quot;^Hash.*&quot;/&gt;
+          &lt;/module&gt;
+        </source>
+        <source>
+          public class InputClassCoupling {
+          public Set _set = new HashSet();
+          public Map _map = new HashMap();
+          public List&lt;String&gt; _list = new ArrayList&lt;&gt;();
+          public Date _date = new Date();
+          }
         </source>
 
         <p>
@@ -260,6 +343,75 @@ public class InputClassCoupling {
     public List&lt;String&gt; _list = new ArrayList&lt;&gt;();
     public Date _date = new Date();
 }
+        </source>
+
+        <p>
+          Override property <code>excludedPackages</code> to mark some packages as excluded.
+          Each member of <code>excludedPackages</code> should be a valid identifier:
+          <ul>
+            <li>
+              <code>java.util</code> - valid, excludes all classes inside <code>java.util</code>,
+              but not from the subpackages.
+            </li>
+            <li>
+              <code>java.util.</code> - invalid, should not end with a dot.
+            </li>
+            <li>
+              <code>java.util.*</code> - invalid, should not end with a star.
+            </li>
+          </ul>
+        </p>
+        <p>
+          Note, that checkstyle will ignore all classes from the <code>java.lang</code> package and its subpackages,
+          even if the <code>java.lang</code> was not listed in the <code>excludedPackages</code> parameter.
+        </p>
+        <p>
+          Also node, that <code>excludedPackages</code> will not exclude classes, imported via wildcard
+          (e.g. <code>import java.math.*</code>). Instead of wildcard import you should use direct import
+          (e.g. <code>import java.math.BigDecimal</code>).
+        </p>
+        <p>
+          Also note, that checkstyle will not exlude classes within the same file
+          even if it was listed in the <code>excludedPackages</code> parameter. For example, assuming the config is
+
+          <source>
+&lt;module name=&quot;ClassDataAbstractionCoupling&quot;&gt;
+    &lt;property name=&quot;excludedPackages&quot; value=&quot;a.b&quot;/&gt;
+&lt;/module&gt;
+          </source>
+
+          And the file <code>a.b.Foo.java</code> is:
+
+          <source>
+package a.b;
+
+import a.b.Bar;
+import a.b.c.Baz;
+
+public class Foo {
+    public Bar bar; // Will be ignored, located inside ignored a.b package
+    public Baz baz; // Will not be ignored, located inside a.b.c package
+    public Data data; // Will not be ignored, same file
+
+    class Data {
+        public Foo foo; // Will not be ignored, same file
+    }
+}
+          </source>
+
+          The <code>bar</code> member will not be counted,
+          since the <code>a.b</code> added to the <code>excludedPackages</code>.
+          The <code>baz</code> member will be counted,
+          since the <code>a.b.c</code> was not added to the <code>excludedPackages</code>.
+          The <code>data</code> and <code>foo</code> members will be counted, as they are inside same file.
+        </p>
+        <p>
+          Example of usage:
+        </p>
+        <source>
+&lt;module name=&quot;ClassDataAbstractionCoupling&quot;&gt;
+    &lt;property name=&quot;excludedPackages&quot; value=&quot;java.util, java.math&quot;/&gt;
+&lt;/module&gt;
         </source>
       </subsection>
 
@@ -306,6 +458,57 @@ public class InputClassCoupling {
           maintenance required in functional programs (on a file basis)
           at least.
         </p>
+        <p>
+          This check processes files in the following way:
+          <ol>
+            <li>
+              Iterates over the list of tokens (defined below) and counts all mentioned classes.
+              <ul>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">PACKAGE_DEF</a>
+                </li>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">IMPORT</a>
+                </li>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>
+                </li>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>
+                </li>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>
+                </li>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE">TYPE</a>
+                </li>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">LITERAL_NEW</a>
+                </li>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_THROWS">
+                    LITERAL_THROWS
+                  </a>
+                </li>
+                <li>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                    ANNOTATION_DEF
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li>
+              If a class was imported with direct import (i.e. <code>import java.math.BigDecimal</code>),
+              or the class was referenced with the package name (i.e. <code>java.math.BigDecimal value</code>)
+              and the package was added to the <code>excludedPackages</code> parameter,
+              the class does not increase complexity.
+            </li>
+            <li>
+              If a class name was added to the <code>excludedClasses</code> parameter,
+              the class does not increase complexity.
+            </li>
+          </ol>
+        </p>
       </subsection>
 
       <subsection name="Properties">
@@ -345,6 +548,12 @@ public class InputClassCoupling {
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>"^$"</code></td>
           </tr>
+          <tr>
+            <td>excludedPackages</td>
+            <td>User-configured packages to ignore</td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
+            <td>{}</td>
+          </tr>
         </table>
       </subsection>
 
@@ -362,6 +571,75 @@ public class InputClassCoupling {
         <source>
 &lt;module name=&quot;ClassFanOutComplexity&quot;&gt;
     &lt;property name=&quot;max&quot; value=&quot;10&quot;/&gt;
+&lt;/module&gt;
+        </source>
+
+        <p>
+          Override property <code>excludedPackages</code> to mark some packages as excluded.
+          Each member of <code>excludedPackages</code> should be a valid identifier:
+          <ul>
+            <li>
+              <code>java.util</code> - valid, excludes all classes inside <code>java.util</code>,
+              but not from the subpackages.
+            </li>
+            <li>
+              <code>java.util.</code> - invalid, should not end with a dot.
+            </li>
+            <li>
+              <code>java.util.*</code> - invalid, should not end with a star.
+            </li>
+          </ul>
+        </p>
+        <p>
+          Note, that checkstyle will ignore all classes from the <code>java.lang</code> package and its subpackages,
+          even if the <code>java.lang</code> was not listed in the <code>excludedPackages</code> parameter.
+        </p>
+        <p>
+          Also node, that <code>excludedPackages</code> will not exclude classes, imported via wildcard
+          (e.g. <code>import java.math.*</code>). Instead of wildcard import you should use direct import
+          (e.g. <code>import java.math.BigDecimal</code>).
+        </p>
+        <p>
+          Also note, that checkstyle will not exlude classes within the same file
+          even if it was listed in the <code>excludedPackages</code> parameter. For example, assuming the config is
+
+          <source>
+&lt;module name=&quot;ClassDataAbstractionCoupling&quot;&gt;
+    &lt;property name=&quot;excludedPackages&quot; value=&quot;a.b&quot;/&gt;
+&lt;/module&gt;
+          </source>
+
+          And the file <code>a.b.Foo.java</code> is:
+
+          <source>
+package a.b;
+
+import a.b.Bar;
+import a.b.c.Baz;
+
+public class Foo {
+    public Bar bar; // Will be ignored, located inside ignored a.b package
+    public Baz baz; // Will not be ignored, located inside a.b.c package
+    public Data data; // Will not be ignored, same file
+
+    class Data {
+        public Foo foo; // Will not be ignored, same file
+    }
+}
+          </source>
+
+          The <code>bar</code> member will not be counted,
+          since the <code>a.b</code> added to the <code>excludedPackages</code>.
+          The <code>baz</code> member will be counted,
+          since the <code>a.b.c</code> was not added to the <code>excludedPackages</code>.
+          The <code>data</code> and <code>foo</code> members will be counted, as they are inside same file.
+        </p>
+        <p>
+          Example of usage:
+        </p>
+        <source>
+&lt;module name=&quot;ClassFanOutComplexity&quot;&gt;
+    &lt;property name=&quot;excludedPackages&quot; value=&quot;java.util, java.math&quot;/&gt;
 &lt;/module&gt;
         </source>
       </subsection>


### PR DESCRIPTION
Issue #3309 

This PR adds `excludedPackages` parameter to the `ClassDataAbstractionCouplingCheck` and `ClassFanOutComplexityCheck`.

The diff is pretty big, because of added support for retrieving package name of imported class. Previously the check excludes classes by the name only. Now it tracks package name (for direct class imports) and therefore also excludes all `java.lang` classes. Unfortunately, it does not support wildcard imports, like `import java.lang.*`, because I don't know how to track them.

I've looked though all diff reports and for each project the metric value either decreases (because of direct imports from `java.lang`) or remains the same.

Diff: https://soon-checkstyle-diffs.github.io/issue-3309/index.html

Now I'm going to run some performance tests. For now the module uses plain `startsWith`, but we should probably use trie or similar structure to check if the package is excluded. 

This PR is still in work, but I want to receive some feedback. Probably, there is better way to get package name for a class.