### PR TITLE
minor: remove redundant line in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,3 @@ replay_pid*
 
 # NonDex files
 .nondex
-.nondex/*


### PR DESCRIPTION
'.nondex/*' is covered by '.nondex'