### PR TITLE
Issue #3965: remove from Input files "Compilable with Java8"

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/InputSuppressWarningsHolder5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/InputSuppressWarningsHolder5.java
@@ -1,10 +1,10 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import java.util.List;
 import java.util.Map;
+
 
 public class InputSuppressWarningsHolder5{
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputLeftCurlyNewLineOptionWithLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputLeftCurlyNewLineOptionWithLambda.java
@@ -1,5 +1,5 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.blocks;
+
 
 public class InputLeftCurlyNewLineOptionWithLambda
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputSingleLineLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputSingleLineLambda.java
@@ -1,5 +1,5 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.blocks;
+
 public class InputSingleLineLambda {
     
     static Runnable r1 = ()->String.CASE_INSENSITIVE_ORDER.equals("Hello world one!");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputDefaultComesLast.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputDefaultComesLast.java
@@ -1,5 +1,5 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.coding;
+
 
 public class InputDefaultComesLast
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputDefaultComesLast2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputDefaultComesLast2.java
@@ -1,5 +1,5 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.coding;
+
 public interface InputDefaultComesLast2 {
 
     String toJson(Object one, Object two, Object three);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputFinalLocalVariableNameLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputFinalLocalVariableNameLambda.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.math.BigDecimal;
+
 
 public class InputFinalLocalVariableNameLambda {
     private interface Lambda {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputHiddenFieldLambdas.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputHiddenFieldLambdas.java
@@ -1,4 +1,3 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.lang.Integer;
@@ -7,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 
 public class InputHiddenFieldLambdas {
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputIllegalInstantiation2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputIllegalInstantiation2.java
@@ -1,8 +1,8 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.function.Function;
 import java.util.function.Supplier;
+
 
 public class InputIllegalInstantiation2
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputInnerAssignmentLambdaExpressions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputInnerAssignmentLambdaExpressions.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.function.Supplier;
+
 
 public class InputInnerAssignmentLambdaExpressions {
     interface MyLambda {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputReturnCountLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputReturnCountLambda.java
@@ -1,10 +1,10 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.lang.Integer;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
+
 
 public class InputReturnCountLambda {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputSuperClone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputSuperClone.java
@@ -1,5 +1,5 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.coding;
+
 
 interface InputSuperClone {
     void clone();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputFinalInDefaultMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputFinalInDefaultMethods.java
@@ -1,4 +1,4 @@
-//Compilable with Java8 //indent:0 exp:0
+//a comment //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation; //indent:0 exp:0
 
 import java.util.ArrayList; //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputLambda1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputLambda1.java
@@ -1,4 +1,4 @@
-//Compilable with Java8 //indent:0 exp:0
+//a comment //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation; //indent:0 exp:0
 
 import java.util.ArrayList; //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputLambda2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputLambda2.java
@@ -1,8 +1,9 @@
-//Compilable with Java8 //indent:0 exp:0
+//a comment //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation; //indent:0 exp:0
 
 import java.util.function.BinaryOperator; //indent:0 exp:0
 import java.util.function.Consumer; //indent:0 exp:0
+
 
 public class InputLambda2 { //indent:0 exp:0
     public <T> Consumer<Integer> params(Consumer<Integer> f1, Consumer<Integer> f2) { //indent:4 exp:4

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputNewHandler.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputNewHandler.java
@@ -1,8 +1,8 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.indentation;
 
 import java.util.ArrayList;
 import java.util.function.Supplier;
+
 
 /**
  *

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/InputFinalInDefaultMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/InputFinalInDefaultMethods.java
@@ -1,5 +1,5 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.modifier;
+
 
 public interface InputFinalInDefaultMethods {
 	final int k = 5; // violation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/InputModifier2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/InputModifier2.java
@@ -1,6 +1,6 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.modifier;
 import java.util.Comparator;
+
 public interface InputModifier2 extends Comparator<Integer> {
     @Override
     default int compare(Integer a, Integer b) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/InputStaticModifierInInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/InputStaticModifierInInterface.java
@@ -1,5 +1,5 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.modifier;
+
 
 public interface InputStaticModifierInInterface
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputStaticModifierInInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/InputStaticModifierInInterface.java
@@ -1,5 +1,5 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.naming;
+
 
 public interface InputStaticModifierInInterface
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputAllowEmptyLambdaExpressions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputAllowEmptyLambdaExpressions.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import java.util.function.*;
+
 
 public class InputAllowEmptyLambdaExpressions {
     Runnable noop = () -> {};

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputGenericWhitespaceMethodRef.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputGenericWhitespaceMethodRef.java
@@ -1,8 +1,8 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import java.util.Optional;
 import java.util.function.Supplier;
+
 
 public class InputGenericWhitespaceMethodRef
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputMethodReferences3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputMethodReferences3.java
@@ -1,6 +1,6 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 import java.util.function.Supplier;
+
 public class InputMethodReferences3
 {
   public static class SomeClass {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputNoWhitespaceAfterMethodRef.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputNoWhitespaceAfterMethodRef.java
@@ -1,8 +1,8 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import java.util.function.Function;
 import java.util.function.IntFunction;
+
 
 public class InputNoWhitespaceAfterMethodRef
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputWhitespaceAroundLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/InputWhitespaceAroundLambda.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import java.util.function.Function;
+
 
 class InputWhitespaceAroundLambda {
     public void foo() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/InputRegressionJava8Class1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/InputRegressionJava8Class1.java
@@ -1,4 +1,4 @@
-//Compilable with Java8
+//start line index in expected file is 2
 package com.puppycrawl.tools.checkstyle.grammars;
 ;
 import java.lang.annotation.ElementType;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/InputRegressionJava8Interface1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/InputRegressionJava8Interface1.java
@@ -1,4 +1,4 @@
-//Compilable with Java8
+//start line index in expected file is 2
 package com.puppycrawl.tools.checkstyle.grammars;
 
 public interface InputRegressionJava8Interface1 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations10.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations10.java
@@ -1,8 +1,8 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
+
 
 public class InputAnnotations10 {
 	public static Object methodName(Object str) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations11.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations11.java
@@ -1,5 +1,5 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
+
 
 class InputAnnotations11 <@Nullable T> {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations2.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
+
 
 @Schedule
 public class InputAnnotations2 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations3.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
+
 
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations4.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
+
 
 
 public class InputAnnotations4 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations5.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
+
 
 
 public class InputAnnotations5 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations6.java
@@ -1,9 +1,9 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import java.util.List;
+
 
 public class InputAnnotations6 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations7.java
@@ -1,8 +1,8 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import java.util.List;
+
 
 public class InputAnnotations7 {
 	

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations8.java
@@ -1,8 +1,8 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import java.util.Map;
+
 
 public class InputAnnotations8 {
 	

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotations9.java
@@ -1,8 +1,8 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import java.util.List;
+
 
 public class InputAnnotations9 {
 	public static <T> void methodName(Object str) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotationsOnArray.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputAnnotationsOnArray.java
@@ -1,4 +1,3 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import static java.lang.annotation.ElementType.TYPE_USE;
@@ -6,6 +5,7 @@ import static java.lang.annotation.ElementType.TYPE_USE;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 
 public final class InputAnnotationsOnArray {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputDefaultMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputDefaultMethods.java
@@ -1,5 +1,5 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
+
 public interface InputDefaultMethods {
 	
 	default public void doSomething(){

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda1.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.util.logging.Logger;
+
 
 public class InputLambda1 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda10.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda10.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.util.logging.Logger;
+
 
 public class InputLambda10 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda11.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda11.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.util.logging.Logger;
+
 
 public class InputLambda11 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda12.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda12.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.util.logging.Logger;
+
 
 public class InputLambda12 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda13.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda13.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.util.logging.Logger;
+
 
 public class InputLambda13 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda14.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda14.java
@@ -1,8 +1,8 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
+
 
 
 public class InputLambda14 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda15.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda15.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.util.function.Function;
 import java.util.logging.Logger;
+
 
 public class InputLambda15
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda16.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda16.java
@@ -1,8 +1,8 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.time.chrono.ChronoLocalDate;
 import java.time.chrono.ChronoLocalDateTime;
 import java.util.Comparator;
+
 
 
 public class InputLambda16 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda17.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda17.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.util.function.Supplier;
+
 public class InputLambda17{
 
     void initPartialTraversalState() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda18.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda18.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.util.function.Predicate;
+
 public class InputLambda18 {
 
     static <T> Predicate<T> isEqual(Object targetRef) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda2.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.util.logging.Logger;
+
 
 public class InputLambda2 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda3.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.util.logging.Logger;
+
 
 public class InputLambda3 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda4.java
@@ -1,8 +1,8 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
+
 
 public class InputLambda4 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda5.java
@@ -1,8 +1,8 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
+
 
 
 public class InputLambda5 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda6.java
@@ -1,8 +1,8 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
+
 
 public class InputLambda6 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda7.java
@@ -1,8 +1,8 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
+
 
 public class InputLambda7 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda8.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.util.logging.Logger;
+
 
 public class InputLambda8 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputLambda9.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.util.logging.Logger;
+
 
 public class InputLambda9 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences.java
@@ -1,9 +1,9 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
 
 public class InputMethodReferences<T> extends ParentClass
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences2.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
 
 public class InputMethodReferences2
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences3.java
@@ -1,6 +1,6 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.util.function.Supplier;
+
 public class InputMethodReferences3
 {
   public static class SomeClass {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences4.java
@@ -1,7 +1,7 @@
-//Compilable with Java8
 //Issue #2729
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 import java.util.Arrays;
+
 
 public class InputMethodReferences4 {
     public void doSomething(final Object... arguments) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences5.java
@@ -1,4 +1,3 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.lang.annotation.Retention;
@@ -7,6 +6,7 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 
 @Target({ METHOD, FIELD })
 @Retention(RUNTIME)

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences6.java
@@ -1,5 +1,5 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
+
 
 public final class InputMethodReferences6 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputMethodReferences7.java
@@ -1,4 +1,3 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.lang.annotation.ElementType;
@@ -7,6 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
 
 public class InputMethodReferences7 {
     interface LambdaInt {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputReceiverParameter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputReceiverParameter.java
@@ -1,5 +1,5 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
+
 
 public class InputReceiverParameter {
     public void m4(InputReceiverParameter this) {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputTypeUseAnnotationsOnQualifiedTypes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/java8/InputTypeUseAnnotationsOnQualifiedTypes.java
@@ -1,9 +1,9 @@
-//Compilable with Java8
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
 import java.awt.geom.Rectangle2D;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
+
 
 public class InputTypeUseAnnotationsOnQualifiedTypes {
     /* Causes parse failure */


### PR DESCRIPTION
#3965 

All `//Compilable with Java8` comments are replaced with empty lines, except the following ones:
https://github.com/checkstyle/checkstyle/blob/master/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputLambda1.java, https://github.com/checkstyle/checkstyle/blob/master/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputLambda1.java.
There are checks for the indent. The comments are not just the comments themselves but also a specific case to be verified. So I replace them with `//a comment`

https://github.com/checkstyle/checkstyle/blob/master/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/InputRegressionJava8Class1.java, https://github.com/checkstyle/checkstyle/blob/master/src/test/resources/com/puppycrawl/tools/checkstyle/grammars/InputRegressionJava8Interface1.java.
There are checks verifying ast structure. The start line index in expected file is 2. Adding new line before class modifier like other files will lead to test failure, or we need update many line numbers in the expected file.

Diff report:
http://www.luolc.com/checkstyle-diff-report/issue3965/