### PR TITLE
Issue #3755: Update  version of Google Java Style Guide (3 November 2016)

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyCatchBlockTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyCatchBlockTest.java
@@ -44,6 +44,8 @@ public class EmptyCatchBlockTest extends BaseCheckTestSupport {
             "28: " + getCheckMessage(EmptyCatchBlockCheck.class, "catch.block.empty"),
             "49: " + getCheckMessage(EmptyCatchBlockCheck.class, "catch.block.empty"),
             "71: " + getCheckMessage(EmptyCatchBlockCheck.class, "catch.block.empty"),
+            "79: " + getCheckMessage(EmptyCatchBlockCheck.class, "catch.block.empty"),
+            "83: " + getCheckMessage(EmptyCatchBlockCheck.class, "catch.block.empty"),
         };
 
         final Configuration checkConfig = getCheckConfig("EmptyCatchBlock");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyBlockBasic.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyBlockBasic.java
@@ -325,3 +325,12 @@ class NewClass {
         };
     }
 }
+
+class Example {
+
+    void doNothing() {} // ok
+
+    void doNothingElse() { // ok
+
+    }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyBlockCatch.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/InputEmptyBlockCatch.java
@@ -72,4 +72,16 @@ class Catch {
             finally {}
         }
     };
+
+    void foo3() {
+        try {
+            foo();
+        } catch (Exception e) {} //warn
+
+        try {
+            foo();
+        } catch (Exception e) /*warn*/ {
+
+        }
+    }
 }

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -356,6 +356,21 @@
                             </td>
                         </tr>
                         <tr>
+                            <td><a name="3.3.4"/><a href="#3.3.4"><img src="images/anchor.png" alt=""/></a></td>
+                            <td>
+                                <a
+                                   href="http://checkstyle.sourceforge.net/reports/google-java-style-20160712.html#s3.3.4-import-class-not-static">
+                                   3.3.4 No static import for classes</a>
+                            </td>
+                            <td>
+                                <img
+                                    src="images/ban_red.png"
+                                    alt="" />
+                                Will be addressed in the issue <a href="https://github.com/checkstyle/checkstyle/issues/4005">#4005</a>.
+                            </td>
+                            <td/>
+                        </tr>
+                        <tr>
                             <td><a name="3.4"/><a href="#3.4"><img src="images/anchor.png" alt=""/></a></td>
                             <td>
                                 <a
@@ -527,10 +542,15 @@
                             </td>
                             <td>
                                 <img
-                                    src="images/ok_green.png"
+                                    src="images/ok_blue.png"
                                     alt="" />
                                 <a
                                     href="config_misc.html#Indentation">Indentation</a>
+                                <br />
+                                The rule "A line is never broken adjacent to the arrow in a lambda, except that a
+                                break may come immediately after the arrow if the body of the lambda consists
+                                of a single unbraced expression" will be addressed in the issue
+                                <a href="https://github.com/checkstyle/checkstyle/issues/4006">#4006</a>.
                             </td>
                             <td>
                                 <a


### PR DESCRIPTION
#3755 

Based on https://github.com/checkstyle/checkstyle/issues/3755#issuecomment-285851574 and https://github.com/checkstyle/checkstyle/issues/3755#issuecomment-285870120 the following changes and updates were done in scope of the issue:

1) Points 1-12 were not addressed as they did not require changes or updates.
2) > 13 Section 3.3.4 No static import for classes requires an implementation of a new option for AvoidStaticImportCheck. The main idea is to check whether there is an import of a class or there is an import of other static member. Now we check both.

Google Java Style Guide coverage page was updated. I added a link to the issue. @romani, a link to 3.3.4 section should be updated to reference updated cached Google Java Style Guide.

3) > 14 Section 4.1.3 Empty blocks: may be concise requires new examples in IT area.

Added. Examples were taken from Google Java Style Guide.

4) > 15 This change will require the implementation of the logic which will process lambdas for NoLineWrapCheck or OperatorWrap. Now they do not treat lambdas.

Google Java Style Guide coverage page was updated. I added a link to the issue.

5) > 16 This says that any line break may (but not must) be preceded by arbitrary whitespace followed by an implementation comment. So it is not mandatory.

google_checks.xml does not include a config for TrailingComments. EmptyBlock and EmptyCatch will treat the blocks of code which have a trailing comments as non-empty. Thus, there is no need in updating the config.

Updated Google Java Style Guide coverage page: http://mezk.github.io/i3755-google-style-guide/site/google_style.html

@romani 
All links which now reference Google Java Style Guide (2016-07-12) should be changed after you cache the updated guide.