### PR TITLE
Issue #4445: Unstable TreeWalkerTest due to an apparent powermock - cobertura conflict

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -321,8 +321,6 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         spy(TreeWalker.class);
         doNothing().when(treeWalkerSpy, "walk",
                 any(DetailAST.class), any(FileContents.class), any(classAstState));
-        when(TreeWalker.class, "appendHiddenCommentNodes", any(DetailAST.class))
-                .thenReturn(null);
         treeWalkerSpy.processFiltered(temporaryFolder.newFile("file.java"), new ArrayList<>());
         verifyPrivate(TreeWalker.class, times(1))
                 .invoke("appendHiddenCommentNodes", any(DetailAST.class));
@@ -344,8 +342,6 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         spy(TreeWalker.class);
         doNothing().when(treeWalkerSpy, "walk",
                 any(DetailAST.class), any(FileContents.class), any(classAstState));
-        when(TreeWalker.class, "appendHiddenCommentNodes", any(DetailAST.class))
-                .thenReturn(null);
         treeWalkerSpy.processFiltered(temporaryFolder.newFile("file.java"), new ArrayList<>());
         verifyPrivate(TreeWalker.class, times(1))
                 .invoke("appendHiddenCommentNodes", any(DetailAST.class));


### PR DESCRIPTION
Issue #4445: Verifying calls to private static method using powermock was causing CI failures due to apparent conflict with cobertura