### PR TITLE
Issue #2840: Implement Javadoc tag parsing to accurately parse Javadoc tags that span multiple lines

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/BlockTagUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/BlockTagUtils.java
@@ -1,0 +1,95 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.puppycrawl.tools.checkstyle.api.LineColumn;
+
+/**
+ * Tools for parsing block tags from a Javadoc comment.
+ *
+ * @author Nathan Naze
+ */
+public final class BlockTagUtils {
+
+    /** Block tag pattern for a first line. */
+    private static final Pattern BLOCK_TAG_PATTERN_FIRST_LINE = Pattern.compile(
+        "/\\*{2,}\\s*@(\\p{Alpha}+)\\s");
+
+    /** Block tag pattern. */
+    private static final Pattern BLOCK_TAG_PATTERN = Pattern.compile(
+        "^\\s*\\**\\s*@(\\p{Alpha}+)\\s");
+
+    /** Closing tag. */
+    private static final String JAVADOC_CLOSING_TAG = "*/";
+
+    /** Not instantiable. */
+    private BlockTagUtils() { }
+
+    /**
+     * Extract the block tags from a Javadoc comment.
+     * @param lines The text of the comment, as separate lines.
+     * @return The tags extracted from the block.
+     */
+    public static List<TagInfo> extractBlockTags(String... lines) {
+        final List<TagInfo> tags = new ArrayList<>();
+
+        for (int i = 0; i < lines.length; i++) {
+            // Starting lines of a comment have a different first line pattern.
+            final boolean isFirstLine = i == 0;
+            final Pattern pattern;
+            if (isFirstLine) {
+                pattern = BLOCK_TAG_PATTERN_FIRST_LINE;
+            }
+            else {
+                pattern = BLOCK_TAG_PATTERN;
+            }
+
+            final String line = lines[i];
+            final Matcher tagMatcher = pattern.matcher(line);
+
+            if (tagMatcher.find()) {
+                final String tagName = tagMatcher.group(1);
+
+                // offset of one for the @ character
+                final int colNum = tagMatcher.start(1) - 1;
+                final int lineNum = i + 1;
+
+                final String remainder = line.substring(tagMatcher.end(1));
+                String tagValue = remainder.trim();
+
+                // Handle the case where we're on the last line of a Javadoc comment.
+                if (tagValue.endsWith(JAVADOC_CLOSING_TAG)) {
+                    final int endIndex = tagValue.length() - JAVADOC_CLOSING_TAG.length();
+                    tagValue = tagValue.substring(0, endIndex).trim();
+                }
+
+                final LineColumn position = new LineColumn(lineNum, colNum);
+                tags.add(new TagInfo(tagName, tagValue, position));
+            }
+        }
+
+        return tags;
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/InlineTagUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/InlineTagUtils.java
@@ -1,0 +1,150 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.puppycrawl.tools.checkstyle.api.LineColumn;
+
+/**
+ * Tools for extracting inline tags from Javadoc comments.
+ *
+ * @author Nathan Naze
+ */
+final class InlineTagUtils {
+
+    /**
+     * Inline tag pattern.
+     */
+    private static final Pattern INLINE_TAG_PATTERN = Pattern.compile(
+            ".*?\\{@(\\p{Alpha}+)\\b(.*?)}", Pattern.DOTALL);
+
+    /** Pattern to recognize leading "*" characters in Javadoc. */
+    private static final Pattern JAVADOC_PREFIX_PATTERN = Pattern.compile(
+        "^\\s*\\*", Pattern.MULTILINE);
+
+    /** Pattern matching whitespace, used by {@link InlineTagUtils#collapseWhitespace(String)}. */
+    private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
+
+    /** Pattern matching a newline. */
+    private static final Pattern NEWLINE_PATTERN = Pattern.compile("\\n");
+
+    /** Line feed character. */
+    private static final String LINE_FEED = "\n";
+
+    /** Carriage return character. */
+    private static final String CARRIAGE_RETURN = "\r";
+
+    /** Non instantiable. */
+    private InlineTagUtils() { }
+
+    /**
+     * Extract inline Javadoc tags from the given comment.
+     * @param lines The Javadoc comment (as lines).
+     * @return The extracted inline Javadoc tags.
+     */
+    public static List<TagInfo> extractInlineTags(String... lines) {
+        for (String line : lines) {
+            if (line.contains(LINE_FEED) || line.contains(CARRIAGE_RETURN)) {
+                throw new AssertionError("comment lines cannot contain newlines");
+            }
+        }
+
+        final String commentText = convertLinesToString(lines);
+        final Matcher inlineTagMatcher = INLINE_TAG_PATTERN.matcher(commentText);
+
+        final List<TagInfo> tags = new ArrayList<>();
+
+        while (inlineTagMatcher.find()) {
+            final String tagName = inlineTagMatcher.group(1);
+
+            // Remove the leading asterisks (in case the tag spans a line) and collapse
+            // the whitespace.
+            String matchedTagValue = inlineTagMatcher.group(2);
+            matchedTagValue = removeLeadingJavaDoc(matchedTagValue);
+            matchedTagValue = collapseWhitespace(matchedTagValue);
+
+            final String tagValue = matchedTagValue;
+
+            final int startIndex = inlineTagMatcher.start(1);
+            final LineColumn position = getLineColumnOfIndex(commentText,
+                // correct start index offset
+                startIndex - 1);
+
+            tags.add(new TagInfo(tagName, tagValue, position));
+        }
+
+        return tags;
+    }
+
+    /**
+     * @param lines A number of lines, in order.
+     * @return The lines, joined together with newlines, as a single string.
+     */
+    public static String convertLinesToString(String... lines) {
+        final StringBuilder builder = new StringBuilder();
+        for (String line : lines) {
+            builder.append(line);
+            builder.append(LINE_FEED);
+        }
+        return builder.toString();
+    }
+
+    /**
+     * @param source Source string.
+     * @param index An index into the string.
+     * @return A position in the source representing what line and column that index appears on.
+     */
+    public static LineColumn getLineColumnOfIndex(String source, int index) {
+        if (index < 0) {
+            throw new AssertionError("index must be positive");
+        }
+
+        if (index >= source.length()) {
+            throw new AssertionError("index must be less than length of source");
+        }
+
+        final String precedingText = source.subSequence(0, index).toString();
+        final String[] precedingLines = NEWLINE_PATTERN.split(precedingText);
+        final String lastLine = precedingLines[precedingLines.length - 1];
+        return new LineColumn(precedingLines.length, lastLine.length());
+    }
+
+    /**
+     * @param str Source string.
+     * @return The given string with all whitespace collapsed.
+     */
+    public static String collapseWhitespace(String str) {
+        final Matcher matcher = WHITESPACE_PATTERN.matcher(str);
+        return matcher.replaceAll(" ").trim();
+    }
+
+    /**
+     * @param source A string to remove leading Javadoc from.
+     * @return The given string with leading Javadoc "*" characters from each line removed.
+     */
+    public static String removeLeadingJavaDoc(String source) {
+        final Matcher matcher = JAVADOC_PREFIX_PATTERN.matcher(source);
+        return matcher.replaceAll("");
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/TagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/TagInfo.java
@@ -1,0 +1,80 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.utils;
+
+import com.puppycrawl.tools.checkstyle.api.LineColumn;
+
+/**
+ * Value object for storing data about a parsed tag.
+ *
+ * @author Nathan Naze
+ */
+public final class TagInfo {
+
+    /**
+     * Name of the tag ("link", "see", etc).
+     */
+    private final String name;
+
+    /**
+     * Value of the tag.
+     */
+    private final String value;
+
+    /**
+     * Position of the tag in the given comment.
+     */
+    private final LineColumn position;
+
+    /**
+     * Constructor.
+     *
+     * @param name The name of the tag.
+     * @param value The value of the tag.
+     * @param position The position of the tag in the comment.
+     */
+    public TagInfo(String name, String value, LineColumn position) {
+        this.name = name;
+        this.value = value;
+        this.position = position;
+    }
+
+    /**
+     * @return Name of the tag.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return Value of the tag.
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * @return Value of the tag.
+     */
+    public LineColumn getPosition() {
+        return position;
+    }
+}
+

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockTagUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockTagUtilsTest.java
@@ -1,0 +1,103 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.internal.TestUtils;
+
+/**
+ * Tests BlockTagUtils.
+ */
+public class BlockTagUtilsTest {
+
+    @Test
+    public void testHasPrivateConstructor() throws Exception {
+        TestUtils.assertUtilsClassHasPrivateConstructor(BlockTagUtils.class);
+    }
+
+    @Test
+    public void testExtractBlockTags() {
+        final String[] text = {
+            "/** @foo abc ",
+            " * @bar def  ",
+            "   @baz ghi  ",
+            " * @qux jkl",
+            " */",
+        };
+
+        final List<TagInfo> tags = BlockTagUtils.extractBlockTags(text);
+        assertEquals(4, tags.size());
+
+        final TagInfo tag1 = tags.get(0);
+        assertEquals("foo", tag1.getName());
+        assertEquals("abc", tag1.getValue());
+        assertEquals(1, tag1.getPosition().getLine());
+        assertEquals(4, tag1.getPosition().getColumn());
+
+        final TagInfo tag2 = tags.get(1);
+        assertEquals("bar", tag2.getName());
+        assertEquals("def", tag2.getValue());
+        assertEquals(2, tag2.getPosition().getLine());
+        assertEquals(3, tag2.getPosition().getColumn());
+
+        final TagInfo tag3 = tags.get(2);
+        assertEquals("baz", tag3.getName());
+        assertEquals("ghi", tag3.getValue());
+        assertEquals(3, tag3.getPosition().getLine());
+        assertEquals(3, tag3.getPosition().getColumn());
+
+        final TagInfo tag4 = tags.get(3);
+        assertEquals("qux", tag4.getName());
+        assertEquals("jkl", tag4.getValue());
+        assertEquals(4, tag4.getPosition().getLine());
+        assertEquals(3, tag4.getPosition().getColumn());
+    }
+
+    @Test
+    public void testVersionStringFormat() {
+        final String[] text = {
+            "/** ",
+            " * @version 1.0",
+            " */",
+        };
+        final List<TagInfo> tags = BlockTagUtils.extractBlockTags(text);
+        assertEquals(1, tags.size());
+        assertEquals("version", tags.get(0).getName());
+        assertEquals("1.0", tags.get(0).getValue());
+    }
+
+    @Test
+    public void testOddVersionString() {
+        final String[] text = {
+            "/**",
+            " * Foo",
+            " * @version 1.0 */"};
+
+        final List<TagInfo> tags = BlockTagUtils.extractBlockTags(text);
+        assertEquals(1, tags.size());
+        assertEquals("version", tags.get(0).getName());
+        assertEquals("1.0", tags.get(0).getValue());
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/InlineTagUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/InlineTagUtilsTest.java
@@ -1,0 +1,191 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.api.LineColumn;
+import com.puppycrawl.tools.checkstyle.internal.TestUtils;
+
+/**
+ * Tests InlineTagUtils
+ */
+public class InlineTagUtilsTest {
+
+    @Test
+    public void testHasPrivateConstructor() throws Exception {
+        TestUtils.assertUtilsClassHasPrivateConstructor(InlineTagUtils.class);
+    }
+
+    @Test
+    public void testExtractInlineTags() {
+        final String[] text = {
+            "/** @see elsewhere ",
+            " * {@link List }, {@link List link text }",
+            "   {@link List#add(Object) link text}",
+            " * {@link Class link text}",
+            " */"};
+        final List<TagInfo> tags = InlineTagUtils.extractInlineTags(text);
+
+        assertEquals(4, tags.size());
+
+        assertTag(tags.get(0), "link", "List", 2, 4);
+        assertTag(tags.get(1), "link", "List link text", 2, 19);
+        assertTag(tags.get(2), "link", "List#add(Object) link text", 3, 4);
+        assertTag(tags.get(3), "link", "Class link text", 4, 4);
+    }
+
+    @Test
+    public void testMultiLineLinkTag() {
+        final String[] text = {
+            "/**",
+            " * {@link foo",
+            " *        bar baz}",
+            " */"};
+
+        final List<TagInfo> tags = InlineTagUtils.extractInlineTags(text);
+
+        assertEquals(1, tags.size());
+        assertTag(tags.get(0), "link", "foo bar baz", 2, 4);
+    }
+
+    private static void assertTag(TagInfo tag, String name, String value, int line, int col) {
+        assertEquals(name, tag.getName());
+        assertEquals(value, tag.getValue());
+        assertEquals(line, tag.getPosition().getLine());
+        assertEquals(col, tag.getPosition().getColumn());
+    }
+
+    @Test
+    public void testCollapseWhitespace() {
+        assertEquals("a b", InlineTagUtils.collapseWhitespace("  a  b  "));
+        assertEquals("", InlineTagUtils.collapseWhitespace("    "));
+        assertEquals("a b c", InlineTagUtils.collapseWhitespace("a\nb\nc\n"));
+    }
+
+    @Test
+    public void testGetLineColumnOfIndex() {
+        final String source = "abc\n" + "def\n" + "hij\n";
+
+        final LineColumn lineColumn1 =
+            InlineTagUtils.getLineColumnOfIndex(source, source.indexOf('a'));
+        assertEquals(1, lineColumn1.getLine());
+        assertEquals(0, lineColumn1.getColumn());
+
+        final LineColumn lineColumn2 =
+            InlineTagUtils.getLineColumnOfIndex(source, source.indexOf('e'));
+        assertEquals(2, lineColumn2.getLine());
+        assertEquals(1, lineColumn2.getColumn());
+
+        final LineColumn lineColumn3 =
+            InlineTagUtils.getLineColumnOfIndex(source, source.indexOf('j'));
+        assertEquals(3, lineColumn3.getLine());
+        assertEquals(2, lineColumn3.getColumn());
+    }
+
+    @Test
+    public void testConvertLinesToString() {
+        final String[] lines = {
+            "abc",
+            "def",
+            "ghi",
+        };
+        assertEquals(
+            "abc\ndef\nghi\n",
+            InlineTagUtils.convertLinesToString(lines));
+    }
+
+    @Test
+    public void extractInlineTags() {
+        final String[] source = {
+            "  {@link foo}",
+        };
+
+        final List<TagInfo> tags = InlineTagUtils.extractInlineTags(source);
+
+        assertEquals(1, tags.size());
+
+        final TagInfo tag = tags.get(0);
+        assertTag(tag, "link", "foo", 1, 3);
+    }
+
+    @Test
+    public void testRemoveLeadingJavaDoc() {
+        assertEquals(" abc", InlineTagUtils.removeLeadingJavaDoc("  * abc"));
+
+        final String source = InlineTagUtils.convertLinesToString(
+            " * {@link foo",
+            " * bar",
+            " * baz}");
+
+        assertEquals(" {@link foo\n" + " bar\n" + " baz}\n",
+            InlineTagUtils.removeLeadingJavaDoc(source));
+    }
+
+    @Test
+    public void testBadInputGetLineColumnOfIndexNegativeIndex() {
+        try {
+            InlineTagUtils.getLineColumnOfIndex("", -1);
+            fail("AssertionError expected");
+        }
+        catch (AssertionError ex) {
+            assertTrue(ex.getMessage().contains("positive"));
+        }
+    }
+
+    @Test
+    public void testBadInputGetLineColumnOfIndexTooLargeIndex() {
+        try {
+            InlineTagUtils.getLineColumnOfIndex("", 1);
+            fail("AssertionError expected");
+        }
+        catch (AssertionError ex) {
+            assertTrue(ex.getMessage().contains("less than length"));
+        }
+    }
+
+    @Test
+    public void testBadInputExtractInlineTagsLineFeed() {
+        try {
+            InlineTagUtils.extractInlineTags("abc\ndef");
+            fail("AssertionError expected");
+        }
+        catch (AssertionError ex) {
+            assertTrue(ex.getMessage().contains("newline"));
+        }
+    }
+
+    @Test
+    public void testBadInputExtractInlineTagsCarriageReturn() {
+        try {
+            InlineTagUtils.extractInlineTags("abc\rdef");
+            fail("AssertionError expected");
+        }
+        catch (AssertionError ex) {
+            assertTrue(ex.getMessage().contains("newline"));
+        }
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java
@@ -55,6 +55,18 @@ public class JavadocUtilsTest {
     }
 
     @Test
+    public void testBlockTag() {
+        final String[] text = {
+            "/** @see elsewhere ",
+            " */",
+        };
+        final Comment comment = new Comment(text, 1, 4, text[1].length());
+        final JavadocTags allTags =
+            JavadocUtils.getJavadocTags(comment, JavadocUtils.JavadocTagType.ALL);
+        assertEquals(1, allTags.getValidTags().size());
+    }
+
+    @Test
     public void testTagType() {
         final String[] text = {
             "/** @see block",
@@ -103,19 +115,16 @@ public class JavadocUtilsTest {
             comment, JavadocUtils.JavadocTagType.ALL).getValidTags();
 
         assertEquals(2, tags.size());
-        for (final JavadocTag tag : tags) {
-            if (JavadocTagInfo.SEE.getName().equals(tag.getTagName())) {
-                assertEquals(1, tag.getLineNo());
-                assertEquals(5, tag.getColumnNo());
-            }
-            else if (JavadocTagInfo.LINK.getName().equals(tag.getTagName())) {
-                assertEquals(2, tag.getLineNo());
-                assertEquals(10, tag.getColumnNo());
-            }
-            else {
-                fail("Unexpected tag: " + tag);
-            }
-        }
+
+        final JavadocTag seeTag = tags.get(0);
+        assertEquals(JavadocTagInfo.SEE.getName(), seeTag.getTagName());
+        assertEquals(1, seeTag.getLineNo());
+        assertEquals(4, seeTag.getColumnNo());
+
+        final JavadocTag linkTag = tags.get(1);
+        assertEquals(JavadocTagInfo.LINK.getName(), linkTag.getTagName());
+        assertEquals(2, linkTag.getLineNo());
+        assertEquals(10, linkTag.getColumnNo());
     }
 
     @Test


### PR DESCRIPTION
Issue #2840: Extract implementations of the block and inline parsers and fix the inline tag parser to properly parse inline tags that span multiple lines. Put tests on both
