### PR TITLE
Issue #4037: Extended parent nested class

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -20,11 +20,13 @@
 package com.puppycrawl.tools.checkstyle.checks.design;
 
 import static com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.utils.CommonUtils.EMPTY_STRING_ARRAY;
 import static org.junit.Assert.assertArrayEquals;
 
 import java.io.File;
 import java.io.IOException;
 
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -90,6 +92,15 @@ public class FinalClassCheckTest
                 getNonCompilablePath(
                         "InputClassWithPrivateCtorWithNestedExtendingClassWithoutPackage.java"),
                 expected);
+    }
+
+    @Test
+    public void testOverriddenExtendedNestedClass() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(FinalClassCheck.class);
+        verify(checkConfig,
+            getPath("InputFinalClassExtendedOverriddenNested.java"),
+                EMPTY_STRING_ARRAY);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputFinalClassExtendedOverriddenNested.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/InputFinalClassExtendedOverriddenNested.java
@@ -1,0 +1,11 @@
+package com.puppycrawl.tools.checkstyle.checks.design;
+
+public class InputFinalClassExtendedOverriddenNested {
+    private class Test {
+        private Test() {
+        }
+    }
+
+    private class Test2 extends Test {
+    }
+}


### PR DESCRIPTION
## Issue #4037 
### Description
- [x] Added test from PR
- [x] Added additional fields to `ClassDesc` class
  - **declaredAsParent** - does class have subclasses
  - **nodeAST** - link to node of AST, to retrieve information about postion of class in file
  - **depthLevel** - level of nesting class: 0 - outside any classes, 1 - outer class, 2 - first nested, 3 - second ...
- [x] Classes handling replaced to `finishTree` method
- [x] Classes deque stores all classes , reason - the need to determine parent classes
#
### Code review 1
- [x] Remove unnecessary stylish changes
#
### Code Review 2
- [x] Move new instances to field's declaration.
- [x] Semantic changes
- [x] Right curly check changes
- [x] Javadoc code styling as pattern
- [x] Clear collections in `beginTree` method.