### PR TITLE
Issue #4387: problem with usage of third-party Check libraries and ch…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,7 +467,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>7.8</version>
+            <version>7.9-SNAPSHOT</version>
           </dependency>
         </dependencies>
         <!-- Specifying configuration here will take effect on the execution of "mvn checkstyle:checkstyle",

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -55,6 +56,10 @@ public class PackageObjectFactory implements ModuleFactory {
     public static final String UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE =
             "PackageObjectFactory.unableToInstantiateExceptionMessage";
 
+    /** Exception message when there is ambigugous module name in config file. */
+    public static final String AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE =
+            "PackageObjectFactory.ambiguousModuleNameExceptionMessage";
+
     /** Suffix of checks. */
     public static final String CHECK_SUFFIX = "Check";
 
@@ -79,8 +84,8 @@ public class PackageObjectFactory implements ModuleFactory {
     /** The class loader used to load Checkstyle core and custom modules. */
     private final ClassLoader moduleClassLoader;
 
-    /** Map of third party Checkstyle module names to their fully qualified names. */
-    private Map<String, String> thirdPartyNameToFullModuleName;
+    /** Map of third party Checkstyle module names to the set of their fully qualified names. */
+    private Map<String, Set<String>> thirdPartyNameToFullModuleNames;
 
     static {
         fillShortToFullModuleNamesMap();
@@ -139,13 +144,23 @@ public class PackageObjectFactory implements ModuleFactory {
         Object instance = null;
         // if the name is a simple class name, try to find it in maps at first
         if (!name.contains(PACKAGE_SEPARATOR)) {
-            instance = createObjectFromMap(name, NAME_TO_FULL_MODULE_NAME);
+            final String fullModuleName = NAME_TO_FULL_MODULE_NAME.get(name);
+            if (fullModuleName == null) {
+                final String fullCheckModuleName =
+                        NAME_TO_FULL_MODULE_NAME.get(name + CHECK_SUFFIX);
+                if (fullCheckModuleName != null) {
+                    instance = createObject(fullCheckModuleName);
+                }
+            }
+            else {
+                instance = createObject(fullModuleName);
+            }
             if (instance == null) {
-                if (thirdPartyNameToFullModuleName == null) {
-                    thirdPartyNameToFullModuleName =
+                if (thirdPartyNameToFullModuleNames == null) {
+                    thirdPartyNameToFullModuleNames =
                             generateThirdPartyNameToFullModuleName(moduleClassLoader);
                 }
-                instance = createObjectFromMap(name, thirdPartyNameToFullModuleName);
+                instance = createObjectFromMap(name, thirdPartyNameToFullModuleNames);
             }
         }
 
@@ -170,37 +185,71 @@ public class PackageObjectFactory implements ModuleFactory {
 
     /**
      * Create object with the help of the supplied map.
-     * @param name name of module.
-     * @param map the supplied map.
-     * @return instance of module if it is found in modules map.
-     * @throws CheckstyleException if the class fails to instantiate.
+     * @param name name of module
+     * @param map the supplied map
+     * @return instance of module if it is found in modules map and no ambiguous classes exist
+     * @throws CheckstyleException if the class fails to instantiate or there are ambiguous classes
      */
-    private Object createObjectFromMap(String name, Map<String, String> map)
+    private Object createObjectFromMap(String name, Map<String, Set<String>> map)
             throws CheckstyleException {
-        final String fullModuleName = map.get(name);
+        final Set<String> fullModuleNames = map.get(name);
         Object instance = null;
-        if (fullModuleName == null) {
-            final String fullCheckModuleName = map.get(name + CHECK_SUFFIX);
-            if (fullCheckModuleName != null) {
-                instance = createObject(fullCheckModuleName);
+        if (fullModuleNames == null) {
+            final Set<String> fullCheckModuleNames = map.get(name + CHECK_SUFFIX);
+            if (fullCheckModuleNames != null) {
+                instance = createObjectFromFullModuleNames(name, fullCheckModuleNames);
             }
         }
         else {
-            instance = createObject(fullModuleName);
+            instance = createObjectFromFullModuleNames(name, fullModuleNames);
         }
         return instance;
     }
 
     /**
-     * Generate the map of third party Checkstyle module names to their fully qualified names.
-     * @param loader the class loader used to load Checkstyle package names
-     * @return the map of third party Checkstyle module names to their fully qualified names
+     * Create Object from optional full module names.
+     * In most case, there should be only one element in {@code fullModuleName}, otherwise
+     * an exception would be thrown.
+     * @param name name of module
+     * @param fullModuleNames the supplied full module names set
+     * @return instance of module if there is only one element in {@code fullModuleName}
+     * @throws CheckstyleException if the class fails to instantiate or there are more than one
+     *      element in {@code fullModuleName}
      */
-    private Map<String, String> generateThirdPartyNameToFullModuleName(ClassLoader loader) {
-        Map<String, String> returnValue;
+    private Object createObjectFromFullModuleNames(String name, Set<String> fullModuleNames)
+            throws CheckstyleException {
+        if (fullModuleNames.size() == 1) {
+            return createObject(fullModuleNames.iterator().next());
+        }
+        else {
+            final String optionalNames = fullModuleNames.stream()
+                    .reduce((fullNames, fullName) -> fullNames + STRING_SEPARATOR + fullName).get();
+            final LocalizedMessage exceptionMessage = new LocalizedMessage(0,
+                    Definitions.CHECKSTYLE_BUNDLE, AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE,
+                    new String[] {name, optionalNames}, null, getClass(), null);
+            throw new CheckstyleException(exceptionMessage.getMessage());
+        }
+    }
+
+    /**
+     * Generate the map of third party Checkstyle module names to the set of their fully qualified
+     * names.
+     * @param loader the class loader used to load Checkstyle package names
+     * @return the map of third party Checkstyle module names to the set of their fully qualified
+     *      names
+     */
+    private Map<String, Set<String>> generateThirdPartyNameToFullModuleName(ClassLoader loader) {
+        Map<String, Set<String>> returnValue;
         try {
             returnValue = ModuleReflectionUtils.getCheckstyleModules(packages, loader).stream()
-                    .collect(Collectors.toMap(Class::getSimpleName, Class::getCanonicalName));
+                    .collect(Collectors.toMap(
+                        Class::getSimpleName,
+                        cls -> Collections.singleton(cls.getCanonicalName()),
+                        (fullNames1, fullNames2) -> {
+                            final Set<String> mergedNames = new LinkedHashSet<>(fullNames1);
+                            mergedNames.addAll(fullNames2);
+                            return mergedNames;
+                        }));
         }
         catch (IOException ignore) {
             returnValue = new HashMap<>();

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages.properties
@@ -9,7 +9,11 @@ DefaultLogger.auditStarted=Starting audit...
 DefaultLogger.auditFinished=Audit done.
 
 PackageObjectFactory.unableToInstantiateExceptionMessage=Unable to instantiate ''{0}'' \
-   class, it is also not possible to instantiate it as {1}. \
-   Please recheck that class name is specified as canonical name or read how to configure \
-   short name usage http://checkstyle.sourceforge.net/config.html\#Packages. Please also \
-   recheck that provided ClassLoader to Checker is configured correctly.
+  class, it is also not possible to instantiate it as {1}. \
+  Please recheck that class name is specified as canonical name or read how to configure \
+  short name usage http://checkstyle.sourceforge.net/config.html\#Packages. Please also \
+  recheck that provided ClassLoader to Checker is configured correctly.
+
+PackageObjectFactory.ambiguousModuleNameExceptionMessage=In config there is ''{0}'', \
+  but in classpath there are {1}, please resolve ambiguity by specifying fully qualified \
+  name in config.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_de.properties
@@ -13,3 +13,7 @@ PackageObjectFactory.unableToInstantiateExceptionMessage=Fehler beim Instanziier
   Bitte prüfen Sie, dass der Klassenname als kanonischer Name angegeben wurde oder lesen Sie, wie Sie \
   abgekürzte Namen konfigurieren: http://checkstyle.sourceforge.net/config.html\#Packages. \
   Bitte prüfen Sie auch, dass der angegebene ClassLoader des Checkers richtig konfiguriert ist.
+
+PackageObjectFactory.ambiguousModuleNameExceptionMessage=In config gibt es ''{0}'', \
+  aber im Klassenpfad gibt es {1}, bitte lösen Sie Mehrdeutigkeit durch die Angabe voll \
+  qualifizierten Namen in config.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_es.properties
@@ -14,3 +14,7 @@ PackageObjectFactory.unableToInstantiateExceptionMessage = No se ha podido crear
   de clase se especifica como nombre canónico o leer cómo configurar nombre de uso \
   a corto http://checkstyle.sourceforge.net/config.html\#Packages. Por favor, vuelva \
   a comprobar también la proporcionada ClassLoader al inspector está configurado correctamente.
+
+PackageObjectFactory.ambiguousModuleNameExceptionMessage=En configuración hay ''{0}'', \
+  pero en classpath hay {1}, por favor, resolver la ambigüedad mediante la especificación \
+  de nombre completo en config.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fi.properties
@@ -14,3 +14,7 @@ PackageObjectFactory.unableToInstantiateExceptionMessage = Ei voitu instantiate 
   määritetty kanoninen nimi tai lukea miten määrittää lyhyt nimi käyttö \
   http://checkstyle.sourceforge.net/config.html\#Packages. Muista myös tarkista, \
   että tarjotaan classloader Checker on määritetty oikein.
+
+PackageObjectFactory.ambiguousModuleNameExceptionMessage=Konfigissa on ''{0}'', \
+  mutta luokkapolussa on {1}, ratkaise epäselvyys määrittämällä täydellinen nimi \
+  konfiguroinnilla.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_fr.properties
@@ -13,3 +13,6 @@ PackageObjectFactory.unableToInstantiateExceptionMessage = Impossible d'instanci
   Veuillez vérifier que le nom de classe est spécifié comme nom canonique ou regardez comment \
   configurer l''utilisation du nom court http://checkstyle.sourceforge.net/config.html\#Packages. \
   Veuillez également vérifier que le ClassLoader fourni au Checker est correctement configuré.
+
+PackageObjectFactory.ambiguousModuleNameExceptionMessage=Dans la configuration il y a ''{0}'', \
+  mais dans classpath il y a {1}, résolvez l'ambiguïté en spécifiant le nom complet dans config.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_ja.properties
@@ -12,3 +12,6 @@ PackageObjectFactory.unableToInstantiateExceptionMessage=''{0}'' クラスをイ
   クラス名を正規名で指定しているか再確認してください。または、単純名の使用を設定する方法 \
   http://checkstyle.sourceforge.net/config.html\#Packages をお読みください。 \
   また、Checker に渡されているクラスローダが正しく設定されているか再確認してください。
+
+PackageObjectFactory.ambiguousModuleNameExceptionMessage=設定には ''{0}''がありますが、\
+  クラスパスには{1}があります。設定に完全修飾名を指定してあいまいさを解決してください。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_pt.properties
@@ -14,3 +14,7 @@ PackageObjectFactory.unableToInstantiateExceptionMessage = Não é possível ins
   é especificado como nome canônico ou ler como configurar o uso do nome curto \
   http://checkstyle.sourceforge.net/config.html\#Packages. Por favor, volte a verificar \
   também que ClassLoader fornecido para Checker está configurado corretamente.
+
+PackageObjectFactory.ambiguousModuleNameExceptionMessage=Na configuração há ''{0}'', \
+  mas no classpath há {1}, resolva a ambiguidade especificando o nome totalmente \
+  qualificado na configuração.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_tr.properties
@@ -13,3 +13,6 @@ PackageObjectFactory.unableToInstantiateExceptionMessage=''{0}'' sınıfını a�
   kullanımını http://checkstyle.sourceforge.net/config.html\#Packages nasıl \
   yapılandırılacağı okuyunuz. Ayrıca Checker şartıyla ClassLoader düzgün \
   yapılandırılmış olduğunu tekrar kontrol ediniz.
+
+PackageObjectFactory.ambiguousModuleNameExceptionMessage=Yapılandırmada ''{0}'' var, \
+  ancak sınıf yolunda {1} var, lütfen yapılandırmada tam adı belirterek belirsizliği gidermek.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/messages_zh.properties
@@ -9,7 +9,10 @@ DefaultLogger.auditStarted=开始检查……
 DefaultLogger.auditFinished=检查完成。
 
 PackageObjectFactory.unableToInstantiateExceptionMessage=无法初始化类： ''{0}'' \
-   ，也无法初始化： {1}。 \
-   请检查类名大小写，或阅读帮助手册中短名称配置部分： \
-   http://checkstyle.sourceforge.net/config.html\#Packages.  \
-   同时，请检查Checker的ClassLoader是否配置正确。
+  ，也无法初始化： {1}。 \
+  请检查类名大小写，或阅读帮助手册中短名称配置部分： \
+  http://checkstyle.sourceforge.net/config.html\#Packages.  \
+  同时，请检查Checker的ClassLoader是否配置正确。
+
+PackageObjectFactory.ambiguousModuleNameExceptionMessage=配置文件中出现 ''{0}''，\
+  但在 classpath 中存在 {1}，请在配置文件中使用 Module 的 fully qualified name 以避免混淆。

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CheckUtil.java
@@ -169,6 +169,8 @@ public final class CheckUtil {
         return classPath.getTopLevelClassesRecursive(packageName).stream()
                 .map(ClassPath.ClassInfo::load)
                 .filter(ModuleReflectionUtils::isCheckstyleModule)
+                .filter(cls -> !cls.getCanonicalName()
+                        .startsWith("com.puppycrawl.tools.checkstyle.packageobjectfactory"))
                 .collect(Collectors.toSet());
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/packageobjectfactory/bar/FooCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/packageobjectfactory/bar/FooCheck.java
@@ -1,0 +1,10 @@
+package com.puppycrawl.tools.checkstyle.packageobjectfactory.bar;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+
+public class FooCheck extends AbstractCheck {
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[] {0};
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/packageobjectfactory/foo/FooCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/packageobjectfactory/foo/FooCheck.java
@@ -1,0 +1,10 @@
+package com.puppycrawl.tools.checkstyle.packageobjectfactory.foo;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+
+public class FooCheck extends AbstractCheck {
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[] {0};
+    }
+}


### PR DESCRIPTION
#4387 

@romani 
https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java#L202
The direct cause is that we have duplicate keys(the class simple name) in this stream.

I guess the reason is we have some classes that have the same simple name in both checkstyle project and sevntu.checkstyle project. 
We could see `HideUtilityClassConstructorCheck` in the log,  and there are https://github.com/sevntu-checkstyle/sevntu.checkstyle/blob/master/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/HideUtilityClassConstructorCheck.java and https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java.

I am not sure which class should I use here. More specifically, to use checkstyle's HideUtilityClassConstructorCheck or sevntu.checkstyle's HideUtilityClassConstructorCheck? (same question with other classes with same name) Currently I just choose the new one in the stream.

I don't know how to reproduce the bug in IDE currently. So I was not able to use a debug mode to check the `packages` field when the bug occurs.