### PR TITLE
Issue #4220: Modified EmptyCatchBlockCheckTest.java and moved its input files to the emptycatchblock subdirectory

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
@@ -40,7 +40,7 @@ public class EmptyCatchBlockCheckTest extends BaseCheckTestSupport {
     @Override
     protected String getPath(String filename) throws IOException {
         return super.getPath("checks" + File.separator
-                + "blocks" + File.separator + filename);
+                + "blocks" + File.separator + "emptycatchblock" + File.separator + filename);
     }
 
     @Test
@@ -58,7 +58,7 @@ public class EmptyCatchBlockCheckTest extends BaseCheckTestSupport {
             "35: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
             "42: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
         };
-        verify(checkConfig, getPath("InputEmptyCatchBlock.java"), expected);
+        verify(checkConfig, getPath("InputEmptyCatchBlockDefault.java"), expected);
     }
 
     @Test
@@ -77,7 +77,7 @@ public class EmptyCatchBlockCheckTest extends BaseCheckTestSupport {
             "230: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
             "239: " + getCheckMessage(MSG_KEY_CATCH_BLOCK_EMPTY),
         };
-        verify(checkConfig, getPath("InputEmptyCatchBlock.java"), expected);
+        verify(checkConfig, getPath("InputEmptyCatchBlockDefault.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptycatchblock/InputEmptyCatchBlockDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptycatchblock/InputEmptyCatchBlockDefault.java
@@ -16,9 +16,9 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ////////////////////////////////////////////////////////////////////////////////
-package com.puppycrawl.tools.checkstyle.checks.blocks;
+package com.puppycrawl.tools.checkstyle.checks.blocks.emptycatchblock;
 import java.io.IOException;
-public class InputEmptyCatchBlock
+public class InputEmptyCatchBlockDefault
 {
     
     private void foo() {


### PR DESCRIPTION
Issue #4220

This PR moves all inputs of EmptyCatchBlockCheckTest of the blocks package to a new subdirectory 'emptycatchblock'.