### PR TITLE
Issue #4220: Modified AvoidNestedBlocksCheckTest.java and moved its input files to the avoidnestedblocks subdirectory

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckTest.java
@@ -36,7 +36,7 @@ public class AvoidNestedBlocksCheckTest
     @Override
     protected String getPath(String filename) throws IOException {
         return super.getPath("checks" + File.separator
-                + "blocks" + File.separator + filename);
+                + "blocks" + File.separator + "avoidnestedblocks" + File.separator + filename);
     }
 
     @Test
@@ -57,7 +57,7 @@ public class AvoidNestedBlocksCheckTest
             "50:17: " + getCheckMessage(MSG_KEY_BLOCK_NESTED),
             "58:17: " + getCheckMessage(MSG_KEY_BLOCK_NESTED),
         };
-        verify(checkConfig, getPath("InputNestedBlocks.java"), expected);
+        verify(checkConfig, getPath("InputAvoidNestedBlocksDefault.java"), expected);
     }
 
     @Test
@@ -72,7 +72,7 @@ public class AvoidNestedBlocksCheckTest
             "44:17: " + getCheckMessage(MSG_KEY_BLOCK_NESTED),
             "58:17: " + getCheckMessage(MSG_KEY_BLOCK_NESTED),
         };
-        verify(checkConfig, getPath("InputNestedBlocks.java"), expected);
+        verify(checkConfig, getPath("InputAvoidNestedBlocksDefault.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/avoidnestedblocks/InputAvoidNestedBlocksDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/avoidnestedblocks/InputAvoidNestedBlocksDefault.java
@@ -2,13 +2,13 @@
 // Test case file for checkstyle.
 // Created: 2001
 ////////////////////////////////////////////////////////////////////////////////
-package com.puppycrawl.tools.checkstyle.checks.blocks;
+package com.puppycrawl.tools.checkstyle.checks.blocks.avoidnestedblocks;
 
 /**
  * Test case for finding nested blocks.
  * @author lkuehne
  **/
-class InputNestedBlocks
+class InputAvoidNestedBlocksDefault
 {
     static
     { // OK


### PR DESCRIPTION
Issue #4220 

This PR moves all inputs of AvoidNestedBlocksCheckTest of the blocks package to a new subdirectory 'avoidnestedblocks'.