### PR TITLE
Issue #4370: Add multi thread mode to checkstyle launcher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1977,7 +1977,7 @@
             <configuration>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatter</param>
-                <param>com.puppycrawl.tools.checkstyle.ConfigurationLoader</param>
+                <param>com.puppycrawl.tools.checkstyle.ConfigurationLoader*</param>
                 <param>com.puppycrawl.tools.checkstyle.PackageNamesLoader</param>
                 <param>com.puppycrawl.tools.checkstyle.DefaultConfiguration</param>
                 <param>com.puppycrawl.tools.checkstyle.DefaultContext</param>
@@ -1990,6 +1990,7 @@
                 <param>com.puppycrawl.tools.checkstyle.Checker</param>
                 <param>com.puppycrawl.tools.checkstyle.ant.*</param>
                 <param>com.puppycrawl.tools.checkstyle.doclets.*</param>
+                <param>com.puppycrawl.tools.checkstyle.ThreadModeSettings</param>
               </targetClasses>
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatterTest</param>
@@ -2005,6 +2006,7 @@
                 <param>com.puppycrawl.tools.checkstyle.CheckerTest</param>
                 <param>com.puppycrawl.tools.checkstyle.ant.*</param>
                 <param>com.puppycrawl.tools.checkstyle.doclets.*</param>
+                <param>com.puppycrawl.tools.checkstyle.ThreadModeSettingsTest</param>
               </targetTests>
               <excludedMethods>
                 <!-- till https://github.com/hcoles/pitest/issues/353 -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -48,12 +48,26 @@ public final class DefaultConfiguration implements Configuration {
     /** The map containing custom messages. */
     private final Map<String, String> messages = new HashMap<>();
 
+    /** The thread mode configuration. */
+    private final ThreadModeSettings threadModeSettings;
+
     /**
      * Instantiates a DefaultConfiguration.
      * @param name the name for this DefaultConfiguration.
      */
     public DefaultConfiguration(String name) {
+        this(name, ThreadModeSettings.SINGLE_THREAD_MODE_INSTANCE);
+    }
+
+    /**
+     * Instantiates a DefaultConfiguration.
+     * @param name the name for this DefaultConfiguration.
+     * @param threadModeSettings the thread mode configuration.
+     */
+    public DefaultConfiguration(String name,
+        ThreadModeSettings threadModeSettings) {
         this.name = name;
+        this.threadModeSettings = threadModeSettings;
     }
 
     @Override
@@ -130,5 +144,13 @@ public final class DefaultConfiguration implements Configuration {
     @Override
     public ImmutableMap<String, String> getMessages() {
         return ImmutableMap.copyOf(messages);
+    }
+
+    /**
+     * Gets the thread mode configuration.
+     * @return the thread mode configuration.
+     */
+    public ThreadModeSettings getThreadModeSettings() {
+        return threadModeSettings;
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ThreadModeSettings.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ThreadModeSettings.java
@@ -1,0 +1,99 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.io.Serializable;
+
+/**
+ * Thread mode settings for the checkstyle modules.
+ * @author Andrew Kuchev
+ */
+public class ThreadModeSettings implements Serializable {
+    /** A checker module name. */
+    public static final String CHECKER_MODULE_NAME = Checker.class.getSimpleName();
+
+    /** A multi thread checker module name. */
+    public static final String MULTI_THREAD_CHECKER_MODULE_NAME =
+            Checker.class.getSimpleName();
+
+    /** A three walker module name. */
+    public static final String TREE_WALKER_MODULE_NAME = TreeWalker.class.getSimpleName();
+
+    /** A multi thread three walker module name. */
+    public static final String MULTI_THREAD_TREE_WALKER_MODULE_NAME =
+            TreeWalker.class.getSimpleName();
+
+    /** A single thread mode settings instance. */
+    public static final ThreadModeSettings SINGLE_THREAD_MODE_INSTANCE =
+            new ThreadModeSettings(1, 1);
+
+    private static final long serialVersionUID = 1L;
+
+    /** The checker threads number. */
+    private final int checkerThreadsNumber;
+    /** The tree walker threads number. */
+    private final int treeWalkerThreadsNumber;
+
+    /**
+     * Initializes the thread mode configuration.
+     * @param checkerThreadsNumber the Checker threads number
+     * @param treeWalkerThreadsNumber the TreeWalker threads number
+     */
+    public ThreadModeSettings(int checkerThreadsNumber, int treeWalkerThreadsNumber) {
+        this.checkerThreadsNumber = checkerThreadsNumber;
+        this.treeWalkerThreadsNumber = treeWalkerThreadsNumber;
+    }
+
+    /**
+     * Gets the number of threads for the Checker module.
+     * @return the number of threads for the Checker module.
+     */
+    public int getCheckerThreadsNumber() {
+        return checkerThreadsNumber;
+    }
+
+    /**
+     * Gets the number of threads for the TreeWalker module.
+     * @return the number of threads for the TreeWalker module.
+     */
+    public int getTreeWalkerThreadsNumber() {
+        return treeWalkerThreadsNumber;
+    }
+
+    /**
+     * Resolves the module name according to the thread settings.
+     * @param name The original module name.
+     * @return resolved module name.
+     */
+    public final String resolveName(String name) {
+        if (CHECKER_MODULE_NAME.equals(name)
+                && getCheckerThreadsNumber() > 1) {
+            throw new IllegalArgumentException(
+                    "Multi thread mode for Checker module is not implemented");
+        }
+        if (TREE_WALKER_MODULE_NAME.equals(name)
+                && getTreeWalkerThreadsNumber() > 1) {
+            throw new IllegalArgumentException(
+                    "Multi thread mode for TreeWalker module is not implemented");
+        }
+
+        return name;
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -51,6 +51,7 @@ import com.puppycrawl.tools.checkstyle.DefaultLogger;
 import com.puppycrawl.tools.checkstyle.ModuleFactory;
 import com.puppycrawl.tools.checkstyle.PackageObjectFactory;
 import com.puppycrawl.tools.checkstyle.PropertiesExpander;
+import com.puppycrawl.tools.checkstyle.ThreadModeSettings;
 import com.puppycrawl.tools.checkstyle.XMLLogger;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -391,11 +392,11 @@ public class CheckstyleAntTask extends Task {
         final RootModule rootModule;
         try {
             final Properties props = createOverridingProperties();
-            final Configuration configuration =
-                ConfigurationLoader.loadConfiguration(
-                    config,
-                    new PropertiesExpander(props),
-                    !executeIgnoredModules);
+            final ThreadModeSettings threadModeSettings =
+                    ThreadModeSettings.SINGLE_THREAD_MODE_INSTANCE;
+            final Configuration configuration = ConfigurationLoader.loadConfiguration(
+                    config, new PropertiesExpander(props),
+                    !executeIgnoredModules, threadModeSettings);
 
             final ClassLoader moduleClassLoader =
                 Checker.class.getClassLoader();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
@@ -521,4 +521,26 @@ public final class CommonUtils {
         }
         return result;
     }
+
+    /**
+     * Checks whether the string contains an integer value.
+     * @param str a string to check
+     * @return true if the given string is an integer, false otherwise.
+     */
+    public static boolean isInt(String str) {
+        boolean isInt;
+        if (str == null) {
+            isInt = false;
+        }
+        else {
+            try {
+                Integer.parseInt(str);
+                isInt = true;
+            }
+            catch (NumberFormatException ignored) {
+                isInt = false;
+            }
+        }
+        return isInt;
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -529,7 +529,7 @@ public class CheckerTest extends BaseCheckTestSupport {
         assertEquals("Cache has unexpected size",
                 expectedNumberOfObjectsInCache, cache.size());
 
-        final String expectedConfigHash = "68EE3C3B4593FD8D86159C670C504542E20C6FA0";
+        final String expectedConfigHash = "B8535A811CA90BE8B7A14D40BCA62B4FC2447B46";
         assertEquals("Cache has unexpected hash",
                 expectedConfigHash, cache.getProperty(PropertyCacheFile.CONFIG_HASH_KEY));
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultConfigurationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultConfigurationTest.java
@@ -53,4 +53,22 @@ public class DefaultConfigurationTest {
                     expected.getMessage());
         }
     }
+
+    @Test
+    public void testDefaultMultiThreadConfiguration() throws Exception {
+        final String name = "MyConfig";
+        final DefaultConfiguration config = new DefaultConfiguration(name);
+        final ThreadModeSettings singleThreadMode =
+                ThreadModeSettings.SINGLE_THREAD_MODE_INSTANCE;
+        assertEquals(singleThreadMode, config.getThreadModeSettings());
+    }
+
+    @Test
+    public void testMultiThreadConfiguration() throws Exception {
+        final String name = "MyConfig";
+        final ThreadModeSettings multiThreadMode =
+                new ThreadModeSettings(4, 2);
+        final DefaultConfiguration config = new DefaultConfiguration(name, multiThreadMode);
+        assertEquals(multiThreadMode, config.getThreadModeSettings());
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -433,7 +433,7 @@ public class PropertyCacheFileTest {
         final PropertyCacheFile cache = new PropertyCacheFile(config, cacheFile.getPath());
         cache.load();
 
-        final String expectedInitialConfigHash = "EEF15651C2D79B29968835FC729E788938CAFE3B";
+        final String expectedInitialConfigHash = "91753B970AFDF9F5F3DFA0D258064841949D3C6B";
         final String actualInitialConfigHash = cache.get(PropertyCacheFile.CONFIG_HASH_KEY);
         assertEquals(expectedInitialConfigHash, actualInitialConfigHash);
 
@@ -450,7 +450,7 @@ public class PropertyCacheFileTest {
             new PropertyCacheFile(config, cacheFile.getPath());
         cacheAfterChangeInConfig.load();
 
-        final String expectedConfigHashAfterChange = "0FFFF89F6636EE8AEB904681F594B0F05E1FF795";
+        final String expectedConfigHashAfterChange = "4CF5EC78955B81D76153ACC2CA6D60CB77FDCB2A";
         final String actualConfigHashAfterChange =
             cacheAfterChangeInConfig.get(PropertyCacheFile.CONFIG_HASH_KEY);
         assertEquals(expectedConfigHashAfterChange, actualConfigHashAfterChange);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TestRootModuleChecker.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TestRootModuleChecker.java
@@ -32,10 +32,11 @@ import com.puppycrawl.tools.checkstyle.api.RootModule;
 public class TestRootModuleChecker implements RootModule {
     private static boolean processed;
     private static List<File> filesToCheck;
+    private static Configuration config;
 
     @Override
     public void configure(Configuration configuration) throws CheckstyleException {
-        // not used
+        config = configuration;
     }
 
     @Override
@@ -67,9 +68,14 @@ public class TestRootModuleChecker implements RootModule {
     public static void reset() {
         processed = false;
         filesToCheck = null;
+        config = null;
     }
 
     public static List<File> getFilesToCheck() {
         return Collections.unmodifiableList(filesToCheck);
+    }
+
+    public static Configuration getConfig() {
+        return config;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
@@ -338,6 +338,21 @@ public class CommonUtilsTest {
         }
     }
 
+    @Test
+    public void testIsIntValidString() throws Exception {
+        assertTrue(CommonUtils.isInt("42"));
+    }
+
+    @Test
+    public void testIsIntInvalidString() throws Exception {
+        assertFalse(CommonUtils.isInt("foo"));
+    }
+
+    @Test
+    public void testIsIntNull() throws Exception {
+        assertFalse(CommonUtils.isInt(null));
+    }
+
     private static class TestCloseable implements Closeable {
         private boolean closed;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/config-multi-thread-mode.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/config-multi-thread-mode.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+
+<module name="com.puppycrawl.tools.checkstyle.TestRootModuleChecker">
+  <module name="Checker">
+    <module name="TreeWalker">
+    </module>
+  </module>
+</module>


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/4370

This MR adds new hidden parameter `-M` allowing user to enable multithread mode. Also, this commit splits `Checker` and `TreeWalker` into `AbstractChecker`, `Checker`, `MultiThreadChecker` and `AbstractTreeWalker`, `TreeWalker`, `MultiThreadTreeWalker` respectively. Multithread class versions are empty, because actual implementation is a subject of another issue. 