### PR TITLE
Issue #4394: united api and filters profiles, increased coverage to 85%

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -2008,6 +2008,8 @@
                 <option value="IfStatementWithTooManyBranches" />
                 <!-- we have to catch Exception in Checker and rethrow it -->
                 <option value="ProhibitedExceptionThrown" />
+                <!-- we have to use it when pass null argument in test purporses -->
+                <option value="NullArgumentToVariableArgMethod" />
             </list>
         </option>
     </inspection_tool>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -25,7 +25,7 @@
               files="AbstractClassNameCheck.java"/>
     <!-- test should be named as their main class -->
     <suppress checks="AbstractClassNameCheck"
-              files="AbstractCheckTest.java|AbstractClassNameCheckTest.java|AbstractTypeAwareCheckTest.java|AbstractJavadocCheckTest.java|AbstractViolationReporterTest.java"/>
+              files="AbstractCheckTest.java|AbstractClassNameCheckTest.java|AbstractTypeAwareCheckTest.java|AbstractJavadocCheckTest.java|AbstractViolationReporterTest.java|AbstractFileSetCheckTest.java"/>
 
     <!-- Tone down the checking for test code -->
     <suppress checks="CyclomaticComplexity" files="[\\/]XdocsPagesTest\.java"/>

--- a/pom.xml
+++ b/pom.xml
@@ -2036,7 +2036,7 @@
       </build>
     </profile>
     <profile>
-      <id>pitest-checkstyle-api</id>
+      <id>pitest-checkstyle-api-filters</id>
       <build>
         <plugins>
           <plugin>
@@ -2046,41 +2046,16 @@
             <configuration>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.api.*</param>
+                <param>com.puppycrawl.tools.checkstyle.filefilters.*</param>
+                <param>com.puppycrawl.tools.checkstyle.filters.*</param>
               </targetClasses>
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.api.*</param>
-              </targetTests>
-              <excludedClasses>
-                <!-- deprecated class -->
-                <param>com.puppycrawl.tools.checkstyle.api.Check</param>
-              </excludedClasses>
-              <mutationThreshold>45</mutationThreshold>
-              <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
-              <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
-              <threads>${pitest.plugin.threads}</threads>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>pitest-checkstyle-filters</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.pitest</groupId>
-            <artifactId>pitest-maven</artifactId>
-            <version>${pitest.plugin.version}</version>
-            <configuration>
-              <targetClasses>
-                <param>com.puppycrawl.tools.checkstyle.filefilters.*</param>
-                <param>com.puppycrawl.tools.checkstyle.filters.*</param>
-              </targetClasses>
-              <targetTests>
+                <param>com.puppycrawl.tools.checkstyle.grammars.comments.CommentsTest</param>
                 <param>com.puppycrawl.tools.checkstyle.filefilters.*</param>
                 <param>com.puppycrawl.tools.checkstyle.filters.*</param>
               </targetTests>
-              <mutationThreshold>95</mutationThreshold>
+              <mutationThreshold>84</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/shippable.yml
+++ b/shippable.yml
@@ -23,8 +23,7 @@ env:
     - PROFILE="-Ppitest-checkstyle-common,no-validations"
     - PROFILE="-Ppitest-checkstyle-main,no-validations"
     - PROFILE="-Ppitest-checkstyle-tree-walker,no-validations"
-    - PROFILE="-Ppitest-checkstyle-api,no-validations"
-    - PROFILE="-Ppitest-checkstyle-filters,no-validations"
+    - PROFILE="-Ppitest-checkstyle-api-filters,no-validations"
     - PROFILE="-Ppitest-checkstyle-utils,no-validations"
     - PROFILE="-Ppitest-checkstyle-gui,no-validations"
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
@@ -19,12 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
+import java.io.File;
+import java.nio.charset.Charset;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class AbstractCheckTest {
+    private static final String INPUT_FOLDER =
+        "src/test/resources/com/puppycrawl/tools/checkstyle/api/abstractcheck/";
 
     @Test
     public void testGetRequiredTokens() {
@@ -33,7 +38,6 @@ public class AbstractCheckTest {
             public int[] getDefaultTokens() {
                 return CommonUtils.EMPTY_INT_ARRAY;
             }
-
         };
         // Eventually it will become clear abstract method
         Assert.assertArrayEquals(CommonUtils.EMPTY_INT_ARRAY, check.getRequiredTokens());
@@ -46,7 +50,6 @@ public class AbstractCheckTest {
             public int[] getDefaultTokens() {
                 return CommonUtils.EMPTY_INT_ARRAY;
             }
-
         };
         // Eventually it will become clear abstract method
         Assert.assertArrayEquals(CommonUtils.EMPTY_INT_ARRAY, check.getAcceptableTokens());
@@ -72,5 +75,62 @@ public class AbstractCheckTest {
         };
         // Eventually it will become clear abstract method
         check.visitToken(null);
+    }
+
+    @Test
+    public void testGetLine() throws Exception {
+        final AbstractCheck check = new AbstractCheck() {
+            @Override
+            public int[] getDefaultTokens() {
+                return CommonUtils.EMPTY_INT_ARRAY;
+            }
+        };
+        check.setFileContents(new FileContents(new FileText(
+            new File(INPUT_FOLDER + "InputAbstractCheckTestFileContence.java"),
+            Charset.defaultCharset().name())));
+
+        Assert.assertEquals(" * I'm a javadoc", check.getLine(3));
+    }
+
+    @Test
+    public void testGetTabWidth() throws Exception {
+        final AbstractCheck check = new AbstractCheck() {
+            @Override
+            public int[] getDefaultTokens() {
+                return CommonUtils.EMPTY_INT_ARRAY;
+            }
+        };
+        final int tabWidth = 4;
+        check.setTabWidth(tabWidth);
+
+        Assert.assertEquals(tabWidth, check.getTabWidth());
+    }
+
+    @Test
+    public void testGetClassLoader() throws Exception {
+        final AbstractCheck check = new AbstractCheck() {
+            @Override
+            public int[] getDefaultTokens() {
+                return CommonUtils.EMPTY_INT_ARRAY;
+            }
+        };
+        final ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+        check.setClassLoader(classLoader);
+
+        Assert.assertEquals(classLoader, check.getClassLoader());
+    }
+
+    @Test
+    public void testGetAcceptableTokens() throws Exception {
+        final int[] defaultTokens = {TokenTypes.CLASS_DEF, TokenTypes.INTERFACE_DEF};
+        final AbstractCheck check = new AbstractCheck() {
+            @Override
+            public int[] getDefaultTokens() {
+                return defaultTokens;
+            }
+        };
+
+        Assert.assertNotEquals(defaultTokens, check.getAcceptableTokens());
+        Assert.assertArrayEquals(defaultTokens, check.getAcceptableTokens());
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
@@ -1,0 +1,97 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedSet;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.Checker;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+
+public class AbstractFileSetCheckTest {
+
+    @Test
+    public void testProcessSequential() throws Exception {
+        final DummyFileSetCheck check = new DummyFileSetCheck();
+        check.configure(new DefaultConfiguration("filesetcheck"));
+        check.setFileExtensions("tmp");
+        final List<String> lines = Arrays.asList("key=value", "ext=tmp");
+        final SortedSet<LocalizedMessage> firstFileMessages =
+            check.process(new File("inputAbstractFileSetCheck.tmp"), Collections.emptyList());
+        final SortedSet<LocalizedMessage> secondFileMessages =
+            check.process(new File("inputAbstractFileSetCheck.txt"), lines);
+
+        assertEquals("File should not be empty.",
+            firstFileMessages.first().getMessage());
+        assertTrue(secondFileMessages.isEmpty());
+    }
+
+    @Test
+    public void testGetFileExtention() throws Exception {
+        final DummyFileSetCheck check = new DummyFileSetCheck();
+        check.setFileExtensions("tmp", ".java");
+        final String[] expectedExtentions = {".tmp", ".java"};
+
+        Assert.assertArrayEquals(expectedExtentions, check.getFileExtensions());
+    }
+
+    @Test
+    @SuppressWarnings("NullArgumentToVariableArgMethod")
+    public void testSetExtentionThrowsExceptionWhenTheyAreNull() throws Exception {
+        final DummyFileSetCheck check = new DummyFileSetCheck();
+        try {
+            check.setFileExtensions(null);
+            fail("Expected exception.");
+        }
+        catch (IllegalArgumentException exception) {
+            assertEquals("Extensions array can not be null", exception.getMessage());
+        }
+    }
+
+    @Test
+    public void testGetMessageDispatcher() throws Exception {
+        final DummyFileSetCheck check = new DummyFileSetCheck();
+        final Checker checker = new Checker();
+        check.setMessageDispatcher(checker);
+
+        assertEquals(checker, check.getMessageDispatcher());
+    }
+
+    private static class DummyFileSetCheck extends AbstractFileSetCheck {
+        private static final String MSG_KEY = "File should not be empty.";
+
+        @Override
+        protected void processFiltered(File file, List<String> lines) throws CheckstyleException {
+            if (lines.isEmpty()) {
+                log(1, MSG_KEY);
+            }
+        }
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/LineColumnTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/LineColumnTest.java
@@ -52,4 +52,12 @@ public class LineColumnTest {
     public void testEqualsAndHashCode() {
         EqualsVerifier.forClass(LineColumn.class).usingGetClass().verify();
     }
+
+    @Test
+    public void testGetters() {
+        final LineColumn lineColumn = new LineColumn(2, 3);
+
+        assertEquals(2, lineColumn.getLine());
+        assertEquals(3, lineColumn.getColumn());
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/BeforeExecutionFileFilterSetTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/BeforeExecutionFileFilterSetTest.java
@@ -67,4 +67,16 @@ public class BeforeExecutionFileFilterSetTest {
         filterSet.addBeforeExecutionFileFilter(new BeforeExecutionExclusionFileFilter());
         assertNotNull("size is the same", filterSet.toString());
     }
+
+    @Test
+    public void testClear() {
+        final BeforeExecutionFileFilterSet filterSet = new BeforeExecutionFileFilterSet();
+        filterSet.addBeforeExecutionFileFilter(new BeforeExecutionExclusionFileFilter());
+
+        assertEquals(1, filterSet.getBeforeExecutionFileFilters().size());
+
+        filterSet.clear();
+
+        assertEquals(0, filterSet.getBeforeExecutionFileFilters().size());
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/FilterSetTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/FilterSetTest.java
@@ -85,4 +85,16 @@ public class FilterSetTest {
         filterSet.addFilter(new SeverityMatchFilter());
         assertNotNull("size is the same", filterSet.toString());
     }
+
+    @Test
+    public void testClear() {
+        final FilterSet filterSet = new FilterSet();
+        filterSet.addFilter(new SeverityMatchFilter());
+
+        assertEquals(1, filterSet.getFilters().size());
+
+        filterSet.clear();
+
+        assertEquals(0, filterSet.getFilters().size());
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
@@ -50,4 +50,34 @@ public class CommentsTest extends BaseCheckTestSupport {
         final Comment comment = new Comment(new String[] {"value"}, 1, 2, 3);
         Assert.assertEquals("Comment[2:1-2:3]", comment.toString());
     }
+
+    @Test
+    public void testGetCommentMeasures() {
+        final String[] commentText = {"/**",
+            "     * Creates new instance.",
+            "     * @param text the lines that make up the comment.",
+            "     * @param firstCol number of the first column of the comment.",
+            "     * @param lastLine number of the last line of the comment.",
+            "     * @param lastCol number of the last column of the comment.",
+            "     */"};
+        final Comment comment = new Comment(commentText, 5, 49, 66);
+
+        Assert.assertEquals(43, comment.getStartLineNo());
+        Assert.assertEquals(5, comment.getStartColNo());
+        Assert.assertEquals(49, comment.getEndLineNo());
+        Assert.assertEquals(66, comment.getEndColNo());
+    }
+
+    @Test
+    public void testIntersects() {
+        final String[] commentText = {"// compute a single number for start and end",
+            "// to simplify conditional logic"};
+        final Comment comment = new Comment(commentText, 9, 89, 53);
+
+        Assert.assertTrue(comment.intersects(89, 9, 89, 41));
+        Assert.assertTrue(comment.intersects(89, 53, 90, 50));
+        Assert.assertTrue(comment.intersects(87, 7, 88, 9));
+        Assert.assertFalse(comment.intersects(90, 7, 91, 20));
+        Assert.assertFalse(comment.intersects(89, 56, 89, 80));
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/api/abstractcheck/InputAbstractCheckTestFileContence.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/api/abstractcheck/InputAbstractCheckTestFileContence.java
@@ -1,0 +1,24 @@
+package com.puppycrawl.tools.checkstyle.api.abstractcheck;
+
+/**
+ * I'm a javadoc
+ */
+public class InputAbstractCheckTestFileContence {
+    private int variable;
+
+    public InputAbstractCheckTestFileContence(int variable) {
+        this.variable = variable;
+    }
+
+    public int getVariable() {
+        return variable;
+    }
+
+    public void setVariable(int variable) {
+        this.variable = variable;
+    }
+
+    public int multiplyBy(int multiplier) {
+        return variable * multiplier;
+    }
+}


### PR DESCRIPTION
Issue #4394

Profiles pitest-checkstyle-api and pitest-checkstyle-filters were united in order to increase coverage of api profile, as they have many common functionality. More then with any other profile. 
Coverage of api profile before union: 67% test coverage and 45% mutation coverage.
Coverage of api profile after union: 92% test coverage and 75% mutation coverage.

[pitest-checkstyle-api profile before changes](https://nimfadora.github.io/api.html)
[pitest-checkstyle-api-filters profile after union before coverage increasing changes](https://nimfadora.github.io/filters_union_api.html)

increased mutation threshold for pitest-checkstyle-api-filters profile by 4%
current threshold: 85%
execution time: 9:51 min