### PR TITLE
Issue #4400: Increase coverage of pitest-checks-common profile to 85%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1950,7 +1950,11 @@
                 <param>com.puppycrawl.tools.checkstyle.ant.*</param>
                 <param>com.puppycrawl.tools.checkstyle.doclets.*</param>
               </targetTests>
-              <mutationThreshold>78</mutationThreshold>
+              <excludedMethods>
+                <!-- till https://github.com/hcoles/pitest/issues/353 -->
+                <param>fillShortToFullModuleNamesMap</param>
+              </excludedMethods>
+              <mutationThreshold>84</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION
Issue #4400

increased mutation threshold for pitest-checkstyle-common by 2%
threshold: 84%
execution time: 04:28 min
threshold will increase slowly as profile is quite big
[pitest report before changes for class](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/Checker.java.html)
[pitest report before changes for package](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/index.html)

`testFinishLocalSetupFullyInitialized` kills the following mutations: [173](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/Checker.java.html#org.pitest.mutationtest.report.html.SourceFile@58688a38_173), [415](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/Checker.java.html#org.pitest.mutationtest.report.html.SourceFile@58688a38_415), [432](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/Checker.java.html#org.pitest.mutationtest.report.html.SourceFile@58688a38_432), [433](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/Checker.java.html#org.pitest.mutationtest.report.html.SourceFile@58688a38_433), [435](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/Checker.java.html#org.pitest.mutationtest.report.html.SourceFile@58688a38_435), [436](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/Checker.java.html#org.pitest.mutationtest.report.html.SourceFile@58688a38_436)
`testAddBeforeExecutionFileFilterAsChild` kills the following mutations: [466](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/Checker.java.html#org.pitest.mutationtest.report.html.SourceFile@58688a38_466)
`testAddListenerAsChild` kills the following mutations: [474](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/Checker.java.html#org.pitest.mutationtest.report.html.SourceFile@58688a38_474)
`testCheckerProcessCallAllNeededMethodsOfChecks` kills the following mutations: [210](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/Checker.java.html#org.pitest.mutationtest.report.html.SourceFile@58688a38_210), [217](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/Checker.java.html#org.pitest.mutationtest.report.html.SourceFile@58688a38_217), [220](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/Checker.java.html#org.pitest.mutationtest.report.html.SourceFile@58688a38_220)
`testFileSetCheckInitWhenAddedAsChild` kills the following mutations: [461](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/Checker.java.html#org.pitest.mutationtest.report.html.SourceFile@58688a38_461)
`testSetFileSetCheckSetsMessageDispatcher` kills the following mutations: [488](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/Checker.java.html#org.pitest.mutationtest.report.html.SourceFile@58688a38_488)