### PR TITLE
Issue #4417: fixed failure to load custom root module

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -444,7 +444,7 @@ public final class Main {
     private static RootModule getRootModule(String name, ClassLoader moduleClassLoader)
             throws CheckstyleException {
         final ModuleFactory factory = new PackageObjectFactory(
-                Checker.class.getPackage().getName() + ".", moduleClassLoader);
+                Checker.class.getPackage().getName(), moduleClassLoader);
 
         return (RootModule) factory.createModule(name);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -812,4 +812,25 @@ public class MainTest {
         Main.main("-c", getPath("config-custom-root-module.xml"),
                 getPath("InputMain.java"));
     }
+
+    @Test
+    public void testCustomSimpleRootModule() throws Exception {
+        TestRootModuleChecker.reset();
+        exit.expectSystemExitWithStatus(-2);
+        exit.checkAssertionAfterwards(() -> {
+            final String checkstylePackage = "com.puppycrawl.tools.checkstyle.";
+
+            assertEquals(String.format(Locale.ROOT, "Checkstyle ends with 1 errors.%n"),
+                    systemOut.getLog());
+            assertTrue(systemErr.getLog().startsWith(
+                    checkstylePackage + "api.CheckstyleException: Unable to instantiate "
+                            + "'TestRootModuleChecker' class, it is also not possible to "
+                            + "instantiate it as " + checkstylePackage
+                            + "TestRootModuleChecker, TestRootModuleCheckerCheck, "
+                            + checkstylePackage + "TestRootModuleCheckerCheck."));
+            assertFalse(TestRootModuleChecker.isProcessed());
+        });
+        Main.main("-c", getPath("config-custom-simple-root-module.xml"),
+                getPath("InputMain.java"));
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/config-custom-simple-root-module.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/config-custom-simple-root-module.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+
+<module name="TestRootModuleChecker">
+</module>


### PR DESCRIPTION
Issue #4417

`testCustomSimpleRootModule` doesn't test a successful module load, just a failure message.

`TestRootModuleChecker` doesn't implement `AutomaticBean` to be able to be instantiated. If we did add this implementation, then `TestRootModuleChecker` gets picked up and wanted to be added to our configurations and such, because all tests see it as a real module. To be able to deduce if a module is in `main` or `test` we would need to settle on a naming convention and override the production `module finder` in the test folder to skip the test named modules.