### PR TITLE
Issue #4395: increase coverage of pitest-checkstyle-utils profile to 99%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2081,8 +2081,23 @@
               </targetClasses>
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.utils.*</param>
+                <param>com.puppycrawl.tools.checkstyle.AstTreeStringPrinterTest</param>
+                <param>com.puppycrawl.tools.checkstyle.ConfigurationLoaderTest</param>
+                <param>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinterTest</param>
+                <param>com.puppycrawl.tools.checkstyle.PackageObjectFactoryTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.FinalParametersCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.TranslationCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.javadoc.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.whitespace.*</param>
+                <param>com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter</param>
+                <param>com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyCommentFilterTest</param>
+                <param>com.puppycrawl.tools.checkstyle.internal.AllChecksTest</param>
               </targetTests>
-              <mutationThreshold>67</mutationThreshold>
+              <mutationThreshold>99</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilityTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilityTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.puppycrawl.tools.checkstyle.internal.TestUtils.assertUtilsClassHasPrivateConstructor;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -91,7 +92,7 @@ public class AnnotationUtilityTest {
         final DetailAST ast3 = new DetailAST();
         ast3.setType(TokenTypes.ANNOTATION);
         ast2.addChild(ast3);
-        Assert.assertTrue(AnnotationUtility.containsAnnotation(ast));
+        assertTrue(AnnotationUtility.containsAnnotation(ast));
     }
 
     @Test
@@ -136,5 +137,38 @@ public class AnnotationUtilityTest {
         catch (IllegalArgumentException ex) {
             assertEquals("the annotation is empty or spaces", ex.getMessage());
         }
+    }
+
+    @Test
+    public void testContainsAnnotationWithNull() {
+        try {
+            AnnotationUtility.getAnnotation(null, "");
+            Assert.fail("IllegalArgumentException is expected");
+        }
+        catch (IllegalArgumentException ex) {
+            assertEquals("the ast is null", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testContainsAnnotation() {
+        final DetailAST astForTest = new DetailAST();
+        astForTest.setType(TokenTypes.PACKAGE_DEF);
+        final DetailAST child = new DetailAST();
+        final DetailAST annotations = new DetailAST();
+        final DetailAST annotation = new DetailAST();
+        final DetailAST annotationNameHolder = new DetailAST();
+        final DetailAST annotationName = new DetailAST();
+        annotations.setType(TokenTypes.ANNOTATIONS);
+        annotation.setType(TokenTypes.ANNOTATION);
+        annotationName.setText("Annotation");
+
+        annotationNameHolder.setNextSibling(annotationName);
+        annotation.setFirstChild(annotationNameHolder);
+        annotations.setFirstChild(annotation);
+        child.setNextSibling(annotations);
+        astForTest.setFirstChild(child);
+
+        assertTrue(AnnotationUtility.containsAnnotation(astForTest, "Annotation"));
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
@@ -1,0 +1,115 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.TestUtils;
+
+public class BlockCommentPositionTest {
+
+    @Test
+    public void testJavaDocsRecognition() throws Exception {
+        final List<BlockCommentPositionTestMetadata> metadataList = Arrays.asList(
+                new BlockCommentPositionTestMetadata("InputBlockCommentPositionOnClass.java",
+                        BlockCommentPosition::isOnClass, 3),
+                new BlockCommentPositionTestMetadata("InputBlockCommentPositionOnMethod.java",
+                        BlockCommentPosition::isOnMethod, 3),
+                new BlockCommentPositionTestMetadata("InputBlockCommentPositionOnField.java",
+                        BlockCommentPosition::isOnField, 3),
+                new BlockCommentPositionTestMetadata("InputBlockCommentPositionOnEnum.java",
+                        BlockCommentPosition::isOnEnum, 3),
+                new BlockCommentPositionTestMetadata("InputBlockCommentPositionOnConstructor.java",
+                        BlockCommentPosition::isOnConstructor, 3),
+                new BlockCommentPositionTestMetadata("InputBlockCommentPositionOnInterface.java",
+                        BlockCommentPosition::isOnInterface, 3),
+                new BlockCommentPositionTestMetadata("InputBlockCommentPositionOnAnnotation.java",
+                        BlockCommentPosition::isOnAnnotationDef, 3),
+                new BlockCommentPositionTestMetadata("InputBlockCommentPositionOnEnumMember.java",
+                        BlockCommentPosition::isOnEnumConstant, 2)
+        );
+
+        for (BlockCommentPositionTestMetadata metadata : metadataList) {
+            final DetailAST ast = TestUtils.parseFile(
+                    new File(getPath(metadata.getFileName()))
+            );
+            final int matches = getJavadocsCount(ast, metadata.getAssertion());
+            assertEquals(metadata.getMatchesNum(), matches);
+        }
+    }
+
+    private static int getJavadocsCount(DetailAST detailAST,
+                                        Function<DetailAST, Boolean> assertion) {
+        int matchFound = 0;
+        DetailAST node = detailAST;
+        while (node != null) {
+            if (node.getType() == TokenTypes.BLOCK_COMMENT_BEGIN
+                    && JavadocUtils.isJavadocComment(node)) {
+                if (!assertion.apply(node)) {
+                    throw new IllegalStateException("Position of comment is defined correctly");
+                }
+                matchFound++;
+            }
+            matchFound += getJavadocsCount(node.getFirstChild(), assertion);
+            node = node.getNextSibling();
+        }
+        return matchFound;
+    }
+
+    private static String getPath(String filename) {
+        return "src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/"
+                + filename;
+    }
+
+    private static final class BlockCommentPositionTestMetadata {
+
+        private final String fileName;
+        private final Function<DetailAST, Boolean> assertion;
+        private final int matchesNum;
+
+        private BlockCommentPositionTestMetadata(String fileName, Function<DetailAST,
+                Boolean> assertion, int matchesNum) {
+            this.fileName = fileName;
+            this.assertion = assertion;
+            this.matchesNum = matchesNum;
+        }
+
+        public String getFileName() {
+            return fileName;
+        }
+
+        public Function<DetailAST, Boolean> getAssertion() {
+            return assertion;
+        }
+
+        public int getMatchesNum() {
+            return matchesNum;
+        }
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.api.Comment;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl;
@@ -246,5 +247,41 @@ public class JavadocUtilsTest {
         catch (IllegalArgumentException ex) {
             assertEquals("Unknown javadoc token name. Given name ", ex.getMessage());
         }
+    }
+
+    @Test
+    public void testGetTokenId() {
+        final int tokenId = JavadocUtils.getTokenId("JAVADOC");
+
+        assertEquals(JavadocTokenTypes.JAVADOC, tokenId);
+    }
+
+    @Test
+    public void testGetJavadocCommentContent() {
+        final DetailAST detailAST = new DetailAST();
+        final DetailAST javadoc = new DetailAST();
+
+        javadoc.setText("1javadoc");
+        detailAST.setFirstChild(javadoc);
+        final String commentContent = JavadocUtils.getJavadocCommentContent(detailAST);
+
+        assertEquals("javadoc", commentContent);
+    }
+
+    @Test
+    public void testGetFirstToken() {
+        final JavadocNodeImpl javadocNode = new JavadocNodeImpl();
+        final JavadocNodeImpl basetag = new JavadocNodeImpl();
+        basetag.setType(JavadocTokenTypes.BASE_TAG);
+        final JavadocNodeImpl body = new JavadocNodeImpl();
+        body.setType(JavadocTokenTypes.BODY);
+
+        body.setParent(javadocNode);
+        basetag.setParent(javadocNode);
+        javadocNode.setChildren(basetag, body);
+
+        final DetailNode result = JavadocUtils.findFirstToken(javadocNode, JavadocTokenTypes.BODY);
+
+        assertEquals(body, result);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnAnnotation.java
@@ -1,0 +1,22 @@
+package com.puppycrawl.tools.checkstyle.utils.blockcommentposition;
+
+/**
+ * I'm a javadoc
+ */
+public @interface InputBlockCommentPositionOnAnnotation {
+}
+
+
+/**
+ * I'm a javadoc
+ */
+@interface InputBlockCommentPositionOnAnnotation1 {
+}
+
+
+/**
+ * I'm a javadoc
+ */
+@Deprecated
+@interface InputBlockCommentPositionOnAnnotation2 {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnClass.java
@@ -1,0 +1,23 @@
+package com.puppycrawl.tools.checkstyle.utils.blockcommentposition;
+
+/**
+ * I'm a javadoc
+ */
+public class InputBlockCommentPositionOnClass {
+
+}
+
+/**
+ * I'm a javadoc
+ */
+class JavaDocOnClass1 {
+}
+
+
+/**
+ * I'm a javadoc
+ */
+@Deprecated
+class JavaDocOnClass2 {
+}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnConstructor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnConstructor.java
@@ -1,0 +1,27 @@
+package com.puppycrawl.tools.checkstyle.utils.blockcommentposition;
+
+
+public class InputBlockCommentPositionOnConstructor {
+    /**
+     * I'm a javadoc
+     */
+    public InputBlockCommentPositionOnConstructor(){
+
+    }
+
+    /**
+     * I'm a javadoc
+     */
+    InputBlockCommentPositionOnConstructor(int a){
+
+    }
+
+    /**
+     * I'm a javadoc
+     */
+    @Deprecated
+    public InputBlockCommentPositionOnConstructor(String s){
+
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnEnum.java
@@ -1,0 +1,21 @@
+package com.puppycrawl.tools.checkstyle.utils.blockcommentposition;
+
+/**
+ * I'm a javadoc
+ */
+public enum InputBlockCommentPositionOnEnum {
+}
+
+/**
+ * I'm a javadoc
+ */
+enum BlockCommentPositionOnEnumInput1 {
+}
+
+/**
+ * I'm a javadoc
+ */
+@Deprecated
+enum BlockCommentPositionOnEnumInput2{
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnEnumMember.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnEnumMember.java
@@ -1,0 +1,14 @@
+package com.puppycrawl.tools.checkstyle.utils.blockcommentposition;
+
+
+public enum InputBlockCommentPositionOnEnumMember {
+    /**
+     * I'm a javadoc
+     */
+    A,
+    /**
+     * I'm a javadoc
+     */
+    @Deprecated
+    B,
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnField.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnField.java
@@ -1,0 +1,19 @@
+package com.puppycrawl.tools.checkstyle.utils.blockcommentposition;
+
+public class InputBlockCommentPositionOnField {
+    /**
+     * I'm a javadoc
+     */
+    int a;
+
+    /**
+     * I'm a javadoc
+     */
+    private int b;
+
+    /**
+     * I'm a javadoc
+     */
+    @Deprecated
+    int c;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnInterface.java
@@ -1,0 +1,20 @@
+package com.puppycrawl.tools.checkstyle.utils.blockcommentposition;
+
+/**
+ * I'm a javadoc
+ */
+public interface InputBlockCommentPositionOnInterface {
+}
+
+/**
+ * I'm a javadoc
+ */
+interface InputBlockCommentPositionOnInterface1 {
+}
+
+/**
+ * I'm a javadoc
+ */
+@Deprecated
+interface InputBlockCommentPositionOnInterface2 {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnMethod.java
@@ -1,0 +1,25 @@
+package com.puppycrawl.tools.checkstyle.utils.blockcommentposition;
+
+public class InputBlockCommentPositionOnMethod {
+    /**
+     * I'm a javadoc
+     */
+    int method(){
+        return 0;
+    }
+
+    /**
+     * I'm a javadoc
+     */
+    public int method1(){
+        return 0;
+    }
+
+    /**
+     * I'm a javadoc
+     */
+    @Deprecated
+    int method2(){
+        return 0;
+    }
+}


### PR DESCRIPTION
Issue #4395 

[pitest report before changes](https://nimfadora.github.io/com.puppycrawl.tools.checkstyle.utils/index.html)

increased mutation threshold for pitest-checkstyle-api-filters profile by 32%
current threshold: 99%
execution time: 02:38 min