### PR TITLE
Issue #4402: Add pitest-checks-annotation profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1502,6 +1502,43 @@
     </profile>
 
     <profile>
+      <id>pitest-checks-annotation</id>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-maven</artifactId>
+            <version>${pitest.plugin.version}</version>
+            <configuration>
+              <targetClasses>
+                <param>com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.annotation.PackageAnnotationCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck</param>
+              </targetClasses>
+              <targetTests>
+                <param>com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.annotation.PackageAnnotationCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheckTest</param>
+              </targetTests>
+              <mutationThreshold>99</mutationThreshold>
+              <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
+              <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
+              <threads>${pitest.plugin.threads}</threads>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>pitest-checks-blocks</id>
       <properties>
         <skipTests>true</skipTests>

--- a/shippable.yml
+++ b/shippable.yml
@@ -6,6 +6,7 @@ jdk:
 
 env:
   matrix:
+    - PROFILE="-Ppitest-checks-annotation,no-validations"
     - PROFILE="-Ppitest-checks-blocks,no-validations"
     - PROFILE="-Ppitest-checks-coding,no-validations"
     - PROFILE="-Ppitest-checks-design,no-validations"


### PR DESCRIPTION
Issue: #4402 add pitest-checks-annotation profile
When I simply add com.puppycrawl.tools.checkstyle.checks.annotation.* build fails:
Failed to execute goal org.pitest:pitest-maven:1.2.0:mutationCoverage (default-cli) on project checkstyle: Execution default-cli of goal org.pitest:pitest-maven:1.2.0:mutationCoverage failed: 65535
So I've added classes manually
execution time: 04:10 min
threshold: 99