### PR TITLE
Issue #4150: Split and Organize Checkstyle inputs by Test for LocalVariableName

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheckTest.java
@@ -35,7 +35,9 @@ public class LocalVariableNameCheckTest
     @Override
     protected String getPath(String filename) throws IOException {
         return super.getPath("checks" + File.separator
-                + "naming" + File.separator + filename);
+                + "naming" + File.separator
+                + "localvariablename" + File.separator
+                + filename);
     }
 
     @Test
@@ -52,7 +54,7 @@ public class LocalVariableNameCheckTest
             "132:20: " + getCheckMessage(MSG_INVALID_PATTERN, "InnerBlockVariable", pattern),
             "207:21: " + getCheckMessage(MSG_INVALID_PATTERN, "O", pattern),
         };
-        verify(checkConfig, getPath("InputSimple.java"), expected);
+        verify(checkConfig, getPath("InputLocalVariableName.java"), expected);
     }
 
     @Test
@@ -61,7 +63,7 @@ public class LocalVariableNameCheckTest
         final DefaultConfiguration checkConfig =
             createCheckConfig(LocalVariableNameCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("InputInner.java"), expected);
+        verify(checkConfig, getPath("InputLocalVariableNameInnerClass.java"), expected);
     }
 
     @Test
@@ -78,6 +80,6 @@ public class LocalVariableNameCheckTest
             "19:21: " + getCheckMessage(MSG_INVALID_PATTERN, "i", pattern),
             "25:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Index", pattern),
         };
-        verify(checkConfig, getPath("InputOneCharInitVarName.java"), expected);
+        verify(checkConfig, getPath("InputLocalVariableNameOneCharInitVarName.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/InputLocalVariableName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/InputLocalVariableName.java
@@ -1,0 +1,225 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for checkstyle.
+// Created: Feb-2001
+// Ignore error
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.naming.localvariablename;
+import java.io.*;
+/**
+ * Contains simple mistakes:
+ * - Long lines
+ * - Tabs
+ * - Format of variables and parameters
+ * - Order of modifiers
+ * @author Oliver Burn
+ **/
+final class InputLocalVariableName
+{
+    // Long line ----------------------------------------------------------------
+    // Contains a tab ->	<-
+    // Contains trailing whitespace ->
+
+    // Name format tests
+    //
+    /** Invalid format **/
+    public static final int badConstant = 2;
+    /** Valid format **/
+    public static final int MAX_ROWS = 2;
+
+    /** Invalid format **/
+    private static int badStatic = 2;
+    /** Valid format **/
+    private static int sNumCreated = 0;
+
+    /** Invalid format **/
+    private int badMember = 2;
+    /** Valid format **/
+    private int mNumCreated1 = 0;
+    /** Valid format **/
+    protected int mNumCreated2 = 0;
+
+    /** commas are wrong **/
+    private int[] mInts = new int[] {1,2, 3,
+                                     4};
+
+    //
+    // Accessor tests
+    //
+    /** should be private **/
+    public static int sTest1;
+    /** should be private **/
+    protected static int sTest3;
+    /** should be private **/
+    static int sTest2;
+
+    /** should be private **/
+    int mTest1;
+    /** should be private **/
+    public int mTest2;
+
+    //
+    // Parameter name format tests
+    //
+
+    /**
+     * @return hack
+     * @param badFormat1 bad format
+     * @param badFormat2 bad format
+     * @param badFormat3 bad format
+     * @throws java.lang.Exception abc
+     **/
+    int test1(int badFormat1,int badFormat2,
+              final int badFormat3)
+        throws java.lang.Exception
+    {
+        return 0;
+    }
+
+    /** method that is 20 lines long **/
+    private void longMethod()
+    {
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+    }
+
+    /** constructor that is 10 lines long **/
+    private InputLocalVariableName()
+    {
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+    }
+
+    /** test local variables */
+    private void localVariables()
+    {
+        // normal decl
+        int abc = 0;
+        int ABC = 0;
+
+        // final decls
+        final int cde = 0;
+        final int CDE = 0;
+
+        // decl in for loop init statement
+        for (int k = 0; k < 1; k++)
+        {
+            String innerBlockVariable = "";
+        }
+        for (int I = 0; I < 1; I++)
+        {
+            String InnerBlockVariable = "";
+        }
+    }
+
+    /** test method pattern */
+    void ALL_UPPERCASE_METHOD()
+    {
+    }
+
+    /** test illegal constant **/
+    private static final int BAD__NAME = 3;
+
+    // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
+    // long line that has a tab ->	<- and would be OK if tab counted as 1 char
+    // tabs that count as one char because of their position ->	<-   ->	<-, OK
+
+    /** some lines to test the error column after tabs */
+    void errorColumnAfterTabs()
+    {
+        // with tab-width 8 all statements below start at the same column,
+        // with different combinations of ' ' and '\t' before the statement
+                int tab0 =1;
+        	int tab1 =1;
+         	int tab2 =1;
+		int tab3 =1;
+  	  	int tab4 =1;
+  	        int tab5 =1;
+    }
+
+    // FIXME:
+    /* FIXME: a
+     * FIXME:
+     * TODO
+     */
+    /* NOTHING */
+    /* YES */ /* FIXME: x */ /* YES!! */
+
+    /** test long comments **/
+    void veryLong()
+    {
+        /*
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          enough talk */
+    }
+
+    /**
+     * @see to lazy to document all args. Testing excessive # args
+     **/
+    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
+                    int aArg6, int aArg7, int aArg8, int aArg9)
+    {
+    }
+}
+
+/** Test class for variable naming in for each clauses. */
+class InputLocalVariableName2
+{
+    /** Some more Javadoc. */
+    public void doSomething()
+    {
+        //"O" should be named "o"
+        for (Object O : new java.util.ArrayList())
+        {
+
+        }
+    }
+}
+
+/** Test enum for member naming check */
+enum InputLocalVariableNameEnum1
+{
+    /** ABC constant */
+    ABC,
+
+    /** XYZ constant */
+    XYZ;
+
+    /** Should be mSomeMemeber */
+    private int someMember;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/InputLocalVariableNameInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/InputLocalVariableNameInnerClass.java
@@ -1,0 +1,79 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for checkstyle.
+// Created: 2001
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.naming.localvariablename;
+
+/**
+ * Tests having inner types
+ * @author Oliver Burn
+ **/
+class InputLocalVariableNameInnerClass
+{
+    // Ignore - two errors
+    class InnerInner2
+    {
+        // Ignore
+        public int fData;
+    }
+
+    // Ignore - 2 errors
+    interface InnerInterface2
+    {
+        // Ignore - should be all upper case
+        String data = "zxzc";
+
+        // Ignore
+        class InnerInterfaceInnerClass
+        {
+            // Ignore - need Javadoc and made private
+            public int rData;
+
+            /** needs to be made private unless allowProtected. */
+            protected int protectedVariable;
+
+            /** needs to be made private unless allowPackage. */
+            int packageVariable;
+        }
+    }
+
+    /** demonstrate bug in handling static final **/
+    protected static Object sWeird = new Object();
+    /** demonstrate bug in handling static final **/
+    static Object sWeird2 = new Object();
+
+    /** demonstrate bug in local final variable */
+    public interface Inter
+    {
+    }
+
+     public static void main()
+     {
+        Inter m = new Inter()
+        {
+            private static final int CDS = 1;
+
+            private int ABC;
+        };
+     }
+
+    /** annotation field incorrectly named. */
+    @interface InnerAnnotation
+    {
+        /** Ignore - should be all upper case. */
+        String data = "zxzc";
+    }
+
+    /** enum with public member variable */
+    enum InnerEnum
+    {
+        /** First constant */
+        A,
+
+        /** Second constant */
+        B;
+
+        /** Should be private */
+        public int someValue;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/InputLocalVariableNameOneCharInitVarName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/InputLocalVariableNameOneCharInitVarName.java
@@ -3,12 +3,12 @@
 // Created: Feb-2001
 // Ignore error
 ////////////////////////////////////////////////////////////////////////////////
-package com.puppycrawl.tools.checkstyle.checks.naming;
+package com.puppycrawl.tools.checkstyle.checks.naming.localvariablename;
 import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
 
-class InputOneCharInitVarName
+class InputLocalVariableNameOneCharInitVarName
 {
 	public void fooMethod()
 	{


### PR DESCRIPTION
This pull request covers to issue #4150 
What was modified:
1) Modified paths to test classes
2) Moved all necessary inputs into /localvariablename package

Results:

All unit tests passed.
the result of mvn clean verify -> Tests run: 103, Failures: 0, Errors: 0, Skipped: 0