### PR TITLE
Issue #4003: Indentation UTs should not use ROOT locale when they tes…

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/indentation/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/indentation/messages_tr.properties
@@ -2,7 +2,7 @@
 
 indentation.child.error = {0} ifadesi doğru hizalanmamış. Bulunduğu sütun {1}, olması gereken sütun {2}.
 indentation.error       = {0} ifadesi doğru hizalanmamış. Bulunduğu sütun {1}, olması gereken sütun {2}.
-indentation.error.multi=''{0}'' yanlış girinti düzeyine sahip '{1}, beklenen düzeyde aşağıdakilerden biri olmalıdır: {2}.
+indentation.error.multi=''{0}'' yanlış girinti düzeyine sahip {1}, beklenen düzeyde aşağıdakilerden biri olmalıdır: {2}.
 indentation.child.error.multi=''{0}'' çocuk yanlış girinti düzeyi {1}, beklenen düzeyde aşağıdakilerden biri olmalıdır var: {2}.
 comments.indentation.single=Yorum beklenen yanlış girinti düzeyi {1}, {2}, girinti olmalıdır hattıyla aynı seviyede sahip {0}.
 comments.indentation.block=Blok Yorum beklenen yanlış girinti düzeyi {1}, {2}, girinti olmalıdır hattıyla aynı seviyede sahip {0}.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -369,7 +369,7 @@ public class BaseCheckTestSupport {
      * @param messageKey the key of message in 'messages.properties' file.
      * @param arguments the arguments of message in 'messages.properties' file.
      */
-    protected String getCheckMessage(
+    protected static String getCheckMessage(
             Class<?> clazz, String messageKey, Object... arguments) {
         return internalGetCheckMessage(getMessageBundle(clazz.getName()), messageKey, arguments);
     }
@@ -382,7 +382,7 @@ public class BaseCheckTestSupport {
      * @param messageKey the key of message in 'messages.properties' file.
      * @param arguments the arguments of message in 'messages.properties' file.
      */
-    protected String internalGetCheckMessage(
+    private static String internalGetCheckMessage(
             String messageBundle, String messageKey, Object... arguments) {
         final ResourceBundle resourceBundle = ResourceBundle.getBundle(
                 messageBundle,


### PR DESCRIPTION
#4003 

- [x] Add a test that verifies message is in property order.
- [x] Load message from resource bundle and chop off property 0. Check that message matches either of the valid two (indentation.error or indentation.child.error, indentation.error.multi or indentation.child.error.multi)

Regarding the changes of `messages_tr.properties`:
There is a redundant `'` in the message. In that case the substitution of arguments will fail. i.e. if we pass arguments `##0##`, `##1##`, `##2##`, then we get
```
'##0##' yanlış girinti düzeyine sahip {1}, beklenen düzeyde aşağıdakilerden biri olmalıdır: {2}.
```
It is not correct. And without fixing it, our new test for property order will fail. So we cannot split it into a separate issue.

Diff report:
http://www.luolc.com/checkstyle-diff-report/issue4003/