### PR TITLE
Issue #4398: increase coverage of pitest-checkstyle-tree-walker profile to 89%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2004,15 +2004,26 @@
                 <param>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</param>
                 <param>com.puppycrawl.tools.checkstyle.AstTreeStringPrinter</param>
                 <param>com.puppycrawl.tools.checkstyle.TreeWalker</param>
-                <param>com.puppycrawl.tools.checkstyle.Main</param>
               </targetClasses>
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinterTest</param>
                 <param>com.puppycrawl.tools.checkstyle.AstTreeStringPrinterTest</param>
                 <param>com.puppycrawl.tools.checkstyle.TreeWalkerTest</param>
-                <param>com.puppycrawl.tools.checkstyle.MainTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.blocks.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.design.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.header.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.imports.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.indentation.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.javadoc.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.metrics.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.modifiers.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.naming.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.regexp.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.sizes.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.whitespace.*</param>
               </targetTests>
-              <mutationThreshold>83</mutationThreshold>
+              <mutationThreshold>89</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -178,8 +178,6 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
                     final FileContents contents = new FileContents(text);
                     final DetailAST rootAST = parse(contents);
 
-                    getMessageCollector().reset();
-
                     if (!ordinaryChecks.isEmpty()) {
                         walk(rootAST, contents, AstState.ORDINARY);
                     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import antlr.NoViableAltException;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.FileText;
 
 public class AstTreeStringPrinterTest {
 
@@ -66,6 +67,18 @@ public class AstTreeStringPrinterTest {
             new File(getPath("InputAstTreeStringPrinterComments.java")), false);
         final String expected = new String(Files.readAllBytes(Paths.get(
             getPath("expectedInputAstTreeStringPrinter.txt"))), StandardCharsets.UTF_8);
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testPrintAst() throws Exception {
+        final FileText text = new FileText(
+                new File(getPath("InputAstTreeStringPrinterComments.java")).getAbsoluteFile(),
+                System.getProperty("file.encoding", "UTF-8"));
+        final String actual = AstTreeStringPrinter.printAst(text, false);
+        final String expected = new String(Files.readAllBytes(Paths.get(
+                getPath("expectedInputAstTreeStringPrinter.txt"))), StandardCharsets.UTF_8);
+
         Assert.assertEquals(expected, actual);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -20,8 +20,10 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.puppycrawl.tools.checkstyle.internal.TestUtils.assertUtilsClassHasPrivateConstructor;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -29,8 +31,11 @@ import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class DetailNodeTreeStringPrinterTest {
 
@@ -51,7 +56,7 @@ public class DetailNodeTreeStringPrinterTest {
         final String expected = new String(Files.readAllBytes(Paths.get(
             getPath("expectedInputJavadocComment.txt"))), StandardCharsets.UTF_8)
             .replaceAll("\\\\r\\\\n", "\\\\n");
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -66,8 +71,31 @@ public class DetailNodeTreeStringPrinterTest {
             final String expected = "[ERROR:0] Javadoc comment at column 1 has parse error. "
                     + "Missed HTML close tag 'qwe'. Sometimes it means that close tag missed "
                     + "for one of previous tags.";
-            Assert.assertEquals(expected, ex.getMessage());
+            assertEquals(expected, ex.getMessage());
         }
+    }
+
+    @Test
+    public void testCreationOfFakeCommentBlock() throws Exception {
+        final Method createFakeBlockComment =
+                Whitebox.getMethod(DetailNodeTreeStringPrinter.class,
+                        "createFakeBlockComment", String.class);
+
+        final DetailAST testCommentBlock =
+                (DetailAST) createFakeBlockComment.invoke(null, "test_comment");
+        assertEquals(TokenTypes.BLOCK_COMMENT_BEGIN, testCommentBlock.getType());
+        assertEquals("/*", testCommentBlock.getText());
+        assertEquals(0, testCommentBlock.getLineNo());
+
+        final DetailAST contentCommentBlock = testCommentBlock.getFirstChild();
+        assertEquals(TokenTypes.COMMENT_CONTENT, contentCommentBlock.getType());
+        assertEquals("*test_comment", contentCommentBlock.getText());
+        assertEquals(0, contentCommentBlock.getLineNo());
+        assertEquals(-1, contentCommentBlock.getColumnNo());
+
+        final DetailAST endCommentBlock = contentCommentBlock.getNextSibling();
+        assertEquals(TokenTypes.BLOCK_COMMENT_END, endCommentBlock.getType());
+        assertEquals("*/", endCommentBlock.getText());
     }
 
     @Test
@@ -78,6 +106,6 @@ public class DetailNodeTreeStringPrinterTest {
         final String expected = new String(Files.readAllBytes(Paths.get(
                 getPath("expectedNoUnnecessaryTextInJavadocAst.txt"))), StandardCharsets.UTF_8)
                 .replaceAll("\\\\r\\\\n", "\\\\n");
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
Issue #4398

removed Main class (forgotten to be removed while splitting to profiles) from tree-walker profile
threshold without Main class : 77%
increased mutation threshold for pitest-checkstyle-tree-walker by 12%
current threshold: 89%
execution time: 9:43 min

[pitest report before changes for package](https://nimfadora.github.io/issue4398.html)