### PR TITLE
Issue #3201: ignoreInlineArrays property 

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
@@ -27,16 +27,33 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <p>
  * Checks if array initialization contains optional trailing comma.
  * </p>
+ *
  * <p>
  * Rationale: Putting this comma in make is easier to change the
  * order of the elements or add new elements on the end.
  * </p>
+ *
+ * <pre>
+ * Properties:
+ * </pre>
+ * <table summary="Properties" border="1">
+ * <tr><th>name</th><th>Description</th><th>type</th><th>default value</th></tr>
+ * <tr><td>ignoreInlineArrays</td><td>The flag controls trailing commas in inline arrays.
+ * If set to true, then you can ignore the lack of a trailing comma,
+ * otherwise an error should be raised.
+ * </td><td>Boolean</td><td>true</td>
+ * </tr>
+ * </table>
+ *
  * <p>
  * An example of how to configure the check is:
  * </p>
  * <pre>
- * &lt;module name="ArrayTrailingComma"/&gt;
+ * &lt;module name="ArrayTrailingComma"&gt;
+ *    &lt;property name=&quot;ignoreInlineArrays&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
  * </pre>
+ *
  * @author o_sukhodolsky
  */
 public class ArrayTrailingCommaCheck extends AbstractCheck {
@@ -46,6 +63,13 @@ public class ArrayTrailingCommaCheck extends AbstractCheck {
      * file.
      */
     public static final String MSG_KEY = "array.trailing.comma";
+
+    /**
+     * The flag controls trailing commas in inline arrays.
+     * If set to true, then you can ignore the lack of a trailing comma, otherwise an error
+     * should be raised.
+     */
+    private boolean ignoreInlineArrays = true;
 
     @Override
     public int[] getDefaultTokens() {
@@ -68,12 +92,23 @@ public class ArrayTrailingCommaCheck extends AbstractCheck {
 
         // if curlies are on the same line
         // or array is empty then check nothing
-        if (arrayInit.getLineNo() != rcurly.getLineNo()
+        if ((!ignoreInlineArrays
+            || arrayInit.getLineNo() != rcurly.getLineNo())
             && arrayInit.getChildCount() != 1) {
             final DetailAST prev = rcurly.getPreviousSibling();
             if (prev.getType() != TokenTypes.COMMA) {
                 log(rcurly.getLineNo(), MSG_KEY);
             }
         }
+    }
+
+    /**
+     * Set the ignoreInlineArrays to enforce.
+     *
+     * @param ignoreInlineArraysStringValue string to decode ignoreInlineArrays from
+     * @throws IllegalArgumentException if unable to decode
+     */
+    public void setIgnoreInlineArrays(boolean ignoreInlineArraysStringValue) {
+        ignoreInlineArrays = ignoreInlineArraysStringValue;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheckTest.java
@@ -58,4 +58,19 @@ public class ArrayTrailingCommaCheckTest
         Assert.assertNotNull(check.getDefaultTokens());
         Assert.assertNotNull(check.getRequiredTokens());
     }
+
+    @Test
+    public void testIgnoreInlineArraysProperty()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+            createCheckConfig(ArrayTrailingCommaCheck.class);
+        checkConfig.addAttribute("ignoreInlineArrays", "false");
+        final String[] expected = {
+            "11: " + getCheckMessage(MSG_KEY),
+            "15: " + getCheckMessage(MSG_KEY),
+        };
+        verify(checkConfig,
+            getPath("InputArrayTrailingCommaIgnoreInlineArrays.java"),
+            expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/arraytrailingcomma/InputArrayTrailingCommaIgnoreInlineArrays.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/arraytrailingcomma/InputArrayTrailingCommaIgnoreInlineArrays.java
@@ -1,0 +1,16 @@
+package com.puppycrawl.tools.checkstyle.checks.coding.arraytrailingcomma;
+
+public class InputArrayTrailingCommaIgnoreInlineArrays {
+    int[] a1 = new int[]
+        {
+            1,
+            2,
+            3,
+        };
+
+    Object[] a2 = new Object[] {"a"};     //violation
+
+    boolean[] a3 = new boolean[] {true,};
+    int [] a4 = new int[]{1
+    };    //violation
+}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -49,6 +49,26 @@ return new int[] { 0 };
         </p>
       </subsection>
 
+      <subsection name="Properties">
+        <table>
+          <tr>
+            <th>name</th>
+            <th>description</th>
+            <th>type</th>
+            <th>default value</th>
+          </tr>
+          <tr>
+            <td>ignoreInlineArrays</td>
+            <td>The flag controls trailing commas in inline arrays.
+                If set to true, then you can ignore the lack of a trailing comma,
+                otherwise an error should be raised.
+            </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+          </tr>
+        </table>
+      </subsection>
+
       <subsection name="Examples">
           <p>
           To configure the check:
@@ -74,6 +94,26 @@ return new int[] { 0 };
             {1.7, 1.9, 0.6},
             {0.8, 7.4, 6.5}
             };        //violation
+          </source>
+
+          <p>
+              With <code>ignoreInlineArrays</code> property set to <code>false</code>
+          </p>
+          <p>
+              Which results in the following violations:
+          </p>
+          <source>
+              int[] a1 = new int[] {
+                1,
+                2,
+                3,
+              };
+
+              Object[] a2 = new Object[] {"a"};        //violation - not ignore inline arrays
+
+              boolean[] a3 = new boolean[] {true,};
+              int [] a4 = new int[]{
+              };        //violation
           </source>
       </subsection>
 


### PR DESCRIPTION
## #3201 
### Description
- [x] Added ` ignoreInlineArrays` property to `ArrayTrailingCommaCheck` control handling the lack of  trailing comma in inline array initialization
- [x] Updated xdocs
- [x] Addet input test file