### PR TITLE
Issue #4168: Split and Organize Checkstyle inputs by Test for MethodTypeParameterName

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodTypeParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodTypeParameterNameCheckTest.java
@@ -36,7 +36,9 @@ public class MethodTypeParameterNameCheckTest
     @Override
     protected String getPath(String filename) throws IOException {
         return super.getPath("checks" + File.separator
-                + "naming" + File.separator + filename);
+                + "naming" + File.separator
+                + "methodtypeparametername" + File.separator
+                + filename);
     }
 
     @Test
@@ -62,7 +64,7 @@ public class MethodTypeParameterNameCheckTest
             "23:6: " + getCheckMessage(MSG_INVALID_PATTERN, "foo", pattern),
             "28:10: " + getCheckMessage(MSG_INVALID_PATTERN, "_fo", pattern),
         };
-        verify(checkConfig, getPath("InputTypeParameterName.java"), expected);
+        verify(checkConfig, getPath("InputMethodTypeParameterName.java"), expected);
     }
 
     @Test
@@ -83,6 +85,6 @@ public class MethodTypeParameterNameCheckTest
             "37:14: " + getCheckMessage(MSG_INVALID_PATTERN, "T", pattern),
             //"40:14: Name 'EE' must match pattern '^foo$'.",
         };
-        verify(checkConfig, getPath("InputTypeParameterName.java"), expected);
+        verify(checkConfig, getPath("InputMethodTypeParameterName.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodtypeparametername/InputMethodTypeParameterName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodtypeparametername/InputMethodTypeParameterName.java
@@ -1,0 +1,62 @@
+package com.puppycrawl.tools.checkstyle.checks.naming.methodtypeparametername;
+
+import java.io.Serializable;
+
+public class InputMethodTypeParameterName <t>
+{
+    public <TT> void foo() { }
+    
+    <e_e> void foo(int i) {
+    }
+}
+
+class Other <foo extends Serializable & Cloneable> {
+    
+    foo getOne() {
+	return null;//comment
+    }
+    
+    <Tfo$o2T extends foo> /*comment*/Tfo$o2T getTwo(Tfo$o2T a) {
+	return null;
+    }
+    
+    <foo extends Runnable> foo getShadow() {
+	return null;
+    }
+    
+    static class Junk <foo> {
+        <_fo extends foo> void getMoreFoo() {
+	}
+    }
+}
+
+class MoreOther <T extends Cloneable> {
+    
+    <E extends T> void getMore() {
+        new Other() {
+            <T> void getMoreFoo() {
+	    }
+	};
+	
+//        Other o = new Other() {
+//            <EE> void getMoreFoo() {
+//            }
+//        };
+    }
+}
+
+interface Boo<Input> {
+    Input boo();
+}
+
+interface FooInterface<T> {
+    T foo();
+}
+
+interface FooInterface2 {
+    Input foo();
+}
+
+class Input {
+
+}


### PR DESCRIPTION
This PR solves issue #4168

The "InputTypeParameterName.java" test file was copied to the folder "methodtypeparametername" since this two files still use it:
- ClassTypeParameterNameCheckTest
- InterfaceTypeParameterNameCheckTest


