### PR TITLE
Pull #4102: changed loops to end execution early

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -166,6 +166,7 @@ public class SuppressWarningsHolder
                 && event.getModuleId().equals(entry.getCheckName());
             if (afterStart && beforeEnd && (nameMatches || idMatches)) {
                 suppressed = true;
+                break;
             }
         }
         return suppressed;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -236,6 +236,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
                      modifier = modifier.getNextSibling()) {
                 if (memberModifiers.contains(modifier.getType())) {
                     result = true;
+                    break;
                 }
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -442,9 +442,10 @@ public class MagicNumberCheck extends AbstractCheck {
         do {
             if (node.getType() == type) {
                 result = true;
+                break;
             }
             node = node.getParent();
-        } while (node != null && !result);
+        } while (node != null);
 
         return result;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -520,6 +520,7 @@ public class RequireThisCheck extends AbstractCheck {
             if (prevSibling != null
                     && prevSibling.getType() == TokenTypes.LITERAL_THIS) {
                 userDefinedArrangementOfThis = true;
+                break;
             }
         }
         return userDefinedArrangementOfThis;
@@ -1189,6 +1190,7 @@ public class RequireThisCheck extends AbstractCheck {
                 final boolean finalMod = mods.branchContains(TokenTypes.FINAL);
                 if (finalMod && member.equals(instanceMember)) {
                     result = true;
+                    break;
                 }
             }
             return result;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
@@ -149,6 +149,7 @@ public final class ThrowsCountCheck extends AbstractCheck {
                 if (child.getType() == TokenTypes.ANNOTATION
                         && "Override".equals(getAnnotationName(child))) {
                     isOverriding = true;
+                    break;
                 }
                 child = child.getNextSibling();
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -940,14 +940,12 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
         ExceptionInfo foundException = null;
 
         // First look for matches on the exception name
-        final ListIterator<ExceptionInfo> throwIt = throwsList.listIterator();
-        while (!found && throwIt.hasNext()) {
-            final ExceptionInfo exceptionInfo = throwIt.next();
-
+        for (ExceptionInfo exceptionInfo : throwsList) {
             if (exceptionInfo.getName().getText().equals(
                     documentedClassInfo.getName().getText())) {
                 found = true;
                 foundException = exceptionInfo;
+                break;
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -303,6 +303,7 @@ public class JavadocTypeCheck
                 && tag.getFirstArg().indexOf(OPEN_ANGLE_BRACKET
                         + typeParamName + CLOSE_ANGLE_BRACKET) == 0) {
                 found = true;
+                break;
             }
         }
         if (!found) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
@@ -115,6 +115,7 @@ public class NoWhitespaceBeforeCheck
             for (int i = 0; !flag && i < before; i++) {
                 if (!Character.isWhitespace(line.charAt(i))) {
                     flag = true;
+                    break;
                 }
             }
             if (flag) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
@@ -132,6 +132,7 @@ public final class CommonUtils {
             for (final String fileExtension : withDotExtensions) {
                 if (fileName.endsWith(fileExtension)) {
                     result = true;
+                    break;
                 }
             }
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputIllegalTypeMemberModifiers.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/InputIllegalTypeMemberModifiers.java
@@ -31,4 +31,5 @@ public class InputIllegalTypeMemberModifiers {
     }
     //WARNING if memberModifiers is set and contains TokenTypes.LITERAL_PROTECTED
     protected AbstractClass a1 = null;
+    public AbstractClass a2 = null;
 }


### PR DESCRIPTION
When scanning Checkstyle's code for a failed check, I found the following places where we had a loop looking for something and assigning a variable if it was found or not. I noticed most of the loops were specifically not ending when a determination was found.

I changed spots involving loops and assigning variables true/false to end their execution sooner as the variable is modified.

Changes to `InputIllegalTypeMemberModifiers` were to keep code coverage at 100% for the check as we lost some on the `for` loop for the fixes.

appveyor required change to `JavadocMethodCheck` that it be changed to a for-each.