### PR TITLE
Issue #3962: Use try-with-resources to fix leaking unclosed InputStream

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -161,9 +161,12 @@ final class ImportControlLoader extends AbstractLoader {
      * @throws CheckstyleException if an error occurs.
      */
     public static ImportControl load(final URI uri) throws CheckstyleException {
-        final InputStream inputStream;
+
+        InputStream inputStream = null;
         try {
             inputStream = uri.toURL().openStream();
+            final InputSource source = new InputSource(inputStream);
+            return load(source, uri);
         }
         catch (final MalformedURLException ex) {
             throw new CheckstyleException("syntax error in url " + uri, ex);
@@ -171,8 +174,9 @@ final class ImportControlLoader extends AbstractLoader {
         catch (final IOException ex) {
             throw new CheckstyleException("unable to find " + uri, ex);
         }
-        final InputSource source = new InputSource(inputStream);
-        return load(source, uri);
+        finally {
+            closeStream(inputStream);
+        }
     }
 
     /**
@@ -195,6 +199,22 @@ final class ImportControlLoader extends AbstractLoader {
         }
         catch (final IOException ex) {
             throw new CheckstyleException("unable to read " + uri, ex);
+        }
+    }
+
+    /**
+     * This method exists only due to bug in cobertura library
+     * https://github.com/cobertura/cobertura/issues/170
+     * @param inputStream the InputStream to close
+     * @throws CheckstyleException if an error occurs.
+     */
+    private static void closeStream(InputStream inputStream) throws CheckstyleException {
+        if (inputStream != null) {
+            try {
+                inputStream.close();
+            } catch (IOException ex) {
+                throw new CheckstyleException("unable to close input stream", ex);
+            }
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
@@ -26,19 +26,31 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 import org.xml.sax.helpers.AttributesImpl;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ImportControlLoader.class, URI.class})
 public class ImportControlLoaderTest {
     private static String getPath(String filename) {
         return "src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/" + filename;
@@ -112,6 +124,48 @@ public class ImportControlLoaderTest {
         catch (InvocationTargetException ex) {
             assertSame(CheckstyleException.class, ex.getCause().getClass());
             assertTrue(ex.getCause().getMessage().startsWith("unable to read"));
+        }
+    }
+
+    @Test
+    public void testInputStreamThatFailsOnClose() throws Exception {
+        final InputStream inputStream = PowerMockito.mock(InputStream.class);
+        Mockito.doThrow(IOException.class).when(inputStream).close();
+        final int available = Mockito.doThrow(IOException.class).when(inputStream).available();
+
+        final URL url = PowerMockito.mock(URL.class);
+        BDDMockito.given(url.openStream()).willReturn(inputStream);
+
+        final URI uri = PowerMockito.mock(URI.class);
+        BDDMockito.given(uri.toURL()).willReturn(url);
+
+        try {
+            ImportControlLoader.load(uri);
+            //Using available to bypass 'ignored result' warning
+            fail("exception expected " + available);
+        } catch (CheckstyleException ex) {
+            assertSame(IOException.class, ex.getCause().getClass());
+        }
+        Mockito.verify(inputStream).close();
+    }
+
+    @Test
+    public void testInputStreamFailsOnRead() throws Exception {
+        final InputStream inputStream = PowerMockito.mock(InputStream.class);
+        final int available = Mockito.doThrow(IOException.class).when(inputStream).available();
+
+        final URL url = PowerMockito.mock(URL.class);
+        BDDMockito.given(url.openStream()).willReturn(inputStream);
+
+        final URI uri = PowerMockito.mock(URI.class);
+        BDDMockito.given(uri.toURL()).willReturn(url);
+
+        try {
+            ImportControlLoader.load(uri);
+            //Using available to bypass 'ignored result' warning
+            fail("exception expected " + available);
+        } catch (CheckstyleException ex) {
+            assertSame(SAXParseException.class, ex.getCause().getClass());
         }
     }
 }


### PR DESCRIPTION
Issue #3962

This PR does fix the leaking file resource but I was unable to write a test to satisfy the coverage requirements. 

I am submitting this to show what I tried to do and request help on how to fix the drop in coverage.

Thanks!
Giorgos