### PR TITLE
Issue #4500: limit exclusion scope of pmd for src/it to src/it/resources

### DIFF
--- a/config/pmd-main.xml
+++ b/config/pmd-main.xml
@@ -7,6 +7,7 @@
     <description>
         PMD ruleset for Checkstyle main code
     </description>
+    <exclude-pattern>.*/src/it/.*</exclude-pattern>
     <exclude-pattern>.*/src/test/.*</exclude-pattern>
     <rule ref="config/pmd.xml"/>
 </ruleset>

--- a/config/pmd-test.xml
+++ b/config/pmd-test.xml
@@ -57,6 +57,10 @@
         <exclude name="ShortMethodName"/>
         <!--tentative-->
         <exclude name="AvoidCatchingGenericException"/>
+        <!--tentative-->
+        <exclude name="NonThreadSafeSingleton"/>
+        <!--tentative-->
+        <exclude name="UseVarargs"/>
     </rule>
 
     <rule ref="rulesets/java/codesize.xml/NcssMethodCount">

--- a/pom.xml
+++ b/pom.xml
@@ -356,7 +356,7 @@
               <ruleset>config/pmd-test.xml</ruleset>
             </rulesets>
             <excludeRoots>
-              <excludeRoot>src/it</excludeRoot>
+              <excludeRoot>src/it/resources</excludeRoot>
               <excludeRoot>src/test/resources</excludeRoot>
               <excludeRoot>target/generated-sources/antlr</excludeRoot>
               <excludeRoot>target/generated-sources/antlr/com/puppycrawl/tools/checkstyle/grammars/javadoc</excludeRoot>


### PR DESCRIPTION
Issue #4500 
changed `<excludeRoot>src/it</excludeRoot>` to `<excludeRoot>src/it/resources</excludeRoot>`

[pmd report](https://nimfadora.github.io/pmd-pr/pmd4500.html)