### PR TITLE
Issue #4043: Split and Organize Checkstyle inputs by Test for OuterTypeNumber

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckTest.java
@@ -36,7 +36,9 @@ public class OuterTypeNumberCheckTest extends BaseCheckTestSupport {
     @Override
     protected String getPath(String filename) throws IOException {
         return super.getPath("checks" + File.separator
-                + "sizes" + File.separator + filename);
+                + "sizes" + File.separator
+                + "outertypenumber" + File.separator
+                + filename);
     }
 
     @Test
@@ -72,7 +74,7 @@ public class OuterTypeNumberCheckTest extends BaseCheckTestSupport {
         final String[] expected = {
             "6:1: " + getCheckMessage(MSG_KEY, 3, 1),
         };
-        verify(checkConfig, getPath("InputSimple.java"), expected);
+        verify(checkConfig, getPath("InputOuterTypeNumberSimple.java"), expected);
     }
 
     @Test
@@ -81,7 +83,7 @@ public class OuterTypeNumberCheckTest extends BaseCheckTestSupport {
             createCheckConfig(OuterTypeNumberCheck.class);
         checkConfig.addAttribute("max", "30");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("InputSimple.java"), expected);
+        verify(checkConfig, getPath("InputOuterTypeNumberSimple.java"), expected);
     }
 
     @Test
@@ -90,6 +92,6 @@ public class OuterTypeNumberCheckTest extends BaseCheckTestSupport {
             createCheckConfig(OuterTypeNumberCheck.class);
         checkConfig.addAttribute("max", "1");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("InputOuterTypeNumber.java"), expected);
+        verify(checkConfig, getPath("InputOuterTypeNumberEmptyInner.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberEmptyInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberEmptyInner.java
@@ -1,7 +1,7 @@
-package com.puppycrawl.tools.checkstyle.checks.sizes;
+package com.puppycrawl.tools.checkstyle.checks.sizes.outertypenumber;
 
 /**Contains empty inner class for OuterTypeNumberCheckTest*/
-public class InputOuterTypeNumber {
+public class InputOuterTypeNumberEmptyInner {
 
     /** Just empty inner class*/
     private class InnerClass {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberSimple.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberSimple.java
@@ -3,7 +3,7 @@
 // Created: Feb-2001
 // Ignore error
 ////////////////////////////////////////////////////////////////////////////////
-package com.puppycrawl.tools.checkstyle.checks.sizes;
+package com.puppycrawl.tools.checkstyle.checks.sizes.outertypenumber;
 import java.io.*;
 /**
  * Contains simple mistakes:
@@ -13,7 +13,7 @@ import java.io.*;
  * - Order of modifiers
  * @author Oliver Burn
  **/
-final class InputSimple
+final class InputOuterTypeNumberSimple
 {
     // Long line ----------------------------------------------------------------
     // Contains a tab ->	<-
@@ -99,7 +99,7 @@ final class InputSimple
     }
 
     /** constructor that is 10 lines long **/
-    private InputSimple()
+    private InputOuterTypeNumberSimple()
     {
         // a line
         // a line
@@ -198,7 +198,7 @@ final class InputSimple
 }
 
 /** Test class for variable naming in for each clauses. */
-class InputSimple2
+class InputOuterTypeNumberSimple2
 {
     /** Some more Javadoc. */
     public void doSomething()


### PR DESCRIPTION
Pull request related to issue #4043 
What was done:
1) Moved all necessary classes to new package /outertypenumber
2) Renamed InputSimple to InputOuterTypeNumberSimple and InputOuterTypeNumber to InputOuterTypeNumberEmptyInner