### PR TITLE
Issue #4400: increase coverage of pitest-checkstyle-common profile to 92%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1963,7 +1963,7 @@
                 <!-- till https://github.com/hcoles/pitest/issues/353 -->
                 <param>fillShortToFullModuleNamesMap</param>
               </excludedMethods>
-              <mutationThreshold>89</mutationThreshold>
+              <mutationThreshold>92</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -870,6 +870,45 @@ public class CheckerTest extends BaseCheckTestSupport {
         assertTrue("FileSetCheck.init() wasn't called", fileSet.isInitCalled());
     }
 
+    @Test
+    public void testDefaultLoggerClosesItStreams() throws Exception {
+        final Checker checker = new Checker();
+        final CloseAndFlushTestByteArrayOutputStream testInfoOutputStream =
+            new CloseAndFlushTestByteArrayOutputStream();
+        final CloseAndFlushTestByteArrayOutputStream testErrorOutputStream =
+            new CloseAndFlushTestByteArrayOutputStream();
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.addListener(new DefaultLogger(testInfoOutputStream,
+            true, testErrorOutputStream, true));
+
+        final File tmpFile = temporaryFolder.newFile("file.java");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+        verify(checker, tmpFile.getPath(), tmpFile.getPath(), expected);
+
+        assertEquals(1, testInfoOutputStream.getCloseCount());
+        assertEquals(3, testInfoOutputStream.getFlushCount());
+        assertEquals(1, testErrorOutputStream.getCloseCount());
+        assertEquals(1, testErrorOutputStream.getFlushCount());
+    }
+
+    @Test
+    public void testXmlLoggerClosesItStreams() throws Exception {
+        final Checker checker = new Checker();
+        final CloseAndFlushTestByteArrayOutputStream testInfoOutputStream =
+            new CloseAndFlushTestByteArrayOutputStream();
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.addListener(new XMLLogger(testInfoOutputStream, true));
+
+        final File tmpFile = temporaryFolder.newFile("file.java");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+        verify(checker, tmpFile.getPath(), tmpFile.getPath(), expected);
+
+        assertEquals(1, testInfoOutputStream.getCloseCount());
+        assertEquals(0, testInfoOutputStream.getFlushCount());
+    }
+
     private static class DummyFilter implements Filter {
 
         @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CloseAndFlushTestByteArrayOutputStream.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CloseAndFlushTestByteArrayOutputStream.java
@@ -1,0 +1,49 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public final class CloseAndFlushTestByteArrayOutputStream extends ByteArrayOutputStream {
+
+    private int closeCount;
+    private int flushCount;
+
+    @Override
+    public void flush() throws IOException {
+        super.flush();
+        flushCount++;
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        closeCount++;
+    }
+
+    public int getCloseCount() {
+        return closeCount;
+    }
+
+    public int getFlushCount() {
+        return flushCount;
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
@@ -19,8 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 
 import org.junit.Test;
 
@@ -29,12 +32,16 @@ import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 public class DefaultLoggerTest {
 
     @Test
-    public void testCtor() {
+    public void testCtor() throws UnsupportedEncodingException {
         final OutputStream infoStream = new ByteArrayOutputStream();
-        final OutputStream errorStream = new ByteArrayOutputStream();
+        final ByteArrayOutputStream errorStream = new ByteArrayOutputStream();
         final DefaultLogger dl = new DefaultLogger(infoStream, true, errorStream, true);
         dl.addException(new AuditEvent(5000, "myfile"), new IllegalStateException("upsss"));
         dl.auditFinished(new AuditEvent(6000, "myfile"));
+        final String output = errorStream.toString("UTF-8");
+
+        assertTrue(output.contains("Error auditing myfile"));
+        assertTrue(output.contains("java.lang.IllegalStateException: upsss"));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
@@ -47,7 +46,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  */
 // -@cs[AbbreviationAsWordInName] Test should be named as its main class.
 public class XMLLoggerTest {
-    private final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+    private final CloseAndFlushTestByteArrayOutputStream outStream =
+        new CloseAndFlushTestByteArrayOutputStream();
 
     @Test
     public void testEncode()
@@ -213,7 +213,9 @@ public class XMLLoggerTest {
             "&lt;exception&gt;&#10;&lt;![CDATA[&#10;stackTrace&#10;example]]&gt;"
                 + "&#10;&lt;/exception&gt;&#10;",
         };
+
         verifyLines(expectedLines);
+        assertEquals(1, outStream.getCloseCount());
     }
 
     private String[] getOutStreamLines()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -24,11 +24,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,13 +53,16 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultLogger;
+import com.puppycrawl.tools.checkstyle.PackageNamesLoader;
 import com.puppycrawl.tools.checkstyle.TestRootModuleChecker;
 import com.puppycrawl.tools.checkstyle.XMLLogger;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(CheckstyleAntTask.class)
+@PrepareForTest({CheckstyleAntTask.class, Closeables.class})
 public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
 
     private static final String FLAWLESS_INPUT_DIR = "ant/checkstyleanttask/flawless/";
@@ -530,6 +537,17 @@ public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
             assertEquals(expected.getLevel(), actual.getLevel());
         }
 
+    }
+
+    @Test
+    public void testPackageNamesLoaderStreamClosed() throws CheckstyleException {
+        mockStatic(Closeables.class);
+        doNothing().when(Closeables.class);
+        Closeables.closeQuietly(any(InputStream.class));
+
+        PackageNamesLoader.getPackageNames(Thread.currentThread().getContextClassLoader());
+        verifyStatic();
+        Closeables.closeQuietly(any(InputStream.class));
     }
 
     private static class CheckstyleAntTaskStub extends CheckstyleAntTask {


### PR DESCRIPTION
Issue #4400 

[pitest report before changes](https://nimfadora.github.io/issue4400.html)

increased mutation threshold for pitest-checkstyle-common profile by 2%
current threshold: 92%
execution time: 13:02 min