### PR TITLE
Issue #4062: Split and Organize Checkstyle inputs by Test for ParentPad

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
@@ -41,7 +41,9 @@ public class ParenPadCheckTest
     @Override
     protected String getPath(String filename) throws IOException {
         return super.getPath("checks" + File.separator
-                + "whitespace" + File.separator + filename);
+                + "whitespace" + File.separator
+                + "parenpad" + File.separator
+                + filename);
     }
 
     @Test
@@ -60,7 +62,7 @@ public class ParenPadCheckTest
             "277:18: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
             "277:23: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
         };
-        verify(checkConfig, getPath("InputWhitespace.java"), expected);
+        verify(checkConfig, getPath("InputParenPadWhitespace.java"), expected);
     }
 
     @Test
@@ -106,7 +108,7 @@ public class ParenPadCheckTest
             "287:55: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
             "287:70: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
         };
-        verify(checkConfig, getPath("InputWhitespace.java"), expected);
+        verify(checkConfig, getPath("InputParenPadWhitespace.java"), expected);
     }
 
     @Test
@@ -123,7 +125,7 @@ public class ParenPadCheckTest
             "48:27: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
             "51:26: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
         };
-        verify(checkConfig, getPath("InputForWhitespace.java"), expected);
+        verify(checkConfig, getPath("InputParenPadForWhitespace.java"), expected);
     }
 
     @Test
@@ -143,7 +145,7 @@ public class ParenPadCheckTest
             "27:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
             "32:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
         };
-        verify(checkConfig, getPath("InputForWhitespace.java"), expected);
+        verify(checkConfig, getPath("InputParenPadForWhitespace.java"), expected);
     }
 
     @Test
@@ -281,7 +283,7 @@ public class ParenPadCheckTest
             "212:51: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
             "212:53: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
         };
-        verify(checkConfig, getPath("InputParenPad.java"), expected);
+        verify(checkConfig, getPath("InputParenPadLeftRightAndNoSpace.java"), expected);
     }
 
     @Test
@@ -317,7 +319,7 @@ public class ParenPadCheckTest
             "212:51: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
             "212:53: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
         };
-        verify(checkConfig, getPath("InputParenPad.java"), expected);
+        verify(checkConfig, getPath("InputParenPadLeftRightAndNoSpace.java"), expected);
     }
 
     @Test
@@ -328,7 +330,7 @@ public class ParenPadCheckTest
         try {
             final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-            verify(checkConfig, getPath("InputParenPad.java"), expected);
+            verify(checkConfig, getPath("InputParenPadLeftRightAndNoSpace.java"), expected);
             fail("exception expected");
         }
         catch (CheckstyleException ex) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadForWhitespace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadForWhitespace.java
@@ -2,9 +2,9 @@
 // Test case file for FOR_ITERATION and whitespace.
 // Created: 2003
 ////////////////////////////////////////////////////////////////////////////////
-package com.puppycrawl.tools.checkstyle.checks.whitespace;
+package com.puppycrawl.tools.checkstyle.checks.whitespace.parenpad;
 
-class InputForWhitespace
+class InputParenPadForWhitespace
 {
     void method1()
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadLambda.java
@@ -1,6 +1,6 @@
-package com.puppycrawl.tools.checkstyle.checks.whitespace;
+package com.puppycrawl.tools.checkstyle.checks.whitespace.parenpad;
 
-public class InputParenPadLambdaOnly {
+class InputParenPadLambda {
     {
         java.util.function.Consumer a = (o) -> { o.toString(); }; // ok
 
@@ -16,9 +16,9 @@ public class InputParenPadLambdaOnly {
 
         java.util.stream.Stream.of().forEach(( Object o ) -> o.toString()); // 2 violations
 
-        java.util.stream.Stream.of().forEach(o -> o.toString( )); // ok
+        java.util.stream.Stream.of().forEach(o -> o.toString( )); // 2 violations
     }
 
-    void someMethod( String param ) { // ok
+    void someMethod( String param ) { // 2 violations
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadLambdaOnly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadLambdaOnly.java
@@ -1,6 +1,6 @@
-package com.puppycrawl.tools.checkstyle.checks.whitespace;
+package com.puppycrawl.tools.checkstyle.checks.whitespace.parenpad;
 
-class InputParenPadLambda {
+public class InputParenPadLambdaOnly {
     {
         java.util.function.Consumer a = (o) -> { o.toString(); }; // ok
 
@@ -16,9 +16,9 @@ class InputParenPadLambda {
 
         java.util.stream.Stream.of().forEach(( Object o ) -> o.toString()); // 2 violations
 
-        java.util.stream.Stream.of().forEach(o -> o.toString( )); // 2 violations
+        java.util.stream.Stream.of().forEach(o -> o.toString( )); // ok
     }
 
-    void someMethod( String param ) { // 2 violations
+    void someMethod( String param ) { // ok
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadLambdaOnlyWithSpace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadLambdaOnlyWithSpace.java
@@ -1,6 +1,6 @@
-package com.puppycrawl.tools.checkstyle.checks.whitespace;
+package com.puppycrawl.tools.checkstyle.checks.whitespace.parenpad;
 
-class InputParenPadLambdaWithSpace {
+class InputParenPadLambdaOnlyWithSpace {
     {
         java.util.function.Consumer a = ( o ) -> { o.toString( ); }; // ok
 
@@ -19,6 +19,6 @@ class InputParenPadLambdaWithSpace {
         java.util.stream.Stream.of().forEach( o -> o.toString() ); // ok
     }
 
-    void someMethod(String param) { // 2 violations
+    void someMethod(String param) { // ok
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadLambdaWithSpace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadLambdaWithSpace.java
@@ -1,6 +1,6 @@
-package com.puppycrawl.tools.checkstyle.checks.whitespace;
+package com.puppycrawl.tools.checkstyle.checks.whitespace.parenpad;
 
-class InputParenPadLambdaOnlyWithSpace {
+class InputParenPadLambdaWithSpace {
     {
         java.util.function.Consumer a = ( o ) -> { o.toString( ); }; // ok
 
@@ -19,6 +19,6 @@ class InputParenPadLambdaOnlyWithSpace {
         java.util.stream.Stream.of().forEach( o -> o.toString() ); // ok
     }
 
-    void someMethod(String param) { // ok
+    void someMethod(String param) { // 2 violations
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadLeftRightAndNoSpace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadLeftRightAndNoSpace.java
@@ -1,10 +1,10 @@
-package com.puppycrawl.tools.checkstyle.checks.whitespace;
+package com.puppycrawl.tools.checkstyle.checks.whitespace.parenpad;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 
-public class InputParenPad
+public class InputParenPadLeftRightAndNoSpace
 {
     class ParenPadNoSpace  {
         ParenPadNoSpace() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadWhitespace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadWhitespace.java
@@ -4,13 +4,13 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com . puppycrawl
     .tools.
-    checkstyle.checks.whitespace;
+    checkstyle.checks.whitespace.parenpad;
 
 /**
  * Class for testing whitespace issues.
  * error missing author tag
  **/
-class InputWhitespace
+class InputParenPadWhitespace
 {
     /** ignore assignment **/
     private int mVar1=1;
@@ -191,7 +191,7 @@ class InputWhitespace
     /** bug 806243 (NoWhitespaceBeforeCheck error for anonymous inner class) */
     void bug806243()
     {
-        Object o = new InputWhitespace() {
+        Object o = new InputParenPadWhitespace() {
             private int j ;
             //           ^ whitespace
         };

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadWithDisabledLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadWithDisabledLambda.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.checks.whitespace;
+package com.puppycrawl.tools.checkstyle.checks.whitespace.parenpad;
 
 public class InputParenPadWithDisabledLambda {
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadWithSpace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadWithSpace.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.checks.whitespace;
+package com.puppycrawl.tools.checkstyle.checks.whitespace.parenpad;
 
 public class InputParenPadWithSpace
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadWithSpaceAndDisabledLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadWithSpaceAndDisabledLambda.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.checks.whitespace;
+package com.puppycrawl.tools.checkstyle.checks.whitespace.parenpad;
 
 class InputParenPadWithSpaceAndDisabledLambda {
     {


### PR DESCRIPTION
Related to issue #4062 
What was done:
1) Moved all necessary classes to new package /parenpad
2) Renamed InputParenPad.java to InputParenPadLeftRightAndNoSpace.java