### PR TITLE
Issue #4342: bumped version of pmd-mvn-plugin to 3.8 and pmd to 5.7.0

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -150,6 +150,8 @@
     <exclude name="FieldDeclarationsShouldBeAtStartOfClass"/>
     <!-- too much alarms of Checks, we will never move logic out of Check, each Check is independent logic container -->
     <exclude name="GodClass"/>
+    <!-- till #4342 -->
+    <exclude name="AccessorMethodGeneration"/>
   </rule>
 
   <rule ref="rulesets/java/design.xml/ConfusingTernary">
@@ -312,6 +314,9 @@
   </rule>
   <rule ref="rulesets/java/typeresolution.xml"/>
   <rule ref="rulesets/java/unnecessary.xml"/>
-  <rule ref="rulesets/java/unusedcode.xml"/>
+  <rule ref="rulesets/java/unusedcode.xml">
+    <!-- till #4342 -->
+    <exclude name="UnusedPrivateMethod"/>
+  </rule>
 
 </ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,8 @@
     <antlr4.version>4.7</antlr4.version>
     <maven.site.plugin.version>3.6</maven.site.plugin.version>
     <maven.findbugs.plugin.version>3.0.4</maven.findbugs.plugin.version>
-    <maven.pmd.plugin.version>3.7</maven.pmd.plugin.version>
+    <maven.pmd.plugin.version>3.8</maven.pmd.plugin.version>
+    <pmd.version>5.7.0</pmd.version>
     <maven.jacoco.plugin.version>0.7.9</maven.jacoco.plugin.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
     <maven.sevntu.checkstyle.plugin.version>1.24.0</maven.sevntu.checkstyle.plugin.version>
@@ -358,6 +359,13 @@
               <excludeRoot>target/generated-sources/antlr/com/puppycrawl/tools/checkstyle/grammars/javadoc</excludeRoot>
             </excludeRoots>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>net.sourceforge.pmd</groupId>
+              <artifactId>pmd-java</artifactId>
+              <version>${pmd.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Issue: #4342 
 
pmd-maven-plugin version was bumped to 3.8
dependencies on pmd 5.7.0 were added to pmd-maven-plugin
all violations were suppressed for now