### PR TITLE
Issue #3970: Split inputs test for EmptyInitializerPadTest

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
@@ -50,8 +50,8 @@ public class EmptyForInitializerPadCheckTest
     @Override
     protected String getPath(String filename) throws IOException {
         return super.getPath("checks" + File.separator
-                + "whitespace" + File.separator + "emptyinitializerpad" +
-                File.separator + filename);
+                + "whitespace" + File.separator + "emptyinitializerpad"
+                + File.separator + filename);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
@@ -50,7 +50,8 @@ public class EmptyForInitializerPadCheckTest
     @Override
     protected String getPath(String filename) throws IOException {
         return super.getPath("checks" + File.separator
-                + "whitespace" + File.separator + filename);
+                + "whitespace" + File.separator + "emptyinitializerpad" +
+                File.separator + filename);
     }
 
     @Test
@@ -65,7 +66,7 @@ public class EmptyForInitializerPadCheckTest
         final String[] expected = {
             "48:14: " + getCheckMessage(MSG_PRECEDED, ";"),
         };
-        verify(checkConfig, getPath("InputForWhitespace.java"), expected);
+        verify(checkConfig, getPath("InputEmptyInitializerPad.java"), expected);
     }
 
     @Test
@@ -74,7 +75,7 @@ public class EmptyForInitializerPadCheckTest
         final String[] expected = {
             "51:13: " + getCheckMessage(MSG_NOT_PRECEDED, ";"),
         };
-        verify(checkConfig, getPath("InputForWhitespace.java"), expected);
+        verify(checkConfig, getPath("InputEmptyInitializerPadDefaultConfig.java"), expected);
     }
 
     @Test
@@ -115,7 +116,7 @@ public class EmptyForInitializerPadCheckTest
         try {
             final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-            verify(checkConfig, getPath("InputForWhitespace.java"), expected);
+            verify(checkConfig, getPath("InputEmptyInitializerPad.java"), expected);
             fail("exception expected");
         }
         catch (CheckstyleException ex) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyinitializerpad/InputEmptyInitializerPad.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyinitializerpad/InputEmptyInitializerPad.java
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for FOR_ITERATION and whitespace.
+// Created: 2003
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptyinitializerpad;
+
+class InputEmptyInitializerPad
+{
+    void method1()
+    {
+        for (int i = 0; i < 1; i++) {
+        }
+        
+        for (int i = 0; i < 1;i++) {
+        }
+
+        for (int i = 0; i < 1;i++ ) {
+        }
+
+        for (int i = 0; i < 1; i++ ) {
+        }
+
+        for (int i = 0; i < 1;) {
+            i++;
+        }
+
+        for (int i = 0; i < 1; ) {
+            i++;
+        }
+        
+        // test eol, there is no space after second SEMI
+        for (int i = 0; i < 1;
+            ) {
+            i++;
+        }
+    }
+
+    void method2()
+    {
+        for ( int i = 0; i < 1; i++ ) {
+        }
+        
+        for ( int i = 0; i < 1; ) {
+            i++;
+        }
+
+        int i = 0;
+        for ( ; i < 1; i++ ) {
+        }
+
+        for (; i < 2; i++ ) {
+        }
+
+        for (
+        ;; ) {
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyinitializerpad/InputEmptyInitializerPadDefaultConfig.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyinitializerpad/InputEmptyInitializerPadDefaultConfig.java
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for FOR_ITERATION and whitespace.
+// Created: 2003
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptyinitializerpad;
+
+class InputEmptyInitializerPadDefaultConfig
+{
+    void method1()
+    {
+        for (int i = 0; i < 1; i++) {
+        }
+        
+        for (int i = 0; i < 1;i++) {
+        }
+
+        for (int i = 0; i < 1;i++ ) {
+        }
+
+        for (int i = 0; i < 1; i++ ) {
+        }
+
+        for (int i = 0; i < 1;) {
+            i++;
+        }
+
+        for (int i = 0; i < 1; ) {
+            i++;
+        }
+        
+        // test eol, there is no space after second SEMI
+        for (int i = 0; i < 1;
+            ) {
+            i++;
+        }
+    }
+
+    void method2()
+    {
+        for ( int i = 0; i < 1; i++ ) {
+        }
+        
+        for ( int i = 0; i < 1; ) {
+            i++;
+        }
+
+        int i = 0;
+        for ( ; i < 1; i++ ) {
+        }
+
+        for (; i < 2; i++ ) {
+        }
+
+        for (
+        ;; ) {
+        }
+    }
+}


### PR DESCRIPTION
This pull request is for resolving Issue #3970. Splitting and copying all test input files to separate folder for EmptyForInitializerPad.
