### PR TITLE
Issue #3989: UTs should not use ROOT locale when they test violation/…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -361,7 +361,7 @@ public final class LocalizedMessage
      * @param locale the locale to use for localization
      */
     public static void setLocale(Locale locale) {
-        BUNDLE_CACHE.clear();
+        clearCache();
         if (Locale.ENGLISH.getLanguage().equals(locale.getLanguage())) {
             sLocale = Locale.ROOT;
         }
@@ -392,12 +392,12 @@ public final class LocalizedMessage
     /**
      * <p>
      * Custom ResourceBundle.Control implementation which allows explicitly read
-     * the properties files as UTF-8
+     * the properties files as UTF-8.
      * </p>
      *
      * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
      */
-    protected static class Utf8Control extends Control {
+    public static class Utf8Control extends Control {
         @Override
         public ResourceBundle newBundle(String aBaseName, Locale aLocale, String aFormat,
                  ClassLoader aLoader, boolean aReload) throws IOException {

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/indentation/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/indentation/messages_zh.properties
@@ -1,5 +1,5 @@
 indentation.error.multi=''{0}'' 缩进了{1}个缩进符，应为以下缩进之一：{2}。
-indentation.child.error.multi=''{0}'' 子元素进了{1}个缩进符，应为以下缩进之一：{2}。
+indentation.child.error.multi=''{0}'' 子元素缩进了{1}个缩进符，应为以下缩进之一：{2}。
 indentation.error=''{0}'' 缩进了{1}个缩进符，应为{2}个。
 indentation.child.error=''{0}'' 子元素缩进了{1}个缩进符，应为{2}个。
 comments.indentation.single=注释应与第{0}行代码同样缩进{2}个缩进符，而不是{1}个。

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -39,13 +39,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Properties;
+import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.MapDifference.ValueDifference;
 import com.google.common.collect.Maps;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 
 public class BaseCheckTestSupport {
     protected final ByteArrayOutputStream stream = new ByteArrayOutputStream();
@@ -64,11 +65,6 @@ public class BaseCheckTestSupport {
             throws Exception {
         final DefaultConfiguration dc = createCheckerConfig(checkConfig);
         final Checker checker = new Checker();
-        // make sure the tests always run with default error messages (language-invariant)
-        // so the tests don't fail in supported locales like German
-        final Locale locale = Locale.ROOT;
-        checker.setLocaleCountry(locale.getCountry());
-        checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(dc);
         checker.addListener(new BriefUtLogger(stream));
@@ -362,15 +358,54 @@ public class BaseCheckTestSupport {
      * @param arguments  the arguments of message in 'messages.properties' file.
      */
     protected String getCheckMessage(String messageKey, Object... arguments) {
-        final Properties pr = new Properties();
-        try {
-            pr.load(getClass().getResourceAsStream("messages.properties"));
-        }
-        catch (IOException ex) {
-            return null;
-        }
-        final MessageFormat formatter = new MessageFormat(pr.getProperty(messageKey),
-                Locale.ROOT);
+        return internalGetCheckMessage(getMessageBundle(), messageKey, arguments);
+    }
+
+    /**
+     * Gets the check message 'as is' from appropriate 'messages.properties'
+     * file.
+     *
+     * @param clazz the related check class.
+     * @param messageKey the key of message in 'messages.properties' file.
+     * @param arguments the arguments of message in 'messages.properties' file.
+     */
+    protected String getCheckMessage(
+            Class<?> clazz, String messageKey, Object... arguments) {
+        return internalGetCheckMessage(getMessageBundle(clazz.getName()), messageKey, arguments);
+    }
+
+    /**
+     * Gets the check message 'as is' from appropriate 'messages.properties'
+     * file.
+     *
+     * @param messageBundle the bundle name.
+     * @param messageKey the key of message in 'messages.properties' file.
+     * @param arguments the arguments of message in 'messages.properties' file.
+     */
+    protected String internalGetCheckMessage(
+            String messageBundle, String messageKey, Object... arguments) {
+        final ResourceBundle resourceBundle = ResourceBundle.getBundle(
+                messageBundle,
+                Locale.getDefault(),
+                Thread.currentThread().getContextClassLoader(),
+                new LocalizedMessage.Utf8Control());
+        final String pattern = resourceBundle.getString(messageKey);
+        final MessageFormat formatter = new MessageFormat(pattern, Locale.ROOT);
         return formatter.format(arguments);
+    }
+
+    private String getMessageBundle() {
+        final String className = getClass().getName();
+        return getMessageBundle(className);
+    }
+
+    private static String getMessageBundle(String className) {
+        final int endIndex = className.lastIndexOf('.');
+        final String messages = "messages";
+        if (endIndex < 0) {
+            return messages;
+        }
+        final String packageName = className.substring(0, endIndex);
+        return packageName + "." + messages;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -767,9 +767,6 @@ public class CheckerTest extends BaseCheckTestSupport {
         checkerConfig.addAttribute("haltOnException", "false");
 
         final Checker checker = new Checker();
-        final Locale locale = Locale.ROOT;
-        checker.setLocaleCountry(locale.getCountry());
-        checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(checkerConfig);
         checker.addListener(new BriefUtLogger(stream));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -62,7 +63,8 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
             writer.write(content);
         }
         final String[] expected1 = {
-            "1:45: Name 'k' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "1:45: " + getCheckMessage(ConstantNameCheck.class,
+                    MSG_INVALID_PATTERN, "k", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
         };
         verify(checkConfig, file.getPath(), expected1);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG_KEY_NO_NEWLINE_EOF;
+import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG_KEY_UNABLE_OPEN;
 import static java.util.Locale.ENGLISH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -188,7 +189,7 @@ public class NewlineAtEndOfFileCheckTest
         final Set<LocalizedMessage> messages = check.process(impossibleFile, lines);
         assertEquals(1, messages.size());
         final Iterator<LocalizedMessage> iterator = messages.iterator();
-        assertEquals("Unable to open ''.", iterator.next().getMessage());
+        assertEquals(getCheckMessage(MSG_KEY_UNABLE_OPEN, ""), iterator.next().getMessage());
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.TranslationCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.checks.TranslationCheck.MSG_KEY_MISSING_TRANSLATION_FILE;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.junit.Assert.assertThat;
@@ -133,7 +134,8 @@ public class TranslationCheckTest extends BaseCheckTestSupport {
         };
 
         final String[] expected = {
-            "0: Properties file 'messages_translation.properties' is missing.",
+            "0: " + getCheckMessage(MSG_KEY_MISSING_TRANSLATION_FILE,
+                    "messages_translation.properties"),
         };
         verify(
             createChecker(checkConfig),
@@ -153,7 +155,8 @@ public class TranslationCheckTest extends BaseCheckTestSupport {
         };
 
         final String[] expected = {
-            "0: Properties file 'messages_translation_de.properties' is missing.",
+            "0: " + getCheckMessage(MSG_KEY_MISSING_TRANSLATION_FILE,
+                    "messages_translation_de.properties"),
         };
         verify(
             createChecker(checkConfig),
@@ -172,7 +175,8 @@ public class TranslationCheckTest extends BaseCheckTestSupport {
         };
 
         final String[] expected = {
-            "0: Properties file 'messages-translation.properties' is missing.",
+            "0: " + getCheckMessage(MSG_KEY_MISSING_TRANSLATION_FILE,
+                    "messages-translation.properties"),
         };
         verify(
             createChecker(checkConfig),
@@ -192,7 +196,8 @@ public class TranslationCheckTest extends BaseCheckTestSupport {
         };
 
         final String[] expected = {
-            "0: Properties file 'messages-translation_tr.properties' is missing.",
+            "0: " + getCheckMessage(MSG_KEY_MISSING_TRANSLATION_FILE,
+                    "messages-translation_tr.properties"),
         };
         verify(
             createChecker(checkConfig),
@@ -231,7 +236,8 @@ public class TranslationCheckTest extends BaseCheckTestSupport {
             };
 
         final String[] expected = {
-            "0: Properties file 'messages_home_de.properties' is missing.",
+            "0: " + getCheckMessage(MSG_KEY_MISSING_TRANSLATION_FILE,
+                    "messages_home_de.properties"),
         };
         verify(
             createChecker(checkConfig),
@@ -276,7 +282,8 @@ public class TranslationCheckTest extends BaseCheckTestSupport {
         };
 
         final String[] expected = {
-            "0: Properties file 'ButtonLabels_ja.properties' is missing.",
+            "0: " + getCheckMessage(MSG_KEY_MISSING_TRANSLATION_FILE,
+                    "ButtonLabels_ja.properties"),
         };
         verify(
             createChecker(checkConfig),
@@ -305,7 +312,8 @@ public class TranslationCheckTest extends BaseCheckTestSupport {
         };
 
         final String[] expected = {
-            "0: Properties file 'ButtonLabels_ja.properties' is missing.",
+            "0: " + getCheckMessage(MSG_KEY_MISSING_TRANSLATION_FILE,
+                    "ButtonLabels_ja.properties"),
         };
 
         verify(
@@ -335,7 +343,8 @@ public class TranslationCheckTest extends BaseCheckTestSupport {
         };
 
         final String[] expected = {
-            "0: Properties file 'ButtonLabels_ja.properties' is missing.",
+            "0: " + getCheckMessage(MSG_KEY_MISSING_TRANSLATION_FILE,
+                    "ButtonLabels_ja.properties"),
         };
 
         verify(
@@ -359,9 +368,9 @@ public class TranslationCheckTest extends BaseCheckTestSupport {
         };
 
         final String[] expected = {
-            "0: Properties file 'MyLabelsI18_fr.properties' is missing.",
-            "0: Properties file 'MyLabelsI18_ja.properties' is missing.",
-            };
+            "0: " + getCheckMessage(MSG_KEY_MISSING_TRANSLATION_FILE, "MyLabelsI18_fr.properties"),
+            "0: " + getCheckMessage(MSG_KEY_MISSING_TRANSLATION_FILE, "MyLabelsI18_ja.properties"),
+        };
 
         verify(
             createChecker(checkConfig),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Locale;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -255,9 +254,6 @@ public class HeaderCheckTest extends BaseFileSetCheckTestSupport {
         checkerConfig.addAttribute("cacheFile", temporaryFolder.newFile().getPath());
 
         final Checker checker = new Checker();
-        final Locale locale = Locale.ROOT;
-        checker.setLocaleCountry(locale.getCountry());
-        checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(checkerConfig);
         checker.addListener(new BriefUtLogger(stream));
@@ -282,9 +278,6 @@ public class HeaderCheckTest extends BaseFileSetCheckTestSupport {
         checkerConfig.addAttribute("cacheFile", temporaryFolder.newFile().getPath());
 
         final Checker checker = new Checker();
-        final Locale locale = Locale.ROOT;
-        checker.setLocaleCountry(locale.getCountry());
-        checker.setLocaleLanguage(locale.getLanguage());
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
         checker.configure(checkerConfig);
         checker.addListener(new BriefUtLogger(stream));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -20,8 +20,8 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck.MSG_JAVADOC_MISSED_HTML_CLOSE;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck.MSG_JAVADOC_PARSE_RULE_ERROR;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck.MSG_JAVADOC_WRONG_SINGLETON_TAG;
-import static com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck.MSG_KEY_PARSE_ERROR;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck.MSG_KEY_UNRECOGNIZED_ANTLR_ERROR;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -62,9 +62,9 @@ public class AbstractJavadocCheckTest extends BaseCheckTestSupport {
     public void testNumberFormatException() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(TempCheck.class);
         final String[] expected = {
-            "3: " + getCheckMessage(MSG_KEY_PARSE_ERROR, 52, "no viable "
-                + "alternative at input '<ul><li>a' {@link EntityEntry} (by way of {@link #;' "
-                + "while parsing HTML_TAG"),
+            "3: " + getCheckMessage(MSG_JAVADOC_PARSE_RULE_ERROR, 52, "no viable "
+                + "alternative at input '<ul><li>a' {@link EntityEntry} (by way of {@link #;'",
+                "HTML_TAG"),
         };
         verify(checkConfig, getPath("InputTestNumberFormatException.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractTypeAwareCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractTypeAwareCheckTest.java
@@ -167,8 +167,7 @@ public class AbstractTypeAwareCheckTest extends BaseCheckTestSupport {
         }
         catch (CheckstyleException ex) {
             final IllegalStateException cause = (IllegalStateException) ex.getCause();
-            assertEquals("Unable to get"
-                            + " class information for @throws tag 'InvalidExceptionName'.",
+            assertEquals(getCheckMessage(MSG_CLASS_INFO, "@throws", "InvalidExceptionName"),
                     cause.getMessage());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
@@ -105,7 +105,7 @@ public class JavadocPackageCheckTest
     public void testHtmlDisallowed() throws Exception {
         final Configuration checkConfig = createCheckConfig(JavadocPackageCheck.class);
         final String[] expected = {
-            "0: Missing package-info.java file.",
+            "0: " + getCheckMessage(MSG_PACKAGE_INFO),
         };
         verify(createChecker(checkConfig),
             getPath("pkghtml" + File.separator + "InputIgnored.java"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/GeneratedJava14LexerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/GeneratedJava14LexerTest.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.grammars;
 
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -63,8 +65,8 @@ public class GeneratedJava14LexerTest
             createCheckConfig(MemberNameCheck.class);
         // input is 'ÃЯ'
         final String[] expected = {
-            "7:9: Name '" + (char) 0xC3 + (char) 0x042F
-                 + "' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "7:9: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN,
+                    "" + (char) 0xC3 + (char) 0x042F, "^[a-z][a-zA-Z0-9]*$"),
         };
         verify(checkConfig, getPath("InputGrammar.java"), expected);
     }


### PR DESCRIPTION
#3989 

Some information that might help:

`getMessageBundle ` in `BaseCheckTestSupport` refers to
https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java#L110
The resource bundle should be loaded with a correct path, which is placed in the same package as the check class. In most cases, UT is in the same package as the related check class, so we can just get the package by the test class itself. In other cases, they are in different packages, so we need to pass an extra class parameter as well.

This fix is to remove the ROOT locale in tests, and that's done. Meanwhile I have found quite a few hard-coded string literals which will lead to localization problem. Other changes have been made to fix them.

Diff report:
http://www.luolc.com/checkstyle-diff-report/issue3989/