### PR TITLE
Issue #4350: expanded exception violation when haltOnException is off

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -21,6 +21,8 @@ package com.puppycrawl.tools.checkstyle;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -327,9 +329,15 @@ public class Checker extends AutomaticBean implements MessageDispatcher, RootMod
             }
 
             LOG.debug("Exception occurred.", ex);
+
+            final StringWriter sw = new StringWriter();
+            final PrintWriter pw = new PrintWriter(sw, true);
+
+            ex.printStackTrace(pw);
+
             fileMessages.add(new LocalizedMessage(0,
                     Definitions.CHECKSTYLE_BUNDLE, EXCEPTION_MSG,
-                    new String[] {ex.getClass().getName() + ": " + ex.getMessage()},
+                    new String[] {sw.getBuffer().toString()},
                     null, getClass(), null));
         }
         return fileMessages;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -172,6 +172,11 @@ public class XMLLogger
                 case '&':
                     sb.append(encodeAmpersand(value, i));
                     break;
+                case '\r':
+                    break;
+                case '\n':
+                    sb.append("&#10;");
+                    break;
                 default:
                     sb.append(chr);
                     break;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -210,11 +210,8 @@ public class XMLLoggerTest {
         logger.addException(ev, new TestException("msg", new RuntimeException("msg")));
         logger.auditFinished(null);
         final String[] expectedLines = {
-            "&lt;exception&gt;",
-            "&lt;![CDATA[",
-            "stackTrace]]&gt;",
-            "&lt;/exception&gt;",
-            "",
+            "&lt;exception&gt;&#10;&lt;![CDATA[&#10;stackTrace&#10;example]]&gt;"
+                + "&#10;&lt;/exception&gt;&#10;",
         };
         verifyLines(expectedLines);
     }
@@ -268,7 +265,7 @@ public class XMLLoggerTest {
 
         @Override
         public void printStackTrace(PrintWriter printWriter) {
-            printWriter.print("stackTrace");
+            printWriter.print("stackTrace\r\nexample");
         }
     }
 


### PR DESCRIPTION
Issue #4350

Expanded violation message to show full stack trace.
`XMLLogger` was changed to accommodate retaining newlines in stacktrace when put to XML file. Depending on parser, if new lines aren't converted then can be changed to single spaces which will distort the stacktrace.

I noticed some issues when deciding how to code this fix.

1)
[`BaseCheckTestSupport` counts lines based on the number of errors.](https://github.com/checkstyle/checkstyle/blob/2f3f4b76f04f0b5071abcaed54648a49a0db3160/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java#L244) So test can only verify the first line of the exception, and not the full trace.

2)
[`AuditListener.addException` isn't called anywhere except in test code.](https://github.com/checkstyle/checkstyle/blob/b4a337a599e853cdc44b19a76da28fcfab2956cd/src/main/java/com/puppycrawl/tools/checkstyle/api/AuditListener.java#L73)
I was thinking of making use of it for this fix, but I don't think `patch-diff-report-util` currently supports the special tag this method produces.
