### PR TITLE
Issue #4035: Rename STMT in BlockOption class to STATEMENT

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/BlockOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/BlockOption.java
@@ -46,5 +46,5 @@ public enum BlockOption {
      * }
      * </pre>
      */
-    STMT
+    STATEMENT
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
@@ -29,7 +29,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 /**
  * Checks for empty blocks. This check does not validate sequential blocks.
  * The policy to verify is specified using the {@link
- * BlockOption} class and defaults to {@link BlockOption#STMT}.
+ * BlockOption} class and defaults to {@link BlockOption#STATEMENT}.
  *
  * <p> By default the check will check the following blocks:
  *  {@link TokenTypes#LITERAL_WHILE LITERAL_WHILE},
@@ -69,7 +69,7 @@ public class EmptyBlockCheck
      * A key is pointing to the warning message text in "messages.properties"
      * file.
      */
-    public static final String MSG_KEY_BLOCK_NO_STMT = "block.noStmt";
+    public static final String MSG_KEY_BLOCK_NO_STATEMENT = "block.noStatement";
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -78,7 +78,7 @@ public class EmptyBlockCheck
     public static final String MSG_KEY_BLOCK_EMPTY = "block.empty";
 
     /** The policy to enforce. */
-    private BlockOption option = BlockOption.STMT;
+    private BlockOption option = BlockOption.STATEMENT;
 
     /**
      * Set the option to enforce.
@@ -141,7 +141,7 @@ public class EmptyBlockCheck
     public void visitToken(DetailAST ast) {
         final DetailAST leftCurly = findLeftCurly(ast);
         if (leftCurly != null) {
-            if (option == BlockOption.STMT) {
+            if (option == BlockOption.STATEMENT) {
                 final boolean emptyBlock;
                 if (leftCurly.getType() == TokenTypes.LCURLY) {
                     emptyBlock = leftCurly.getNextSibling().getType() != TokenTypes.CASE_GROUP;
@@ -152,7 +152,7 @@ public class EmptyBlockCheck
                 if (emptyBlock) {
                     log(leftCurly.getLineNo(),
                         leftCurly.getColumnNo(),
-                        MSG_KEY_BLOCK_NO_STMT,
+                        MSG_KEY_BLOCK_NO_STATEMENT,
                         ast.getText());
                 }
             }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages.properties
@@ -1,6 +1,6 @@
 block.empty=Empty {0} block.
 block.nested=Avoid nested blocks.
-block.noStmt=Must have at least one statement.
+block.noStatement=Must have at least one statement.
 
 catch.block.empty=Empty catch block.
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_de.properties
@@ -1,6 +1,6 @@
 block.empty=Der Block ist leer: {0}
 block.nested=Verschachtelte Blöcke sollten vermieden werden.
-block.noStmt=Ein Block muss mindestens eine Anweisung enthalten.
+block.noStatement=Ein Block muss mindestens eine Anweisung enthalten.
 
 catch.block.empty=Der catch-Block ist leer.
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_es.properties
@@ -1,6 +1,6 @@
 block.empty=Bloque {0} vacío.
 block.nested=Evitar bloques anidados.
-block.noStmt=Debe tener al menos una sentencia.
+block.noStatement=Debe tener al menos una sentencia.
 
 catch.block.empty=Bloque catch vacío.
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_fi.properties
@@ -1,6 +1,6 @@
 block.empty=Tyhjä {0}-rakenne.
 block.nested=Avoid nested blocks.
-block.noStmt=Pitää olla ainakin yksi lause.
+block.noStatement=Pitää olla ainakin yksi lause.
 
 catch.block.empty=Tyhjä catch-rakenne.
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_fr.properties
@@ -1,6 +1,6 @@
 block.empty=Bloc ''{0}'' vide.
 block.nested=Évitez d''imbriquer les blocs.
-block.noStmt=Le bloc devrait contenir au moins une instruction.
+block.noStatement=Le bloc devrait contenir au moins une instruction.
 
 catch.block.empty=Bloc catch vide.
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_ja.properties
@@ -1,6 +1,6 @@
 block.empty=空の {0} ブロックです。
 block.nested=ネストしたブロックは避けてください。
-block.noStmt=少なくとも文が1つは必要です。
+block.noStatement=少なくとも文が1つは必要です。
 
 catch.block.empty=空の catch ブロックです。
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_pt.properties
@@ -1,6 +1,6 @@
 block.empty=Block {0} vazio.
 block.nested=Avoid nested blocks.
-block.noStmt=Tem que ter pelo menos uma instrução.
+block.noStatement=Tem que ter pelo menos uma instrução.
 
 catch.block.empty=Bloco catch vazio.
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_tr.properties
@@ -2,7 +2,7 @@
 
 block.empty  = Boş blok bulundu: {0}
 block.nested = İç içe bloklar kullanılmamalıdır.
-block.noStmt = Blok en az bir ifade içermeli.
+block.noStatement = Blok en az bir ifade içermeli.
 
 catch.block.empty=Boş catch bloğu.
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/blocks/messages_zh.properties
@@ -1,6 +1,6 @@
 block.empty=空 {0} 块。
 block.nested=避免内嵌块。
-block.noStmt=块中应至少有一条代码语句。
+block.noStatement=块中应至少有一条代码语句。
 
 catch.block.empty=空 catch 块。
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
@@ -20,7 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.blocks;
 
 import static com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck.MSG_KEY_BLOCK_EMPTY;
-import static com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck.MSG_KEY_BLOCK_NO_STMT;
+import static com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck.MSG_KEY_BLOCK_NO_STATEMENT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -61,14 +61,14 @@ public class EmptyBlockCheckTest
         final DefaultConfiguration checkConfig =
             createCheckConfig(EmptyBlockCheck.class);
         final String[] expected = {
-            "33:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "35:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "37:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "40:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "63:5: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "71:29: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "73:41: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "84:12: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
+            "33:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "35:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "37:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "40:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "63:5: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "71:29: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "73:41: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "84:12: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
         };
         verify(checkConfig, getPath("InputEmptyBlockSemantic.java"), expected);
     }
@@ -94,16 +94,16 @@ public class EmptyBlockCheckTest
             throws Exception {
         final DefaultConfiguration checkConfig =
             createCheckConfig(EmptyBlockCheck.class);
-        checkConfig.addAttribute("option", BlockOption.STMT.toString());
+        checkConfig.addAttribute("option", BlockOption.STATEMENT.toString());
         final String[] expected = {
-            "33:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "35:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "37:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "40:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "63:5: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "71:29: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "73:41: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "84:12: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
+            "33:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "35:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "37:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "40:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "63:5: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "71:29: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "73:41: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "84:12: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
         };
         verify(checkConfig, getPath("InputEmptyBlockSemantic.java"), expected);
     }
@@ -112,15 +112,15 @@ public class EmptyBlockCheckTest
     public void allowEmptyLoops() throws Exception {
         final DefaultConfiguration checkConfig =
                 createCheckConfig(EmptyBlockCheck.class);
-        checkConfig.addAttribute("option", BlockOption.STMT.toString());
+        checkConfig.addAttribute("option", BlockOption.STATEMENT.toString());
         checkConfig.addAttribute("tokens", "LITERAL_TRY, LITERAL_CATCH,"
                 + "LITERAL_FINALLY, LITERAL_DO, LITERAL_IF,"
                 + "LITERAL_ELSE, INSTANCE_INIT, STATIC_INIT, LITERAL_SWITCH");
         final String[] expected = {
-            "16:29: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "19:42: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "22:29: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
-            "23:28: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT),
+            "16:29: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "19:42: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "22:29: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
+            "23:28: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT),
         };
         verify(checkConfig, getPath("InputEmptyBlockSemantic2.java"), expected);
     }
@@ -178,16 +178,16 @@ public class EmptyBlockCheckTest
     @Test
     public void testForbidCaseWithoutStmt() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyBlockCheck.class);
-        checkConfig.addAttribute("option", BlockOption.STMT.toString());
+        checkConfig.addAttribute("option", BlockOption.STATEMENT.toString());
         checkConfig.addAttribute("tokens", "LITERAL_CASE");
         final String[] expected = {
-            "12:28: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "case"),
-            "18:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "case"),
-            "22:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "case"),
-            "29:29: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "case"),
-            "31:37: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "case"),
-            "32:29: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "case"),
-            "32:40: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "case"),
+            "12:28: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "18:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "22:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "29:29: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "31:37: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "32:29: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "32:40: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
         };
         verify(checkConfig, getPath("InputEmptyBlockCase.java"), expected);
     }
@@ -211,18 +211,18 @@ public class EmptyBlockCheckTest
     @Test
     public void testForbidDefaultWithoutStatement() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(EmptyBlockCheck.class);
-        checkConfig.addAttribute("option", BlockOption.STMT.toString());
+        checkConfig.addAttribute("option", BlockOption.STATEMENT.toString());
         checkConfig.addAttribute("tokens", "LITERAL_DEFAULT");
         final String[] expected = {
-            "5:30: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
-            "11:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
-            "15:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
-            "26:30: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
-            "36:22: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
-            "44:47: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
-            "50:22: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
-            "65:22: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
-            "78:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STMT, "default"),
+            "5:30: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "default"),
+            "11:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "default"),
+            "15:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "default"),
+            "26:30: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "default"),
+            "36:22: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "default"),
+            "44:47: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "default"),
+            "50:22: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "default"),
+            "65:22: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "default"),
+            "78:13: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "default"),
         };
         verify(checkConfig, getPath("InputEmptyBlockDefault.java"), expected);
     }

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -193,7 +193,7 @@ switch (a)
             <td>option</td>
             <td>policy on block contents</td>
             <td><a href="property_types.html#block">block policy</a></td>
-            <td><code>stmt</code></td>
+            <td><code>statement</code></td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -276,8 +276,8 @@ switch (a)
             block.empty</a>
           </li>
           <li>
-            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22block.noStmt%22">
-            block.noStmt</a>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22block.noStatement%22">
+            block.noStatement</a>
           </li>
         </ul>
         <p>

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -202,7 +202,7 @@
           </td>
         </tr>
         <tr>
-          <td><code>stmt</code></td>
+          <td><code>statement</code></td>
           <td>
             Require that there is a statement in the block. For example:
             <pre>


### PR DESCRIPTION
Issue #4035 

Renamed `STMT` in BlockOption class to `STATEMENT`. Also made subsequent changes in the EmptyBlockCheck, EmptyBlockCheckTest, config_blocks.xml, property_types.xml and messages.properties.