### PR TITLE
Issue#2974: EmptyLineSeparator check now validates newlines before comments

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -221,13 +221,13 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
     private boolean allowNoEmptyLineBetweenFields;
 
     /** Allows multiple empty lines between class members. */
-    private boolean allowMultipleEmptyLines = false;
+    private boolean allowMultipleEmptyLines = true;
 
     /** Allows multiple empty lines inside class members. */
-    private boolean allowMultipleEmptyLinesInsideClassMembers = false;
+    private boolean allowMultipleEmptyLinesInsideClassMembers = true;
 
     /**
-     * Allow no empty line between the fields.
+     * Allow no empty line between fields.
      * @param allow
      *        User's value.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -218,13 +218,13 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
             "empty.line.separator.multiple.lines.inside";
 
     /** Allows no empty line between fields. */
-    private boolean allowNoEmptyLineBetweenFields;
+    private boolean allowNoEmptyLineBetweenFields = true;
 
     /** Allows multiple empty lines between class members. */
-    private boolean allowMultipleEmptyLines = true;
+    private boolean allowMultipleEmptyLines = false;
 
     /** Allows multiple empty lines inside class members. */
-    private boolean allowMultipleEmptyLinesInsideClassMembers = true;
+    private boolean allowMultipleEmptyLinesInsideClassMembers = false;
 
     /**
      * Allow no empty line between the fields.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -218,16 +218,16 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
             "empty.line.separator.multiple.lines.inside";
 
     /** Allows no empty line between fields. */
-    private boolean allowNoEmptyLineBetweenFields;
+    private boolean allowNoEmptyLineBetweenFields = true;
 
     /** Allows multiple empty lines between class members. */
-    private boolean allowMultipleEmptyLines = true;
+    private boolean allowMultipleEmptyLines = false;
 
     /** Allows multiple empty lines inside class members. */
-    private boolean allowMultipleEmptyLinesInsideClassMembers = true;
+    private boolean allowMultipleEmptyLinesInsideClassMembers = false;
 
     /**
-     * Allow no empty line between fields.
+     * Allow no empty line between the fields.
      * @param allow
      *        User's value.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -218,7 +218,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
             "empty.line.separator.multiple.lines.inside";
 
     /** Allows no empty line between fields. */
-    private boolean allowNoEmptyLineBetweenFields = true;
+    private boolean allowNoEmptyLineBetweenFields;
 
     /** Allows multiple empty lines between class members. */
     private boolean allowMultipleEmptyLines = false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -218,13 +218,13 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
             "empty.line.separator.multiple.lines.inside";
 
     /** Allows no empty line between fields. */
-    private boolean allowNoEmptyLineBetweenFields = true;
+    private boolean allowNoEmptyLineBetweenFields;
 
     /** Allows multiple empty lines between class members. */
-    private boolean allowMultipleEmptyLines = false;
+    private boolean allowMultipleEmptyLines = true;
 
     /** Allows multiple empty lines inside class members. */
-    private boolean allowMultipleEmptyLinesInsideClassMembers = false;
+    private boolean allowMultipleEmptyLinesInsideClassMembers = true;
 
     /**
      * Allow no empty line between the fields.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -71,7 +71,7 @@ public class EmptyLineSeparatorCheckTest
     public void testAllowNoEmptyLineBetweenFields() throws Exception {
 
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowNoEmptyLineBetweenFields", "true");
+        checkConfig.addAttribute("allowNoEmptyLineBetweenFields", "false");
 
         final String[] expected = {
             "21: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "import"),
@@ -98,7 +98,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testMultipleEmptyLinesBetweenClassMembers() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
         final String[] expected = {
             "21: " + getCheckMessage(MSG_MULTIPLE_LINES, "package"),
             "24: " + getCheckMessage(MSG_MULTIPLE_LINES, "import"),
@@ -114,7 +114,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testFormerArrayIndexOutOfBounds() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputEmptyLineSeparatorFormerException.java"), expected);
     }
@@ -122,8 +122,8 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testAllowMultipleFieldInClass() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
-        checkConfig.addAttribute("allowNoEmptyLineBetweenFields", "true");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
+        checkConfig.addAttribute("allowNoEmptyLineBetweenFields", "false");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputEmptyLineSeparatorMultipleFieldsInClass.java"), expected);
     }
@@ -131,7 +131,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testAllowMultipleImportSeparatedFromPackage() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
         final String[] expected = {
             "1: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "import"),
         };
@@ -161,7 +161,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testPrePreviousLineEmptiness() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputPrePreviousLineEmptiness.java"), expected);
     }
@@ -169,7 +169,8 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testDisAllowMultipleEmptyLinesInsideClassMembers() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLinesInsideClassMembers", "false");
+        checkConfig.addAttribute("allowMultipleEmptyLinesInsideClassMembers", "tr
+ue");
         final String[] expected = {
             "27: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
             "39: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -169,8 +169,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testDisAllowMultipleEmptyLinesInsideClassMembers() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLinesInsideClassMembers", "tr
-ue");
+        checkConfig.addAttribute("allowMultipleEmptyLinesInsideClassMembers", "true");
         final String[] expected = {
             "27: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
             "39: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -98,7 +98,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testMultipleEmptyLinesBetweenClassMembers() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
         final String[] expected = {
             "21: " + getCheckMessage(MSG_MULTIPLE_LINES, "package"),
             "24: " + getCheckMessage(MSG_MULTIPLE_LINES, "import"),
@@ -114,7 +114,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testFormerArrayIndexOutOfBounds() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputEmptyLineSeparatorFormerException.java"), expected);
     }
@@ -122,7 +122,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testAllowMultipleFieldInClass() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
         checkConfig.addAttribute("allowNoEmptyLineBetweenFields", "true");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputEmptyLineSeparatorMultipleFieldsInClass.java"), expected);
@@ -131,7 +131,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testAllowMultipleImportSeparatedFromPackage() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
         final String[] expected = {
             "1: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "import"),
         };
@@ -161,7 +161,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testPrePreviousLineEmptiness() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputPrePreviousLineEmptiness.java"), expected);
     }
@@ -169,7 +169,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testDisAllowMultipleEmptyLinesInsideClassMembers() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLinesInsideClassMembers", "true");
+        checkConfig.addAttribute("allowMultipleEmptyLinesInsideClassMembers", "false");
         final String[] expected = {
             "27: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
             "39: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -98,7 +98,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testMultipleEmptyLinesBetweenClassMembers() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
         final String[] expected = {
             "21: " + getCheckMessage(MSG_MULTIPLE_LINES, "package"),
             "24: " + getCheckMessage(MSG_MULTIPLE_LINES, "import"),
@@ -114,7 +114,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testFormerArrayIndexOutOfBounds() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputEmptyLineSeparatorFormerException.java"), expected);
     }
@@ -122,7 +122,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testAllowMultipleFieldInClass() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
         checkConfig.addAttribute("allowNoEmptyLineBetweenFields", "true");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputEmptyLineSeparatorMultipleFieldsInClass.java"), expected);
@@ -131,7 +131,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testAllowMultipleImportSeparatedFromPackage() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
         final String[] expected = {
             "1: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "import"),
         };
@@ -161,7 +161,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testPrePreviousLineEmptiness() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
+        checkConfig.addAttribute("allowMultipleEmptyLines", "true");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputPrePreviousLineEmptiness.java"), expected);
     }
@@ -169,7 +169,7 @@ public class EmptyLineSeparatorCheckTest
     @Test
     public void testDisAllowMultipleEmptyLinesInsideClassMembers() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyLineSeparatorCheck.class);
-        checkConfig.addAttribute("allowMultipleEmptyLinesInsideClassMembers", "false");
+        checkConfig.addAttribute("allowMultipleEmptyLinesInsideClassMembers", "true");
         final String[] expected = {
             "27: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
             "39: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),


### PR DESCRIPTION
fixes issue #2974 