### PR TITLE
Issue #3612: Fixed left curly indentation

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
@@ -91,7 +91,7 @@ public class ArrayInitHandler extends BlockParentHandler {
     protected IndentLevel getChildrenExpectedIndent() {
         final IndentLevel expectedIndent =
             new IndentLevel(getIndent(), getIndentCheck().getArrayInitIndent(),
-                    getIndentCheck().getLineWrappingIndentation());
+                getLineWrappingIndentation());
 
         final int firstLine = getFirstLine(Integer.MAX_VALUE, getListChild());
         final int lcurlyPos = expandedTabsColumnNo(getLeftCurly());
@@ -127,14 +127,5 @@ public class ArrayInitHandler extends BlockParentHandler {
         else {
             return realColumnNo;
         }
-    }
-
-    /**
-     * A shortcut for {@code IndentationCheck} property.
-     * @return value of lineWrappingIndentation property
-     *         of {@code IndentationCheck}
-     */
-    private int getLineWrappingIndentation() {
-        return getIndentCheck().getLineWrappingIndentation();
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -151,13 +151,26 @@ public class BlockParentHandler extends AbstractExpressionHandler {
      * Check the indentation of the left curly brace.
      */
     protected void checkLeftCurly() {
-        // the lcurly can either be at the correct indentation, or nested
-        // with a previous expression
-        final DetailAST lcurly = getLeftCurly();
-        final int lcurlyPos = expandedTabsColumnNo(lcurly);
+        checkCurly("lcurly", getLeftCurly());
+    }
 
-        if (!curlyIndent().isAcceptable(lcurlyPos) && isOnStartOfLine(lcurly)) {
-            logError(lcurly, "lcurly", lcurlyPos, curlyIndent());
+    /**
+     * Check the indentation of the right curly brace.
+     */
+    protected void checkRightCurly() {
+        checkCurly("rcurly", getRightCurly());
+    }
+
+    /**
+     * Checks the indentation of the given curly.
+     * @param curlyName The type of the curly (either "lcurly" or "rcurly").
+     * @param curly The left or right cury expression.
+     */
+    protected void checkCurly(String curlyName, DetailAST curly) {
+        final int curlyPos = expandedTabsColumnNo(curly);
+
+        if (!curlyIndent().isAcceptable(curlyPos) && isOnStartOfLine(curly)) {
+            logError(curly, curlyName, curlyPos, curlyIndent());
         }
     }
 
@@ -177,19 +190,6 @@ public class BlockParentHandler extends AbstractExpressionHandler {
      */
     protected boolean canChildrenBeNested() {
         return false;
-    }
-
-    /**
-     * Check the indentation of the right curly brace.
-     */
-    protected void checkRightCurly() {
-        final DetailAST rcurly = getRightCurly();
-        final int rcurlyPos = expandedTabsColumnNo(rcurly);
-
-        if (!curlyIndent().isAcceptable(rcurlyPos)
-                && isOnStartOfLine(rcurly)) {
-            logError(rcurly, "rcurly", rcurlyPos, curlyIndent());
-        }
     }
 
     /**
@@ -281,7 +281,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
             }
             else if (isOnStartOfLine(getRightCurly())) {
                 final IndentLevel level = new IndentLevel(curlyIndent(), getBasicOffset());
-                level.addAcceptedIndent(level.getFirstIndentLevel() + getLineWrappingIndent());
+                level.addAcceptedIndent(level.getFirstIndentLevel() + getLineWrappingIndentation());
                 indentLevel = level;
             }
         }
@@ -298,7 +298,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
      * @return value of lineWrappingIndentation property
      *         of {@code IndentationCheck}
      */
-    private int getLineWrappingIndent() {
+    protected final int getLineWrappingIndentation() {
         return getIndentCheck().getLineWrappingIndentation();
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java
@@ -87,23 +87,9 @@ public class ObjectBlockHandler extends BlockParentHandler {
     }
 
     @Override
-    protected void checkRightCurly() {
-        final DetailAST rcurly = getRightCurly();
-        final int rcurlyPos = expandedTabsColumnNo(rcurly);
-        final IndentLevel level = curlyIndent();
-        level.addAcceptedIndent(level.getFirstIndentLevel() + getLineWrappingIndentation());
-
-        if (!level.isAcceptable(rcurlyPos) && isOnStartOfLine(rcurly)) {
-            logError(rcurly, "rcurly", rcurlyPos, level);
-        }
-    }
-
-    /**
-     * A shortcut for {@code IndentationCheck} property.
-     * @return value of lineWrappingIndentation property
-     *         of {@code IndentationCheck}
-     */
-    private int getLineWrappingIndentation() {
-        return getIndentCheck().getLineWrappingIndentation();
+    protected IndentLevel curlyIndent() {
+        final IndentLevel indent = super.curlyIndent();
+        indent.addAcceptedIndent(indent.getFirstIndentLevel() + getLineWrappingIndentation());
+        return indent;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1609,6 +1609,29 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
+    public void testAnonymousClassInMethodWithCurlyOnNewLine() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
+        checkConfig.addAttribute("tabWidth", "4");
+        checkConfig.addAttribute("basicOffset", "4");
+        checkConfig.addAttribute("braceAdjustment", "0");
+        checkConfig.addAttribute("caseIndent", "4");
+        checkConfig.addAttribute("lineWrappingIndentation", "8");
+        checkConfig.addAttribute("throwsIndent", "4");
+        checkConfig.addAttribute("arrayInitIndent", "4");
+        final String[] expected = {
+            "38: " + getCheckMessage(MSG_ERROR_MULTI, "object def rcurly", 18, "8, 12, 16"),
+            "40: " + getCheckMessage(MSG_ERROR, "new", 14, 16),
+            "46: " + getCheckMessage(MSG_ERROR_MULTI, "object def rcurly", 14, "8, 12, 16"),
+            "58: " + getCheckMessage(MSG_ERROR_MULTI, "object def lcurly", 18, "8, 12, 16"),
+            "64: " + getCheckMessage(MSG_ERROR_MULTI, "object def rcurly", 18, "8, 12, 16"),
+            "67: " + getCheckMessage(MSG_ERROR_MULTI, "object def lcurly", 14, "8, 12, 16"),
+            "73: " + getCheckMessage(MSG_ERROR_MULTI, "object def rcurly", 14, "8, 12, 16"),
+        };
+        verifyWarns(checkConfig,
+            getPath("InputAnonymousClassInMethodCurlyOnNewLine.java"), expected);
+    }
+
+    @Test
     public void testAnnotationDefinition() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(IndentationCheck.class);
         checkConfig.addAttribute("tabWidth", "4");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputAnonymousClassInMethodCurlyOnNewLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/InputAnonymousClassInMethodCurlyOnNewLine.java
@@ -1,0 +1,76 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation; //indent:0 exp:0
+
+import java.util.List; //indent:0 exp:0
+import java.util.Map; //indent:0 exp:0
+import java.util.function.Supplier; //indent:0 exp:0
+
+/**                                                                         //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration: //indent:1 exp:1
+ *                                                                          //indent:1 exp:1
+ * arrayInitIndent = 4                                                      //indent:1 exp:1
+ * basicOffset = 4                                                          //indent:1 exp:1
+ * braceAdjustment = 0                                                      //indent:1 exp:1
+ * caseIndent = 4                                                           //indent:1 exp:1
+ * forceStrictCondition = false                                             //indent:1 exp:1
+ * lineWrappingIndentation = 8                                              //indent:1 exp:1
+ * tabWidth = 4                                                             //indent:1 exp:1
+ * throwsIndent = 4                                                         //indent:1 exp:1
+ */                                                                         //indent:1 exp:1
+public class InputAnonymousClassInMethodCurlyOnNewLine //indent:0 exp:0
+{ //indent:0 exp:0
+    private void aMethod() //indent:4 exp:4
+    { //indent:4 exp:4
+        final Supplier<Map<String, List<AbstractExpressionHandler>>> sup1 = //indent:8 exp:8
+                new Supplier<Map<String, List<com.puppycrawl.tools.checkstyle.checks.indentation.AbstractExpressionHandler>>>() { //indent:16 exp:>=16
+                    @Override //indent:20 exp:20
+                    public Map<String, List<AbstractExpressionHandler>> get() //indent:20 exp:20
+                    { //indent:20 exp:20
+                        return null; //indent:24 exp:24
+                    } //indent:20 exp:20
+                }; //indent:16 exp:16
+        final Supplier<Map<String, List<AbstractExpressionHandler>>> sup2 = //indent:8 exp:8
+                  new Supplier<Map<String, List<com.puppycrawl.tools.checkstyle.checks.indentation.AbstractExpressionHandler>>>() { //indent:18 exp:>=16
+                    @Override //indent:20 exp:20
+                    public Map<String, List<AbstractExpressionHandler>> get() //indent:20 exp:20
+                    { //indent:20 exp:20
+                        return null; //indent:24 exp:24
+                    } //indent:20 exp:20
+                  }; //indent:18 exp:8,12,16 warn
+        final Supplier<Map<String, List<AbstractExpressionHandler>>> sup3 = //indent:8 exp:8
+              new Supplier<Map<String, List<com.puppycrawl.tools.checkstyle.checks.indentation.AbstractExpressionHandler>>>() { //indent:14 exp:>=16 warn
+                    @Override //indent:20 exp:20
+                    public Map<String, List<AbstractExpressionHandler>> get() //indent:20 exp:20
+                    { //indent:20 exp:20
+                        return null; //indent:24 exp:24
+                    } //indent:20 exp:20
+              }; //indent:14 exp:8,12,16 warn
+        final Supplier<Map<String, List<AbstractExpressionHandler>>> sup4 = //indent:8 exp:8
+                new Supplier<Map<String, List<com.puppycrawl.tools.checkstyle.checks.indentation.AbstractExpressionHandler>>>() //indent:16 exp:>=16
+                { //indent:16 exp:16
+                    @Override //indent:20 exp:20
+                    public Map<String, List<AbstractExpressionHandler>> get() //indent:20 exp:20
+                    { //indent:20 exp:20
+                        return null; //indent:24 exp:24
+                    } //indent:20 exp:20
+                }; //indent:16 exp:16
+        final Supplier<Map<String, List<AbstractExpressionHandler>>> sup5 = //indent:8 exp:8
+                new Supplier<Map<String, List<com.puppycrawl.tools.checkstyle.checks.indentation.AbstractExpressionHandler>>>() //indent:16 exp:>=16
+                  { //indent:18 exp:8,12,16 warn
+                      @Override //indent:22 exp:22
+                      public Map<String, List<AbstractExpressionHandler>> get() //indent:22 exp:22
+                      { //indent:22 exp:22
+                          return null; //indent:26 exp:26
+                      } //indent:22 exp:22
+                  }; //indent:18 exp:8,12,16 warn
+        final Supplier<Map<String, List<AbstractExpressionHandler>>> sup6 = //indent:8 exp:8
+                new Supplier<Map<String, List<com.puppycrawl.tools.checkstyle.checks.indentation.AbstractExpressionHandler>>>() //indent:16 exp:>=16
+              { //indent:14 exp:8,12,16 warn
+                  @Override //indent:18 exp:18
+                  public Map<String, List<AbstractExpressionHandler>> get() //indent:18 exp:18
+                  { //indent:18 exp:18
+                      return null; //indent:22 exp:22
+                  } //indent:18 exp:18
+              }; //indent:14 exp:8,12,16 warn
+    } //indent:4 exp:4
+} //indent:0 exp:0
+


### PR DESCRIPTION
Issue #3612 (related PR #3613)

Unfortunately, I'm unable to create regression diffs on all projects, because checkstyle fails with `OutOfMemory` error while generating report (it fails on master as well).

I've made reports for guava (https://soon-checkstyle-diffs.github.io/issue-3612/guava/) and jdk (https://soon-checkstyle-diffs.github.io/issue-3612/jdk/) using their checkstyle configs. Is it possible to set different checkstyle configs for different projects at once? Probably, in the properties file?

I'm also a little bit confused with the line number 32 in the test case. I'm not sure if it should raise a warning. 