### PR TITLE
Issue #4159: EmptyBlock should process LITERAL_DEFAULT

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
@@ -238,7 +238,8 @@ public class EmptyBlockCheck
     private static DetailAST findLeftCurly(DetailAST ast) {
         final DetailAST leftCurly;
         final DetailAST slistAST = ast.findFirstToken(TokenTypes.SLIST);
-        if (ast.getType() == TokenTypes.LITERAL_CASE
+        if ((ast.getType() == TokenTypes.LITERAL_CASE
+                || ast.getType() == TokenTypes.LITERAL_DEFAULT)
                 && ast.getNextSibling() != null
                 && ast.getNextSibling().getFirstChild().getType() == TokenTypes.SLIST) {
             leftCurly = ast.getNextSibling().getFirstChild();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
@@ -189,4 +189,39 @@ public class EmptyBlockCheckTest
         };
         verify(checkConfig, getPath("InputEmptyCase.java"), expected);
     }
+
+    @Test
+    public void testAllowEmptyDefaultWithText() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(EmptyBlockCheck.class);
+        checkConfig.addAttribute("option", BlockOption.TEXT.toString());
+        checkConfig.addAttribute("tokens", "LITERAL_DEFAULT");
+        final String[] expected = {
+            "5:30: " + getCheckMessage(MSG_KEY_BLOCK_EMPTY, "default"),
+            "11:13: " + getCheckMessage(MSG_KEY_BLOCK_EMPTY, "default"),
+            "36:22: " + getCheckMessage(MSG_KEY_BLOCK_EMPTY, "default"),
+            "44:47: " + getCheckMessage(MSG_KEY_BLOCK_EMPTY, "default"),
+            "50:22: " + getCheckMessage(MSG_KEY_BLOCK_EMPTY, "default"),
+            "78:13: " + getCheckMessage(MSG_KEY_BLOCK_EMPTY, "default"),
+        };
+        verify(checkConfig, getPath("InputEmptyDefault.java"), expected);
+    }
+
+    @Test
+    public void testForbidDefaultWithoutStatement() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(EmptyBlockCheck.class);
+        checkConfig.addAttribute("option", BlockOption.STMT.toString());
+        checkConfig.addAttribute("tokens", "LITERAL_DEFAULT");
+        final String[] expected = {
+            "5:30: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
+            "11:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
+            "15:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
+            "26:30: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
+            "36:22: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
+            "44:47: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
+            "50:22: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
+            "65:22: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
+            "78:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
+        };
+        verify(checkConfig, getPath("InputEmptyDefault.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputEmptyDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputEmptyDefault.java
@@ -1,0 +1,89 @@
+public class InputEmptyDefault {
+    void method1(int a) {
+        switch (a) {}
+        switch (a) {default: ; } // no violation
+        switch (a) {default: {}} // violation
+        switch (a) {
+            default:
+        }
+        switch (a) {
+            default:             // violation
+            {}
+        }
+        switch (a) {
+            default:             // violation if checking statements
+            { // text
+            }
+        }
+    }
+
+    void method2(int a) {
+        switch (a) {
+            case 1:a++;
+            case 2:a++;
+            default:             // no violation
+                switch (a) {
+                    default: {   // violation if checking for statements
+
+                    }
+                }
+        }
+    }
+
+    void method3(int a, int b) {
+        switch (a) {
+            case 1: break;
+            default: {} method2(a);  // violation
+        }
+
+        switch (b) {
+            case 2: break;
+            default: method2(b); {}  // no violation
+        }
+
+        switch (a+b) {case 1: break; default: {} ; } // violation
+    }
+
+    void method4(int a, int b) {
+        switch (a) {
+            case 1:
+            default: {}    // violation
+        }
+
+        switch (b) {
+            case 1:
+            default:       // no violation
+        }
+
+        switch (a+b) {
+            default:       // no violation
+            case 1: { }
+        }
+
+        switch (a-b) {
+            case 1:
+            default: {     // violation if checking statements
+
+            } ;
+            case 2: { }
+        }
+    }
+
+    void method5(int a, int b) {
+        switch (a) {
+            case 1:
+            case 2:
+            case 3:
+            default:       // violation
+            {
+            }
+        }
+
+        switch (b) {
+            default:       // no violation
+            case 1:
+            case 2: { } method2(b);
+            case 3:
+        }
+    }
+}

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -150,6 +150,35 @@ switch (a)
     <section name="EmptyBlock">
       <subsection name="Description">
         <p> Checks for empty blocks. This check does not validate sequential blocks. </p>
+
+        <p> Sequential blocks won't be checked. Also, no violations for fallthrough: </p>
+        <source>
+            switch (a) {
+            case 1:                          // no violation
+            case 2:                          // no violation
+            case 3: someMethod(); { }        // no violation
+            default: break;
+            }
+        </source>
+
+        <p>
+          This check processes LITERAL_CASE and LITERAL_DEFAULT separately.
+          So, if tokens=LITERAL_DEFAULT, following code will not trigger any violation,
+          as the empty block belongs to LITERAL_CASE:
+        </p>
+        <p> Configuration: </p>
+        <source>
+&lt;module name=&quot;EmptyBlock&quot;&gt;
+    &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_DEFAULT&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p> Result: </p>
+        <source>
+              switch (a) {
+              default:        // no violation for "default:" as empty block belong to "case 1:"
+              case 1: { }
+              }
+        </source>
       </subsection>
 
       <subsection name="Properties">


### PR DESCRIPTION
Issue #4159 : LITERAL_DEFAULT is now processed by EmptyBlockCheck. Corresponding UTs added