### PR TITLE
Issue #3976: Split and Organize Checkstyle inputs by Test for EmptyForIteratorPad

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
@@ -48,8 +48,8 @@ public class EmptyForIteratorPadCheckTest
 
     @Override
     protected String getPath(String filename) throws IOException {
-        return super.getPath("checks" + File.separator
-                + "whitespace" + File.separator + filename);
+        return super.getPath("checks" + File.separator + "whitespace" + File.separator
+            + "emptyforiteratorpad" + File.separator + filename);
     }
 
     @Test
@@ -66,7 +66,7 @@ public class EmptyForIteratorPadCheckTest
             "43:32: " + getCheckMessage(MSG_WS_FOLLOWED, ";"),
             "55:11: " + getCheckMessage(MSG_WS_FOLLOWED, ";"),
         };
-        verify(checkConfig, getPath("InputForWhitespace.java"), expected);
+        verify(checkConfig, getPath("InputEmptyForIteratorPad.java"), expected);
     }
 
     @Test
@@ -75,7 +75,7 @@ public class EmptyForIteratorPadCheckTest
         final String[] expected = {
             "23:31: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ";"),
         };
-        verify(checkConfig, getPath("InputForWhitespace.java"), expected);
+        verify(checkConfig, getPath("InputEmptyForIteratorPad.java"), expected);
     }
 
     @Test
@@ -95,7 +95,7 @@ public class EmptyForIteratorPadCheckTest
         try {
             final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-            verify(checkConfig, getPath("InputForWhitespace.java"), expected);
+            verify(checkConfig, getPath("InputEmptyForIteratorPad.java"), expected);
             fail("exception expected");
         }
         catch (CheckstyleException ex) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad/InputEmptyForIteratorPad.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad/InputEmptyForIteratorPad.java
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for FOR_ITERATION.
+// Created: 2003
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptyforiteratorpad;
+
+class InputEmptyForIteratorPad
+{
+    void method1()
+    {
+        for (int i = 0; i < 1; i++) {
+        }
+        
+        for (int i = 0; i < 1;i++) {
+        }
+
+        for (int i = 0; i < 1;i++ ) {
+        }
+
+        for (int i = 0; i < 1; i++ ) {
+        }
+
+        for (int i = 0; i < 1;) {
+            i++;
+        }
+
+        for (int i = 0; i < 1; ) {
+            i++;
+        }
+        
+        // test eol, there is no space after second SEMI
+        for (int i = 0; i < 1;
+            ) {
+            i++;
+        }
+    }
+
+    void method2()
+    {
+        for ( int i = 0; i < 1; i++ ) {
+        }
+        
+        for ( int i = 0; i < 1; ) {
+            i++;
+        }
+
+        int i = 0;
+        for ( ; i < 1; i++ ) {
+        }
+
+        for (; i < 2; i++ ) {
+        }
+
+        for (
+        ;; ) {
+        }
+    }
+}


### PR DESCRIPTION
fixes #3976 