### PR TITLE
Issue #3666: Remove deprecated method 'getFilename' from FileContents class

### DIFF
--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -66,14 +66,6 @@
       </Or>
     </Match>
     <Match>
-      <!-- till https://github.com/checkstyle/checkstyle/issues/3666 -->
-      <and>
-        <Class name="com.puppycrawl.tools.checkstyle.api.FileContents" />
-        <Method name="~setFile[nN]ame" />
-      </and>
-      <Bug pattern="NM_CONFUSING" />
-    </Match>
-    <Match>
       <!-- false positive, beginTree is a kind of constructor for Checks -->
       <Or>
         <Class name="com.puppycrawl.tools.checkstyle.checks.AbstractDeclarationCollector" />

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -308,16 +308,6 @@ public final class FileContents implements CommentListener {
     }
 
     /**
-     * Getter.
-     * @return the name of the file
-     * @deprecated use {@link #getFileName} instead
-     */
-    @Deprecated
-    public String getFilename() {
-        return fileName;
-    }
-
-    /**
      * Checks if the specified line is blank.
      * @param lineNo the line number to check
      * @return if the specified line consists only of tabs and spaces.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -29,14 +28,6 @@ import java.util.Collections;
 import org.junit.Test;
 
 public class FileContentsTest {
-
-    @Test
-    @SuppressWarnings("deprecation")
-    public void testDeprecatedCtor() {
-        // just to make UT coverage 100%
-        final FileContents fileContents = new FileContents("filename.java", "1", "2");
-        assertEquals("filename.java", fileContents.getFilename());
-    }
 
     @Test
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Issue #3666 

The method 'getFilename' has been removed as it was deprecated and the subsequent changes to FileContentsTest and findbugs-exclude.xml have been made.