### PR TITLE
Issue #4101: changed external resources in cache to have special prefix

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -70,6 +70,14 @@ final class PropertyCacheFile {
      */
     public static final String CONFIG_HASH_KEY = "configuration*?";
 
+    /**
+     * The property prefix to use for storing the hashcode of an
+     * external resource. To avoid name clashes with the files that are
+     * checked the prefix is chosen in such a way that it cannot be a
+     * valid file name and makes it clear it is a resource.
+     */
+    public static final String EXTERNAL_RESOURCE_KEY_PREFIX = "module-resource*?:";
+
     /** The details on files. **/
     private final Properties details = new Properties();
 
@@ -273,7 +281,8 @@ final class PropertyCacheFile {
                 contentHashSum = getHashCodeBasedOnObjectContent(ex);
             }
             finally {
-                resources.add(new ExternalResource(location, contentHashSum));
+                resources.add(new ExternalResource(EXTERNAL_RESOURCE_KEY_PREFIX + location,
+                        contentHashSum));
             }
         }
         return resources;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -624,6 +625,7 @@ public class CheckerTest extends BaseCheckTestSupport {
      * It is OK to have long test method name here as it describes the test purpose.
      * @noinspection InstanceMethodNamingConvention
      */
+    // -@cs[ExecutableStatementCount] This test needs to verify many things.
     @Test
     public void testCacheAndCheckWhichAddsNewResourceLocationButKeepsSameCheckerInstance()
             throws Exception {
@@ -637,6 +639,8 @@ public class CheckerTest extends BaseCheckTestSupport {
         final DynamicalResourceHolderCheck check = new DynamicalResourceHolderCheck();
         final String firstExternalResourceLocation = getPath("checks" + File.separator
             + "imports" + File.separator + "import-control_one.xml");
+        final String firstExternalResourceKey = PropertyCacheFile.EXTERNAL_RESOURCE_KEY_PREFIX
+                + firstExternalResourceLocation;
         check.setFirstExternalResourceLocation(firstExternalResourceLocation);
 
         final DefaultConfiguration checkerConfig = new DefaultConfiguration("checkstyle_checks");
@@ -662,6 +666,8 @@ public class CheckerTest extends BaseCheckTestSupport {
         // Change a list of external resources which are used by the check
         final String secondExternalResourceLocation = "checks" + File.separator
             + "imports" + File.separator + "import-control_one-re.xml";
+        final String secondExternalResourceKey = PropertyCacheFile.EXTERNAL_RESOURCE_KEY_PREFIX
+                + secondExternalResourceLocation;
         check.setSecondExternalResourceLocation(secondExternalResourceLocation);
 
         verify(checker, pathToEmptyFile, expected);
@@ -677,12 +683,14 @@ public class CheckerTest extends BaseCheckTestSupport {
             cacheAfterSecondRun.getProperty(PropertyCacheFile.CONFIG_HASH_KEY)
         );
         assertEquals(
-            cacheAfterFirstRun.getProperty(firstExternalResourceLocation),
-            cacheAfterSecondRun.getProperty(firstExternalResourceLocation)
+            cacheAfterFirstRun.getProperty(firstExternalResourceKey),
+            cacheAfterSecondRun.getProperty(firstExternalResourceKey)
         );
+        assertNotNull(cacheAfterFirstRun.getProperty(firstExternalResourceKey));
         final int expectedNumberOfObjectsInCacheAfterSecondRun = 4;
         assertEquals(expectedNumberOfObjectsInCacheAfterSecondRun, cacheAfterSecondRun.size());
-        assertNotNull(cacheAfterSecondRun.getProperty(secondExternalResourceLocation));
+        assertNull(cacheAfterFirstRun.getProperty(secondExternalResourceKey));
+        assertNotNull(cacheAfterSecondRun.getProperty(secondExternalResourceKey));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -249,7 +249,8 @@ public class PropertyCacheFileTest {
             nonExistingExternalResources.add(externalResourceFileName);
             cache.putExternalResources(nonExistingExternalResources);
 
-            externalResourceHashes[i] = cache.get(externalResourceFileName);
+            externalResourceHashes[i] = cache.get(PropertyCacheFile.EXTERNAL_RESOURCE_KEY_PREFIX
+                    + externalResourceFileName);
             assertNotNull(externalResourceHashes[i]);
 
             cache.persist();
@@ -301,7 +302,8 @@ public class PropertyCacheFileTest {
             nonExistingExternalResources.add(externalResourceFileName);
             cache.putExternalResources(nonExistingExternalResources);
 
-            externalResourceHashes[i] = cache.get(externalResourceFileName);
+            externalResourceHashes[i] = cache.get(PropertyCacheFile.EXTERNAL_RESOURCE_KEY_PREFIX
+                    + externalResourceFileName);
             assertNotNull(externalResourceHashes[i]);
 
             cache.persist();


### PR DESCRIPTION
Issue #4101

Edit:
The new assertions in `CheckerTest` were because parts of the test wasn't failing with the changes made when they should have been.