### PR TITLE
Adds support for (multi-dimensional) array types

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -30,7 +30,6 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
 
 /**
@@ -315,12 +314,26 @@ public final class IllegalTypeCheck extends AbstractCheck {
      * @param ast node to check.
      */
     private void checkClassName(DetailAST ast) {
-        final DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
-        final FullIdent ident = CheckUtils.createFullType(type);
+        DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
+       
+        // to handle (multi-dimensional) array types
+        String arraySquareBraces = "";
+        while (type.findFirstToken(TokenTypes.ARRAY_DECLARATOR) != null) {
+            type = type.findFirstToken(TokenTypes.ARRAY_DECLARATOR);
+            arraySquareBraces += "[]";
+        }
+
+        // to handle fully qualified type names, such as java.util.TreeMap
+        final FullIdent ident = FullIdent.createFullIdent(type.getFirstChild());
+
+        // append square braces for array types
+        final String typeName = ident.getText() + arraySquareBraces;
 
         if (isMatchingClassName(ident.getText())) {
-            log(ident.getLineNo(), ident.getColumnNo(),
-                MSG_KEY, ident.getText());
+            log(ident.getLineNo(),
+                ident.getColumnNo(),
+                MSG_KEY,
+                typeName);
         }
     }
 


### PR DESCRIPTION
The proposed change addresses #4425 and #4429, adding support for (multi-dimensional) array types, to support flagging of array types.

        <module name="IllegalTypeCheck">
            <property name="illegalClassNames" value="Boolean, Boolean[][], int[]"/>
        </module>

The call to CheckUtils.createFullType() was replaced because it doesn't handle array types.

Mandatory to understand and do:
0) The issue you are trying to fix/resolve has to have the "approved" label.
1) Put in the description of Pull Request the reference to an issue if it exists. Example: "Issue: #XXXXXX"
2) Commit message should adhere to the following rules:
   a) Must match one of the following patterns:\n"
      ^Issue #\\d+: .*$
      ^Pull #\\d+: .*$
      ^(minor|config|infra|doc|spelling): .*$
   b) It contains only one line of text
   c) Must not end with a period, space, or tab
   d) Commit message should be less than or equal to 200 characters

To avoid multiple iterations of fixes and CIs failures, please read http://checkstyle.sourceforge.net/contributing.html

ATTENTION: We are not merging Pull Requests that are not passing our CIs, but we will help to resolve issues.

Thanks for reading, remove whole this message and type what you need.
