### PR TITLE
Issue #1571: Move all dtd schemas to sourceforge site

### DIFF
--- a/config/catalog.xml
+++ b/config/catalog.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <system systemId="http://checkstyle.sourceforge.net/dtds/configuration_1_0.dtd" uri="./../src/main/java/resources/com/puppycrawl/tools/checkstyle/configuration_1_0.dtd"/>
+    <system systemId="http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd" uri="./../src/main/java/resources/com/puppycrawl/tools/checkstyle/configuration_1_1.dtd"/>
+    <system systemId="http://checkstyle.sourceforge.net/dtds/configuration_1_2.dtd" uri="./../src/main/java/resources/com/puppycrawl/tools/checkstyle/configuration_1_2.dtd"/>
+    <system systemId="http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd" uri="./../src/main/java/resources/com/puppycrawl/tools/checkstyle/configuration_1_3.dtd"/>
+    <system systemId="http://checkstyle.sourceforge.net/dtds/packages_1_0.dtd" uri="./../src/main/java/resources/com/puppycrawl/tools/checkstyle/packages_1_0.dtd"/>
+    <system systemId="http://checkstyle.sourceforge.net/dtds/suppressions_1_0.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_0.dtd"/>
+    <system systemId="http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd" uri="./../src/main/java/resources/com/puppycrawl/tools/checkstyle/suppressions_1_1.dtd"/>
+    <system systemId="http://checkstyle.sourceforge.net/dtds/import_control_1_0.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_0.dtd"/>
+    <system systemId="http://checkstyle.sourceforge.net/dtds/import_control_1_1.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_1.dtd"/>
+    <system systemId="http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_2.dtd"/>
+</catalog>

--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
   <!--

--- a/config/checkstyle_non_main_files_checks.xml
+++ b/config/checkstyle_non_main_files_checks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
     <property name="charset" value="UTF-8"/>

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd">
 
 <suppressions>
     

--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
         "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_2.dtd">
 
 <module name="Checker">
     <!-- All checks are from https://github.com/sevntu-checkstyle/sevntu.checkstyle project -->

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE suppressions PUBLIC
         "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+        "http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd">
 
 <suppressions>
 

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd">
 
 <suppressions>
     <suppress checks="FileLength"

--- a/pom.xml
+++ b/pom.xml
@@ -957,6 +957,9 @@
               <systemId>src/main/resources/com/puppycrawl/tools/checkstyle/configuration_1_3.dtd</systemId>
             </validationSet>
           </validationSets>
+          <catalogs>
+            <catalog>config/catalog.xml</catalog>
+          </catalogs>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/resources/checkstyle_packages.xml
+++ b/src/main/resources/checkstyle_packages.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE checkstyle-packages PUBLIC
     "-//Puppy Crawl//DTD Package Names 1.0//EN"
-    "http://www.puppycrawl.com/dtds/packages_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/packages_1_0.dtd">
 
 <checkstyle-packages>
   <package name="com.puppycrawl.tools.checkstyle">

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_0.dtd
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_0.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Import Control 1.0//EN"
-    "http://www.puppycrawl.com/dtds/import_control_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_0.dtd">
 -->
 
 <!--

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_1.dtd
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_1.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Import Control 1.1//EN"
-    "http://www.puppycrawl.com/dtds/import_control_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_1.dtd">
 -->
 
 <!--

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/configuration_1_0.dtd
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/configuration_1_0.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.0//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_0.dtd">
 
 -->
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/configuration_1_1.dtd
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/configuration_1_1.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd">
 -->
 
 <!ELEMENT module (module|property|metadata)*>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/configuration_1_2.dtd
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/configuration_1_2.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_2.dtd">
 -->
 
 <!ELEMENT module (module|property|metadata)*>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/configuration_1_3.dtd
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/configuration_1_3.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 -->
 
 <!ELEMENT module (module|property|metadata|message)*>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_0.dtd
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_0.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.0//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_0.dtd">
 -->
 
 <!ELEMENT suppressions (suppress*)>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_1.dtd
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_1.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd">
 -->
 
 <!ELEMENT suppressions (suppress*)>

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style

--- a/src/main/resources/sun_checks.xml
+++ b/src/main/resources/sun_checks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <!--
 

--- a/src/site/resources/files/suppressions_none.xml
+++ b/src/site/resources/files/suppressions_none.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.0//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_0.dtd">
 <suppressions>
 </suppressions>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/ant/ant_task_test_checks.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/ant/ant_task_test_checks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
   <module name="TreeWalker">

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/api/import-control_complete.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/api/import-control_complete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE import-control PUBLIC
     "-//Puppy Crawl//DTD Import Control 1.0//EN"
-    "http://www.puppycrawl.com/dtds/import_control_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_0.dtd">
 
 <import-control pkg="com">
   <allow class="some.class"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_MODIFIED_FOR_UT.dtd
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_MODIFIED_FOR_UT.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Import Control 1.1//EN"
-    "http://www.puppycrawl.com/dtds/import_control_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_1.dtd">
 -->
 
 <!--

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_broken.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_broken.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE import-control PUBLIC
     "-//Puppy Crawl//DTD Import Control 1.0//EN"
-    "http://www.puppycrawl.com/dtds/import_control_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_0.dtd">
 
 <import-control>
 </import-control>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_complete.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_complete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE import-control PUBLIC
     "-//Puppy Crawl//DTD Import Control 1.0//EN"
-    "http://www.puppycrawl.com/dtds/import_control_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_0.dtd">
 
 <import-control pkg="com">
   <allow class="some.class"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_one.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_one.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE import-control PUBLIC
     "-//Puppy Crawl//DTD Import Control 1.0//EN"
-    "http://www.puppycrawl.com/dtds/import_control_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_0.dtd">
 
 <import-control pkg="com.puppycrawl.tools.checkstyle.checks">
   <allow class="java.awt.Image"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_two.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_two.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE import-control PUBLIC
     "-//Puppy Crawl//DTD Import Control 1.0//EN"
-    "http://www.puppycrawl.com/dtds/import_control_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_0.dtd">
 
 <import-control pkg="com.puppycrawl.tools.checkstyle.checks">
   <allow class="java.awt.Image"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_wrong.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/import-control_wrong.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE import-control PUBLIC
     "-//Puppy Crawl//DTD Import Control 1.0//EN"
-    "http://www.puppycrawl.com/dtds/import_control_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_0.dtd">
 
 <import-control pkg="wrong">
 </import-control>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/config-Incorrect.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/config-Incorrect.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
         "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd">
 
 #<module name="Checker">
     <module name="TreeWalker">

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/config-classname-prop.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/config-classname-prop.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
         "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd">
 
 <module name="Checker">
     <module name="TreeWalker">

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/config-classname.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/config-classname.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
         "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd">
 
 <module name="Checker">
     <module name="TreeWalker">

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/config-classname2-error.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/config-classname2-error.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
         "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd">
 
 <module name="Checker">
     <module name="TreeWalker">

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/config-classname2.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/config-classname2.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
         "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd">
 
 <module name="Checker">
     <module name="TreeWalker">

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/config-custom-root-module.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/config-custom-root-module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <module name="com.puppycrawl.tools.checkstyle.TestRootModuleChecker">
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/config-filelength.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/config-filelength.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
         "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd">
 
 <module name="Checker">
     <module name="FileLength">

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/config-incorrectChildren.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/config-incorrectChildren.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_2.dtd">
 <module name="Checker">
   <module name="RegexpSingleline">
     <property name="format" value="\s+$"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/config-incorrectChildren2.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/config-incorrectChildren2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_2.dtd">
 <module name="Checker">
   <module name="TreeWalker">
     <module name="JavadocMethod">

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/config-non-existing-classname.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/config-non-existing-classname.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
         "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd">
 
 <module name="Checker">
     <module name="TreeWalker">

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configs/checkstyle_checks.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configs/checkstyle_checks.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd">
 
 <module name="Checker">
     <metadata name="any-possible-value" value="just smth"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configs/config_nonexisting_property.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configs/config_nonexisting_property.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
     <property name="tabWidth" value="${nonexisting}" />

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configs/config_with_checker_ignore.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configs/config_with_checker_ignore.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
     <property name="severity" value="ignore"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configs/config_with_ignore.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configs/config_with_ignore.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
     <module name="TreeWalker">

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configs/custom_messages.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configs/custom_messages.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
     <property name="tabWidth" value="4" />

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configs/empty_configuration.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configs/empty_configuration.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd">
 
 <module name="Checker">
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configs/including.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configs/including.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_1.dtd" [
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd" [
   <!ENTITY includedConfig SYSTEM "included.xml">
 ]>
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configs/missing_config_name.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configs/missing_config_name.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd">
 
 <module nam="Checker">
     <property name="tabWidth" value="4"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configs/missing_config_parent.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configs/missing_config_parent.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd">
 
 <!--suppress XmlWrongRootElement - wrong element used for test purposes -->
 <property name="tabWidth" value="4"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configs/missing_property_name.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configs/missing_property_name.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd">
 
 <module name="Checker">
     <property nam="tabWidth" value="4"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configs/missing_property_value.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configs/missing_property_value.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd">
 
 <module name="Checker">
     <property name="tabWidth" valu="4"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configs/subdir/including.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configs/subdir/including.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_1.dtd" [
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_1.dtd" [
   <!ENTITY includedConfig SYSTEM "../included.xml">
 ]>
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_bad_int.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_bad_int.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.0//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_0.dtd">
 <suppressions>
   <suppress files="file0" checks="check0" lines="a" />
 </suppressions>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_id.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_id.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd">
 <suppressions>
   <suppress files="file0" id="777"/>
 </suppressions>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_invalid_file.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_invalid_file.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd">
 <suppressions>
   <suppress files="a[l" checks="abc"/>
 </suppressions>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_multiple.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_multiple.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.0//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_0.dtd">
 <suppressions>
   <suppress files="file0" checks="check0"/>
   <suppress files="file1" checks="check1" lines="1,2-3"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_no_check.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_no_check.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.0//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_0.dtd">
 <suppressions>
   <suppress files="file0"/>
 </suppressions>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_no_check_and_id.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_no_check_and_id.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd">
 <suppressions>
   <suppress files="file0"/>
 </suppressions>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_no_file.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_no_file.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.0//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_0.dtd">
 <suppressions>
   <suppress checks="check0"/>
 </suppressions>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_none.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_none.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.0//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_0.dtd">
 <suppressions>
 </suppressions>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/import-control_complete.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/import-control_complete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE import-control PUBLIC
     "-//Puppy Crawl//DTD Import Control 1.0//EN"
-    "http://www.puppycrawl.com/dtds/import_control_1_0.dtd">
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_0.dtd">
 
 <import-control pkg="com">
   <allow class="some.class"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/suppress_all.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/suppress_all.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd">
 
 <suppressions>
     <suppress checks="." files="."/>

--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -791,7 +791,7 @@
 
     &lt;!DOCTYPE checkstyle-packages PUBLIC
     &quot;-//Puppy Crawl//DTD Package Names 1.0//EN&quot;
-    &quot;http://www.puppycrawl.com/dtds/packages_1_0.dtd&quot;&gt;
+    &quot;http://checkstyle.sourceforge.net/dtds/packages_1_0.dtd&quot;&gt;
 
 &lt;checkstyle-packages&gt;
   &lt;package name=&quot;com.mycompany.checks&quot;/&gt;
@@ -850,7 +850,7 @@
       <source>
 &lt;!DOCTYPE module PUBLIC
     &quot;-//Puppy Crawl//DTD Check Configuration 1.3//EN&quot;
-    &quot;http://www.puppycrawl.com/dtds/configuration_1_3.dtd&quot;&gt;
+    &quot;http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd&quot;&gt;
       </source>
 
       <p>
@@ -890,7 +890,7 @@
       <source>
 &lt;!DOCTYPE checkstyle-packages PUBLIC
 &quot;-//Puppy Crawl//DTD Package Names 1.1//EN&quot;
-&quot;http://www.puppycrawl.com/dtds/packages_1_1.dtd&quot;&gt;
+&quot;http://checkstyle.sourceforge.net/dtds/packages_1_1.dtd&quot;&gt;
       </source>
 
       <h4>Suppressions XML Document</h4>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -531,7 +531,7 @@ public class UserService {
 
 &lt;!DOCTYPE suppressions PUBLIC
 &quot;-//Puppy Crawl//DTD Suppressions 1.1//EN&quot;
-&quot;http://www.puppycrawl.com/dtds/suppressions_1_1.dtd&quot;&gt;
+&quot;http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd&quot;&gt;
 
 &lt;suppressions&gt;
 &lt;suppress checks=&quot;JavadocStyleCheck&quot;

--- a/src/xdocs/report_issue.xml
+++ b/src/xdocs/report_issue.xml
@@ -76,7 +76,7 @@ private static final int SOMETHING = 1;
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
         "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 <module name="Checker">
     <module name="TreeWalker">
         <module name="WhitespaceAround">

--- a/src/xdocs/writingchecks.xml
+++ b/src/xdocs/writingchecks.xml
@@ -556,7 +556,7 @@ public class MethodLimitCheck extends AbstractCheck
 &lt;?xml version=&quot;1.0&quot;?&gt;
 &lt;!DOCTYPE module PUBLIC
     &quot;-//Puppy Crawl//DTD Check Configuration 1.3//EN&quot;
-    &quot;http://www.puppycrawl.com/dtds/configuration_1_3.dtd&quot;&gt;
+    &quot;http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd&quot;&gt;
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;module name=&quot;TreeWalker&quot;&gt;
           &lt;!-- your standard Checks that come with Checkstyle --&gt;


### PR DESCRIPTION
Issue #1571

@romani 
Please, upload all dtd schemas to SourceForge and I will restart CIs build to fix failing UTs. I'll make a separate PR or commit to use http://www.mojohaus.org/xml-maven-plugin/examples/catalog.html .