### PR TITLE
infra: hipparchus is bumped to 1.2 version , orekit still use 1.1-SNA…

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -63,8 +63,8 @@ build:
           CS_POM_VERSION=$(mvn -q -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
           echo CS_version: ${CS_POM_VERSION}
           git clone https://github.com/Hipparchus-Math/hipparchus.git
-          git checkout 905006092493e350dcd68dd7b2ec1dedaf4983b7
           cd hipparchus
+          git checkout 905006092493e350dcd68dd7b2ec1dedaf4983b7
           mvn clean install -DskipTests
           cd ../
           git clone https://github.com/CS-SI/Orekit.git

--- a/wercker.yml
+++ b/wercker.yml
@@ -63,6 +63,7 @@ build:
           CS_POM_VERSION=$(mvn -q -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
           echo CS_version: ${CS_POM_VERSION}
           git clone https://github.com/Hipparchus-Math/hipparchus.git
+          git checkout 905006092493e350dcd68dd7b2ec1dedaf4983b7
           cd hipparchus
           mvn clean install -DskipTests
           cd ../


### PR DESCRIPTION
…PSHOT, so we need to build latest 1.1-SNAPSHOT version


Problem is described at - https://github.com/checkstyle/checkstyle/pull/3926#issuecomment-287546931