### PR TITLE
Issue #3219: added errors of javadoc tree parsing printing

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
@@ -56,7 +56,14 @@ public final class DetailNodeTreeStringPrinter {
      * @throws IOException if the file could not be read.
      */
     public static String printFileAst(File file) throws IOException {
-        return printTree(parseFile(file), "", "");
+        String tree;
+        try {
+            tree = printTree(parseFile(file), "", "");
+        }
+        catch (IllegalArgumentException exception) {
+            tree = exception.getMessage().replace("[ERROR:0] ", "");
+        }
+        return tree;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -57,17 +57,12 @@ public class DetailNodeTreeStringPrinterTest {
     @Test
     public void testParseFileWithError() throws Exception {
         LocalizedMessage.setLocale(Locale.ROOT);
-        try {
-            DetailNodeTreeStringPrinter.printFileAst(
-                    new File(getPath("InputJavadocWithError.javadoc")));
-            Assert.fail("Javadoc parser didn't failed on missing end tag");
-        }
-        catch (IllegalArgumentException ex) {
-            final String expected = "[ERROR:0] Javadoc comment at column 1 has parse error. "
-                    + "Missed HTML close tag 'qwe'. Sometimes it means that close tag missed "
-                    + "for one of previous tags.";
-            Assert.assertEquals(expected, ex.getMessage());
-        }
+        final String actual = DetailNodeTreeStringPrinter.printFileAst(
+                new File(getPath("InputJavadocWithError.javadoc")));
+        final String expected = "Javadoc comment at column 1 has parse error. "
+                + "Missed HTML close tag 'qwe'. Sometimes it means that close tag missed "
+                + "for one of previous tags.";
+        Assert.assertEquals(expected, actual);
     }
 
 }


### PR DESCRIPTION
Issue #3219 
Added javadoc tree parsing errors printing.
