### PR TITLE
Issue #3607: Use reflection to load Checks base on checkstyle_package…

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -40,6 +40,7 @@
   <allow pkg="org.antlr.v4.runtime" local-only="true"/>
   <allow class="com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.+"
           local-only="true" regex="true"/>
+  <allow pkg="org.reflections" local-only="true"/>
 
   <!-- allowed till https://github.com/checkstyle/checkstyle/issues/3455 -->
   <allow class="com.google.common.base.CaseFormat" local-only="true"/>

--- a/pom.xml
+++ b/pom.xml
@@ -252,13 +252,18 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>20.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
       <version>1.10.1</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.11</version>
     </dependency>
 
     <!-- test scope stuff -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -20,13 +20,22 @@
 package com.puppycrawl.tools.checkstyle;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
@@ -48,8 +57,10 @@ import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
  * @author lkuehne
  */
 public class PackageObjectFactory implements ModuleFactory {
+
     /** Map of Checkstyle module names to their fully qualified names. */
-    private static final Map<String, String> NAME_TO_FULL_MODULE_NAME = new HashMap<>();
+    private static final Map<String, String> NAME_TO_FULL_MODULE_NAME =
+            generateNameToFullModuleNameMap(Thread.currentThread().getContextClassLoader());
 
     /** Exception message when null class loader is given. */
     private static final String NULL_LOADER_MESSAGE = "moduleClassLoader must not be null";
@@ -72,10 +83,6 @@ public class PackageObjectFactory implements ModuleFactory {
 
     /** The class loader used to load Checkstyle core and custom modules. */
     private final ClassLoader moduleClassLoader;
-
-    static {
-        fillShortToFullModuleNamesMap();
-    }
 
     /**
      * Creates a new {@code PackageObjectFactory} instance.
@@ -122,14 +129,13 @@ public class PackageObjectFactory implements ModuleFactory {
     @Override
     public Object createModule(String name) throws CheckstyleException {
         Object instance = createObjectFromMap(name);
+        final String nameCheck = name + CHECK_SUFFIX;
         if (instance == null) {
-            instance = createObjectWithIgnoringProblems(name, getAllPossibleNames(name));
+            instance = createObjectWithIgnoringProblems(nameCheck, getAllPossibleNames(nameCheck));
         }
         if (instance == null) {
-            final String nameCheck = name + CHECK_SUFFIX;
-            instance = createObjectWithIgnoringProblems(nameCheck, getAllPossibleNames(nameCheck));
+            instance = createObjectWithIgnoringProblems(name, getAllPossibleNames(name));
             if (instance == null) {
-
                 final String attemptedNames = joinPackageNamesWithClassName(name, packages)
                         + STRING_SEPARATOR + nameCheck + STRING_SEPARATOR
                         + joinPackageNamesWithClassName(nameCheck, packages);
@@ -202,7 +208,7 @@ public class PackageObjectFactory implements ModuleFactory {
      * @return a string which is obtained by joining package names with a class name.
      */
     private static String joinPackageNamesWithClassName(String className, Set<String> packages) {
-        return packages.stream().filter(name -> name != null)
+        return packages.stream().filter(Objects::nonNull)
             .collect(Collectors.joining(className + STRING_SEPARATOR, "", className));
     }
 
@@ -239,463 +245,66 @@ public class PackageObjectFactory implements ModuleFactory {
     }
 
     /**
-     * Fill short-to-full module names map.
+     * Generate the map of Checkstyle module names to their fully qualified names.
+     * @param loader the class loader used to load Checkstyle package names
+     * @return the map of Checkstyle module names to their fully qualified names
      */
-    private static void fillShortToFullModuleNamesMap() {
-        fillChecksFromAnnotationPackage();
-        fillChecksFromBlocksPackage();
-        fillChecksFromCodingPackage();
-        fillChecksFromDesingPackage();
-        fillChecksFromHeaderPackage();
-        fillChecksFromImportsPackage();
-        fillChecksFromIndentationPackage();
-        fillChecksFromJavadocPackage();
-        fillChecksFromMetricsPackage();
-        fillChecksFromModifierPackage();
-        fillChecksFromNamingPackage();
-        fillChecksFromRegexpPackage();
-        fillChecksFromSizesPackage();
-        fillChecksFromWhitespacePackage();
-        fillModulesFromChecksPackage();
-        fillModulesFromFilefiltersPackage();
-        fillModulesFromFiltersPackage();
-        fillModulesFromCheckstylePackage();
+    private static Map<String, String> generateNameToFullModuleNameMap(ClassLoader loader) {
+        Map<String, String> returnValue;
+        try {
+            final Reflections reflections = new Reflections(new ConfigurationBuilder()
+                    .setScanners(new SubTypesScanner(false))
+                    .setUrls(ClasspathHelper.forPackage(BASE_PACKAGE))
+                    .filterInputsBy(new FilterBuilder()
+                            .include(FilterBuilder.prefix(BASE_PACKAGE))));
+            final Set<String> packageNames = PackageNamesLoader.getPackageNames(loader);
+            returnValue = reflections.getSubTypesOf(Object.class).stream()
+                    .filter(clazz -> packageNames.contains(clazz.getPackage().getName() + "."))
+                    .filter(PackageObjectFactory::shouldAddToMap)
+                    .collect(Collectors.toMap(Class::getSimpleName, Class::getCanonicalName));
+        } catch (CheckstyleException ignore) {
+            returnValue = new HashMap<>();
+        }
+        return returnValue;
     }
 
     /**
-     * Fill short-to-full module names map with Checks from annotation package.
+     * Whether the class should be added to the map.
+     * @param clazz the class to check
+     * @return true if the class should be added to the map
      */
-    private static void fillChecksFromAnnotationPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("AnnotationLocationCheck",
-                BASE_PACKAGE + ".checks.annotation.AnnotationLocationCheck");
-        NAME_TO_FULL_MODULE_NAME.put("AnnotationUseStyleCheck",
-                BASE_PACKAGE + ".checks.annotation.AnnotationUseStyleCheck");
-        NAME_TO_FULL_MODULE_NAME.put("MissingDeprecatedCheck",
-                BASE_PACKAGE + ".checks.annotation.MissingDeprecatedCheck");
-        NAME_TO_FULL_MODULE_NAME.put("MissingOverrideCheck",
-                BASE_PACKAGE + ".checks.annotation.MissingOverrideCheck");
-        NAME_TO_FULL_MODULE_NAME.put("PackageAnnotationCheck",
-                BASE_PACKAGE + ".checks.annotation.PackageAnnotationCheck");
-        NAME_TO_FULL_MODULE_NAME.put("SuppressWarningsCheck",
-                BASE_PACKAGE + ".checks.annotation.SuppressWarningsCheck");
+    private static boolean shouldAddToMap(Class<?> clazz) {
+        return !Modifier.isAbstract(clazz.getModifiers())
+                && !clazz.isMemberClass()
+                && !clazz.getSimpleName().startsWith("Input")
+                && isNameCorrespondingToCorrectPackage(
+                        clazz.getSimpleName(), clazz.getPackage().getName());
     }
 
     /**
-     * Fill short-to-full module names map with Checks from blocks package.
+     * Whether the class name is corresponding to a correct package.
+     * @param className the class name to check.
+     * @param packageName the package of the class.
+     * @return true if the class the class name is corresponding to a correct package
      */
-    private static void fillChecksFromBlocksPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("AvoidNestedBlocksCheck",
-                BASE_PACKAGE + ".checks.blocks.AvoidNestedBlocksCheck");
-        NAME_TO_FULL_MODULE_NAME.put("EmptyBlockCheck",
-                BASE_PACKAGE + ".checks.blocks.EmptyBlockCheck");
-        NAME_TO_FULL_MODULE_NAME.put("EmptyCatchBlockCheck",
-                BASE_PACKAGE + ".checks.blocks.EmptyCatchBlockCheck");
-        NAME_TO_FULL_MODULE_NAME.put("LeftCurlyCheck",
-                BASE_PACKAGE + ".checks.blocks.LeftCurlyCheck");
-        NAME_TO_FULL_MODULE_NAME.put("NeedBracesCheck",
-                BASE_PACKAGE + ".checks.blocks.NeedBracesCheck");
-        NAME_TO_FULL_MODULE_NAME.put("RightCurlyCheck",
-                BASE_PACKAGE + ".checks.blocks.RightCurlyCheck");
+    private static boolean isNameCorrespondingToCorrectPackage(
+            String className, String packageName) {
+        return packageName.contains(BASE_PACKAGE + ".checks") && className.endsWith(CHECK_SUFFIX)
+                    || packageName.endsWith("filefilters") && className.endsWith("FileFilter")
+                    || packageName.endsWith("filters") && className.endsWith("Filter")
+                    || isModuleWithSpecialName(className);
     }
 
     /**
-     * Fill short-to-full module names map with Checks from coding package.
+     * Whether a class not following common naming notation should be added to the map.
+     * @param className the class name to check.
+     * @return true if the class is not following the common naming notation and should
+     *      be added to the map.
      */
-    // -@cs[ExecutableStatementCount] splitting this method is not reasonable.
-    private static void fillChecksFromCodingPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("ArrayTrailingCommaCheck",
-                BASE_PACKAGE + ".checks.coding.ArrayTrailingCommaCheck");
-        NAME_TO_FULL_MODULE_NAME.put("AvoidInlineConditionalsCheck",
-                BASE_PACKAGE + ".checks.coding.AvoidInlineConditionalsCheck");
-        NAME_TO_FULL_MODULE_NAME.put("CovariantEqualsCheck",
-                BASE_PACKAGE + ".checks.coding.CovariantEqualsCheck");
-        NAME_TO_FULL_MODULE_NAME.put("DeclarationOrderCheck",
-                BASE_PACKAGE + ".checks.coding.DeclarationOrderCheck");
-        NAME_TO_FULL_MODULE_NAME.put("DefaultComesLastCheck",
-                BASE_PACKAGE + ".checks.coding.DefaultComesLastCheck");
-        NAME_TO_FULL_MODULE_NAME.put("EmptyStatementCheck",
-                BASE_PACKAGE + ".checks.coding.EmptyStatementCheck");
-        NAME_TO_FULL_MODULE_NAME.put("EqualsAvoidNullCheck",
-                BASE_PACKAGE + ".checks.coding.EqualsAvoidNullCheck");
-        NAME_TO_FULL_MODULE_NAME.put("EqualsHashCodeCheck",
-                BASE_PACKAGE + ".checks.coding.EqualsHashCodeCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ExplicitInitializationCheck",
-                BASE_PACKAGE + ".checks.coding.ExplicitInitializationCheck");
-        NAME_TO_FULL_MODULE_NAME.put("FallThroughCheck",
-                BASE_PACKAGE + ".checks.coding.FallThroughCheck");
-        NAME_TO_FULL_MODULE_NAME.put("FinalLocalVariableCheck",
-                BASE_PACKAGE + ".checks.coding.FinalLocalVariableCheck");
-        NAME_TO_FULL_MODULE_NAME.put("HiddenFieldCheck",
-                BASE_PACKAGE + ".checks.coding.HiddenFieldCheck");
-        NAME_TO_FULL_MODULE_NAME.put("IllegalCatchCheck",
-                BASE_PACKAGE + ".checks.coding.IllegalCatchCheck");
-        NAME_TO_FULL_MODULE_NAME.put("IllegalInstantiationCheck",
-                BASE_PACKAGE + ".checks.coding.IllegalInstantiationCheck");
-        NAME_TO_FULL_MODULE_NAME.put("IllegalThrowsCheck",
-                BASE_PACKAGE + ".checks.coding.IllegalThrowsCheck");
-        NAME_TO_FULL_MODULE_NAME.put("IllegalTokenCheck",
-                BASE_PACKAGE + ".checks.coding.IllegalTokenCheck");
-        NAME_TO_FULL_MODULE_NAME.put("IllegalTokenTextCheck",
-                BASE_PACKAGE + ".checks.coding.IllegalTokenTextCheck");
-        NAME_TO_FULL_MODULE_NAME.put("IllegalTypeCheck",
-                BASE_PACKAGE + ".checks.coding.IllegalTypeCheck");
-        NAME_TO_FULL_MODULE_NAME.put("InnerAssignmentCheck",
-                BASE_PACKAGE + ".checks.coding.InnerAssignmentCheck");
-        NAME_TO_FULL_MODULE_NAME.put("MagicNumberCheck",
-                BASE_PACKAGE + ".checks.coding.MagicNumberCheck");
-        NAME_TO_FULL_MODULE_NAME.put("MissingCtorCheck",
-                BASE_PACKAGE + ".checks.coding.MissingCtorCheck");
-        NAME_TO_FULL_MODULE_NAME.put("MissingSwitchDefaultCheck",
-                BASE_PACKAGE + ".checks.coding.MissingSwitchDefaultCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ModifiedControlVariableCheck",
-                BASE_PACKAGE + ".checks.coding.ModifiedControlVariableCheck");
-        NAME_TO_FULL_MODULE_NAME.put("MultipleStringLiteralsCheck",
-                BASE_PACKAGE + ".checks.coding.MultipleStringLiteralsCheck");
-        NAME_TO_FULL_MODULE_NAME.put("MultipleVariableDeclarationsCheck",
-                BASE_PACKAGE + ".checks.coding.MultipleVariableDeclarationsCheck");
-        NAME_TO_FULL_MODULE_NAME.put("NestedForDepthCheck",
-                BASE_PACKAGE + ".checks.coding.NestedForDepthCheck");
-        NAME_TO_FULL_MODULE_NAME.put("NestedIfDepthCheck",
-                BASE_PACKAGE + ".checks.coding.NestedIfDepthCheck");
-        NAME_TO_FULL_MODULE_NAME.put("NestedTryDepthCheck",
-                BASE_PACKAGE + ".checks.coding.NestedTryDepthCheck");
-        NAME_TO_FULL_MODULE_NAME.put("NoCloneCheck",
-                BASE_PACKAGE + ".checks.coding.NoCloneCheck");
-        NAME_TO_FULL_MODULE_NAME.put("NoFinalizerCheck",
-                BASE_PACKAGE + ".checks.coding.NoFinalizerCheck");
-        NAME_TO_FULL_MODULE_NAME.put("OneStatementPerLineCheck",
-                BASE_PACKAGE + ".checks.coding.OneStatementPerLineCheck");
-        NAME_TO_FULL_MODULE_NAME.put("OverloadMethodsDeclarationOrderCheck",
-                BASE_PACKAGE + ".checks.coding.OverloadMethodsDeclarationOrderCheck");
-        NAME_TO_FULL_MODULE_NAME.put("PackageDeclarationCheck",
-                BASE_PACKAGE + ".checks.coding.PackageDeclarationCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ParameterAssignmentCheck",
-                BASE_PACKAGE + ".checks.coding.ParameterAssignmentCheck");
-        NAME_TO_FULL_MODULE_NAME.put("RequireThisCheck",
-                BASE_PACKAGE + ".checks.coding.RequireThisCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ReturnCountCheck",
-                BASE_PACKAGE + ".checks.coding.ReturnCountCheck");
-        NAME_TO_FULL_MODULE_NAME.put("SimplifyBooleanExpressionCheck",
-                BASE_PACKAGE + ".checks.coding.SimplifyBooleanExpressionCheck");
-        NAME_TO_FULL_MODULE_NAME.put("SimplifyBooleanReturnCheck",
-                BASE_PACKAGE + ".checks.coding.SimplifyBooleanReturnCheck");
-        NAME_TO_FULL_MODULE_NAME.put("StringLiteralEqualityCheck",
-                BASE_PACKAGE + ".checks.coding.StringLiteralEqualityCheck");
-        NAME_TO_FULL_MODULE_NAME.put("SuperCloneCheck",
-                BASE_PACKAGE + ".checks.coding.SuperCloneCheck");
-        NAME_TO_FULL_MODULE_NAME.put("SuperFinalizeCheck",
-                BASE_PACKAGE + ".checks.coding.SuperFinalizeCheck");
-        NAME_TO_FULL_MODULE_NAME.put("UnnecessaryParenthesesCheck",
-                BASE_PACKAGE + ".checks.coding.UnnecessaryParenthesesCheck");
-        NAME_TO_FULL_MODULE_NAME.put("VariableDeclarationUsageDistanceCheck",
-                BASE_PACKAGE + ".checks.coding.VariableDeclarationUsageDistanceCheck");
-    }
-
-    /**
-     * Fill short-to-full module names map with Checks from design package.
-     */
-    private static void fillChecksFromDesingPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("DesignForExtensionCheck",
-                BASE_PACKAGE + ".checks.design.DesignForExtensionCheck");
-        NAME_TO_FULL_MODULE_NAME.put("FinalClassCheck",
-                BASE_PACKAGE + ".checks.design.FinalClassCheck");
-        NAME_TO_FULL_MODULE_NAME.put("HideUtilityClassConstructorCheck",
-                BASE_PACKAGE + ".checks.design.HideUtilityClassConstructorCheck");
-        NAME_TO_FULL_MODULE_NAME.put("InnerTypeLastCheck",
-                BASE_PACKAGE + ".checks.design.InnerTypeLastCheck");
-        NAME_TO_FULL_MODULE_NAME.put("InterfaceIsTypeCheck",
-                BASE_PACKAGE + ".checks.design.InterfaceIsTypeCheck");
-        NAME_TO_FULL_MODULE_NAME.put("MutableExceptionCheck",
-                BASE_PACKAGE + ".checks.design.MutableExceptionCheck");
-        NAME_TO_FULL_MODULE_NAME.put("OneTopLevelClassCheck",
-                BASE_PACKAGE + ".checks.design.OneTopLevelClassCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ThrowsCountCheck",
-                BASE_PACKAGE + ".checks.design.ThrowsCountCheck");
-        NAME_TO_FULL_MODULE_NAME.put("VisibilityModifierCheck",
-                BASE_PACKAGE + ".checks.design.VisibilityModifierCheck");
-    }
-
-    /**
-     * Fill short-to-full module names map with Checks from header package.
-     */
-    private static void fillChecksFromHeaderPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("HeaderCheck",
-                BASE_PACKAGE + ".checks.header.HeaderCheck");
-        NAME_TO_FULL_MODULE_NAME.put("RegexpHeaderCheck",
-                BASE_PACKAGE + ".checks.header.RegexpHeaderCheck");
-    }
-
-    /**
-     * Fill short-to-full module names map with Checks from imports package.
-     */
-    private static void fillChecksFromImportsPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("AvoidStarImportCheck",
-                BASE_PACKAGE + ".checks.imports.AvoidStarImportCheck");
-        NAME_TO_FULL_MODULE_NAME.put("AvoidStaticImportCheck",
-                BASE_PACKAGE + ".checks.imports.AvoidStaticImportCheck");
-        NAME_TO_FULL_MODULE_NAME.put("CustomImportOrderCheck",
-                BASE_PACKAGE + ".checks.imports.CustomImportOrderCheck");
-        NAME_TO_FULL_MODULE_NAME.put("IllegalImportCheck",
-                BASE_PACKAGE + ".checks.imports.IllegalImportCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ImportControlCheck",
-                BASE_PACKAGE + ".checks.imports.ImportControlCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ImportOrderCheck",
-                BASE_PACKAGE + ".checks.imports.ImportOrderCheck");
-        NAME_TO_FULL_MODULE_NAME.put("RedundantImportCheck",
-                BASE_PACKAGE + ".checks.imports.RedundantImportCheck");
-        NAME_TO_FULL_MODULE_NAME.put("UnusedImportsCheck",
-                BASE_PACKAGE + ".checks.imports.UnusedImportsCheck");
-    }
-
-    /**
-     * Fill short-to-full module names map with Checks from indentation package.
-     */
-    private static void fillChecksFromIndentationPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("CommentsIndentationCheck",
-                BASE_PACKAGE + ".checks.indentation.CommentsIndentationCheck");
-        NAME_TO_FULL_MODULE_NAME.put("IndentationCheck",
-                BASE_PACKAGE + ".checks.indentation.IndentationCheck");
-    }
-
-    /**
-     * Fill short-to-full module names map with Checks from javadoc package.
-     */
-    private static void fillChecksFromJavadocPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("AtclauseOrderCheck",
-                BASE_PACKAGE + ".checks.javadoc.AtclauseOrderCheck");
-        NAME_TO_FULL_MODULE_NAME.put("JavadocMethodCheck",
-                BASE_PACKAGE + ".checks.javadoc.JavadocMethodCheck");
-        NAME_TO_FULL_MODULE_NAME.put("JavadocPackageCheck",
-                BASE_PACKAGE + ".checks.javadoc.JavadocPackageCheck");
-        NAME_TO_FULL_MODULE_NAME.put("JavadocParagraphCheck",
-                BASE_PACKAGE + ".checks.javadoc.JavadocParagraphCheck");
-        NAME_TO_FULL_MODULE_NAME.put("JavadocStyleCheck",
-                BASE_PACKAGE + ".checks.javadoc.JavadocStyleCheck");
-        NAME_TO_FULL_MODULE_NAME.put("JavadocTagContinuationIndentationCheck",
-                BASE_PACKAGE + ".checks.javadoc.JavadocTagContinuationIndentationCheck");
-        NAME_TO_FULL_MODULE_NAME.put("JavadocTypeCheck",
-                BASE_PACKAGE + ".checks.javadoc.JavadocTypeCheck");
-        NAME_TO_FULL_MODULE_NAME.put("JavadocVariableCheck",
-                BASE_PACKAGE + ".checks.javadoc.JavadocVariableCheck");
-        NAME_TO_FULL_MODULE_NAME.put("NonEmptyAtclauseDescriptionCheck",
-                BASE_PACKAGE + ".checks.javadoc.NonEmptyAtclauseDescriptionCheck");
-        NAME_TO_FULL_MODULE_NAME.put("SingleLineJavadocCheck",
-                BASE_PACKAGE + ".checks.javadoc.SingleLineJavadocCheck");
-        NAME_TO_FULL_MODULE_NAME.put("SummaryJavadocCheck",
-                BASE_PACKAGE + ".checks.javadoc.SummaryJavadocCheck");
-        NAME_TO_FULL_MODULE_NAME.put("WriteTagCheck",
-                BASE_PACKAGE + ".checks.javadoc.WriteTagCheck");
-    }
-
-    /**
-     * Fill short-to-full module names map with Checks from metrics package.
-     */
-    private static void fillChecksFromMetricsPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("BooleanExpressionComplexityCheck",
-                BASE_PACKAGE + ".checks.metrics.BooleanExpressionComplexityCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ClassDataAbstractionCouplingCheck",
-                BASE_PACKAGE + ".checks.metrics.ClassDataAbstractionCouplingCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ClassFanOutComplexityCheck",
-                BASE_PACKAGE + ".checks.metrics.ClassFanOutComplexityCheck");
-        NAME_TO_FULL_MODULE_NAME.put("CyclomaticComplexityCheck",
-                BASE_PACKAGE + ".checks.metrics.CyclomaticComplexityCheck");
-        NAME_TO_FULL_MODULE_NAME.put("JavaNCSSCheck",
-                BASE_PACKAGE + ".checks.metrics.JavaNCSSCheck");
-        NAME_TO_FULL_MODULE_NAME.put("NPathComplexityCheck",
-                BASE_PACKAGE + ".checks.metrics.NPathComplexityCheck");
-    }
-
-    /**
-     * Fill short-to-full module names map with Checks from modifier package.
-     */
-    private static void fillChecksFromModifierPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("ModifierOrderCheck",
-                BASE_PACKAGE + ".checks.modifier.ModifierOrderCheck");
-        NAME_TO_FULL_MODULE_NAME.put("RedundantModifierCheck",
-                BASE_PACKAGE + ".checks.modifier.RedundantModifierCheck");
-    }
-
-    /**
-     * Fill short-to-full module names map with Checks from naming package.
-     */
-    private static void fillChecksFromNamingPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("AbbreviationAsWordInNameCheck",
-                BASE_PACKAGE + ".checks.naming.AbbreviationAsWordInNameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("AbstractClassNameCheck",
-                BASE_PACKAGE + ".checks.naming.AbstractClassNameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("CatchParameterNameCheck",
-                BASE_PACKAGE + ".checks.naming.CatchParameterNameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ClassTypeParameterNameCheck",
-                BASE_PACKAGE + ".checks.naming.ClassTypeParameterNameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ConstantNameCheck",
-                BASE_PACKAGE + ".checks.naming.ConstantNameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("InterfaceTypeParameterNameCheck",
-                BASE_PACKAGE + ".checks.naming.InterfaceTypeParameterNameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("LocalFinalVariableNameCheck",
-                BASE_PACKAGE + ".checks.naming.LocalFinalVariableNameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("LocalVariableNameCheck",
-                BASE_PACKAGE + ".checks.naming.LocalVariableNameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("MemberNameCheck",
-                BASE_PACKAGE + ".checks.naming.MemberNameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("MethodNameCheck",
-                BASE_PACKAGE + ".checks.naming.MethodNameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("MethodTypeParameterNameCheck",
-                BASE_PACKAGE + ".checks.naming.MethodTypeParameterNameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("PackageNameCheck",
-                BASE_PACKAGE + ".checks.naming.PackageNameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ParameterNameCheck",
-                BASE_PACKAGE + ".checks.naming.ParameterNameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("StaticVariableNameCheck",
-                BASE_PACKAGE + ".checks.naming.StaticVariableNameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("TypeNameCheck",
-                BASE_PACKAGE + ".checks.naming.TypeNameCheck");
-    }
-
-    /**
-     * Fill short-to-full module names map with Checks from regexp package.
-     */
-    private static void fillChecksFromRegexpPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("RegexpCheck",
-                BASE_PACKAGE + ".checks.regexp.RegexpCheck");
-        NAME_TO_FULL_MODULE_NAME.put("RegexpMultilineCheck",
-                BASE_PACKAGE + ".checks.regexp.RegexpMultilineCheck");
-        NAME_TO_FULL_MODULE_NAME.put("RegexpOnFilenameCheck",
-                BASE_PACKAGE + ".checks.regexp.RegexpOnFilenameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("RegexpSinglelineCheck",
-                BASE_PACKAGE + ".checks.regexp.RegexpSinglelineCheck");
-        NAME_TO_FULL_MODULE_NAME.put("RegexpSinglelineJavaCheck",
-                BASE_PACKAGE + ".checks.regexp.RegexpSinglelineJavaCheck");
-    }
-
-    /**
-     * Fill short-to-full module names map with Checks from sizes package.
-     */
-    private static void fillChecksFromSizesPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("AnonInnerLengthCheck",
-                BASE_PACKAGE + ".checks.sizes.AnonInnerLengthCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ExecutableStatementCountCheck",
-                BASE_PACKAGE + ".checks.sizes.ExecutableStatementCountCheck");
-        NAME_TO_FULL_MODULE_NAME.put("FileLengthCheck",
-                BASE_PACKAGE + ".checks.sizes.FileLengthCheck");
-        NAME_TO_FULL_MODULE_NAME.put("LineLengthCheck",
-                BASE_PACKAGE + ".checks.sizes.LineLengthCheck");
-        NAME_TO_FULL_MODULE_NAME.put("MethodCountCheck",
-                BASE_PACKAGE + ".checks.sizes.MethodCountCheck");
-        NAME_TO_FULL_MODULE_NAME.put("MethodLengthCheck",
-                BASE_PACKAGE + ".checks.sizes.MethodLengthCheck");
-        NAME_TO_FULL_MODULE_NAME.put("OuterTypeNumberCheck",
-                BASE_PACKAGE + ".checks.sizes.OuterTypeNumberCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ParameterNumberCheck",
-                BASE_PACKAGE + ".checks.sizes.ParameterNumberCheck");
-    }
-
-    /**
-     * Fill short-to-full module names map with Checks from whitespace package.
-     */
-    private static void fillChecksFromWhitespacePackage() {
-        NAME_TO_FULL_MODULE_NAME.put("EmptyForInitializerPadCheck",
-                BASE_PACKAGE + ".checks.whitespace.EmptyForInitializerPadCheck");
-        NAME_TO_FULL_MODULE_NAME.put("EmptyForIteratorPadCheck",
-                BASE_PACKAGE + ".checks.whitespace.EmptyForIteratorPadCheck");
-        NAME_TO_FULL_MODULE_NAME.put("EmptyLineSeparatorCheck",
-                BASE_PACKAGE + ".checks.whitespace.EmptyLineSeparatorCheck");
-        NAME_TO_FULL_MODULE_NAME.put("FileTabCharacterCheck",
-                BASE_PACKAGE + ".checks.whitespace.FileTabCharacterCheck");
-        NAME_TO_FULL_MODULE_NAME.put("GenericWhitespaceCheck",
-                BASE_PACKAGE + ".checks.whitespace.GenericWhitespaceCheck");
-        NAME_TO_FULL_MODULE_NAME.put("MethodParamPadCheck",
-                BASE_PACKAGE + ".checks.whitespace.MethodParamPadCheck");
-        NAME_TO_FULL_MODULE_NAME.put("NoLineWrapCheck",
-                BASE_PACKAGE + ".checks.whitespace.NoLineWrapCheck");
-        NAME_TO_FULL_MODULE_NAME.put("NoWhitespaceAfterCheck",
-                BASE_PACKAGE + ".checks.whitespace.NoWhitespaceAfterCheck");
-        NAME_TO_FULL_MODULE_NAME.put("NoWhitespaceBeforeCheck",
-                BASE_PACKAGE + ".checks.whitespace.NoWhitespaceBeforeCheck");
-        NAME_TO_FULL_MODULE_NAME.put("OperatorWrapCheck",
-                BASE_PACKAGE + ".checks.whitespace.OperatorWrapCheck");
-        NAME_TO_FULL_MODULE_NAME.put("ParenPadCheck",
-                BASE_PACKAGE + ".checks.whitespace.ParenPadCheck");
-        NAME_TO_FULL_MODULE_NAME.put("SeparatorWrapCheck",
-                BASE_PACKAGE + ".checks.whitespace.SeparatorWrapCheck");
-        NAME_TO_FULL_MODULE_NAME.put("SingleSpaceSeparatorCheck",
-                BASE_PACKAGE + ".checks.whitespace.SingleSpaceSeparatorCheck");
-        NAME_TO_FULL_MODULE_NAME.put("TypecastParenPadCheck",
-                BASE_PACKAGE + ".checks.whitespace.TypecastParenPadCheck");
-        NAME_TO_FULL_MODULE_NAME.put("WhitespaceAfterCheck",
-                BASE_PACKAGE + ".checks.whitespace.WhitespaceAfterCheck");
-        NAME_TO_FULL_MODULE_NAME.put("WhitespaceAroundCheck",
-                BASE_PACKAGE + ".checks.whitespace.WhitespaceAroundCheck");
-    }
-
-    /**
-     * Fill short-to-full module names map with modules from checks package.
-     */
-    private static void fillModulesFromChecksPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("ArrayTypeStyleCheck",
-                BASE_PACKAGE + ".checks.ArrayTypeStyleCheck");
-        NAME_TO_FULL_MODULE_NAME.put("AvoidEscapedUnicodeCharactersCheck",
-                BASE_PACKAGE + ".checks.AvoidEscapedUnicodeCharactersCheck");
-        NAME_TO_FULL_MODULE_NAME.put("DescendantTokenCheck",
-                BASE_PACKAGE + ".checks.DescendantTokenCheck");
-        NAME_TO_FULL_MODULE_NAME.put("FileContentsHolder",
-                BASE_PACKAGE + ".checks.FileContentsHolder");
-        NAME_TO_FULL_MODULE_NAME.put("FinalParametersCheck",
-                BASE_PACKAGE + ".checks.FinalParametersCheck");
-        NAME_TO_FULL_MODULE_NAME.put("NewlineAtEndOfFileCheck",
-                BASE_PACKAGE + ".checks.NewlineAtEndOfFileCheck");
-        NAME_TO_FULL_MODULE_NAME.put("OuterTypeFilenameCheck",
-                BASE_PACKAGE + ".checks.OuterTypeFilenameCheck");
-        NAME_TO_FULL_MODULE_NAME.put("SuppressWarningsHolder",
-                BASE_PACKAGE + ".checks.SuppressWarningsHolder");
-        NAME_TO_FULL_MODULE_NAME.put("TodoCommentCheck",
-                BASE_PACKAGE + ".checks.TodoCommentCheck");
-        NAME_TO_FULL_MODULE_NAME.put("TrailingCommentCheck",
-                BASE_PACKAGE + ".checks.TrailingCommentCheck");
-        NAME_TO_FULL_MODULE_NAME.put("TranslationCheck",
-                BASE_PACKAGE + ".checks.TranslationCheck");
-        NAME_TO_FULL_MODULE_NAME.put("UncommentedMainCheck",
-                BASE_PACKAGE + ".checks.UncommentedMainCheck");
-        NAME_TO_FULL_MODULE_NAME.put("UniquePropertiesCheck",
-                BASE_PACKAGE + ".checks.UniquePropertiesCheck");
-        NAME_TO_FULL_MODULE_NAME.put("UpperEllCheck",
-                BASE_PACKAGE + ".checks.UpperEllCheck");
-    }
-
-    /**
-     * Fill short-to-full module names map with modules from filefilters package.
-     */
-    private static void fillModulesFromFilefiltersPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("BeforeExecutionExclusionFileFilter",
-                BASE_PACKAGE + ".filefilters.BeforeExecutionExclusionFileFilter");
-    }
-
-    /**
-     * Fill short-to-full module names map with modules from filters package.
-     */
-    private static void fillModulesFromFiltersPackage() {
-        NAME_TO_FULL_MODULE_NAME.put("CsvFilter",
-                BASE_PACKAGE + ".filters.CsvFilter");
-        NAME_TO_FULL_MODULE_NAME.put("IntMatchFilter",
-                BASE_PACKAGE + ".filters.IntMatchFilter");
-        NAME_TO_FULL_MODULE_NAME.put("IntRangeFilter",
-                BASE_PACKAGE + ".filters.IntRangeFilter");
-        NAME_TO_FULL_MODULE_NAME.put("SeverityMatchFilter",
-                BASE_PACKAGE + ".filters.SeverityMatchFilter");
-        NAME_TO_FULL_MODULE_NAME.put("SuppressionCommentFilter",
-                BASE_PACKAGE + ".filters.SuppressionCommentFilter");
-        NAME_TO_FULL_MODULE_NAME.put("SuppressionFilter",
-                BASE_PACKAGE + ".filters.SuppressionFilter");
-        NAME_TO_FULL_MODULE_NAME.put("SuppressWarningsFilter",
-                BASE_PACKAGE + ".filters.SuppressWarningsFilter");
-        NAME_TO_FULL_MODULE_NAME.put("SuppressWithNearbyCommentFilter",
-                BASE_PACKAGE + ".filters.SuppressWithNearbyCommentFilter");
-    }
-
-    /**
-     * Fill short-to-full module names map with modules from checkstyle package.
-     */
-    private static void fillModulesFromCheckstylePackage() {
-        NAME_TO_FULL_MODULE_NAME.put("Checker", BASE_PACKAGE + ".Checker");
-        NAME_TO_FULL_MODULE_NAME.put("TreeWalker", BASE_PACKAGE + ".TreeWalker");
+    private static boolean isModuleWithSpecialName(String className) {
+        final String[] specialNames = {
+            "Checker", "TreeWalker", "FileContentsHolder", "SuppressWarningsHolder",
+        };
+        return Arrays.stream(specialNames).anyMatch(specialName -> specialName.equals(className));
     }
 }


### PR DESCRIPTION
#3607 

At first I didn't introduced reflections lib, instead used guava to get the classes. But later I saw #3455 , then I tried reflections. But in fact guava is also a dependency of reflections. :(

To be honest, I don't think the current fix is good enough. Please give me any suggestions that could avoid using reflections lib. 

Do I need to generate a diff report for this fix?

In addition, I am not sure whether the CI would pass or not. `mvn clean verify` success on my local. But the behavior of reflections seems a bit strange, sometimes.