### PR TITLE
Issue #4342: Modified version of maven-pmd and fixed InefficientEmptyStringCheck

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -57,7 +57,6 @@
     <allow pkg="java.nio" local-only="true" />
 
     <!-- allowed till https://github.com/checkstyle/checkstyle/issues/3455 -->
-    <allow class="com.google.common.base.CharMatcher" local-only="true"/>
     <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
   </subpackage>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.grammars.CommentListener;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * Represents the contents of a file.
@@ -322,8 +323,7 @@ public final class FileContents implements CommentListener {
      * @return if the specified line consists only of tabs and spaces.
      **/
     public boolean lineIsBlank(int lineNo) {
-        // possible improvement: avoid garbage creation in trim()
-        return line(lineNo).trim().isEmpty();
+        return CommonUtils.isBlank(line(lineNo));
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -28,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * <p>
@@ -299,7 +300,7 @@ public class AvoidEscapedUnicodeCharactersCheck
      */
     private static boolean isTrailingBlockComment(TextBlock comment, String line) {
         return comment.getText().length != 1
-            || line.substring(comment.getEndColNo() + 1).trim().isEmpty();
+            || CommonUtils.isBlank(line.substring(comment.getEndColNo() + 1));
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -172,7 +172,8 @@ public class TrailingCommentCheck extends AbstractCheck {
 
                 // do not check comment which doesn't end line
                 if (comment.getText().length == 1
-                        && !line.substring(comment.getEndColNo() + 1).trim().isEmpty()) {
+                        && !CommonUtils.isBlank(line
+                            .substring(comment.getEndColNo() + 1))) {
                     continue;
                 }
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
@@ -194,9 +194,10 @@ public class EmptyBlockCheck
             }
         }
         else {
-            // check only whitespace of first & last lines
-            if (lines[slistLineNo - 1].substring(slistColNo + 1).trim().isEmpty()
-                    && lines[rcurlyLineNo - 1].substring(0, rcurlyColNo).trim().isEmpty()) {
+            final String firstLine = lines[slistLineNo - 1].substring(slistColNo + 1);
+            final String lastLine = lines[rcurlyLineNo - 1].substring(0, rcurlyColNo);
+            if (CommonUtils.isBlank(firstLine)
+                    && CommonUtils.isBlank(lastLine)) {
                 // check if all lines are also only whitespace
                 returnValue = !checkIsAllLinesAreWhitespace(lines, slistLineNo, rcurlyLineNo);
             }
@@ -221,7 +222,7 @@ public class EmptyBlockCheck
     private static boolean checkIsAllLinesAreWhitespace(String[] lines, int lineFrom, int lineTo) {
         boolean result = true;
         for (int i = lineFrom; i < lineTo - 1; i++) {
-            if (!lines[i].trim().isEmpty()) {
+            if (!CommonUtils.isBlank(lines[i])) {
                 result = false;
                 break;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -25,6 +25,7 @@ import java.util.regex.Pattern;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * Checks for fall through in switch statements
@@ -353,7 +354,7 @@ public class FallThroughCheck extends AbstractCheck {
             //    }
             final int startLineNo = currentCase.getLineNo();
             for (int i = endLineNo - 2; i > startLineNo - 1; i--) {
-                if (!lines[i].trim().isEmpty()) {
+                if (!CommonUtils.isBlank(lines[i])) {
                     allThroughComment = matchesComment(reliefPattern, lines[i], i + 1);
                     break;
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -29,6 +29,7 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * <p>
@@ -711,7 +712,8 @@ public class CustomImportOrderCheck extends AbstractCheck {
         //  [lineNo - 2] is the number of the previous line
         //  because the numbering starts from zero.
         int lineBeforeIndex = lineNo - 2;
-        while (lineBeforeIndex >= 0 && lines[lineBeforeIndex].trim().isEmpty()) {
+        while (lineBeforeIndex >= 0
+                && CommonUtils.isBlank(lines[lineBeforeIndex])) {
             lineBeforeIndex--;
             result++;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -152,7 +152,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
     private void checkEmptyLine(DetailNode newline) {
         final DetailNode nearestToken = getNearestNode(newline);
         if (!isLastEmptyLine(newline) && nearestToken.getType() == JavadocTokenTypes.TEXT
-                && !nearestToken.getText().trim().isEmpty()) {
+                && !CommonUtils.isBlank(nearestToken.getText())) {
             log(newline.getLineNumber(), MSG_TAG_AFTER);
         }
     }
@@ -199,7 +199,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
         if (previousSibling != null
                 && previousSibling.getParent().getType() == JavadocTokenTypes.JAVADOC) {
             if (previousSibling.getType() == JavadocTokenTypes.TEXT
-                    && previousSibling.getText().trim().isEmpty()) {
+                    && CommonUtils.isBlank(previousSibling.getText())) {
                 previousSibling = JavadocUtils.getPreviousSibling(previousSibling);
             }
             result = previousSibling != null
@@ -218,7 +218,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
         DetailNode previousNode = JavadocUtils.getPreviousSibling(paragraphTag);
         while (previousNode != null) {
             if (previousNode.getType() == JavadocTokenTypes.TEXT
-                    && !previousNode.getText().trim().isEmpty()
+                    && !CommonUtils.isBlank(previousNode.getText())
                 || previousNode.getType() != JavadocTokenTypes.LEADING_ASTERISK
                     && previousNode.getType() != JavadocTokenTypes.NEWLINE
                     && previousNode.getType() != JavadocTokenTypes.TEXT) {
@@ -257,7 +257,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
         DetailNode nextNode = JavadocUtils.getNextSibling(newLine);
         while (nextNode != null && nextNode.getType() != JavadocTokenTypes.JAVADOC_TAG) {
             if (nextNode.getType() == JavadocTokenTypes.TEXT
-                    && !nextNode.getText().trim().isEmpty()
+                    && !CommonUtils.isBlank(nextNode.getText())
                     || nextNode.getType() == JavadocTokenTypes.HTML_ELEMENT) {
                 result = false;
                 break;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -25,6 +25,7 @@ import java.util.List;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtils;
 
 /**
@@ -96,7 +97,7 @@ public class JavadocTagContinuationIndentationCheck extends AbstractJavadocCheck
                         .getNextSibling(newlineNode));
                 if (textNode != null && textNode.getType() == JavadocTokenTypes.TEXT) {
                     final String text = textNode.getText();
-                    if (!text.trim().isEmpty()
+                    if (!CommonUtils.isBlank(text.trim())
                             && (text.length() <= offset
                                     || !text.substring(1, offset + 1).trim().isEmpty())) {
                         log(textNode.getLineNumber(), MSG_KEY, offset);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -168,7 +168,7 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
         boolean containsInheritDoc = false;
         for (DetailNode child : ast.getChildren()) {
             if (child.getType() == JavadocTokenTypes.TEXT) {
-                if (!child.getText().trim().isEmpty()) {
+                if (!CommonUtils.isBlank(child.getText())) {
                     extraTextFound = true;
                 }
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -488,7 +488,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
         final int number = 3;
         if (lineNo >= number) {
             final String prePreviousLine = getLines()[lineNo - number];
-            result = prePreviousLine.trim().isEmpty();
+            result = CommonUtils.isBlank(prePreviousLine);
         }
         return result;
     }
@@ -549,7 +549,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
         if (lineNo != 1) {
             // [lineNo - 2] is the number of the previous line as the numbering starts from zero.
             final String lineBefore = getLines()[lineNo - 2];
-            result = lineBefore.trim().isEmpty();
+            result = CommonUtils.isBlank(lineBefore);
         }
         return result;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
@@ -229,7 +229,7 @@ public class SingleSpaceSeparatorCheck extends AbstractCheck {
      *         text on the {@code line}.
      */
     private static boolean isFirstInLine(String line, int columnNo) {
-        return line.substring(0, columnNo + 1).trim().isEmpty();
+        return CommonUtils.isBlank(line.substring(0, columnNo + 1));
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtility.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtility.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.utils;
 
-import com.google.common.base.CharMatcher;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -146,7 +145,7 @@ public final class AnnotationUtility {
             throw new IllegalArgumentException("the annotation is null");
         }
 
-        if (CharMatcher.WHITESPACE.matchesAllOf(annotation)) {
+        if (CommonUtils.isBlank(annotation)) {
             throw new IllegalArgumentException(
                     "the annotation is empty or spaces");
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
@@ -36,7 +36,6 @@ import java.util.regex.PatternSyntaxException;
 
 import org.apache.commons.beanutils.ConversionException;
 
-import com.google.common.base.CharMatcher;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
 /**
@@ -425,17 +424,6 @@ public final class CommonUtils {
     }
 
     /**
-     * Check if a string is blank.
-     * A string is considered blank if it is null, empty or contains only  whitespace characters,
-     * as determined by {@link CharMatcher#WHITESPACE}.
-     * @param str the string to check
-     * @return true if str is either null, empty or whitespace-only.
-     */
-    public static boolean isBlank(String str) {
-        return str == null || CharMatcher.WHITESPACE.matchesAllOf(str);
-    }
-
-    /**
      * Returns file name without extension.
      * We do not use the method from Guava library to reduce Checkstyle's dependencies
      * on external libraries.
@@ -511,5 +499,24 @@ public final class CommonUtils {
         }
 
         return isName;
+    }
+
+    /**
+     * Checks if the value arg is blank by either being null,
+     * empty, or contains only whitespace characters.
+     * @param value A string to check.
+     * @return true if the arg is blank.
+     */
+    public static boolean isBlank(String value) {
+        boolean result = true;
+        if (value != null && !value.isEmpty()) {
+            for (int i = 0; i < value.length(); i++) {
+                if (!Character.isWhitespace(value.charAt(i))) {
+                    result = false;
+                    break;
+                }
+            }
+        }
+        return result;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
@@ -278,6 +278,46 @@ public class CommonUtilsTest {
     }
 
     @Test
+    public void testIsBlank() throws Exception {
+        assertFalse(CommonUtils.isBlank("string"));
+    }
+
+    @Test
+    public void testIsBlankAheadWhitespace() throws Exception {
+        assertFalse(CommonUtils.isBlank("  string"));
+    }
+
+    @Test
+    public void testIsBlankBehindWhitespace() throws Exception {
+        assertFalse(CommonUtils.isBlank("string    "));
+    }
+
+    @Test
+    public void testIsBlankWithWhitespacesAround() throws Exception {
+        assertFalse(CommonUtils.isBlank("    string    "));
+    }
+
+    @Test
+    public void testIsBlankWhitespaceInside() throws Exception {
+        assertFalse(CommonUtils.isBlank("str    ing"));
+    }
+
+    @Test
+    public void testIsBlankNullString() throws Exception {
+        assertTrue(CommonUtils.isBlank(null));
+    }
+
+    @Test
+    public void testIsBlankWithEmptyString() throws Exception {
+        assertTrue(CommonUtils.isBlank(""));
+    }
+
+    @Test
+    public void testIsBlankWithWhitespacesOnly() throws Exception {
+        assertTrue(CommonUtils.isBlank("   "));
+    }
+
+    @Test
     @PrepareForTest({ CommonUtils.class, CommonUtilsTest.class })
     @SuppressWarnings("unchecked")
     public void testLoadSuppressionsUriSyntaxException() throws Exception {


### PR DESCRIPTION
#4342 
The issue with InefficientEmptyStringCheck was caused by String.trim().isEmpty() which creates new String object. I added a method that checks whether String is empty or not without creating temporary String.

https://pmd.github.io/pmd-5.6.1/pmd-java/rules/java/strings.html#InefficientEmptyStringCheck