### PR TITLE
Pull #4328: moved variables inside if blocks to reduce execution time

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractDeclarationCollector.java
@@ -120,8 +120,8 @@ public abstract class AbstractDeclarationCollector extends AbstractCheck {
                 frameStack.addFirst(new BlockFrame(frame));
                 break;
             case TokenTypes.METHOD_DEF :
-                final String name = ast.findFirstToken(TokenTypes.IDENT).getText();
                 if (frame instanceof ClassFrame) {
+                    final String name = ast.findFirstToken(TokenTypes.IDENT).getText();
                     final DetailAST mods =
                             ast.findFirstToken(TokenTypes.MODIFIERS);
                     if (mods.branchContains(TokenTypes.LITERAL_STATIC)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -317,8 +317,6 @@ public abstract class AbstractTypeAwareCheck extends AbstractCheck {
                  child != null;
                  child = child.getNextSibling()) {
                 if (child.getType() == TokenTypes.TYPE_PARAMETER) {
-                    final String alias =
-                        child.findFirstToken(TokenTypes.IDENT).getText();
                     final DetailAST bounds =
                         child.findFirstToken(TokenTypes.TYPE_UPPER_BOUNDS);
                     if (bounds != null) {
@@ -326,6 +324,8 @@ public abstract class AbstractTypeAwareCheck extends AbstractCheck {
                             FullIdent.createFullIdentBelow(bounds);
                         final AbstractClassInfo classInfo =
                             createClassInfo(new Token(name), currentClassName);
+                        final String alias =
+                                child.findFirstToken(TokenTypes.IDENT).getText();
                         paramsMap.put(alias, classInfo);
                     }
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
@@ -85,7 +85,6 @@ public class OuterTypeFilenameCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        final String outerTypeName = ast.findFirstToken(TokenTypes.IDENT).getText();
         if (seenFirstToken) {
             final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
             if (modifiers.findFirstToken(TokenTypes.LITERAL_PUBLIC) != null
@@ -94,6 +93,7 @@ public class OuterTypeFilenameCheck extends AbstractCheck {
             }
         }
         else {
+            final String outerTypeName = ast.findFirstToken(TokenTypes.IDENT).getText();
 
             if (fileName.equals(outerTypeName)) {
                 validFirst = true;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -404,9 +404,6 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
         final int valuePairCount =
             annotation.getChildCount(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
 
-        final DetailAST valuePair =
-            annotation.findFirstToken(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
-
         //in compact style with one value
         if (arrayInit != null
             && arrayInit.getChildCount(TokenTypes.EXPR) == 1) {
@@ -415,6 +412,8 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
         }
         //in expanded style with one value and the correct element name
         else if (valuePairCount == 1) {
+            final DetailAST valuePair =
+                    annotation.findFirstToken(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
             final DetailAST nestedArrayInit =
                 valuePair.findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -385,7 +385,6 @@ public class NeedBracesCheck extends AbstractCheck {
      */
     private static boolean isSingleLineIf(DetailAST literalIf) {
         boolean result = false;
-        final DetailAST ifCondition = literalIf.findFirstToken(TokenTypes.EXPR);
         if (literalIf.getParent().getType() == TokenTypes.SLIST) {
             final DetailAST literalIfLastChild = literalIf.getLastChild();
             final DetailAST block;
@@ -395,6 +394,7 @@ public class NeedBracesCheck extends AbstractCheck {
             else {
                 block = literalIfLastChild;
             }
+            final DetailAST ifCondition = literalIf.findFirstToken(TokenTypes.EXPR);
             result = ifCondition.getLineNo() == block.getLineNo();
         }
         return result;
@@ -441,8 +441,8 @@ public class NeedBracesCheck extends AbstractCheck {
             final DetailAST block = slist.getFirstChild();
             if (block.getType() != TokenTypes.SLIST) {
                 final DetailAST caseBreak = slist.findFirstToken(TokenTypes.LITERAL_BREAK);
-                final boolean atOneLine = literalCase.getLineNo() == block.getLineNo();
                 if (caseBreak != null) {
+                    final boolean atOneLine = literalCase.getLineNo() == block.getLineNo();
                     result = atOneLine && block.getLineNo() == caseBreak.getLineNo();
                 }
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -203,10 +203,10 @@ public class IllegalInstantiationCheck
             // ast != "new Boolean[]"
             final FullIdent typeIdent = FullIdent.createFullIdent(typeNameAst);
             final String typeName = typeIdent.getText();
-            final int lineNo = newTokenAst.getLineNo();
-            final int colNo = newTokenAst.getColumnNo();
             final String fqClassName = getIllegalInstantiation(typeName);
             if (fqClassName != null) {
+                final int lineNo = newTokenAst.getLineNo();
+                final int colNo = newTokenAst.getColumnNo();
                 log(lineNo, colNo, MSG_KEY, fqClassName);
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
@@ -109,9 +109,9 @@ public final class IllegalThrowsCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST detailAST) {
         final DetailAST methodDef = detailAST.getParent();
-        DetailAST token = detailAST.getFirstChild();
         // Check if the method with the given name should be ignored.
         if (!isIgnorableMethod(methodDef)) {
+            DetailAST token = detailAST.getFirstChild();
             while (token != null) {
                 if (token.getType() != TokenTypes.COMMA) {
                     final FullIdent ident = FullIdent.createFullIdent(token);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -259,7 +259,6 @@ public class ImportOrderCheck
 
         for (int i = 0; i < packageGroups.length; i++) {
             String pkg = packageGroups[i];
-            final StringBuilder pkgBuilder = new StringBuilder(pkg);
             final Pattern grp;
 
             // if the pkg name is the wildcard, make it match zero chars
@@ -276,6 +275,7 @@ public class ImportOrderCheck
                 grp = Pattern.compile(pkg);
             }
             else {
+                final StringBuilder pkgBuilder = new StringBuilder(pkg);
                 if (!CommonUtils.endsWithChar(pkg, '.')) {
                     pkgBuilder.append('.');
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -545,13 +545,13 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * @return the scope of the method/constructor
      */
     private static Scope calculateScope(final DetailAST ast) {
-        final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
         final Scope scope;
 
         if (ScopeUtils.isInInterfaceOrAnnotationBlock(ast)) {
             scope = Scope.PUBLIC;
         }
         else {
+            final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
             scope = ScopeUtils.getScopeFromMods(mods);
         }
         return scope;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -223,15 +223,14 @@ public class JavadocTypeCheck
      * @return whether we should check a given node.
      */
     private boolean shouldCheck(final DetailAST ast) {
-        final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
-        final Scope declaredScope = ScopeUtils.getScopeFromMods(mods);
         final Scope customScope;
 
         if (ScopeUtils.isInInterfaceOrAnnotationBlock(ast)) {
             customScope = Scope.PUBLIC;
         }
         else {
-            customScope = declaredScope;
+            final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
+            customScope = ScopeUtils.getScopeFromMods(mods);
         }
         final Scope surroundingScope = ScopeUtils.getSurroundingScope(ast);
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java
@@ -95,9 +95,9 @@ class MultilineDetector {
             boolean foundMatch = matcher.find();
 
             while (foundMatch) {
-                final LineColumn start = text.lineColumn(matcher.start());
                 currentMatches++;
                 if (currentMatches > options.getMaximum()) {
+                    final LineColumn start = text.lineColumn(matcher.start());
                     if (options.getMessage().isEmpty()) {
                         options.getReporter().log(start.getLine(),
                                 MSG_REGEXP_EXCEEDED, matcher.pattern().toString());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
@@ -247,12 +247,12 @@ public class RegexpCheck extends AbstractCheck {
         else {
             end = text.lineColumn(matcher.end() - 1);
         }
-        final int startColumn = start.getColumn();
-        final int endLine = end.getLine();
-        final int endColumn = end.getColumn();
         boolean ignore = false;
         if (ignoreComments) {
             final FileContents theFileContents = getFileContents();
+            final int startColumn = start.getColumn();
+            final int endLine = end.getLine();
+            final int endColumn = end.getColumn();
             ignore = theFileContents.hasIntersectionWithComment(startLine,
                 startColumn, endLine, endColumn);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/AbstractParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/AbstractParenPadCheck.java
@@ -107,9 +107,9 @@ public abstract class AbstractParenPadCheck
      * @param ast the token representing a right parentheses
      */
     protected void processRight(DetailAST ast) {
-        final String line = getLines()[ast.getLineNo() - 1];
         final int before = ast.getColumnNo() - 1;
         if (before >= 0) {
+            final String line = getLines()[ast.getLineNo() - 1];
             if (option == PadOption.NOSPACE
                 && Character.isWhitespace(line.charAt(before))
                 && !CommonUtils.hasWhitespaceBefore(before, line)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
@@ -394,10 +394,10 @@ public final class JavadocUtils {
      */
     public static DetailNode getPreviousSibling(DetailNode node) {
         DetailNode previousSibling = null;
-        final DetailNode parent = node.getParent();
         final int previousSiblingIndex = node.getIndex() - 1;
-        final DetailNode[] children = parent.getChildren();
         if (previousSiblingIndex >= 0) {
+            final DetailNode parent = node.getParent();
+            final DetailNode[] children = parent.getChildren();
             previousSibling = children[previousSiblingIndex];
         }
         return previousSibling;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -521,8 +521,6 @@ public class XdocsPagesTest {
 
                 final String actualTypeName = columns.get(2).getTextContent().replace("\n", "")
                         .replace("\r", "").replaceAll(" +", " ").trim();
-                final String actualValue = columns.get(3).getTextContent().replace("\n", "")
-                        .replace("\r", "").replaceAll(" +", " ").trim();
 
                 Assert.assertFalse(fileName + " section '" + sectionName
                         + "' should have a type for " + propertyName, actualTypeName.isEmpty());
@@ -532,14 +530,19 @@ public class XdocsPagesTest {
                 final Class<?> clss = descriptor.getPropertyType();
                 final String expectedTypeName =
                         getModulePropertyExpectedTypeName(clss, instance, propertyName);
-                final String expectedValue = getModulePropertyExpectedValue(clss, instance,
-                        propertyName);
 
                 if (expectedTypeName != null) {
+                    final String expectedValue = getModulePropertyExpectedValue(clss, instance,
+                            propertyName);
+
                     Assert.assertEquals(fileName + " section '" + sectionName
                             + "' should have the type for " + propertyName, expectedTypeName,
                             actualTypeName);
+
                     if (expectedValue != null) {
+                        final String actualValue = columns.get(3).getTextContent().replace("\n", "")
+                                .replace("\r", "").replaceAll(" +", " ").trim();
+
                         Assert.assertEquals(fileName + " section '" + sectionName
                                 + "' should have the value for " + propertyName, expectedValue,
                                 actualValue);


### PR DESCRIPTION
I created a check to see if variables could be moved inside if statements (ignoring loops).
Changes are the result of violations the check produced.

It did produce 3 other violations, 2 of which can't be moved and are a current limitation of the check. The variables are a save and the next statements change the values for which the variable is created for. So moving is not possible.
The last violation wasn't moved because other similar variables were around it and I didn't want to break the style.
````
[ERROR] checkstyle\src\main\java\com\puppycrawl\tools\checkstyle\checks\coding\FinalLocalVariableCheck.java:259:17: Variable 'prevScopeUnitializedVariableData' can be moved inside the block to restrict runtime creation. [VariablePlacement]
[ERROR] checkstyle\src\main\java\com\puppycrawl\tools\checkstyle\checks\coding\FinalLocalVariableCheck.java:283:9: Variable 'poppedScopeAssignedVariableData' can be moved inside the block to restrict runtime creation. [VariablePlacement]
[ERROR] checkstyle\src\main\java\com\puppycrawl\tools\checkstyle\utils\JavadocUtils.java:228:13: Variable 'tagValue' can be moved inside the block to restrict runtime creation. [VariablePlacement]
````

I will provide regression and change the commit to reference this PR.