### PR TITLE
Issue #4342: suppressed production code violations as they should not be fixed

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -150,7 +150,8 @@
     <exclude name="FieldDeclarationsShouldBeAtStartOfClass"/>
     <!-- too much alarms of Checks, we will never move logic out of Check, each Check is independent logic container -->
     <exclude name="GodClass"/>
-    <!-- till #4342 -->
+    <!--we do not care about this minor overhead, we are not Android application and we do not want to change
+     visibility of methods. Package-private visibility should be avoid almost always.-->
     <exclude name="AccessorMethodGeneration"/>
   </rule>
 
@@ -313,9 +314,16 @@
   </rule>
   <rule ref="rulesets/java/typeresolution.xml"/>
   <rule ref="rulesets/java/unnecessary.xml"/>
-  <rule ref="rulesets/java/unusedcode.xml">
-    <!-- till #4342 -->
-    <exclude name="UnusedPrivateMethod"/>
+  <rule ref="rulesets/java/unusedcode.xml"/>
+  <rule ref="rulesets/java/unusedcode.xml/UnusedPrivateMethod">
+    <properties>
+      <!-- generates false-positives on private methods called within a file -->
+      <property name="violationSuppressXPath"
+                value="//MethodDeclaration[@Name='countTokens' and ../../..[@Image='DescendantTokenCheck']]"/>
+      <!-- generates false-positives on private methods called within a file -->
+      <property name="violationSuppressXPath"
+                value="//MethodDeclaration[@Name='getHashCodeBasedOnObjectContent' and ../../..[@Image='PropertyCacheFile']]"/>
+    </properties>
   </rule>
 
 </ruleset>


### PR DESCRIPTION
Issue #4342 

suppressed issues as the don't seem to be ones that should be fixed.

`AccessorMethodGeneration` as it stated [here](https://github.com/checkstyle/checkstyle/issues/4342#issuecomment-310384718)
`UnusedPrivateMethod` as it generates false-positives on private methods called within a file

[pmd report](https://nimfadora.github.io/pmd-pr/pmd4342.html)