### PR TITLE
Issue #4395: increase coverage of pitest-checkstyle-utils profile to 49%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2087,7 +2087,7 @@
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.utils.*</param>
               </targetTests>
-              <mutationThreshold>40</mutationThreshold>
+              <mutationThreshold>49</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtilsTest.java
@@ -20,11 +20,14 @@
 package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.puppycrawl.tools.checkstyle.internal.TestUtils.assertUtilsClassHasPrivateConstructor;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class ScopeUtilsTest {
@@ -36,117 +39,163 @@ public class ScopeUtilsTest {
 
     @Test
     public void testInEnumOnRoot() {
-        final DetailAST ast = new DetailAST();
-        Assert.assertFalse(ScopeUtils.isInEnumBlock(ast));
+        assertFalse(ScopeUtils.isInEnumBlock(new DetailAST()));
     }
 
     @Test
     public void testInEnumBlockInNew() {
-        final DetailAST ast = new DetailAST();
-        ast.setType(TokenTypes.LITERAL_NEW);
-        final DetailAST ast2 = new DetailAST();
-        ast2.setType(TokenTypes.MODIFIERS);
-        ast.addChild(ast2);
-
-        Assert.assertFalse(ScopeUtils.isInEnumBlock(ast2));
+        assertFalse(ScopeUtils.isInEnumBlock(
+                getNode(TokenTypes.LITERAL_NEW, TokenTypes.MODIFIERS)));
     }
 
     @Test
     public void testInEnumBlockWithEnum() {
-        final DetailAST ast0 = new DetailAST();
-        ast0.setType(TokenTypes.OBJBLOCK);
-        final DetailAST ast1 = new DetailAST();
-        ast1.setType(TokenTypes.ENUM_DEF);
-        ast0.addChild(ast1);
-        final DetailAST ast2 = new DetailAST();
-        ast2.setType(TokenTypes.MODIFIERS);
-        ast1.addChild(ast2);
-
-        Assert.assertTrue(ScopeUtils.isInEnumBlock(ast2));
+        assertTrue(ScopeUtils.isInEnumBlock(
+                getNode(TokenTypes.OBJBLOCK, TokenTypes.ENUM_DEF, TokenTypes.MODIFIERS)));
     }
 
     @Test
     public void testInEnumBlockInInterface() {
-        final DetailAST ast = new DetailAST();
-        ast.setType(TokenTypes.INTERFACE_DEF);
-        final DetailAST ast2 = new DetailAST();
-        ast2.setType(TokenTypes.MODIFIERS);
-        ast.addChild(ast2);
-
-        Assert.assertFalse(ScopeUtils.isInEnumBlock(ast2));
+        assertFalse(ScopeUtils.isInEnumBlock(
+                getNode(TokenTypes.INTERFACE_DEF, TokenTypes.MODIFIERS)));
     }
 
     @Test
     public void testInEnumBlockInAnnotation() {
-        final DetailAST ast = new DetailAST();
-        ast.setType(TokenTypes.ANNOTATION_DEF);
-        final DetailAST ast2 = new DetailAST();
-        ast2.setType(TokenTypes.MODIFIERS);
-        ast.addChild(ast2);
-
-        Assert.assertFalse(ScopeUtils.isInEnumBlock(ast2));
+        assertFalse(ScopeUtils.isInEnumBlock(
+                getNode(TokenTypes.ANNOTATION_DEF, TokenTypes.MODIFIERS)));
     }
 
     @Test
     public void testInEnumBlockInClass() {
-        final DetailAST ast = new DetailAST();
-        ast.setType(TokenTypes.CLASS_DEF);
-        final DetailAST ast2 = new DetailAST();
-        ast2.setType(TokenTypes.MODIFIERS);
-        ast.addChild(ast2);
+        assertFalse(ScopeUtils.isInEnumBlock(
+                getNode(TokenTypes.CLASS_DEF, TokenTypes.MODIFIERS)));
+    }
 
-        Assert.assertFalse(ScopeUtils.isInEnumBlock(ast2));
+    @Test
+    public void testInEnumBlockInLiteralNew() {
+        assertFalse(ScopeUtils.isInEnumBlock(
+                getNode(TokenTypes.LITERAL_NEW, TokenTypes.IDENT)));
     }
 
     @Test
     public void testIsOuterMostTypeInterface() {
-        final DetailAST ast = new DetailAST();
-        ast.setType(TokenTypes.INTERFACE_DEF);
-        final DetailAST ast2 = new DetailAST();
-        ast2.setType(TokenTypes.MODIFIERS);
-        ast.addChild(ast2);
-
-        Assert.assertFalse(ScopeUtils.isOuterMostType(ast2));
+        assertFalse(ScopeUtils.isOuterMostType(
+                getNode(TokenTypes.INTERFACE_DEF, TokenTypes.MODIFIERS)));
     }
 
     @Test
     public void testIsOuterMostTypeAnnotation() {
-        final DetailAST ast = new DetailAST();
-        ast.setType(TokenTypes.ANNOTATION_DEF);
-        final DetailAST ast2 = new DetailAST();
-        ast2.setType(TokenTypes.MODIFIERS);
-        ast.addChild(ast2);
-
-        Assert.assertFalse(ScopeUtils.isOuterMostType(ast2));
+        assertFalse(ScopeUtils.isOuterMostType(
+                getNode(TokenTypes.ANNOTATION_DEF, TokenTypes.MODIFIERS)));
     }
 
     @Test
     public void testIsOuterMostTypeEnum() {
-        final DetailAST ast = new DetailAST();
-        ast.setType(TokenTypes.ENUM_DEF);
-        final DetailAST ast2 = new DetailAST();
-        ast2.setType(TokenTypes.MODIFIERS);
-        ast.addChild(ast2);
+        assertFalse(ScopeUtils.isOuterMostType(
+                getNode(TokenTypes.ENUM_DEF, TokenTypes.MODIFIERS)));
+    }
 
-        Assert.assertFalse(ScopeUtils.isOuterMostType(ast2));
+    @Test
+    public void testIsOuterMostTypeClass() {
+        assertFalse(ScopeUtils.isOuterMostType(
+                getNode(TokenTypes.CLASS_DEF, TokenTypes.MODIFIERS)));
     }
 
     @Test
     public void testIsLocalVariableDefCatch() {
-        final DetailAST ast = new DetailAST();
-        ast.setType(TokenTypes.LITERAL_CATCH);
-        final DetailAST ast2 = new DetailAST();
-        ast2.setType(TokenTypes.PARAMETER_DEF);
-        ast.addChild(ast2);
-
-        Assert.assertTrue(ScopeUtils.isLocalVariableDef(ast2));
+        assertTrue(ScopeUtils.isLocalVariableDef(
+                getNode(TokenTypes.LITERAL_CATCH, TokenTypes.PARAMETER_DEF)));
     }
 
     @Test
     public void testIsLocalVariableDefUnexpected() {
-        final DetailAST ast = new DetailAST();
-        ast.setType(TokenTypes.LITERAL_CATCH);
+        assertFalse(ScopeUtils.isLocalVariableDef(getNode(TokenTypes.LITERAL_CATCH)));
+    }
 
-        Assert.assertFalse(ScopeUtils.isLocalVariableDef(ast));
+    @Test
+    public void testIsClassFieldDef() {
+        assertTrue(ScopeUtils.isClassFieldDef(
+                getNode(TokenTypes.CLASS_DEF, TokenTypes.OBJBLOCK, TokenTypes.VARIABLE_DEF)));
+    }
+
+    @Test
+    public void testSurroundingScope() {
+        assertEquals(Scope.PUBLIC, ScopeUtils.getSurroundingScope(getNodeWithParentScope(
+            TokenTypes.LITERAL_PUBLIC, "public", TokenTypes.ANNOTATION_DEF)));
+        assertEquals(Scope.PROTECTED, ScopeUtils.getSurroundingScope(
+            getNodeWithParentScope(TokenTypes.LITERAL_PROTECTED, "protected",
+            TokenTypes.INTERFACE_DEF)));
+        assertEquals(Scope.PRIVATE, ScopeUtils.getSurroundingScope(
+            getNodeWithParentScope(TokenTypes.LITERAL_PRIVATE, "private", TokenTypes.ENUM_DEF)));
+        assertEquals(Scope.PACKAGE, ScopeUtils.getSurroundingScope(
+            getNodeWithParentScope(TokenTypes.LITERAL_STATIC, "static", TokenTypes.CLASS_DEF)));
+    }
+
+    @Test
+    public void testIsInScope() {
+        assertTrue(ScopeUtils.isInScope(getNodeWithParentScope(TokenTypes.LITERAL_PUBLIC,
+                "public", TokenTypes.ANNOTATION_DEF), Scope.PUBLIC));
+        assertFalse(ScopeUtils.isInScope(getNodeWithParentScope(TokenTypes.LITERAL_PROTECTED,
+                "protected", TokenTypes.INTERFACE_DEF), Scope.PRIVATE));
+    }
+
+    @Test
+    public void testSurroundingScopeOfNodeChildOfLiteralNewIsAnoninner() {
+        assertEquals(Scope.ANONINNER, ScopeUtils.getSurroundingScope(
+                getNode(TokenTypes.LITERAL_NEW, TokenTypes.IDENT)));
+    }
+
+    @Test
+    public void testIsInInterfaceBlock() {
+        final DetailAST ast = getNode(TokenTypes.INTERFACE_DEF, TokenTypes.OBJBLOCK,
+                TokenTypes.CLASS_DEF, TokenTypes.MODIFIERS);
+
+        assertTrue(ScopeUtils.isInInterfaceBlock(ast.getParent()));
+        assertFalse(ScopeUtils.isInInterfaceBlock(ast));
+    }
+
+    @Test
+    public void testIsInAnnotationBlock() {
+        final DetailAST ast = getNode(TokenTypes.ANNOTATION_DEF, TokenTypes.OBJBLOCK,
+                TokenTypes.INTERFACE_DEF, TokenTypes.MODIFIERS);
+
+        assertTrue(ScopeUtils.isInAnnotationBlock(ast.getParent()));
+        assertFalse(ScopeUtils.isInAnnotationBlock(ast));
+    }
+
+    @Test
+    public void testisInInterfaceOrAnnotationBlock() {
+        assertTrue(ScopeUtils.isInInterfaceOrAnnotationBlock(
+                getNode(TokenTypes.ANNOTATION_DEF, TokenTypes.OBJBLOCK)));
+        assertTrue(ScopeUtils.isInInterfaceOrAnnotationBlock(
+                getNode(TokenTypes.INTERFACE_DEF, TokenTypes.OBJBLOCK)));
+        assertFalse(ScopeUtils.isInInterfaceOrAnnotationBlock(
+                getNode(TokenTypes.CLASS_DEF, TokenTypes.OBJBLOCK)));
+        assertFalse(ScopeUtils.isInInterfaceOrAnnotationBlock(
+                getNode(TokenTypes.LITERAL_NEW, TokenTypes.IDENT)));
+        assertFalse(ScopeUtils.isInInterfaceOrAnnotationBlock(
+                getNode(TokenTypes.ENUM_DEF, TokenTypes.OBJBLOCK)));
+    }
+
+    private static DetailAST getNode(int... nodeTypes) {
+        DetailAST ast = new DetailAST();
+        ast.setType(nodeTypes[0]);
+        for (int i = 1; i < nodeTypes.length; i++) {
+            final DetailAST astChild = new DetailAST();
+            astChild.setType(nodeTypes[i]);
+            ast.addChild(astChild);
+            ast = astChild;
+        }
+        return ast;
+    }
+
+    private static DetailAST getNodeWithParentScope(int literal, String scope,
+                                                    int parentTokenType) {
+        final DetailAST ast = getNode(parentTokenType, TokenTypes.MODIFIERS, literal);
+        ast.setText(scope);
+        final DetailAST ast2 = getNode(TokenTypes.OBJBLOCK);
+        ast.getParent().getParent().addChild(ast2);
+        return ast;
     }
 }


### PR DESCRIPTION
Issue #4395 

increased mutation threshold for pitest-checkstyle-common by 9%
threshold: 49%
execution time: 01:36 min
[pitest report before changes for class](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle.utils/ScopeUtils.java.html)
[pitest report before changes for package](https://nimfadora.github.io/issue4395.html)