### PR TITLE
Issue #4393: Walk and parse ASTs only when needed

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -171,17 +171,23 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
             final String msg = "%s occurred during the analysis of file %s.";
             final String fileName = file.getPath();
             try {
-                final FileText text = FileText.fromLines(file, lines);
-                final FileContents contents = new FileContents(text);
-                final DetailAST rootAST = parse(contents);
+                if (!ordinaryChecks.isEmpty()
+                        || !commentChecks.isEmpty()) {
+                    final FileText text = FileText.fromLines(file, lines);
+                    final FileContents contents = new FileContents(text);
+                    final DetailAST rootAST = parse(contents);
 
-                getMessageCollector().reset();
+                    getMessageCollector().reset();
 
-                walk(rootAST, contents, AstState.ORDINARY);
+                    if (!ordinaryChecks.isEmpty()) {
+                        walk(rootAST, contents, AstState.ORDINARY);
+                    }
+                    if (!commentChecks.isEmpty()) {
+                        final DetailAST astWithComments = appendHiddenCommentNodes(rootAST);
 
-                final DetailAST astWithComments = appendHiddenCommentNodes(rootAST);
-
-                walk(astWithComments, contents, AstState.WITH_COMMENTS);
+                        walk(astWithComments, contents, AstState.WITH_COMMENTS);
+                    }
+                }
             }
             catch (final TokenStreamRecognitionException tre) {
                 final String exceptionMsg = String.format(Locale.ROOT, msg,


### PR DESCRIPTION
Issue #4393 : ASTs to be generated and walked only when there are corresponding type of checks. No parsing if no checks are specified
