### PR TITLE
Issue #3555: refactoring: CodeSelectorPModel do double copy of collection in c-tor

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -158,5 +158,6 @@
     <allow class="com.puppycrawl.tools.checkstyle.gui.MainFrameModel.ParseMode"
            local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser" local-only="true"/>
+    <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
   </subpackage>
 </import-control>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import javax.swing.JTextArea;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 
@@ -47,10 +48,12 @@ public class CodeSelector {
                         final List<Integer> lines2position) {
         this.editor = editor;
         if (node instanceof DetailAST) {
-            pModel = new CodeSelectorPresentation((DetailAST) node, lines2position);
+            pModel = new CodeSelectorPresentation((DetailAST) node,
+                    ImmutableList.copyOf(lines2position));
         }
         else {
-            pModel = new CodeSelectorPresentation((DetailNode) node, lines2position);
+            pModel = new CodeSelectorPresentation((DetailNode) node,
+                    ImmutableList.copyOf(lines2position));
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentation.java
@@ -19,10 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.gui;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
@@ -45,22 +44,22 @@ public class CodeSelectorPresentation {
      * Constructor.
      * @param ast ast node.
      * @param lines2position list to map lines.
+     * @noinspection AssignmentToCollectionOrArrayFieldFromParameter
      */
-    public CodeSelectorPresentation(DetailAST ast, List<Integer> lines2position) {
+    public CodeSelectorPresentation(DetailAST ast, ImmutableList<Integer> lines2position) {
         node = ast;
-        final List<Integer> copy = new ArrayList<>(lines2position);
-        this.lines2position = Collections.unmodifiableList(copy);
+        this.lines2position = lines2position;
     }
 
     /**
      * Constructor.
      * @param node DetailNode node.
      * @param lines2position list to map lines.
+     * @noinspection AssignmentToCollectionOrArrayFieldFromParameter
      */
-    public CodeSelectorPresentation(DetailNode node, List<Integer> lines2position) {
+    public CodeSelectorPresentation(DetailNode node, ImmutableList<Integer> lines2position) {
         this.node = node;
-        final List<Integer> copy = new ArrayList<>(lines2position);
-        this.lines2position = Collections.unmodifiableList(copy);
+        this.lines2position = lines2position;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java
@@ -22,11 +22,11 @@ package com.puppycrawl.tools.checkstyle.gui;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
 import antlr.ANTLRException;
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -75,11 +75,11 @@ public class MainFrameModel {
         }
     }
 
-    /** Lines to position map. */
-    private final List<Integer> linesToPosition = new ArrayList<>();
-
     /** Parse tree model. */
     private final ParseTreeTableModel parseTreeTableModel;
+
+    /** Lines to position map. */
+    private ImmutableList<Integer> linesToPosition = ImmutableList.of();
 
     /** Current mode. */
     private ParseMode parseMode = ParseMode.PLAIN_JAVA;
@@ -172,11 +172,14 @@ public class MainFrameModel {
 
     /**
      * Get lines to position map.
+     * It returns unmodifiable collection to
+     * prevent additional overhead of copying
+     * and possible state modifications.
      * @return lines to position map.
+     * @noinspection ReturnOfCollectionOrArrayField
      */
-    public List<Integer> getLinesToPosition() {
-        final List<Integer> copy = new ArrayList<>(linesToPosition);
-        return Collections.unmodifiableList(copy);
+    public ImmutableList<Integer> getLinesToPosition() {
+        return linesToPosition;
     }
 
     /**
@@ -208,17 +211,17 @@ public class MainFrameModel {
                 parseTreeTableModel.setParseMode(parseMode);
                 final String[] sourceLines = getFileText(file).toLinesArray();
 
-                // clear for each new file
-                linesToPosition.clear();
+                final List<Integer> linesToPositionTemp = new ArrayList<>();
                 // starts line counting at 1
-                linesToPosition.add(0);
+                linesToPositionTemp.add(0);
 
                 final StringBuilder sb = new StringBuilder();
                 // insert the contents of the file to the text area
                 for (final String element : sourceLines) {
-                    linesToPosition.add(sb.length());
+                    linesToPositionTemp.add(sb.length());
                     sb.append(element).append(System.lineSeparator());
                 }
+                linesToPosition = ImmutableList.copyOf(linesToPositionTemp);
                 text = sb.toString();
             }
             catch (IOException | ANTLRException ex) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java
@@ -25,8 +25,6 @@ import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EventObject;
 import java.util.List;
 
@@ -39,6 +37,8 @@ import javax.swing.KeyStroke;
 import javax.swing.LookAndFeel;
 import javax.swing.table.TableCellEditor;
 import javax.swing.tree.TreePath;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * This example shows how to create a simple TreeTable component,
@@ -232,10 +232,10 @@ public class TreeTable extends JTable {
     /**
      * Sets line position map.
      * @param linePositionMap Line position map.
+     * @noinspection AssignmentToCollectionOrArrayFieldFromParameter
      */
-    public void setLinePositionMap(List<Integer> linePositionMap) {
-        final List<Integer> copy = new ArrayList<>(linePositionMap);
-        this.linePositionMap = Collections.unmodifiableList(copy);
+    public void setLinePositionMap(ImmutableList<Integer> linePositionMap) {
+        this.linePositionMap = linePositionMap;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentationTest.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
@@ -38,7 +39,7 @@ public class CodeSelectorPresentationTest {
 
     private DetailAST tree;
 
-    private List<Integer> linesToPosition;
+    private ImmutableList<Integer> linesToPosition;
 
     @Before
     public void loadFile() throws CheckstyleException {
@@ -46,7 +47,7 @@ public class CodeSelectorPresentationTest {
         model.setParseMode(ParseMode.JAVA_WITH_JAVADOC_AND_COMMENTS);
         model.openFile(new File(getPath("InputJavadocAttributesAndMethods.java")));
         tree = ((DetailAST) model.getParseTreeTableModel().getRoot()).getFirstChild();
-        linesToPosition = convertLinesToPosition(model.getLinesToPosition());
+        linesToPosition = ImmutableList.copyOf(convertLinesToPosition(model.getLinesToPosition()));
     }
 
     private static String getPath(String filename) {


### PR DESCRIPTION
Issue #3555 
What was made:
Replaced creating temporary list and then creating unmodifiable view with `Collections.unmodifiableList` with assigning `line2position` field to new ArrayList and then adding all elements from origin list to field with `addAll()` method. All tests passed correctly/ During manual test case I checked that modifications of element's in original collection will not modify elements in copy as was supposed.