### PR TITLE
add new check to detect a certain annotation and field modifier

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -151,6 +151,14 @@
     <module name="PackageAnnotation"/>
     <module name="SuppressWarnings"/>
     <module name="SuppressWarningsHolder"/>
+    <module name="AvoidAnnotationCombination">
+      <property name="modifier" value="STATIC"/>
+      <property name="modifier" value="PUBLIC"/>
+      <property name="modifier" value="PROTECTED"/>
+      <property name="modifier" value="PRIVATE"/>
+      <property name="modifier" value="FINAL"/>
+      <property name="annotation" value=".*"/>
+    </module>
 
     <!-- Block Checks -->
     <module name="AvoidNestedBlocks">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -270,6 +270,8 @@ public class PackageObjectFactory implements ModuleFactory {
                 BASE_PACKAGE + ".checks.annotation.AnnotationLocationCheck");
         NAME_TO_FULL_MODULE_NAME.put("AnnotationUseStyleCheck",
                 BASE_PACKAGE + ".checks.annotation.AnnotationUseStyleCheck");
+        NAME_TO_FULL_MODULE_NAME.put("AvoidAnnotationCombinationCheck",
+                BASE_PACKAGE + ".checks.annotation.AvoidAnnotationCombinationCheck");
         NAME_TO_FULL_MODULE_NAME.put("MissingDeprecatedCheck",
                 BASE_PACKAGE + ".checks.annotation.MissingDeprecatedCheck");
         NAME_TO_FULL_MODULE_NAME.put("MissingOverrideCheck",

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AvoidAnnotationCombinationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AvoidAnnotationCombinationCheck.java
@@ -1,0 +1,117 @@
+package com.puppycrawl.tools.checkstyle.checks.annotation;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.AnnotationUtility;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * Created by ltudor on 3/28/17.
+ */
+public final class AvoidAnnotationCombinationCheck extends AbstractCheck {
+    /**
+     * A key is pointing to the warning message text in "messages.properties"
+     * file.
+     */
+    public static final String MSG_KEY_ANNOTATION_COMBINATION_ILLEGAL = "annotation.combination.illegal";
+
+    /**
+     * Matches {@code @} at the beginning of a string.
+     * Used for transforming annotations specified as {@code @Override} into {@code Override}.
+     */
+    private static final Pattern MATCH_STARTING_AT = CommonUtils.createPattern("^\\@");
+
+    /**
+     * This field contains the de-cannonized annotation set by the user.
+     * If the user specifies the annotation as FQDN e.g. {@code java.lang.Override} then this will contain
+     * just {@code Override} -- but the {@link #fullAnnotation} Optional instance will store the FQDN form (in
+     * this case {@code java.lang.Override}.
+     * Also note that this value is stripped of any leading {@code @} so if the user specifies {@code @Override}
+     * it will store just {@code Override}.
+     *
+     * @see #fullAnnotation
+     */
+    private String annotation;
+
+    /**
+     * Stores the FQDN of the annotation if given by the user otherwise will be empty.
+     * If the user specifies in {@link #setAnnotation(String)} the value {@code java.lang.Override} then this
+     * member will be initialize to an Optional instance with the value {@code java.lang.Override}. If however
+     * the user specifies in {@link #setAnnotation(String)} just {@code Override} as the value then this will be
+     * an empty Optional.
+     *
+     * @see #setAnnotation(String)
+     */
+    private Optional<String> fullAnnotation;
+
+    /**
+     * Stores the modifier as specified via the user (e.g. {@code final} or {@code static} etc.).
+     * Based on this we compute internally the value of {@link #modifierInt}.
+     *
+     * @see TokenUtils#getTokenId(String)
+     */
+    private String modifier;
+
+    /**
+     * Token value for the token specified in {@link #modifier}.
+     * "Computed" via {@link TokenUtils#getTokenId(String)}.
+     *
+     * @see #modifier
+     */
+    private int modifierInt;
+
+    public String getAnnotation() {
+        return annotation;
+    }
+
+    public void setAnnotation(String annotation) {
+        String processed = MATCH_STARTING_AT.matcher(annotation).replaceFirst("");
+        int lastIdx = processed.lastIndexOf('.');
+        if (lastIdx >= 0) {
+            this.fullAnnotation = Optional.of(processed);
+            this.annotation = processed.substring(lastIdx + 1);
+        } else {
+            this.fullAnnotation = Optional.empty();
+            this.annotation = processed;
+        }
+    }
+
+    public String getModifier() {
+        return modifier;
+    }
+
+    public void setModifier(String modifier) {
+        this.modifier = modifier;
+        this.modifierInt = TokenUtils.getTokenId(modifier);
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getRequiredTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return getRequiredTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return new int[]
+                {TokenTypes.VARIABLE_DEF,};
+    }
+
+    @Override
+    public void visitToken(final DetailAST ast) {
+        if (!ast.branchContains(modifierInt)) return;
+        if (AnnotationUtility.containsAnnotation(ast, annotation)
+                || fullAnnotation.map(s -> AnnotationUtility.containsAnnotation(ast, s)).orElse(false)) {
+            log(ast.getLineNo(), MSG_KEY_ANNOTATION_COMBINATION_ILLEGAL, annotation, modifier);
+        }
+    }
+}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/annotation/messages.properties
@@ -14,3 +14,4 @@ tag.not.valid.on=The Javadoc {0} tag is not valid at this location.
 annotation.location=Annotation ''{0}'' have incorrect indentation level {1}, expected level should be {2}.
 annotation.location.alone=Annotation ''{0}'' should be alone on line.
 
+annotation.combination.illegal=Annotation ''{0}'' cannot be applied in conjunction with modifier ''{1}''

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AvoidAnnotationCombinationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AvoidAnnotationCombinationCheckTest.java
@@ -1,0 +1,54 @@
+package com.puppycrawl.tools.checkstyle.checks.annotation;
+
+import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static com.puppycrawl.tools.checkstyle.checks.annotation.AvoidAnnotationCombinationCheck.MSG_KEY_ANNOTATION_COMBINATION_ILLEGAL;
+
+/**
+ * Created by ltudor on 3/28/17.
+ */
+public class AvoidAnnotationCombinationCheckTest extends BaseCheckTestSupport {
+    @Override
+    protected String getPath(String filename) throws IOException {
+        return super.getPath("checks" + File.separator
+                + "annotation" + File.separator + filename);
+    }
+
+    /**
+     * This tests that specifying a combination modifier + annotation correctly flags it.
+     */
+    @Test
+    public void testBadOverrideFromObject() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(AvoidAnnotationCombinationCheck.class);
+        checkConfig.addAttribute("annotation", "SuppressWarnings");
+        checkConfig.addAttribute("modifier", "FINAL");
+
+        final String[] expected = {
+                "7: " + getCheckMessage(MSG_KEY_ANNOTATION_COMBINATION_ILLEGAL, "SuppressWarnings", "FINAL")
+        };
+
+        verify(checkConfig, getPath("WrongAnnotationAndModifierCombination.java"), expected);
+    }
+
+    /**
+     * This tests that specifying a combination modifier + annotation correctly flags it.
+     */
+    @Test
+    public void testBadOverrideFromObjectWithFqdn() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(AvoidAnnotationCombinationCheck.class);
+        checkConfig.addAttribute("annotation", "java.lang.SuppressWarnings");
+        checkConfig.addAttribute("modifier", "FINAL");
+
+        final String[] expected = {
+                "7: " + getCheckMessage(MSG_KEY_ANNOTATION_COMBINATION_ILLEGAL, "SuppressWarnings", "FINAL")
+        };
+
+        verify(checkConfig, getPath("WrongAnnotationAndModifierCombination.java"), expected);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/WrongAnnotationAndModifierCombination.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/WrongAnnotationAndModifierCombination.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.checks.annotation;
+
+/**
+ * Created by ltudor on 3/28/17.
+ */
+public class WrongAnnotationAndModifierCombination {
+    @SuppressWarnings("something")
+    final int value = 1;
+}

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -68,6 +68,10 @@
         <td>Checks the order of at-clauses.</td>
       </tr>
       <tr>
+        <td><a href="config_misc.html#AvoidAnnotationCombination">AvoidAnnotationCombination</a></td>
+        <td>Avoid certain annotations to be used in combination with a given modifier.</td>
+      </tr>
+      <tr>
         <td><a href="config_misc.html#AvoidEscapedUnicodeCharacters">AvoidEscapedUnicodeCharacters</a></td>
         <td>Restrict using Unicode escapes.</td>
       </tr>

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -343,6 +343,95 @@ public void test(&#64;MyAnnotation String s) { // OK
       </subsection>
     </section>
 
+      <section name="AvoidAnnotationCombination">
+          <subsection name="Description">
+              <p> This prevents the usage of a certain annotation in conjunction with a given field modifier.
+              </p>
+          </subsection>
+          <subsection name="Properties">
+              <table>
+                  <tr>
+                      <th>name</th>
+                      <th>description</th>
+                      <th>type</th>
+                      <th>default value</th>
+                  </tr>
+                  <tr>
+                      <td>annotation</td>
+                      <td>
+                          <p>
+                              Defines the annotation name / FQDN.
+                          </p>
+                      </td>
+                      <td>
+                          <a href="property_types.html#string">string</a>
+                      </td>
+                      <td>
+                          <code>never</code>
+                      </td>
+                  </tr>
+                  <tr>
+                      <td>modifier</td>
+                      <td>
+                          Modifier not allowed in conjunction with the annotation
+                      </td>
+                      <td>
+                          <a href="property_types.html#access_modifiers">access_modifiers</a>
+                      </td>
+                      <td>
+                          <code>never</code>
+                      </td>
+                  </tr>
+              </table>
+          </subsection>
+          <subsection name="Examples">
+              <p> To configure the check:</p>
+              <source> &lt;module name=&quot;AvoidAnnotationCombination&quot;/&gt;
+              </source>
+
+              <p>
+                  Disable Governator's own Configuration annotation on final fields
+              </p>
+              <source>
+                  &lt;module name=&quot;AvoidAnnotationCombination&quot;&gt;
+                  &lt;property name=&quot;annotation&quot; value=&quot;Configuration&quot;/&gt;
+                  &lt;property name=&quot;modifier&quot; value=&quot;FINAL&quot;/&gt;
+                  &lt;/module&gt;
+              </source>
+          </subsection>
+
+
+          <subsection name="Example of Usage">
+              <ul>
+                  <li>
+                      <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidAnnotationCombination">
+                          Checkstyle Style</a>
+                  </li>
+              </ul>
+          </subsection>
+
+          <subsection name="Error Messages">
+              <ul>
+                  <li>
+                      <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.combination.illegal%22">
+                          annotation.combination.illegal</a>
+                  </li>
+              </ul>
+              <p>
+                  All messages can be customized if the default message doesn't suit you.
+                  Please <a href="config.html#Custom_messages">see the documentation</a> to learn how to.
+              </p>
+          </subsection>
+
+          <subsection name="Package">
+              <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
+          </subsection>
+
+          <subsection name="Parent Module">
+              <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
+          </subsection>
+      </section>
+
     <section name="MissingDeprecated">
       <subsection name="Description">
         <p> Verifies that both the java.lang.Deprecated annotation is


### PR DESCRIPTION
The reason behind this is to prevent in some of the projects I work on in Netflix the usage of Governator's `@Configuration` annotation on `final` fields -- doing this has no effect (since the field is final) but misleads often the developer in thinking it works.
As such I have created a new check `AvoidAnnotationCombinationCheck` and it passes all tests bar one which from what I can see tests that the new error message I have introduced is translated in all languages. I speak English, Romanian and French so I could help with those but I certainly cannot do it to all the languages Checkstyle supports. As such I am looking for a bit of help here -- I couldn't find any mention of that anywhere in the docco? Once someone helps me with that then I can add a commit which contains all the translations and then the final test will pass.
If there is anything else I need to change also happy to do so.
Thanks,