### PR TITLE
Issue #3951: SeparatorWrap: add support for method reference operator

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -505,6 +505,7 @@
     <module name="SeparatorWrap">
       <property name="tokens" value="DOT"/>
       <property name="tokens" value="AT"/>
+      <property name="tokens" value="METHOD_REF"/>
       <property name="option" value="nl"/>
     </module>
     <module name="SeparatorWrap">

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/SeparatorWrapTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/SeparatorWrapTest.java
@@ -19,6 +19,8 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule451wheretobreak;
 
+import static com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck.MSG_LINE_NEW;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -59,6 +61,20 @@ public class SeparatorWrapTest extends BaseCheckTestSupport {
 
         final Configuration checkConfig = getCheckConfig("SeparatorWrap", "SeparatorWrapComma");
         final String filePath = getPath("InputSeparatorWrapComma.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void separatorWrapMethodRefTest() throws Exception {
+
+        final String[] expected = {
+            "17:49: " + getCheckMessage(SeparatorWrapCheck.class, MSG_LINE_NEW, "::"),
+        };
+
+        final Configuration checkConfig = getCheckConfig("SeparatorWrap", "SeparatorWrapMethodRef");
+        final String filePath = getPath("InputSeparatorWrapMethodRef.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapMethodRef.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapMethodRef.java
@@ -1,0 +1,20 @@
+package com.google.checkstyle.test.chapter4formatting.rule451wheretobreak;
+
+import java.util.Arrays;
+
+public class InputSeparatorWrapMethodRef {
+
+    void goodCase() {
+        String[] stringArray = { "Barbara", "James", "Mary", "John",
+            "Patricia", "Robert", "Michael", "Linda" };
+        Arrays.sort(stringArray, String
+                ::compareToIgnoreCase);
+    }
+
+    void badCase() {
+        String[] stringArray = { "Barbara", "James", "Mary", "John",
+            "Patricia", "Robert", "Michael", "Linda" };
+        /*warn*/ Arrays.sort(stringArray, String::
+                compareToIgnoreCase);
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1463,7 +1463,7 @@ public final class TokenTypes {
     public static final int COLON = GeneratedJavaTokenTypes.COLON;
 
     /**
-     * The <code>::</code> (double colon) operator.
+     * The <code>::</code> (double colon) separator.
      * It is part of Java 8 syntax that is used for method reference.
      * The token does not appear in tree, {@link #METHOD_REF} should be used instead.
      *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
@@ -132,6 +132,7 @@ public class SeparatorWrapCheck
             TokenTypes.RPAREN,
             TokenTypes.ARRAY_DECLARATOR,
             TokenTypes.RBRACK,
+            TokenTypes.METHOD_REF,
         };
     }
 

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -93,6 +93,11 @@
             <property name="tokens" value="COMMA"/>
             <property name="option" value="EOL"/>
         </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapMethodRef"/>
+            <property name="tokens" value="METHOD_REF"/>
+            <property name="option" value="nl"/>
+        </module>
         <module name="PackageName">
             <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
             <message key="name.invalidPattern"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
@@ -74,6 +74,16 @@ public class SeparatorWrapCheckTest
     }
 
     @Test
+    public void testMethodRef() throws Exception {
+        checkConfig.addAttribute("option", "NL");
+        checkConfig.addAttribute("tokens", "METHOD_REF");
+        final String[] expected = {
+            "17:56: " + getCheckMessage(MSG_LINE_NEW, "::"),
+        };
+        verify(checkConfig, getPath("InputSeparatorWrapForTestMethodRef.java"), expected);
+    }
+
+    @Test
     public void testGetDefaultTokens() {
         final SeparatorWrapCheck separatorWrapCheckObj = new SeparatorWrapCheck();
         final int[] actual = separatorWrapCheckObj.getDefaultTokens();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapForTestMethodRef.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapForTestMethodRef.java
@@ -1,0 +1,20 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.separatorwrap;
+
+import java.util.Arrays;
+
+public class InputSeparatorWrapForTestMethodRef {
+
+    void goodCase() {
+        String[] stringArray = { "Barbara", "James", "Mary", "John",
+            "Patricia", "Robert", "Michael", "Linda" };
+        Arrays.sort(stringArray, String
+                ::compareToIgnoreCase);
+    }
+
+    void badCase() {
+        String[] stringArray = { "Barbara", "James", "Mary", "John",
+            "Patricia", "Robert", "Michael", "Linda" };
+        /* violation */ Arrays.sort(stringArray, String::
+                compareToIgnoreCase);
+    }
+}

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1591,7 +1591,9 @@ import static java.math.BigInteger.ZERO;
                     <a
                      href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR">ARRAY_DECLARATOR</a>,
                      <a
-                      href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RBRACK">RBRACK</a>.
+                      href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RBRACK">RBRACK</a>,
+                      <a
+                       href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">METHOD_REF</a>.
             </td>
 
             <td>
@@ -1628,6 +1630,25 @@ s.
     isEmpty();
 foo(i,
     s);
+        </source>
+        <p>
+          Example for checking method reference at new line (good case and bad case):
+        </p>
+        <source>
+Arrays.sort(stringArray, String:: // violation
+    compareToIgnoreCase);
+Arrays.sort(stringArray, String
+    ::compareToIgnoreCase); // good
+        </source>
+        <p>
+          An example of how to configure the check for <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">METHOD_REF</a> at new line:
+        </p>
+        <source>
+&lt;module name="SeparatorWrap"&gt;
+    &lt;property name="tokens" value="METHOD_REF"/&gt;
+    &lt;property name="option" value="nl"/&gt;
+&lt;/module&gt;
         </source>
         <p>
           An example of how to configure the check for comma at the new line is:


### PR DESCRIPTION
#3951 

Firstly, we need to confirm the check logic. As the issue mentioned: `want '::' operator at end of previous line`, but it is not correct according to google style: http://checkstyle.sourceforge.net/reports/google-java-style-20170228.html#s4.5.1-line-wrapping-where-to-break

> When a line is broken at a non-assignment operator the break comes before the symbol.
> - This also applies to the following "operator-like" symbols:
>   - the two colons of a method reference (::)

Notice that the break should come before `::`. 

Configurations for Google style is updated as well.

~~Diff report is on the way.~~

Diff report:
http://www.luolc.com/checkstyle-diff-report/issue3951/