### PR TITLE
Issue #4400: increase coverage of pitest-checkstyle-common profile to 89%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1954,7 +1954,7 @@
                 <!-- till https://github.com/hcoles/pitest/issues/353 -->
                 <param>fillShortToFullModuleNamesMap</param>
               </excludedMethods>
-              <mutationThreshold>84</mutationThreshold>
+              <mutationThreshold>89</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/cache.tmp
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/cache.tmp
@@ -1,0 +1,1 @@
+key=value

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/externalResourse.tmp
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/externalResourse.tmp
@@ -1,0 +1,1 @@
+key=value


### PR DESCRIPTION
Issue #4400 

increased mutation threshold for pitest-checkstyle-common by 5%
threshold: 89%
execution time: 11:46 min

[pitest report before changes for PropertyCacheFile](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle/PropertyCacheFile.java.html)
[pitest report before changes for CheckstyleAntTast](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle.ant/CheckstyleAntTask.java.html)
[pitest report before changes for package](https://nimfadora.github.io/issue4400.html)