### PR TITLE
Issue #3896: Test failed due to locale message settings. (with non-En…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -62,11 +62,11 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Andrei Selkin
  */
 public class Checker extends AutomaticBean implements MessageDispatcher, RootModule {
+    /** Message to use when an exception occurs and should be printed as a violation. */
+    public static final String EXCEPTION_MSG = "general.exception";
+
     /** Logger for Checker. */
     private static final Log LOG = LogFactory.getLog(Checker.class);
-
-    /** Message to use when an exception occurs and should be printed as a violation. */
-    private static final String EXCEPTION_MSG = "general.exception";
 
     /** Maintains error count. */
     private final SeverityLevelCounter counter = new SeverityLevelCounter(

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -361,6 +361,7 @@ public final class LocalizedMessage
      * @param locale the locale to use for localization
      */
     public static void setLocale(Locale locale) {
+        BUNDLE_CACHE.clear();
         if (Locale.ENGLISH.getLanguage().equals(locale.getLanguage())) {
             sLocale = Locale.ROOT;
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static com.puppycrawl.tools.checkstyle.Checker.EXCEPTION_MSG;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -766,13 +767,16 @@ public class CheckerTest extends BaseCheckTestSupport {
         checkerConfig.addAttribute("haltOnException", "false");
 
         final Checker checker = new Checker();
+        final Locale locale = Locale.ROOT;
+        checker.setLocaleCountry(locale.getCountry());
+        checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(checkerConfig);
         checker.addListener(new BriefUtLogger(stream));
 
         final String filePath = getPath("InputMain.java");
         final String[] expected = {
-            "0: Got an exception - java.lang.IndexOutOfBoundsException: test",
+            "0: " + getCheckMessage(EXCEPTION_MSG, "java.lang.IndexOutOfBoundsException: test"),
         };
 
         verify(checker, filePath, filePath, expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -25,9 +25,12 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 
 public class DetailNodeTreeStringPrinterTest {
 
@@ -53,6 +56,7 @@ public class DetailNodeTreeStringPrinterTest {
 
     @Test
     public void testParseFileWithError() throws Exception {
+        LocalizedMessage.setLocale(Locale.ROOT);
         try {
             DetailNodeTreeStringPrinter.printFileAst(
                     new File(getPath("InputJavadocWithError.javadoc")));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Locale;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -254,6 +255,9 @@ public class HeaderCheckTest extends BaseFileSetCheckTestSupport {
         checkerConfig.addAttribute("cacheFile", temporaryFolder.newFile().getPath());
 
         final Checker checker = new Checker();
+        final Locale locale = Locale.ROOT;
+        checker.setLocaleCountry(locale.getCountry());
+        checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(checkerConfig);
         checker.addListener(new BriefUtLogger(stream));
@@ -278,6 +282,9 @@ public class HeaderCheckTest extends BaseFileSetCheckTestSupport {
         checkerConfig.addAttribute("cacheFile", temporaryFolder.newFile().getPath());
 
         final Checker checker = new Checker();
+        final Locale locale = Locale.ROOT;
+        checker.setLocaleCountry(locale.getCountry());
+        checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(checkerConfig);
         checker.addListener(new BriefUtLogger(stream));


### PR DESCRIPTION
…glish locale settings)

#3896 

http://www.luolc.com/checkstyle-diff-report/issue3896/
No difference. It is an issue about localization which can only be reproduced on a non-English environment.