### PR TITLE
minor: fix link to bluej web site to avoid a violation from linkcheck

### DIFF
--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -338,7 +338,7 @@
                   <td>Combines multiple tools (CheckStyle, findbugs, PMD, Cobertura, etc.)</td>
               </tr>
               <tr>
-                  <td><a href="http://www.bluej.org">BlueJ</a></td>
+                  <td><a href="https://www.bluej.org/">BlueJ</a></td>
                   <td>Rick Giles</td>
                   <td><a href="http://bluejcheckstyle.sourceforge.net/">bluejcheckstyle home page</a></td>
                   <td/>


### PR DESCRIPTION
The problem was detected at https://app.codeship.com/projects/124310/builds/23433281 .

According to [redirectcheck.com](http://redirectcheck.com) the link to the BlueJ web site has been moved from http://www.bluej.org to https://www.bluej.org/ .

redirectcheck.com report:
```
www.bluej.org

HTTP/1.1 301 Moved Permanently
Date: Tue, 14 Mar 2017 20:31:54 GMT
Server: Apache/2.4.7 (Ubuntu) OpenSSL/1.0.1f
Location: https://www.bluej.org/
Content-Length: 230
Content-Type: text/html; charset=iso-8859-1

https://www.bluej.org/

HTTP/1.1 200 OK
Date: Tue, 14 Mar 2017 20:31:55 GMT
Server: Apache/2.4.7 (Ubuntu) OpenSSL/1.0.1f
Last-Modified: Tue, 14 Mar 2017 16:28:56 GMT
ETag: "2085-54ab353066213"
Accept-Ranges: bytes
Content-Length: 8325
Vary: Accept-Encoding
Content-Type: text/html
```

```curl www.bluej.org```

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://www.bluej.org/">here</a>.</p>
</body></html>
```
