### PR TITLE
Issue #4341: Copy dtds schemas from resources dir to target/site/dtds during pre-site phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -524,6 +524,32 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.0.2</version>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>pre-site</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/site/dtds</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/resources/com/puppycrawl/tools/checkstyle</directory>
+                  <includes>
+                    <include>*.dtd</include>
+                  </includes>
+                </resource>
+                <resource>
+                  <directory>src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports</directory>
+                  <includes>
+                    <include>*.dtd</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Issue #4341 

Used maven-resources-plugin to copy dtds schemes from resources folder to target/site/dtds.

Plugin goal doc:
https://maven.apache.org/plugins/maven-resources-plugin/copy-resources-mojo.html

Maven phases doc:
https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html

The plugin will automatically create dtds dir. 

@romani 
I think that pre-site phase is a good step to perform the copying.