### PR TITLE
Issue #3496: Enforce ReturnCount max=1 (part 3)

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -92,5 +92,5 @@
 
     <!-- Until https://github.com/checkstyle/checkstyle/issues/3496 -->
     <suppress id="returnCountMaxOne" files=".*[\\/]ant[\\/]|.*[\\/]filters[\\/]|.*[\\/]api[\\/]|.*[\\/]annotation[\\/]|
-        |.*[\\/]coding[\\/]|.*[\\/]indentation[\\/]|.*[\\/]javadoc[\\/]"/>
+        |.*[\\/]coding[\\/]|.*[\\/]indentation[\\/]"/>
 </suppressions>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
@@ -94,12 +94,11 @@ public class JavadocNodeImpl implements DetailNode {
 
     @Override
     public DetailNode[] getChildren() {
-        if (children == null) {
-            return EMPTY_DETAIL_NODE_ARRAY;
+        DetailNode[] nodeChildren = EMPTY_DETAIL_NODE_ARRAY;
+        if (children != null) {
+            nodeChildren = Arrays.copyOf(children, children.length);
         }
-        else {
-            return Arrays.copyOf(children, children.length);
-        }
+        return nodeChildren;
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -194,17 +194,18 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * @return true, if line is empty line.
      */
     private static boolean isEmptyLine(DetailNode newLine) {
+        boolean result = false;
         DetailNode previousSibling = JavadocUtils.getPreviousSibling(newLine);
-        if (previousSibling == null
-                || previousSibling.getParent().getType() != JavadocTokenTypes.JAVADOC) {
-            return false;
+        if (previousSibling != null
+                && previousSibling.getParent().getType() == JavadocTokenTypes.JAVADOC) {
+            if (previousSibling.getType() == JavadocTokenTypes.TEXT
+                    && previousSibling.getText().trim().isEmpty()) {
+                previousSibling = JavadocUtils.getPreviousSibling(previousSibling);
+            }
+            result = previousSibling != null
+                    && previousSibling.getType() == JavadocTokenTypes.LEADING_ASTERISK;
         }
-        if (previousSibling.getType() == JavadocTokenTypes.TEXT
-                && previousSibling.getText().trim().isEmpty()) {
-            previousSibling = JavadocUtils.getPreviousSibling(previousSibling);
-        }
-        return previousSibling != null
-                && previousSibling.getType() == JavadocTokenTypes.LEADING_ASTERISK;
+        return result;
     }
 
     /**
@@ -213,6 +214,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * @return true, if line with paragraph tag is first line in javadoc.
      */
     private static boolean isFirstParagraph(DetailNode paragraphTag) {
+        boolean result = true;
         DetailNode previousNode = JavadocUtils.getPreviousSibling(paragraphTag);
         while (previousNode != null) {
             if (previousNode.getType() == JavadocTokenTypes.TEXT
@@ -220,11 +222,12 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
                 || previousNode.getType() != JavadocTokenTypes.LEADING_ASTERISK
                     && previousNode.getType() != JavadocTokenTypes.NEWLINE
                     && previousNode.getType() != JavadocTokenTypes.TEXT) {
-                return false;
+                result = false;
+                break;
             }
             previousNode = JavadocUtils.getPreviousSibling(previousNode);
         }
-        return true;
+        return result;
     }
 
     /**
@@ -250,16 +253,18 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
      * @return true, if NEWLINE node is a last node in javadoc.
      */
     private static boolean isLastEmptyLine(DetailNode newLine) {
+        boolean result = true;
         DetailNode nextNode = JavadocUtils.getNextSibling(newLine);
         while (nextNode != null && nextNode.getType() != JavadocTokenTypes.JAVADOC_TAG) {
             if (nextNode.getType() == JavadocTokenTypes.TEXT
                     && !nextNode.getText().trim().isEmpty()
                     || nextNode.getType() == JavadocTokenTypes.HTML_ELEMENT) {
-                return false;
+                result = false;
+                break;
             }
             nextNode = JavadocUtils.getNextSibling(nextNode);
         }
-        return true;
+        return result;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -129,13 +129,15 @@ public class JavadocTagContinuationIndentationCheck extends AbstractJavadocCheck
      * @return true, if description node is a description of in-line tag.
      */
     private static boolean isInlineDescription(DetailNode description) {
+        boolean isInline = false;
         DetailNode inlineTag = description.getParent();
         while (inlineTag != null) {
             if (inlineTag.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG) {
-                return true;
+                isInline = true;
+                break;
             }
             inlineTag = inlineTag.getParent();
         }
-        return false;
+        return isInline;
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
@@ -169,28 +169,29 @@ class TagParser {
      * @return id for given tag
      */
     private static String getTagId(String[] javadocText, Point tagStart) {
+        String tagId = "";
         int column = tagStart.getColumnNo() + 1;
         String text = javadocText[tagStart.getLineNo()];
-        if (column >= text.length()) {
-            return "";
+        if (column < text.length()) {
+
+            if (text.charAt(column) == '/') {
+                column++;
+            }
+
+            text = text.substring(column).trim();
+            int position = 0;
+
+            //Character.isJavaIdentifier... may not be a valid HTML
+            //identifier but is valid for generics
+            while (position < text.length()
+                    && (Character.isJavaIdentifierStart(text.charAt(position))
+                        || Character.isJavaIdentifierPart(text.charAt(position)))) {
+                position++;
+            }
+
+            tagId = text.substring(0, position);
         }
-
-        if (text.charAt(column) == '/') {
-            column++;
-        }
-
-        text = text.substring(column).trim();
-        int position = 0;
-
-        //Character.isJavaIdentifier... may not be a valid HTML
-        //identifier but is valid for generics
-        while (position < text.length()
-            && (Character.isJavaIdentifierStart(text.charAt(position))
-                || Character.isJavaIdentifierPart(text.charAt(position)))) {
-            position++;
-        }
-
-        return text.substring(0, position);
+        return tagId;
     }
 
     /**


### PR DESCRIPTION
#3496 

This one is for com.puppycrawl.tools.checkstyle.checks.javadoc.
Javadoc checks are slow, so I've made reports only on a few projects (no regression):
[JavadocParagraph](https://vladlis.github.io/3496/part3/1/index.html)
[JavadocTagContinuationIndentation](https://vladlis.github.io/3496/part3/2/index.html)
[JavadocVariable](https://vladlis.github.io/3496/part3/3/index.html)

Did not test JavadocMethodCheck as it is deprecated.
