### PR TITLE
Issue #4022: Removed shouldStartLine property for RightCurly

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
@@ -21,7 +21,6 @@ package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
 
 import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_ALONE;
 import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_BREAK_BEFORE;
-import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_NEW;
 import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_SAME;
 
 import org.junit.Test;
@@ -83,10 +82,11 @@ public class RightCurlyTest extends AbstractModuleTestSupport {
     public void testRightCurlyAloneOther() throws Exception {
         final String[] expected = {
             "97:5: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 5),
-            "97:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_NEW, "}", 6),
+            "97:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 6),
             "108:5: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 5),
-            "108:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_NEW, "}", 6),
-            "122:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_NEW, "}", 6),
+            "108:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 6),
+            "122:5: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 5),
+            "122:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 6),
         };
 
         final Configuration checkConfig = getModuleConfig("RightCurly", "RightCurlyAlone");

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRightCurlyTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRightCurlyTest.java
@@ -71,7 +71,7 @@ public class XpathRegressionRightCurlyTest extends AbstractXpathTestSupport {
 
         final String[] expectedViolation = {
             "9:15: " + getCheckMessage(RightCurlyCheck.class,
-                RightCurlyCheck.MSG_KEY_LINE_NEW, "}", 15),
+                RightCurlyCheck.MSG_KEY_LINE_ALONE, "}", 15),
         };
 
         final List<String> expectedXpathQueries = Collections.singletonList(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 
 import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_ALONE;
 import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_BREAK_BEFORE;
-import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_NEW;
 import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_SAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -102,13 +101,13 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
         checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF");
-        checkConfig.addAttribute("shouldStartLine", "true");
         final String[] expected = {
             "111:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "111:6: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 6),
+            "111:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
             "122:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "122:6: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 6),
-            "136:6: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 6),
+            "122:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
+            "136:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "136:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
         };
         verify(checkConfig, getPath("InputRightCurlyLeft.java"), expected);
     }
@@ -117,7 +116,6 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     public void testShouldStartLine() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
-        checkConfig.addAttribute("shouldStartLine", "false");
         final String[] expected = {
             "93:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
             "97:72: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 72),
@@ -129,7 +127,6 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     public void testMethodCtorNamedClassClosingBrace() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
-        checkConfig.addAttribute("shouldStartLine", "false");
         final String[] expected = {
             "93:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
             "97:72: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 72),
@@ -199,7 +196,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "107:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
             "111:88: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 88),
             "111:40: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 40),
-            "114:18: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 18),
+            "114:18: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 18),
             "118:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
             "121:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
             "123:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
@@ -207,25 +204,24 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "136:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "138:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "138:33: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 33),
-            "148:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "150:75: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 75),
             "151:58: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 58),
             "151:74: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 74),
             "152:58: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 58),
             "153:58: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 58),
             "153:74: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 74),
-            "159:37: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 37),
+            "159:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
             "166:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
             "181:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "188:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "188:13: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 13),
+            "188:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
             "197:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "197:10: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 10),
+            "197:10: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 10),
             "201:54: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 54),
-            "201:55: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 55),
+            "201:55: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 55),
             "204:75: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 75),
             "204:76: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 76),
-            "204:77: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 77),
+            "204:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 77),
             "208:76: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 76),
             "216:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
         };
@@ -241,26 +237,35 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             + "LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT");
         final String[] expected = {
             "60:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 26),
-            "69:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
             "74:42: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 42),
-            "77:18: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 18),
+            "77:18: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 18),
             "85:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
+            "89:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 77),
             "97:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "99:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "119:37: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 37),
-            "126:37: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 37),
-            "148:13: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 13),
+            "110:75: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 75),
+            "111:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 77),
+            "111:93: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 93),
+            "112:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 77),
+            "113:64: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 64),
+            "113:80: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 80),
+            "119:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
+            "126:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
+            "141:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "148:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "148:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
             "157:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "157:10: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 10),
+            "157:10: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 10),
             "161:54: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 54),
-            "161:55: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 55),
+            "161:55: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 55),
             "164:75: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 75),
             "164:76: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 76),
-            "164:77: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 77),
+            "168:80: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 80),
+            "164:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 77),
             "176:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
-            "182:24: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 24),
-            "185:24: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 24),
-            "188:24: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 24),
+            "182:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
+            "185:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
+            "188:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
         };
         verify(checkConfig, getPath("InputRightCurlyAloneOrSingleline.java"), expected);
     }
@@ -341,7 +346,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "25:35: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 35),
             "27:92: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 92),
             "33:67: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 67),
-            "35:15: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 15),
+            "35:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
             "37:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
         };
         verify(checkConfig, getPath("InputRightCurlyTryResource.java"), expected);
@@ -353,7 +358,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", RightCurlyOption.ALONE_OR_SINGLELINE.toString());
         final String[] expected = {
             "19:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "35:15: " + getCheckMessage(MSG_KEY_LINE_NEW, "}", 15),
+            "35:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
             "37:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
         };
         verify(checkConfig, getPath("InputRightCurlyTryResource.java"), expected);
@@ -396,6 +401,52 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig,
             getPath("InputRightCurlySameLambda.java"), expected);
+    }
+
+    @Test
+    public void testOptionAlone() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, LITERAL_IF, LITERAL_ELSE, "
+                + "LITERAL_DO, LITERAL_WHILE, LITERAL_FOR, STATIC_INIT, INSTANCE_INIT");
+        final String[] expected = {
+            "7:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
+            "8:21: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 21),
+            "12:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 26),
+            "21:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
+            "38:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "42:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
+            "45:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
+            "47:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
+            "49:17: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 17),
+            "51:53: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 53),
+            "53:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
+            "53:52: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 52),
+            "61:42: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 42),
+            "63:43: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 43),
+            "67:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+        };
+        verify(checkConfig, getPath("InputRightCurlyAlone.java"),
+                expected);
+    }
+
+    @Test
+    public void testOptionAloneOrSingleLine() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option", RightCurlyOption.ALONE_OR_SINGLELINE.toString());
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, LITERAL_IF, LITERAL_ELSE, "
+                + "LITERAL_DO, LITERAL_WHILE, LITERAL_FOR, STATIC_INIT, INSTANCE_INIT");
+        final String[] expected = {
+            "12:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 26),
+            "21:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
+            "29:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "38:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "42:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
+            "63:43: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 43),
+            "67:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+        };
+        verify(checkConfig, getPath(
+                "InputRightCurlyAloneOrSingleLine2.java"), expected);
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAlone.java
@@ -1,0 +1,68 @@
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyAlone {
+
+    private int a;
+    private static int b;
+    {  a = 2; }  //violation
+    static { b = 3; }  //violation
+
+    void method1() {
+        Thread t = new Thread() {@Override public void run() {
+            int a; int b;} //violation
+        };
+    }
+
+    void method2(java.util.HashSet<String> set) {
+        java.util.Map<String, String> map1 = new java.util.LinkedHashMap<String, String>() {{
+            put("Hello", "World");
+            put("first", "second");
+            put("polygene", "lubricants");
+            put("alpha", "betical");}  //violation
+        };
+
+        java.util.Map<String, String> map2 = new java.util.LinkedHashMap<String, String>() {{
+            put("Hello", "World");
+            put("first", "second");
+            put("polygene", "lubricants");
+            put("alpha", "betical");
+        }}; //NO violation
+    }
+
+    void method3() {
+        method2(new java.util.HashSet<String>() {{
+            add("XZ13s");
+            add("AB21/X");
+            add("YYLEX");
+            add("AR5E");
+        }});  //violation
+    }
+
+    int method4(int a) {
+        if (a>2) a*=10; return ++a; }   //violation
+
+    void method5(int a) {
+        while (a > 5) { a--; }  //violation
+
+        if (a > 4) { a++; }  //violation
+
+        do {a--;} while (a > 3);  //violation
+
+        for (int i = 1; i < 10; i++) { byte b = 10; }  //violation
+
+        if (a < 2) { --a; } else if (a > 3) { a++; } //2 violations
+
+        java.util.List<String> list = new java.util.ArrayList<>();
+        list.stream()
+                .filter(e -> {return !e.isEmpty() && !"null".equals(e);} )
+                .collect(java.util.stream.Collectors.toList());
+    }
+
+    class TestClass { private int field; }  //violation
+
+    class TestClass2 { private int field; };  //violation
+
+    class TestClass3 {
+        private int field;
+    };  //violation
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLine2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLine2.java
@@ -1,0 +1,68 @@
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyAloneOrSingleLine2 {
+
+    private int a;
+    private static int b;
+    {  a = 2; }
+    static { b = 3; }
+
+    void method1() {
+        Thread t = new Thread() {@Override public void run() {
+            int a; int b;} //violation
+        };
+    }
+
+    void method2(java.util.HashSet<String> set) {
+        java.util.Map<String, String> map1 = new java.util.LinkedHashMap<String, String>() {{
+            put("Hello", "World");
+            put("first", "second");
+            put("polygene", "lubricants");
+            put("alpha", "betical");}  //violation
+        };
+
+        java.util.Map<String, String> map2 = new java.util.LinkedHashMap<String, String>() {{
+            put("Hello", "World");
+            put("first", "second");
+            put("polygene", "lubricants");
+            put("alpha", "betical");
+        }};; //violation
+    }
+
+    void method3() {
+        method2(new java.util.HashSet<String>() {{
+            add("XZ13s");
+            add("AB21/X");
+            add("YYLEX");
+            add("AR5E");
+        }});  //violation
+    }
+
+    int method4(int a) {
+        if (a>2) a*=10; return ++a; }   //violation
+
+    void method5(int a) {
+        while (a > 5) { a--; }
+
+        if (a > 4) { a++; }
+
+        do {a--;} while (a > 3);  //NO violation
+
+        for (int i = 1; i < 10; i++) { byte b = 10; }
+
+        if (a < 2) { --a; } else if (a > 3) { a++; }
+
+        java.util.List<String> list = new java.util.ArrayList<>();
+        list.stream()
+                .filter(e -> {return !e.isEmpty() && !"null".equals(e);} )
+                .collect(java.util.stream.Collectors.toList());
+    }
+
+    class TestClass { private int field; }
+
+    class TestClass2 { private int field; };  //violation
+
+    class TestClass3 {
+        private int field;
+    };  //violation
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleline.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleline.java
@@ -105,7 +105,7 @@ public class InputRightCurlyAloneOrSingleline {
             put("first", "second");
             put("polygene", "lubricants");
             put("alpha", "betical");
-        }}; // it's ok
+        }}; //NO violation
 
         Thread t = new Thread() {@Override public void run() {super.run();}};
         new Object() { @Override protected void finalize() { "".toString(); }  { int a = 5; }};
@@ -138,14 +138,14 @@ public class InputRightCurlyAloneOrSingleline {
             add("AB21/X");
             add("YYLEX");
             add("AR5E");
-        }});  //it's ok, can't be formatted better
+        }});  //violation
 
         foo23(new java.util.HashSet<String>() {{
             add("XZ13s");
             add("AB21/X");
             add("YYLEX");
             add("AR5E");
-        }});} //violation
+        }});} //2 violations
 
 
     void foo23(java.util.HashSet<String> set) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAnnotations.java
@@ -145,7 +145,7 @@ class InputRightCurlyAnnotations
             put("first", "second");
             put("polygene", "lubricants");
             put("alpha", "betical");
-        }}; //violation
+        }}; //NO violation
 
         Thread t = new Thread() {@Override public void run() {super.run();}}; //violation
         new Object() { public int hashCode() { return 1; }  { int a = 5; }}; //violation

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -897,14 +897,6 @@ for(int i = 0; i &lt; 10; value.incrementValue()); // OK
             <td>3.0</td>
           </tr>
           <tr>
-            <td>shouldStartLine</td>
-            <td>should we check if <code>'}'</code>
-            starts line.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>4.2</td>
-          </tr>
-          <tr>
             <td>tokens</td>
             <td>tokens to check</td>
 
@@ -1014,10 +1006,6 @@ for(int i = 0; i &lt; 10; value.incrementValue()); // OK
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22line.break.before%22">
             line.break.before</a>
-          </li>
-          <li>
-            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22line.new%22">
-            line.new</a>
           </li>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22line.same%22">


### PR DESCRIPTION
Issue #4022 

_Some Test cases borrowed from a comment in #3775_

**Behavioral Changes:**
1. [This](https://github.com/checkstyle/checkstyle/blob/master/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputRightCurlyAloneOrSingleline.java#L108), [This](https://github.com/checkstyle/checkstyle/blob/master/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputRightCurlyAloneOrSingleline.java#L141), and [This (column '9')](https://github.com/checkstyle/checkstyle/blob/master/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputRightCurlyAloneOrSingleline.java#L148) are now violations

2. [This](https://github.com/checkstyle/checkstyle/blob/master/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputRightCurlyAloneOrSingleline.java#L69) is no more a violation

3. All the `MSG_KEY_LINE_NEW` in errors replaced by `MSG_KEY_LINE_ALONE` 

**DO NOTE**:

Unlike to what was mentioned in the comments in Issue 3775, [this](https://github.com/ps-sp/checkstyle/blob/6279c97c0e2a30c69de320bd9e136099f925a422/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/InputRightCurlyWithoutShouldStartLine.java#L58) results in violation for both option=ALONE and option=ALONE_OR_SINGLELINE