### PR TITLE
Adding IDEA project files to gitignore and excluding them from checkstyle list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ bin
 
 # IDEA project files
 checkstyle.iml
+checkstyle.ipr
+checkstyle.iws
 .idea
 
 # Temp files

--- a/pom.xml
+++ b/pom.xml
@@ -530,6 +530,8 @@
                 bin/**/*,
                 <!-- IDEA project files -->
                 *.iml,
+                *.ipr,
+                *.iws,
                 .idea/**/*,
                 <!-- Temp files -->
                 *~,


### PR DESCRIPTION
**Intellij IDEA** generates `checkstyle.ipr` and `checkstyle.iws` files which are not excluded from checkstyle list, that causes verification to be failed.

Files `checkstyle.ipr` and `checkstyle.iws` are not specified in **gitignore** file.