### PR TITLE
Issue #4220: Modified LeftCurlyCheckTest.java and moved its input files to leftcurly subdirectory

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -50,13 +50,13 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
     @Override
     protected String getPath(String filename) throws IOException {
         return super.getPath("checks" + File.separator
-                + "blocks" + File.separator + filename);
+                + "blocks" + File.separator + "leftcurly" + File.separator + filename);
     }
 
     @Override
     protected String getNonCompilablePath(String filename) throws IOException {
         return super.getNonCompilablePath("checks" + File.separator
-                + "blocks" + File.separator + filename);
+                + "blocks" + File.separator + "leftcurly" + File.separator + filename);
     }
 
     /* Additional test for jacoco, since valueOf()
@@ -85,7 +85,7 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
             "18:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "22:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
         };
-        verify(checkConfig, getPath("InputScopeInnerInterfaces.java"), expected);
+        verify(checkConfig, getPath("InputLeftCurlyDefault.java"), expected);
     }
 
     @Test
@@ -99,7 +99,7 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
             "45:12: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 12),
             "50:18: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 18),
         };
-        verify(checkConfig, getPath("InputScopeInnerInterfaces.java"), expected);
+        verify(checkConfig, getPath("InputLeftCurlyDefault.java"), expected);
     }
 
     @Test
@@ -118,7 +118,7 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
             "45:12: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 12),
             "50:18: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 18),
         };
-        verify(checkConfig, getPath("InputScopeInnerInterfaces.java"), expected);
+        verify(checkConfig, getPath("InputLeftCurlyDefault.java"), expected);
     }
 
     @Test
@@ -189,7 +189,7 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
             "157:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
             "164:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
         };
-        verify(checkConfig, getPath("InputLeftCurlyOther.java"), expected);
+        verify(checkConfig, getPath("InputLeftCurlyDefault3.java"), expected);
     }
 
     @Test
@@ -203,7 +203,7 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
             "158:12: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 12),
             "165:16: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 16),
         };
-        verify(checkConfig, getPath("InputLeftCurlyOther.java"), expected);
+        verify(checkConfig, getPath("InputLeftCurlyDefault3.java"), expected);
     }
 
     @Test
@@ -217,7 +217,7 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
             "69:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "105:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
         };
-        verify(checkConfig, getPath("InputBraces.java"), expected);
+        verify(checkConfig, getPath("InputLeftCurlyMissingBraces.java"), expected);
     }
 
     @Test
@@ -275,7 +275,7 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("option", LeftCurlyOption.EOL.toString());
         checkConfig.addAttribute("ignoreEnums", "true");
         final String[] expectedWhileTrue = CommonUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("InputLeftCurlyEnums.java"), expectedWhileTrue);
+        verify(checkConfig, getPath("InputLeftCurlyIgnoreEnums.java"), expectedWhileTrue);
     }
 
     @Test
@@ -285,7 +285,7 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
         final String[] expectedWhileFalse = {
             "4:17: " + getCheckMessage(MSG_KEY_LINE_BREAK_AFTER, "{", 17),
         };
-        verify(checkConfig, getPath("InputLeftCurlyEnums.java"), expectedWhileFalse);
+        verify(checkConfig, getPath("InputLeftCurlyIgnoreEnums.java"), expectedWhileFalse);
     }
 
     @Test
@@ -343,7 +343,7 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
         checkConfig.addAttribute("option", LeftCurlyOption.EOL.toString());
         checkConfig.addAttribute("maxLineLength", "100");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("InputLeftCurlyAllInOneLine.java"), expected);
+        verify(checkConfig, getPath("InputLeftCurlyFirstLine.java"), expected);
     }
 
     @Test
@@ -360,7 +360,7 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
             "67:12: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 12),
             "72:18: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 18),
         };
-        verify(checkConfig, getPath("InputScopeInnerInterfaces2.java"), expected);
+        verify(checkConfig, getPath("InputLeftCurlyCoverageIncrease.java"), expected);
     }
 
     @Test
@@ -370,7 +370,7 @@ public class LeftCurlyCheckTest extends BaseCheckTestSupport {
         try {
             final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-            verify(checkConfig, getPath("InputScopeInnerInterfaces.java"), expected);
+            verify(checkConfig, getPath("InputLeftCurlyDefault.java"), expected);
             fail("exception expected");
         }
         catch (CheckstyleException ex) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputLeftCurlyAllInOneLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputLeftCurlyAllInOneLine.java
@@ -1,4 +1,0 @@
-package com.puppycrawl.tools.checkstyle.checks.blocks;import java.lang.annotation.ElementType;import java.lang.annotation.Target;import java.util.ArrayList;import java.util.List;class InputLeftCurlyAllInOneLine{
-    
-   
-}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyAnnotations.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.checks.blocks;
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyCoverageIncrease.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyCoverageIncrease.java
@@ -2,9 +2,9 @@
 // Test case file for checkstyle.
 // Created: 2001
 ////////////////////////////////////////////////////////////////////////////////
-package com.puppycrawl.tools.checkstyle.checks.blocks;
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
 
-public class InputScopeInnerInterfaces2{
+public class InputLeftCurlyCoverageIncrease {
     // inner interfaces with different scopes
 
     

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyDefault.java
@@ -2,9 +2,9 @@
 // Test case file for checkstyle.
 // Created: 2001
 ////////////////////////////////////////////////////////////////////////////////
-package com.puppycrawl.tools.checkstyle.checks.blocks;
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
 
-public class InputScopeInnerInterfaces
+public class InputLeftCurlyDefault
 {
     private interface PrivateInterface
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyDefault3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyDefault3.java
@@ -1,0 +1,170 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for checkstyle.
+// Created: 2001
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+/**
+ * Test case for correct use of braces.
+ * @author Oliver Burn
+ **/
+class InputLeftCurlyDefault3
+{
+    /** @see test method **/
+    int foo() throws InterruptedException
+    {
+        int x = 1;
+        int a = 2;
+        while (true)
+        {
+            try
+            {
+                if (x > 0)
+                {
+                    break;
+                }
+                else if (x < 0) {
+                    ;
+                }
+                else
+                {
+                    break;
+                }
+                switch (a)
+                {
+                case 0:
+                    break;
+                default:
+                    break;
+                }
+            }
+            catch (Exception e)
+            {
+                break;
+            }
+            finally
+            {
+                break;
+            }
+        }
+
+        synchronized (this)
+        {
+            do
+            {
+                x = 2;
+            } while (x == 2);
+        }
+
+        this.wait(666
+                 ); // Bizarre, but legal
+
+        for (int k = 0; k < 1; k++)
+        {
+            String innerBlockVariable = "";
+        }
+
+        // test input for bug reported by Joe Comuzzi
+        if (System.currentTimeMillis() > 1000)
+            return 1;
+        else
+            return 2;
+    }
+
+    // Test static initialiser
+    static
+    {
+        int x = 1; // should not require any javadoc
+    }
+
+
+
+    public enum GreetingsEnum
+    {
+        HELLO,
+        GOODBYE
+    };
+
+    void method2()
+    {
+        boolean flag = true;
+        if (flag) {
+            System.identityHashCode("heh");
+            flag = !flag; } String.CASE_INSENSITIVE_ORDER.
+              equals("Xe-xe");
+        // it is ok to have rcurly on the same line as previous
+        // statement if lcurly on the same line.
+        if (flag) { String.CASE_INSENSITIVE_ORDER.equals("it is ok."); }
+    }
+}
+
+/**
+ * Test input for closing brace if that brace terminates 
+ * a statement or the body of a constructor. 
+ */
+class FooCtor
+{
+	int i;
+	public FooCtor()
+    {
+		i = 1;
+    }}
+
+/**
+* Test input for closing brace if that brace terminates 
+* a statement or the body of a method. 
+*/
+class FooMethod
+{
+	public void fooMethod()
+    {
+		int i = 1;
+    }}
+
+/**
+* Test input for closing brace if that brace terminates 
+* a statement or the body of a named class. 
+*/
+class FooInner
+{
+	class InnerFoo
+    {
+		public void fooInnerMethod ()
+        {
+			
+		}
+    }}
+
+/**
+ * False positive 
+ *
+ */
+class Absent_CustomFieldSerializer3 {
+
+    public static void serialize() {} //false positive. Expected nothing but was "'}' should be alone on a line." 
+}
+
+class Absent_CustomFieldSerializer4
+{
+    public Absent_CustomFieldSerializer4() {}
+}
+
+class EmptyClass2 {}
+
+interface EmptyInterface3 {}
+
+class ClassWithStaticInitializers
+{
+    static {
+    }
+    static
+    {}
+
+    static class Inner
+    {
+        static {
+            int i = 1;
+        }
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyFirstLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyFirstLine.java
@@ -1,0 +1,4 @@
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;import java.lang.annotation.ElementType;import java.lang.annotation.Target;import java.util.ArrayList;import java.util.List;class InputLeftCurlyFirstLine {
+    
+   
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyIgnoreEnums.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyIgnoreEnums.java
@@ -1,6 +1,6 @@
-package com.puppycrawl.tools.checkstyle.checks.blocks;
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
 
-public class InputLeftCurlyEnums {
+public class InputLeftCurlyIgnoreEnums {
     enum Colors {RED,
         BLUE,
         GREEN

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyLineBreakAfter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyLineBreakAfter.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.checks.blocks;
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyMethod.java
@@ -2,7 +2,7 @@
 // Test case file for checkstyle.
 // Created: 2001
 ////////////////////////////////////////////////////////////////////////////////
-package com.puppycrawl.tools.checkstyle.checks.blocks;
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
 
 /**
  * Test case for correct use of braces.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyMissingBraces.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyMissingBraces.java
@@ -1,0 +1,119 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for checkstyle.
+// Created: 2001
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+/**
+ * Test case for correct use of braces.
+ * @author Oliver Burn
+ **/
+class InputLeftCurlyMissingBraces
+{
+    /** @return helper func **/
+    boolean condition()
+    {
+        return false;
+    }
+
+    /** Test do/while loops **/
+    void testDoWhile()
+    {
+        // Valid
+        do {
+            testDoWhile();
+        }
+        while (condition());
+
+        // Invalid
+        do testDoWhile(); while (condition());
+    }
+
+    /** Test while loops **/
+    void testWhile()
+    {
+        // Valid
+        while (condition()) {
+            testWhile();
+        }
+
+        // Invalid
+        while(condition());
+        while (condition())
+            testWhile();
+        while (condition())
+            if (condition())
+                testWhile();
+    }
+
+    /** Test for loops **/
+    void testFor()
+    {
+        // Valid
+        for (int i = 1; i < 5; i++) {
+            testFor();
+        }
+
+        // Invalid
+        for(int i = 1;i < 5;i++);
+        for (int i = 1; i < 5; i++)
+            testFor();
+        for (int i = 1; i < 5;
+             i++)
+            if (i > 2)
+                testFor();
+    }
+
+    /** Test if constructs **/
+    public void testIf()
+    {
+        // Valid
+        if (condition()) {
+            testIf();
+        }
+        else if (condition()) {
+            testIf();
+        }
+        else {
+            testIf();
+        }
+
+        // Invalid
+        if (condition());
+        if (condition())
+            testIf();
+        if (condition())
+            testIf();
+        else
+            testIf();
+        if (condition())
+            testIf();
+        else {
+            testIf();
+        }
+        if (condition()) {
+            testIf();
+        }
+        else
+            testIf();
+        if (condition())
+            if (condition())
+                testIf();
+    }
+
+    void whitespaceAfterSemi()
+    {
+        //reject
+        int i = 1;int j = 2;
+
+        //accept
+        for (;;) {
+        }
+    }
+
+    /** Empty constructor block. **/
+    public InputLeftCurlyMissingBraces() {}
+    
+    /** Empty method block. **/
+    public void emptyImplementation() {}
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyNewLineOptionWithLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyNewLineOptionWithLambda.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.checks.blocks;
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
 
 
 public class InputLeftCurlyNewLineOptionWithLambda


### PR DESCRIPTION
Issue #4220

This PR moves all inputs of LeftCurlyCheckTest of the blocks package to a new subdirectory 'leftcurly'.

Since a few tests were being shared by different tests, two new files were created.

Also `InputLeftCurlyAllInOneLine.java` shows up as deleted and a new file `InputLeftCurlyFirstLine.java` is created. This happens because the change in the name of the class of the file is relatively large to the contents present in the file. This has been done previously as well in PR #3964 with the file `InputGh47.java` when it was changed to `InputGenericWhitespaceList.java`