### PR TITLE
Issue #4475: added since version column to all module properties

### DIFF
--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -293,12 +293,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>basedir</td>
             <td>base directory name; stripped off in messages about files</td>
             <td><a href="property_types.html#string">string</a></td>
             <td><code>null</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>cacheFile</td>
@@ -306,6 +308,7 @@
                 to avoid repeated checks of the same files</td>
             <td><a href="property_types.html#string">string</a></td>
             <td><code>null</code> (no cache file)</td>
+            <td>6.16</td>
           </tr>
           <tr>
             <td>localeCountry</td>
@@ -313,6 +316,7 @@
             <td><a href="property_types.html#string">string</a>: either
             the empty string or an uppercase ISO 3166 2-letter code</td>
             <td>default locale country for the Java Virtual Machine</td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>localeLanguage</td>
@@ -320,24 +324,28 @@
             <td><a href="property_types.html#string">string</a>: either
             the empty string or a lowercase ISO 639 code</td>
             <td>default locale language for the Java Virtual Machine</td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>charset</td>
             <td>name of the file charset</td>
             <td><a href="property_types.html#string">String</a></td>
             <td>System property &quot;file.encoding&quot;</td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>fileExtensions</td>
             <td>file extensions that are accepted</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>null</code></td>
+            <td>6.3</td>
           </tr>
           <tr>
             <td>severity</td>
             <td>the default severity level of all violations</td>
             <td><a href="property_types.html#severity">Severity</a></td>
             <td><code>error</code></td>
+            <td>3.1</td>
           </tr>
           <tr>
             <td>haltOnException</td>
@@ -345,6 +353,7 @@
             exception during verification</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>7.4</td>
           </tr>
         </table>
       </subsection>
@@ -443,6 +452,7 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>tabWidth</td>
@@ -451,6 +461,7 @@
             href="config_sizes.html#LineLength"><code>LineLength</code></a></td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>8</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>fileExtensions</td>
@@ -460,6 +471,7 @@
             not have the extension <code>.java</code></td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>java</code></td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -51,24 +51,28 @@ public String getNameIfPresent() { ... }
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>allowSamelineMultipleAnnotations</td>
             <td>To allow annotation(s) to be located on the same line as target element.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
            <td><code>false</code></td>
+            <td>6.0</td>
           </tr>
           <tr>
             <td>allowSamelineSingleParameterlessAnnotation</td>
             <td>To allow single parameterless annotation to be located on the same line as target element.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>6.1</td>
           </tr>
           <tr>
             <td>allowSamelineParameterizedAnnotation</td>
             <td>To allow one and only parameterized annotation to be located on the same line as target element.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>6.4</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -98,6 +102,7 @@ public String getNameIfPresent() { ... }
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
             </td>
+            <td>6.0</td>
           </tr>
         </table>
       </subsection>
@@ -234,6 +239,7 @@ public void test(&#64;MyAnnotation String s) { // OK
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>elementStyle</td>
@@ -248,6 +254,7 @@ public void test(&#64;MyAnnotation String s) { // OK
             <td>
               <code>compact_no_array</code>
             </td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>closingParens</td>
@@ -260,6 +267,7 @@ public void test(&#64;MyAnnotation String s) { // OK
             <td>
               <code>never</code>
             </td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>trailingArrayComma</td>
@@ -272,6 +280,7 @@ public void test(&#64;MyAnnotation String s) { // OK
             <td>
               <code>never</code>
             </td>
+            <td>5.0</td>
           </tr>
         </table>
       </subsection>
@@ -356,6 +365,7 @@ public void test(&#64;MyAnnotation String s) { // OK
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>skipNoJavadoc</td>
@@ -366,6 +376,7 @@ public void test(&#64;MyAnnotation String s) { // OK
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>6.16</td>
           </tr>
         </table>
       </subsection>
@@ -442,6 +453,7 @@ public static final int COUNTER = 10; // violation as javadoc exists
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>javaFiveCompatibility</td>
@@ -460,6 +472,7 @@ public static final int COUNTER = 10; // violation as javadoc exists
             <td>
               <code>false</code>
             </td>
+            <td>5.0</td>
           </tr>
         </table>
       </subsection>
@@ -601,6 +614,7 @@ public static final int COUNTER = 10; // violation as javadoc exists
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
@@ -614,6 +628,7 @@ public static final int COUNTER = 10; // violation as javadoc exists
             <td>
               <code>"^$|^\s+$"</code>
             </td>
+            <td>5.0</td>
           </tr>
 
           <tr>
@@ -646,6 +661,7 @@ public static final int COUNTER = 10; // violation as javadoc exists
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>.
             </td>
+            <td>5.0</td>
           </tr>
 
         </table>
@@ -724,6 +740,7 @@ public static final int COUNTER = 10; // violation as javadoc exists
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>aliasList</td>
@@ -731,6 +748,7 @@ public static final int COUNTER = 10; // violation as javadoc exists
             <td><a href="property_types.html#stringSet">String Set</a> in a format of comma separated attribute=value entries.
             The attribute is the fully qualified name of the Check and value is its alias.</td>
             <td>null</td>
+            <td>5.7</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -95,12 +95,14 @@ switch (a)
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>allowInSwitchCase</td>
             <td>Allow nested blocks in case statements</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -188,12 +190,14 @@ switch (a)
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>option</td>
             <td>policy on block contents</td>
             <td><a href="property_types.html#block">block policy</a></td>
             <td><code>statement</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -230,6 +234,7 @@ switch (a)
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">LITERAL_SWITCH</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">LITERAL_SYNCHRONIZED</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -310,18 +315,21 @@ switch (a)
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>exceptionVariableName</td>
             <td>The name of variable associated with exception</td>
             <td><a href="property_types.html#string">String</a></td>
             <td>^$</td>
+            <td>6.4</td>
           </tr>
           <tr>
             <td>commentFormat</td>
             <td>The format of the first comment inside empty catch</td>
             <td><a href="property_types.html#string">String</a></td>
             <td>.*</td>
+            <td>6.4</td>
           </tr>
         </table>
       </subsection>
@@ -456,18 +464,21 @@ try {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>option</td>
             <td>policy on placement of a left curly brace (<code>'{'</code>)</td>
             <td><a href="property_types.html#lcurly">left curly brace policy</a></td>
             <td><code>eol</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>ignoreEnums</td>
             <td>If true, Check will ignore enums when left curly brace policy is EOL</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>true</td>
+            <td>6.9</td>
           </tr>
           <tr>
             <td>maxLineLength</td>
@@ -476,6 +487,7 @@ try {
                 since checkstyle 6.10 release.</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>80</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -526,6 +538,7 @@ try {
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#OBJBLOCK">OBJBLOCK</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">LAMBDA</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -614,18 +627,21 @@ try {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>allowSingleLineStatement</td>
             <td>allows single-line statements without braces</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>6.5</td>
           </tr>
           <tr>
             <td>allowEmptyLoopBody</td>
             <td>allows loops with empty bodies</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>6.12.1</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -649,6 +665,7 @@ try {
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">LITERAL_WHILE</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -785,12 +802,14 @@ for(int i = 0; i &lt; 10; value.incrementValue()); // OK
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>option</td>
             <td>policy on placement of a right curly brace (<code>'}'</code>)</td>
             <td><a href="property_types.html#rcurly">right curly brace policy</a></td>
             <td><code>same</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>shouldStartLine</td>
@@ -798,6 +817,7 @@ for(int i = 0; i &lt; 10; value.incrementValue()); // OK
             starts line.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>4.2</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -842,6 +862,7 @@ for(int i = 0; i &lt; 10; value.incrementValue()); // OK
              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">LITERAL_IF</a>,
             <a
              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">LITERAL_ELSE</a>.</td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -404,18 +404,21 @@ public class A {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>ignoreConstructors</td>
             <td>whether to ignore constructors</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.2</td>
           </tr>
           <tr>
             <td>ignoreModifiers</td>
             <td>whether to ignore modifiers</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.2</td>
           </tr>
         </table>
       </subsection>
@@ -529,12 +532,14 @@ public class A {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>skipIfLastAndSharedWithCase</td>
             <td>whether to allow <code>default</code> along with case if they are not last</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>7.7</td>
           </tr>
         </table>
       </subsection>
@@ -710,12 +715,14 @@ String nullString = null;
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>ignoreEqualsIgnoreCase</td>
             <td>whether to ignore <code>String.equalsIgnoreCase()</code> invocations</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>5.4</td>
           </tr>
         </table>
       </subsection>
@@ -868,6 +875,7 @@ String nullString = null;
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>onlyObjectReferences</td>
@@ -875,6 +883,7 @@ String nullString = null;
                 null for objects should be checked</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>7.8</td>
           </tr>
         </table>
       </subsection>
@@ -1016,6 +1025,7 @@ case 5:
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>checkLastCaseGroup</td>
@@ -1024,6 +1034,7 @@ case 5:
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>4.0</td>
           </tr>
           <tr>
             <td>reliefPattern</td>
@@ -1033,6 +1044,7 @@ case 5:
             </td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"fallthru|falls? ?through"</code></td>
+            <td>4.0</td>
           </tr>
         </table>
       </subsection>
@@ -1120,6 +1132,7 @@ case 5:
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>validateEnhancedForLoopVariable</td>
@@ -1133,6 +1146,7 @@ case 5:
               false
              </code>
             </td>
+            <td>6.5</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -1147,6 +1161,7 @@ case 5:
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
             </td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -1246,12 +1261,14 @@ case 5:
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>ignoreFormat</td>
             <td>pattern for names of variables and parameters to ignore</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>null</code></td>
+            <td>3.2</td>
           </tr>
 
           <tr>
@@ -1259,6 +1276,7 @@ case 5:
             <td>Controls whether to ignore constructor parameters.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>3.2</td>
           </tr>
 
           <tr>
@@ -1274,6 +1292,7 @@ case 5:
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>3.2</td>
           </tr>
 
           <tr>
@@ -1300,6 +1319,7 @@ case 5:
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>6.3</td>
           </tr>
 
           <tr>
@@ -1307,6 +1327,7 @@ case 5:
             <td>Controls whether to ignore parameters of abstract methods.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>4.0</td>
           </tr>
 
           <tr>
@@ -1327,6 +1348,7 @@ case 5:
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">PARAMETER_DEF</a>,
               LAMBDA.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -1471,6 +1493,7 @@ class SomeClass
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>illegalClassNames</td>
@@ -1478,6 +1501,7 @@ class SomeClass
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>&quot;java.lang.Exception,
             java.lang.Throwable, java.lang.RuntimeException&quot;</code></td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -1568,12 +1592,14 @@ class SomeClass
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>classes</td>
             <td>classes that should not be instantiated</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td>{}</td>
+            <td>3.0</td>
           </tr>
 
           <tr>
@@ -1588,6 +1614,7 @@ class SomeClass
             <td>
               CLASS_DEF.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -1658,6 +1685,7 @@ class SomeClass
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>illegalClassNames</td>
@@ -1667,12 +1695,14 @@ class SomeClass
               <code>&quot;java.lang.Throwable,
               java.lang.Error, java.lang.RuntimeException&quot;</code>
             </td>
+            <td>4.0</td>
           </tr>
           <tr>
             <td>ignoredMethodNames</td>
             <td>names of methods to ignore</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>finalize</code></td>
+            <td>5.4</td>
           </tr>
           <tr>
             <td>ignoreOverriddenMethods</td>
@@ -1680,6 +1710,7 @@ class SomeClass
              annotation).</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>6.4</td>
           </tr>
         </table>
       </subsection>
@@ -1773,6 +1804,7 @@ class SomeClass
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>tokens</td>
@@ -1784,6 +1816,7 @@ class SomeClass
             <td>
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LABELED_STAT">LABELED_STAT</a>.
             </td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -1849,18 +1882,21 @@ class SomeClass
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>illegal pattern</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>&quot;$^&quot; (empty)</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>ignoreCase</td>
             <td>Controls whether to ignore case when matching.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>message</td>
@@ -1868,6 +1904,7 @@ class SomeClass
             if empty then the default message is used.</td>
             <td><a href="property_types.html#string">String</a></td>
             <td><code>&quot;&quot;</code>(empty)</td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -1883,6 +1920,7 @@ class SomeClass
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CHAR_LITERAL">CHAR_LITERAL</a>.
             </td>
             <td>empty</td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -1969,12 +2007,14 @@ class SomeClass
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>validateAbstractClassNames</td>
             <td>Whether to validate abstract class names</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>6.10</td>
           </tr>
           <tr>
             <td>illegalClassNames</td>
@@ -1984,30 +2024,35 @@ class SomeClass
             <td>&quot;java.util.HashSet, java.util.HashMap, java.util.LinkedHashMap,
             java.util.LinkedHashSet, java.util.TreeSet,
             java.util.TreeMap&quot;</td>
+            <td>3.2</td>
           </tr>
           <tr>
           <td>legalAbstractClassNames</td>
           <td>Abstract classes that may be used as types. </td>
           <td><a href="property_types.html#stringSet">String Set</a></td>
           <td/>
+          <td>4.2</td>
         </tr>
         <tr>
             <td>ignoredMethodNames</td>
             <td>Methods that should not be checked.</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td>&quot;getInitialContext, getEnvironment&quot; </td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>format</td>
             <td>Pattern for illegal class names.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^(.*[.])?Abstract.*$"</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>memberModifiers</td>
             <td>Check methods and fields with only corresponding modifiers.</td>
             <td><a href="property_types.html#stringSet">List of tokens</a></td>
             <td><code>null</code></td>
+            <td>6.3</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -2023,6 +2068,7 @@ class SomeClass
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">PARAMETER_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>.
             </td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -2195,30 +2241,35 @@ static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>ignoreNumbers</td>
             <td>non-magic numbers</td>
             <td><a href="property_types.html#intSet">Number Set</a></td>
             <td>-1, 0, 1, 2</td>
+            <td>3.1</td>
           </tr>
           <tr>
             <td>ignoreHashCodeMethod</td>
             <td>ignore magic numbers in hashCode methods</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><span class="default">false</span></td>
+            <td>5.3</td>
           </tr>
           <tr>
             <td>ignoreAnnotation</td>
             <td>ignore magic numbers in annotation declarations.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><span class="default">false</span></td>
+            <td>5.4</td>
           </tr>
           <tr>
               <td>ignoreFieldDeclaration</td>
               <td>ignore magic numbers in field declarations.</td>
               <td><a href="property_types.html#boolean">Boolean</a></td>
               <td><span class="default">false</span></td>
+              <td>6.6</td>
           </tr>
           <tr>
               <td>constantWaiverParentToken</td>
@@ -2241,6 +2292,7 @@ static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">PLUS</a>,
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">MINUS</a>.
               </td>
+              <td>6.11</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -2257,6 +2309,7 @@ static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">NUM_INT</a>,
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">NUM_LONG</a>.
             </td>
+            <td>3.1</td>
           </tr>
         </table>
       </subsection>
@@ -2530,6 +2583,7 @@ class MyClass {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
 
           <tr>
@@ -2544,6 +2598,7 @@ class MyClass {
               false
              </code>
             </td>
+            <td>6.8</td>
           </tr>
         </table>
       </subsection>
@@ -2638,6 +2693,7 @@ class MyClass {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>allowedDuplicates</td>
@@ -2647,6 +2703,7 @@ class MyClass {
             </td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>1</td>
+            <td>3.5</td>
           </tr>
           <tr>
             <td>ignoreStringsRegexp</td>
@@ -2655,6 +2712,7 @@ class MyClass {
             </td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^""$"</code></td>
+            <td>4.0</td>
           </tr>
           <tr>
             <td>ignoreOccurrenceContext</td>
@@ -2671,6 +2729,7 @@ class MyClass {
               <code>ANNOTATION</code>
               (ignore strings inside the context of an annotation)
             </td>
+            <td>4.4</td>
           </tr>
         </table>
       </subsection>
@@ -2831,12 +2890,14 @@ class MyClass {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>allowed nesting depth</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><span class="default">1</span></td>
+            <td>5.3</td>
           </tr>
         </table>
       </subsection>
@@ -2908,12 +2969,14 @@ class MyClass {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>allowed nesting depth</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>1</code></td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -2985,12 +3048,14 @@ class MyClass {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>allowed nesting depth</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>1</code></td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -3348,12 +3413,14 @@ public void foo(int i, String s) {}
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>matchDirectoryStructure</td>
             <td>Whether to check for directory and package name match.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>7.6.1</td>
           </tr>
         </table>
       </subsection>
@@ -3525,24 +3592,28 @@ public class AnnotationLocationCheck extends AbstractCheck {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>checkFields</td>
             <td>Whether to check references to fields.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>checkMethods</td>
             <td>Whether to check references to methods.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>validateOnlyOverlapping</td>
             <td>Whether to check only overlapping by variables or arguments.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>6.17</td>
           </tr>
         </table>
       </subsection>
@@ -3750,24 +3821,28 @@ class C {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>maximum allowed number of return statements in non-void methods/lambdas</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>2</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>maxForVoid</td>
             <td>maximum allowed number of return statements in void methods/constructors/lambdas</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>1</code></td>
+            <td>6.19</td>
           </tr>
           <tr>
             <td>format</td>
             <td>method names to ignore</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^equals$"</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -3783,6 +3858,7 @@ class C {
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">LAMBDA</a>.
             </td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -4219,6 +4295,7 @@ if (&quot;something&quot;.equals(x))
                   <th>description</th>
                   <th>type</th>
                   <th>default value</th>
+                  <th>since</th>
               </tr>
               <tr>
                   <td>tokens</td>
@@ -4272,6 +4349,7 @@ if (&quot;something&quot;.equals(x))
                     <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">SR_ASSIGN</a>,
                     <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">STAR_ASSIGN</a>.
                   </td>
+                  <td>3.4</td>
               </tr>
           </table>
       </subsection>
@@ -4354,6 +4432,7 @@ if (&quot;something&quot;.equals(x))
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
 
           <tr>
@@ -4361,6 +4440,7 @@ if (&quot;something&quot;.equals(x))
             <td>A distance between declaration of variable and its first usage. Values should be greater than 0.</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>3</td>
+            <td>5.8</td>
           </tr>
 
           <tr>
@@ -4368,6 +4448,7 @@ if (&quot;something&quot;.equals(x))
             <td>pattern for ignoring the distance calculation</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>""</code></td>
+            <td>5.8</td>
           </tr>
 
           <tr>
@@ -4375,6 +4456,7 @@ if (&quot;something&quot;.equals(x))
             <td>Allows to calculate the distance between declaration of variable and its first usage in the different scopes.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.8</td>
           </tr>
 
           <tr>
@@ -4382,6 +4464,7 @@ if (&quot;something&quot;.equals(x))
             <td>Allows to ignore variables with a 'final' modifier.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.8</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -148,6 +148,7 @@ public abstract class Plant {
                     <th>description</th>
                     <th>type</th>
                     <th>default value</th>
+                    <th>since</th>
                 </tr>
                 <tr>
                     <td>ignoredAnnotations</td>
@@ -156,6 +157,7 @@ public abstract class Plant {
                     </td>
                     <td><a href="property_types.html#stringSet">String Set</a></td>
                     <td><code>Test, Before, After, BeforeClass, AfterClass</code></td>
+                    <td>7.2</td>
                 </tr>
             </table>
         </subsection>
@@ -474,6 +476,7 @@ public class StringUtils // not final to allow subclassing
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>allowMarkerInterfaces</td>
@@ -483,6 +486,7 @@ public class StringUtils // not final to allow subclassing
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>3.1</td>
           </tr>
         </table>
       </subsection>
@@ -568,18 +572,21 @@ public class StringUtils // not final to allow subclassing
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>pattern for exception class names</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^.*Exception$|^.*Error$|^.*Throwable$"</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>extendedClassNameFormat</td>
             <td>pattern for extended class names</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^.*Exception$|^.*Error$|^.*Throwable$"</code></td>
+            <td>6.2</td>
           </tr>
         </table>
       </subsection>
@@ -759,18 +766,21 @@ public class Foo{
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>maximum allowed number of throws statements</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>4</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>ignorePrivateMethods</td>
             <td>whether private methods must be ignored</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>6.7</td>
           </tr>
         </table>
       </subsection>
@@ -906,36 +916,42 @@ public class Foo{
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>packageAllowed</td>
             <td>whether package visible members are allowed</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>protectedAllowed</td>
             <td>whether protected members are allowed</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>publicMemberPattern</td>
             <td>pattern for public members that should be ignored</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^serialVersionUID$"</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>allowPublicFinalFields</td>
             <td>allows public final fields</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>7.0</td>
           </tr>
           <tr>
             <td>allowPublicImmutableFields</td>
             <td>allows immutable fields to be declared as public if defined in final class</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>6.4</td>
           </tr>
           <tr>
             <td>immutableClassCanonicalNames</td>
@@ -946,12 +962,14 @@ public class Foo{
             java.lang.StackTraceElement, java.math.BigInteger, java.math.BigDecimal, java.io.File,
             java.util.Locale, java.util.UUID, java.net.URL, java.net.URI,
             java.net.Inet4Address, java.net.Inet6Address, java.net.InetSocketAddress,</td>
+            <td>6.4.1</td>
           </tr>
           <tr>
             <td>ignoreAnnotationCanonicalNames</td>
             <td>ignore annotations canonical names</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td>org.junit.Rule, org.junit.ClassRule, com.google.common.annotations.VisibleForTesting</td>
+            <td>6.5</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_filefilters.xml
+++ b/src/xdocs/config_filefilters.xml
@@ -50,12 +50,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>fileNamePattern</td>
             <td>Regular expression to match the file name against.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>null</code></td>
+            <td>7.2</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -36,12 +36,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>severity</td>
             <td>the severity level of this filter</td>
             <td><a href="property_types.html#severity">Severity</a></td>
             <td><code>error</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>acceptOnMatch</td>
@@ -56,6 +58,7 @@
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -119,42 +122,49 @@
                   <th>description</th>
                   <th>type</th>
                   <th>default value</th>
+                  <th>since</th>
               </tr>
               <tr>
                   <td>offCommentFormat</td>
                   <td>comment pattern to trigger filter to begin suppression</td>
                   <td><a href="property_types.html#regexp">Regular Expression</a></td>
                   <td><code>"CHECKSTYLE:OFF"</code></td>
+                  <td>3.5</td>
               </tr>
               <tr>
                   <td>onCommentFormat</td>
                   <td>comment pattern to trigger filter to end suppression</td>
                   <td><a href="property_types.html#regexp">Regular Expression</a></td>
                   <td><code>"CHECKSTYLE:ON"</code></td>
+                  <td>3.5</td>
               </tr>
               <tr>
                   <td>checkFormat</td>
                   <td>check pattern to suppress</td>
                   <td><a href="property_types.html#regexp">Regular Expression</a></td>
                   <td><code>".*"</code></td>
+                  <td>3.5</td>
               </tr>
               <tr>
                   <td>messageFormat</td>
                   <td>message pattern to suppress</td>
                   <td><a href="property_types.html#regexp">Regular Expression</a></td>
                   <td><code>null</code></td>
+                  <td>3.5</td>
               </tr>
               <tr>
                   <td>checkCPP</td>
                   <td>whether to check C++ style comments (<code>//</code>)</td>
                   <td><a href="property_types.html#boolean">Boolean</a></td>
                   <td><code>true</code></td>
+                  <td>3.5</td>
               </tr>
               <tr>
                   <td>checkC</td>
                   <td>whether to check C style comments (<code>/* ... */</code>)</td>
                   <td><a href="property_types.html#boolean">Boolean</a></td>
                   <td><code>true</code></td>
+                  <td>3.5</td>
               </tr>
           </table>
           <p>
@@ -419,6 +429,7 @@ public class UserService {
                <th>description</th>
                <th>type</th>
                <th>default value</th>
+               <th>since</th>
              </tr>
              <tr>
                <td>file</td>
@@ -440,6 +451,7 @@ public class UserService {
                </td>
                <td><a href="property_types.html#string">string</a></td>
                <td><code>none</code></td>
+               <td>3.2</td>
              </tr>
              <tr>
                <td>optional</td>
@@ -452,6 +464,7 @@ public class UserService {
                </td>
                <td><a href="property_types.html#boolean">Boolean</a></td>
                <td><code>false</code></td>
+               <td>6.15</td>
              </tr>
           </table>
       </subsection>
@@ -764,24 +777,28 @@ public static void foo() {
                     <th>description</th>
                     <th>type</th>
                     <th>default value</th>
+                    <th>since</th>
                 </tr>
                 <tr>
                     <td>commentFormat</td>
                     <td>comment pattern to trigger filter to begin suppression</td>
                     <td><a href="property_types.html#regexp">Regular Expression</a></td>
                     <td><code>"SUPPRESS CHECKSTYLE (\w+)"</code></td>
+                    <td>5.0</td>
                 </tr>
                 <tr>
                     <td>checkFormat</td>
                     <td>check pattern to suppress</td>
                     <td><a href="property_types.html#regexp">Regular Expression</a></td>
                     <td><code>".*"</code></td>
+                    <td>5.0</td>
                 </tr>
                 <tr>
                     <td>messageFormat</td>
                     <td>message pattern to suppress</td>
                     <td><a href="property_types.html#regexp">Regular Expression</a></td>
                     <td><code>null</code></td>
+                    <td>5.0</td>
                 </tr>
                 <tr>
                     <td>influenceFormat</td>
@@ -789,18 +806,21 @@ public static void foo() {
                         lines preceding/at/following the suppression comment</td>
                     <td><a href="property_types.html#regexp">Regular Expression</a></td>
                     <td><code>"0"</code></td>
+                    <td>5.0</td>
                 </tr>
                 <tr>
                     <td>checkCPP</td>
                     <td>whether to check C++ style comments (<code>//</code>)</td>
                     <td><a href="property_types.html#boolean">Boolean</a></td>
                     <td><code>true</code></td>
+                    <td>5.0</td>
                 </tr>
                 <tr>
                     <td>checkC</td>
                     <td>whether to check C style comments (<code>/* ... */</code>)</td>
                     <td><a href="property_types.html#boolean">Boolean</a></td>
                     <td><code>true</code></td>
+                    <td>5.0</td>
                 </tr>
             </table>
         </subsection>

--- a/src/xdocs/config_header.xml
+++ b/src/xdocs/config_header.xml
@@ -59,12 +59,14 @@ line 5: ////////////////////////////////////////////////////////////////////
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>headerFile</td>
             <td>name of the file containing the required header</td>
             <td><a href="property_types.html#uri">URI</a></td>
             <td><code>null</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>charset</td>
@@ -72,6 +74,7 @@ line 5: ////////////////////////////////////////////////////////////////////
             <td><a href="property_types.html#string">string</a></td>
             <td>the charset property of the parent
             <a href="config.html#Checker">Checker</a> module</td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>header</td>
@@ -82,18 +85,21 @@ line 5: ////////////////////////////////////////////////////////////////////
             </td>
             <td><a href="property_types.html#string">string</a></td>
             <td><code>null</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>ignoreLines</td>
             <td>line numbers to ignore</td>
             <td><a href="property_types.html#intSet">Integer Set</a></td>
             <td><code>{}</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>fileExtensions</td>
             <td>file type extension of files to process</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>{}</code></td>
+            <td>6.9</td>
           </tr>
         </table>
       </subsection>
@@ -257,12 +263,14 @@ line 6: ^\W*$
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>headerFile</td>
             <td>name of the file containing the required header</td>
             <td><a href="property_types.html#uri">URI</a></td>
             <td><code>null</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>charset</td>
@@ -270,6 +278,7 @@ line 6: ^\W*$
             <td><a href="property_types.html#string">string</a></td>
             <td>the charset property of the parent
             <a href="config.html#Checker">Checker</a> module</td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>header</td>
@@ -281,18 +290,21 @@ line 6: ^\W*$
             </td>
             <td><a href="property_types.html#string">string</a></td>
             <td><code>null</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>multiLines</td>
             <td>line numbers to repeat (zero or more times)</td>
             <td><a href="property_types.html#intSet">Integer Set</a></td>
             <td><code>{}</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>fileExtensions</td>
             <td>file type extension of files to process</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>{}</code></td>
+            <td>6.9</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -42,6 +42,7 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>excludes</td>
@@ -52,6 +53,7 @@
             </td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>empty list</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>allowClassImports</td>
@@ -61,6 +63,7 @@
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.3</td>
           </tr>
           <tr>
             <td>allowStaticMemberImports</td>
@@ -70,6 +73,7 @@
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.3</td>
           </tr>
         </table>
       </subsection>
@@ -150,6 +154,7 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>excludes</td>
@@ -169,6 +174,7 @@
             </td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>empty list</code></td>
+            <td>5.0</td>
           </tr>
         </table>
       </subsection>
@@ -328,36 +334,42 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>customImportOrderRules</td>
             <td>List of order declaration customizing by user.</td>
             <td><a href="property_types.html#string">string</a></td>
             <td><code>null</code></td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>standardPackageRegExp</td>
             <td>RegExp for STANDARD_JAVA_PACKAGE group imports.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^(java|javax)\."</code></td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>thirdPartyPackageRegExp</td>
             <td>RegExp for THIRD_PARTY_PACKAGE group imports.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>".*"</code></td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>specialImportsRegExp</td>
             <td>RegExp for SPECIAL_IMPORTS group imports.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^$"</code></td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>separateLineBetweenGroups</td>
             <td>Force empty line separator between import groups.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>sortImportsInGroupAlphabetically</td>
@@ -366,6 +378,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
                    ASCII sort order</a>.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.8</td>
           </tr>
         </table>
       </subsection>
@@ -600,6 +613,7 @@ import android.*;
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>illegalPkgs</td>
@@ -607,6 +621,7 @@ import android.*;
                 interpreted as regular expressions. Note, all properties for match will be used.</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>sun</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>illegalClasses</td>
@@ -614,12 +629,14 @@ import android.*;
                 interpreted as regular expressions. Note, all properties for match will be used.</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>{}</code></td>
+            <td>7.8</td>
           </tr>
           <tr>
             <td>regexp</td>
             <td>Whether the <b>illegalPkgs</b> and <b>illegalClasses</b> should be interpreted as regular expressions</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>7.8</td>
           </tr>
         </table>
 
@@ -883,6 +900,7 @@ public class InputIllegalImport { }
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>file</td>
@@ -893,6 +911,7 @@ public class InputIllegalImport { }
             </td>
             <td><a href="property_types.html#uri">URI</a></td>
             <td><code>null</code></td>
+            <td>4.0</td>
           </tr>
           <tr>
             <td>url</td>
@@ -903,6 +922,7 @@ public class InputIllegalImport { }
             </td>
             <td><a href="property_types.html#uri">URI</a></td>
             <td><code>null</code></td>
+            <td>4.4</td>
           </tr>
           <tr>
             <td>path</td>
@@ -913,6 +933,7 @@ public class InputIllegalImport { }
             </td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>".*"</code></td>
+            <td>7.5</td>
           </tr>
         </table>
       </subsection>
@@ -1245,12 +1266,14 @@ import java.util.stream.IntStream;
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>option</td>
             <td>policy on the relative order between regular imports and static imports</td>
             <td><a href="property_types.html#importOrder">import order</a></td>
             <td><code>under</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>groups</td>
@@ -1261,12 +1284,14 @@ import java.util.stream.IntStream;
             </td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>empty list</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>ordered</td>
             <td>whether imports within group should be sorted</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>true</td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>separated</td>
@@ -1276,6 +1301,7 @@ import java.util.stream.IntStream;
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>caseSensitive</td>
@@ -1285,6 +1311,7 @@ import java.util.stream.IntStream;
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>true</td>
+            <td>3.3</td>
           </tr>
           <tr>
             <td>sortStaticImportsAlphabetically</td>
@@ -1292,12 +1319,14 @@ import java.util.stream.IntStream;
             are sorted alphabetically or not</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>6.5</td>
           </tr>
           <tr>
             <td>useContainerOrderingForStatic</td>
             <td>whether to use container ordering (Eclipse IDE term) for static imports or not</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>7.1</td>
           </tr>
 
           <tr>
@@ -1312,6 +1341,7 @@ import java.util.stream.IntStream;
             <td>
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">STATIC_IMPORT</a>.
             </td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -1666,12 +1696,14 @@ class FooBar {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>processJavadoc</td>
             <td>whether to process Javadoc</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.4</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -37,6 +37,7 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>target</td>
@@ -52,6 +53,7 @@
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
             </td>
+            <td>6.0</td>
           </tr>
           <tr>
             <td>tagOrder</td>
@@ -60,6 +62,7 @@
             <td><code>&#64;author, &#64;version, &#64;param,
                   &#64;return, &#64;throws, &#64;exception, &#64;see, &#64;since, &#64;serial,
                   &#64;serialField, &#64;serialData, &#64;deprecated</code></td>
+            <td>6.0</td>
           </tr>
         </table>
       </subsection>
@@ -207,36 +210,42 @@ public int checkReturnTag(final int aTagIndex,
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>minLineCount</td>
             <td>Minimal amount of lines in method to demand documentation presence.</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>-1</code></td>
+            <td>6.0</td>
           </tr>
           <tr>
             <td>allowedAnnotations</td>
             <td>List of annotations that could allow missed documentation.</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>Override</code></td>
+            <td>6.0</td>
           </tr>
           <tr>
             <td>validateThrows</td>
             <td>Allows validating throws tags.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>6.0</td>
           </tr>
           <tr>
             <td>scope</td>
             <td>visibility scope where Javadoc comments are checked</td>
             <td><a href="property_types.html#scope">Scope</a></td>
             <td><code>private</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>excludeScope</td>
             <td>visibility scope where Javadoc comments are not checked</td>
             <td><a href="property_types.html#scope">Scope</a></td>
             <td><code>null</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>allowUndeclaredRTE</td>
@@ -244,6 +253,7 @@ public int checkReturnTag(final int aTagIndex,
             are not declared if they are a subclass of <code>java.lang.RuntimeException</code></td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>allowThrowsTagsForSubclasses</td>
@@ -251,6 +261,7 @@ public int checkReturnTag(final int aTagIndex,
             are subclass of one of declared exception.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>3.1</td>
           </tr>
           <tr>
             <td>allowMissingParamTags</td>
@@ -258,6 +269,7 @@ public int checkReturnTag(final int aTagIndex,
             but does not have matching param tags in the javadoc.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>3.1</td>
           </tr>
           <tr>
             <td>allowMissingThrowsTags</td>
@@ -266,6 +278,7 @@ public int checkReturnTag(final int aTagIndex,
             in the javadoc.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>3.1</td>
           </tr>
           <tr>
             <td>allowMissingReturnTag</td>
@@ -273,12 +286,14 @@ public int checkReturnTag(final int aTagIndex,
             non-void type and does not have a return tag in the javadoc.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>3.1</td>
           </tr>
           <tr>
             <td>allowMissingJavadoc</td>
             <td>whether to ignore errors when a method javadoc is missed.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>4.0</td>
           </tr>
           <tr>
             <td>allowMissingPropertyJavadoc</td>
@@ -306,6 +321,7 @@ public boolean isSomething()
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>4.0</td>
           </tr>
           <tr>
             <td>logLoadErrors</td>
@@ -321,6 +337,7 @@ public boolean isSomething()
             (potentially masking a configuration error).</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>4.2</td>
           </tr>
           <tr>
             <td>suppressLoadErrors</td>
@@ -333,12 +350,14 @@ public boolean isSomething()
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>4.2</td>
           </tr>
           <tr>
             <td>ignoreMethodNamesRegex</td>
             <td>ignore method whose names are matching specified regex</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>null</code></td>
+            <td>6.3</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -355,6 +374,7 @@ public boolean isSomething()
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">ANNOTATION_FIELD_DEF</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -504,6 +524,7 @@ public boolean isSomething()
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>allowLegacy</td>
@@ -513,12 +534,14 @@ public boolean isSomething()
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>fileExtensions</td>
             <td>file type extension of files to process</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>{}</code></td>
+            <td>5.0</td>
           </tr>
         </table>
       </subsection>
@@ -597,12 +620,14 @@ public boolean isSomething()
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>allowNewlineParagraph</td>
             <td>whether the &lt;p&gt; tag should be placed immediately before the first word</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>6.9</td>
           </tr>
         </table>
       </subsection>
@@ -776,18 +801,21 @@ public boolean isSomething()
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>scope</td>
             <td>visibility scope where Javadoc comments are checked</td>
             <td><a href="property_types.html#scope">Scope</a></td>
             <td><code>private</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>excludeScope</td>
             <td>visibility scope where Javadoc comments are not checked</td>
             <td><a href="property_types.html#scope">Scope</a></td>
             <td><code>null</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>checkFirstSentence</td>
@@ -796,6 +824,7 @@ public boolean isSomething()
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>endOfSentenceFormat</td>
@@ -804,6 +833,7 @@ public boolean isSomething()
             </td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"([.?!][ \t\n\r\f&lt;])|([.?!]$)"</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>checkEmptyJavadoc</td>
@@ -812,12 +842,14 @@ public boolean isSomething()
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>checkHtml</td>
             <td>Whether to check for incomplete HTML tags.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -846,6 +878,7 @@ public boolean isSomething()
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">PACKAGE_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
             </td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -965,12 +998,14 @@ public boolean isSomething()
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>offset</td>
             <td>How many spaces to use for new indentation level.</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><span class="default">4</span></td>
+            <td>6.0</td>
           </tr>
         </table>
       </subsection>
@@ -1077,30 +1112,35 @@ public boolean isSomething()
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>scope</td>
             <td>visibility scope where Javadoc comments are checked</td>
             <td><a href="property_types.html#scope">Scope</a></td>
             <td><code>private</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>excludeScope</td>
             <td>visibility scope where Javadoc comments are not checked</td>
             <td><a href="property_types.html#scope">Scope</a></td>
             <td><code>null</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>authorFormat</td>
             <td>pattern for @author tag</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>null</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>versionFormat</td>
             <td>pattern for @version tag</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>null</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>allowMissingParamTags</td>
@@ -1108,12 +1148,14 @@ public boolean isSomething()
                 but does not have matching param tags in the javadoc.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>4.0</td>
           </tr>
           <tr>
             <td>allowUnknownTags</td>
             <td>whether to ignore errors when a Javadoc tag is not recognised.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.1</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -1131,6 +1173,7 @@ public boolean isSomething()
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">ANNOTATION_DEF</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -1255,24 +1298,28 @@ public boolean isSomething()
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>scope</td>
             <td>visibility scope where Javadoc comments are checked</td>
             <td><a href="property_types.html#scope">Scope</a></td>
             <td><code>private</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>excludeScope</td>
             <td>visibility scope where Javadoc comments are not checked</td>
             <td><a href="property_types.html#scope">Scope</a></td>
             <td><code>null</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
               <td>ignoreNamePattern</td>
               <td>regexp to define variable names to ignore</td>
               <td><a href="property_types.html#regexp">Regular Expression</a></td>
               <td><code>null</code></td>
+              <td>5.8</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -1283,6 +1330,7 @@ public boolean isSomething()
             <td>
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -1381,6 +1429,7 @@ public boolean isSomething()
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>javadocTokens</td>
@@ -1397,6 +1446,7 @@ public boolean isSomething()
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#THROWS_LITERAL">THROWS_LITERAL</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#DEPRECATED_LITERAL">DEPRECATED_LITERAL</a>.
             </td>
+            <td>7.3</td>
           </tr>
         </table>
       </subsection>
@@ -1486,18 +1536,21 @@ public boolean isSomething()
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>ignoredTags</td>
             <td>allows to specify at-clauses which are ignored by the check.</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>null</code></td>
+            <td>6.8</td>
           </tr>
           <tr>
             <td>ignoreInlineTags</td>
             <td>whether inline tags must be ignored.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>6.8</td>
           </tr>
         </table>
       </subsection>
@@ -1595,18 +1648,21 @@ public boolean isSomething()
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>forbiddenSummaryFragments</td>
             <td>forbidden summary fragments</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^$"</code></td>
+            <td>6.0</td>
           </tr>
           <tr>
             <td>period</td>
             <td>period symbol at the end of first javadoc sentence</td>
             <td><a href="property_types.html#string">String literal</a></td>
             <td><code>.</code></td>
+            <td>6.2</td>
           </tr>
         </table>
       </subsection>
@@ -1755,24 +1811,28 @@ public class TestClass {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>tag</td>
             <td>Name of tag</td>
             <td><a href="property_types.html#string">String</a></td>
            <td><code>null</code></td>
+           <td>4.2</td>
           </tr>
           <tr>
             <td>tagFormat</td>
             <td>Format of tag</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>null</code></td>
+            <td>4.2</td>
           </tr>
           <tr>
             <td>tagSeverity</td>
             <td>Severity level when tag is found and printed</td>
             <td><a href="property_types.html#severity">Severity</a></td>
             <td><code>info</code></td>
+            <td>4.2</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -1793,6 +1853,7 @@ public class TestClass {
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">ANNOTATION_DEF</a>.
             </td>
+            <td>4.2</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -56,6 +56,7 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
@@ -65,6 +66,7 @@
             </td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>3</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -84,6 +86,7 @@
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">BOR</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">BXOR</a>.
             </td>
+            <td>3.4</td>
           </tr>
         </table>
       </subsection>
@@ -211,12 +214,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>the maximum threshold allowed</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>7</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>excludedClasses</td>
@@ -234,18 +239,21 @@
                 List, ArrayList, Deque, Queue, LinkedList,
                 Set, HashSet, SortedSet, TreeSet,
                 Map, HashMap, SortedMap, TreeMap</td>
+            <td>5.7</td>
           </tr>
           <tr>
             <td>excludeClassesRegexps</td>
             <td>User-configured regular expressions to ignore classes</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>"^$"</code></td>
+            <td>7.7</td>
           </tr>
           <tr>
             <td>excludedPackages</td>
             <td>User-configured packages to ignore</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td>{}</td>
+            <td>7.7</td>
           </tr>
         </table>
       </subsection>
@@ -518,12 +526,14 @@ public class Foo {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>the maximum threshold allowed</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>20</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>excludedClasses</td>
@@ -541,18 +551,21 @@ public class Foo {
                 List, ArrayList, Deque, Queue, LinkedList,
                 Set, HashSet, SortedSet, TreeSet,
                 Map, HashMap, SortedMap, TreeMap</td>
+            <td>5.7</td>
           </tr>
           <tr>
             <td>excludeClassesRegexps</td>
             <td>User-configured regular expressions to ignore classes</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>"^$"</code></td>
+            <td>7.7</td>
           </tr>
           <tr>
             <td>excludedPackages</td>
             <td>User-configured packages to ignore</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td>{}</td>
+            <td>7.7</td>
           </tr>
         </table>
       </subsection>
@@ -716,18 +729,21 @@ public class Foo {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>the maximum threshold allowed</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>10</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>switchBlockAsSingleDecisionPoint</td>
             <td>whether to treat the whole switch block as a single decision point</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>6.11</td>
           </tr>
 
           <tr>
@@ -760,6 +776,7 @@ public class Foo {
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>.
             </td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -919,6 +936,7 @@ class SwitchExample {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>methodMaximum</td>
@@ -928,6 +946,7 @@ class SwitchExample {
             </td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>50</code></td>
+            <td>3.5</td>
           </tr>
           <tr>
             <td>classMaximum</td>
@@ -937,6 +956,7 @@ class SwitchExample {
             </td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>1500</code></td>
+            <td>3.5</td>
           </tr>
           <tr>
             <td>fileMaximum</td>
@@ -946,6 +966,7 @@ class SwitchExample {
             </td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>2000</code></td>
+            <td>3.5</td>
           </tr>
         </table>
       </subsection>
@@ -1091,12 +1112,14 @@ class SwitchExample {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>the maximum threshold allowed</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>200</code></td>
+            <td>3.4</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -37,6 +37,7 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>javaStyle</td>
@@ -45,6 +46,7 @@
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>3.1</td>
           </tr>
         </table>
       </subsection>
@@ -130,30 +132,35 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>allowEscapesForControlCharacters</td>
             <td>Allow use escapes for non-printable(control) characters.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>allowByTailComment</td>
             <td>Allow use escapes if trail comment is present.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>allowIfAllCharactersEscaped</td>
             <td>Allow if all characters in literal are escaped.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>allowNonPrintableEscapes</td>
             <td>Allow non-printable escapes.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>5.8</td>
           </tr>
         </table>
       </subsection>
@@ -443,6 +450,7 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
             <tr>
             <td>tokens</td>
@@ -456,6 +464,7 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SINGLE_LINE_COMMENT">SINGLE_LINE_COMMENT</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BLOCK_COMMENT_BEGIN">BLOCK_COMMENT_BEGIN</a>.
             </td>
+            <td>6.10</td>
           </tr>
         </table>
       </subsection>
@@ -535,6 +544,7 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>limitedTokens</td>
@@ -544,30 +554,35 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
             </td>
             <td>empty set</td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>minimumDepth</td>
             <td>the minimum depth for descendant counts</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>0</td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>maximumDepth</td>
             <td>the maximum depth for descendant counts</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>java.lang.Integer.MAX_VALUE</td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>minimumNumber</td>
             <td>a minimum count for descendants</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>0</td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>maximumNumber</td>
             <td>a maximum count for descendants</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>java.lang.Integer.MAX_VALUE</td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>sumTokenCounts</td>
@@ -577,18 +592,21 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>minimumMessage</td>
             <td>error message when the minimum count is not reached</td>
             <td><a href="property_types.html#string">String</a></td>
             <td>&quot;descendant.token.min&quot;</td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>maximumMessage</td>
             <td>error message when the maximum count is exceeded</td>
             <td><a href="property_types.html#string">String</a></td>
             <td>&quot;descendant.token.max&quot;</td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -888,12 +906,14 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>ignorePrimitiveTypes</td>
             <td>ignore primitive types as parameters</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>6.2</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -909,6 +929,7 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -1005,42 +1026,49 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>basicOffset</td>
             <td>how far new indentation level should be indented when on the next line</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>4</td>
+            <td>3.1</td>
           </tr>
           <tr>
             <td>braceAdjustment</td>
             <td>how far a braces should be indented when on the next line</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>0</td>
+            <td>3.1</td>
           </tr>
           <tr>
             <td>caseIndent</td>
             <td>how far a case label should be indented when on next line</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>4</td>
+            <td>3.1</td>
           </tr>
           <tr>
             <td>throwsIndent</td>
             <td>how far a throws clause should be indented when on next line</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>4</td>
+            <td>5.7</td>
           </tr>
           <tr>
             <td>arrayInitIndent</td>
             <td>how far an array initialisation should be indented when on next line</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>4</td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>lineWrappingIndentation</td>
             <td>how far continuation line should be indented when line-wrapping is present</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>4</td>
+            <td>5.9</td>
           </tr>
           <tr>
             <td>forceStrictCondition</td>
@@ -1048,6 +1076,7 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
                 have to be same as lineWrappingIndentation parameter. If value is false, line wrap indent could be bigger on any value user would like.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>6.3</td>
           </tr>
         </table>
       </subsection>
@@ -1178,6 +1207,7 @@ void foo(String aFooString,
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>lineSeparator</td>
@@ -1188,12 +1218,14 @@ void foo(String aFooString,
               (Mac-style), &quot;lf&quot; (Unix-style) and &quot;lf_cr_crlf&quot; (lf, cr or crlf).
             </td>
             <td>&quot;system&quot;</td>
+            <td>3.1</td>
           </tr>
           <tr>
             <td>fileExtensions</td>
             <td>file type extension of the files to check.</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td>all files</td>
+            <td>3.1</td>
           </tr>
 
         </table>
@@ -1344,12 +1376,14 @@ void foo(String aFooString,
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>Pattern to match comments against</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"TODO:"</code></td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -1491,12 +1525,14 @@ d = e / f;        // Another comment for this line
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>pattern for strings allowed before the comment</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^[\s});]*$"</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>legalComment</td>
@@ -1505,6 +1541,7 @@ d = e / f;        // Another comment for this line
                 comment will be trimmed before matching.)</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>null</code></td>
+            <td>4.2</td>
           </tr>
         </table>
       </subsection>
@@ -1612,6 +1649,7 @@ messages.properties: Key 'ok' missing.
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>fileExtensions</td>
@@ -1623,6 +1661,7 @@ messages.properties: Key 'ok' missing.
             </td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>properties</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>baseName</td>
@@ -1631,6 +1670,7 @@ messages.properties: Key 'ok' missing.
               the check to distinguish config and localization resources.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^messages.*$"</code></td>
+            <td>6.17</td>
           </tr>
           <tr>
             <td>requiredTranslations</td>
@@ -1648,6 +1688,7 @@ messages.properties: Key 'ok' missing.
             </td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>empty String Set</code></td>
+            <td>6.11</td>
           </tr>
         </table>
       </subsection>
@@ -1778,6 +1819,7 @@ messages_home_fr_CA_UNIX.properties
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>excludedClasses</td>
@@ -1785,6 +1827,7 @@ messages_home_fr_CA_UNIX.properties
             to have a main method.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^$"</code></td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -1864,12 +1907,14 @@ messages_home_fr_CA_UNIX.properties
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>fileExtensions</td>
             <td>file type extension of the files to check.</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td>properties</td>
+            <td>5.7</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_modifier.xml
+++ b/src/xdocs/config_modifier.xml
@@ -262,6 +262,7 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>tokens</td>
@@ -287,6 +288,7 @@
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE">RESOURCE</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -60,6 +60,7 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>allowedAbbreviationLength</td>
@@ -67,6 +68,7 @@
              (abbreviations in the classes, interfaces, variables and methods names, ... ).</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>3</td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>allowedAbbreviations</td>
@@ -74,18 +76,21 @@
             Abbreviations should be separated by comma, no spaces are allowed.</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td>null</td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>ignoreFinal</td>
             <td>allow to skip variables with final modifier.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>true</td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>ignoreStatic</td>
             <td>allow to skip variables with static modifier.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>true</td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>ignoreOverriddenMethods</td>
@@ -93,6 +98,7 @@
             (that usually mean inherited name).</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>true</td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -119,6 +125,7 @@
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>.
             </td>
+            <td>5.8</td>
           </tr>
         </table>
       </subsection>
@@ -193,12 +200,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^Abstract.+$"</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>ignoreModifier</td>
@@ -209,6 +218,7 @@
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.3</td>
           </tr>
           <tr>
             <td>ignoreName</td>
@@ -219,6 +229,7 @@
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.3</td>
           </tr>
         </table>
       </subsection>
@@ -297,6 +308,7 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
@@ -307,6 +319,7 @@
             <td>
               <code>"^(e|t|ex|[a-z][a-z][a-zA-Z]+)$"</code>
             </td>
+            <td>6.14</td>
           </tr>
         </table>
       </subsection>
@@ -380,12 +393,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^[A-Z]$"</code></td>
+            <td>5.0</td>
           </tr>
         </table>
       </subsection>
@@ -449,24 +464,28 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>applyToPublic</td>
             <td>Controls whether to apply the check to public member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>applyToProtected</td>
             <td>Controls whether to apply the check to protected member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>applyToPackage</td>
@@ -475,12 +494,14 @@
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>applyToPrivate</td>
             <td>Controls whether to apply the check to private member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.0</td>
           </tr>
         </table>
       </subsection>
@@ -550,12 +571,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^[A-Z]$"</code></td>
+            <td>5.8</td>
           </tr>
         </table>
       </subsection>
@@ -619,12 +642,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
           <td>tokens</td>
@@ -640,6 +665,7 @@
             <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">PARAMETER_DEF</a>,
             <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE">RESOURCE</a>.
           </td>
+          <td>3.0</td>
         </tr>
         </table>
       </subsection>
@@ -703,12 +729,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>allowOneCharVarInForLoop</td>
@@ -720,6 +748,7 @@ for (int i = 1; i &lt; 10; i++) {}
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.8</td>
           </tr>
         </table>
       </subsection>
@@ -798,24 +827,28 @@ for (int i = 1; i &lt; 10; i++) {}
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>applyToPublic</td>
             <td>Controls whether to apply the check to public member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>applyToProtected</td>
             <td>Controls whether to apply the check to protected member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>applyToPackage</td>
@@ -824,12 +857,14 @@ for (int i = 1; i &lt; 10; i++) {}
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>applyToPrivate</td>
             <td>Controls whether to apply the check to private member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>3.4</td>
           </tr>
         </table>
       </subsection>
@@ -903,12 +938,14 @@ for (int i = 1; i &lt; 10; i++) {}
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>allowClassName</td>
@@ -927,18 +964,21 @@ class MyClass {
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>applyToPublic</td>
             <td>Controls whether to apply the check to public member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.1</td>
           </tr>
           <tr>
             <td>applyToProtected</td>
             <td>Controls whether to apply the check to protected member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.1</td>
           </tr>
           <tr>
             <td>applyToPackage</td>
@@ -947,12 +987,14 @@ class MyClass {
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.1</td>
           </tr>
           <tr>
             <td>applyToPrivate</td>
             <td>Controls whether to apply the check to private member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.1</td>
           </tr>
         </table>
       </subsection>
@@ -1023,12 +1065,14 @@ class MyClass {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^[A-Z]$"</code></td>
+            <td>5.0</td>
           </tr>
         </table>
       </subsection>
@@ -1091,12 +1135,14 @@ class MyClass {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^[a-z]+(\.[a-zA-Z_][a-zA-Z0-9_]*)*$"</code></td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -1174,12 +1220,14 @@ class MyClass {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>ignoreOverridden</td>
@@ -1196,12 +1244,14 @@ public boolean equals(Object o) {
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>6.12.1</td>
           </tr>
           <tr>
             <td>accessModifiers</td>
             <td>Access modifiers of methods where parameters are checked.</td>
             <td><a href="property_types.html#access_modifiers">Access Modifier Set</a></td>
             <td><code>public, protected, package, private</code></td>
+            <td>7.5</td>
           </tr>
         </table>
       </subsection>
@@ -1305,24 +1355,28 @@ public boolean equals(Object o) {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>applyToPublic</td>
             <td>Controls whether to apply the check to public member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>applyToProtected</td>
             <td>Controls whether to apply the check to protected member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>applyToPackage</td>
@@ -1331,12 +1385,14 @@ public boolean equals(Object o) {
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>applyToPrivate</td>
             <td>Controls whether to apply the check to private member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.0</td>
           </tr>
         </table>
       </subsection>
@@ -1399,24 +1455,28 @@ public boolean equals(Object o) {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>Specifies valid identifiers.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^[A-Z][a-zA-Z0-9]*$"</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>applyToPublic</td>
             <td>Controls whether to apply the check to public member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>applyToProtected</td>
             <td>Controls whether to apply the check to protected member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>applyToPackage</td>
@@ -1425,12 +1485,14 @@ public boolean equals(Object o) {
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>applyToPrivate</td>
             <td>Controls whether to apply the check to private member.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -1456,6 +1518,7 @@ public boolean equals(Object o) {
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
                 ANNOTATION_DEF</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_regexp.xml
+++ b/src/xdocs/config_regexp.xml
@@ -76,12 +76,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>pattern</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"$^"</code> (empty)</td>
+            <td>4.0</td>
           </tr>
           <tr>
             <td>message</td>
@@ -89,12 +91,14 @@
               if empty then the default (hard-coded) message is used.</td>
             <td><a href="property_types.html#string">String</a></td>
             <td><code>&quot;&quot;</code>(empty)</td>
+            <td>4.0</td>
           </tr>
           <tr>
             <td>illegalPattern</td>
             <td>Controls whether the pattern is required or illegal.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>4.0</td>
           </tr>
           <tr>
             <td>duplicateLimit</td>
@@ -104,18 +108,21 @@
               limit is exceeded errors will be logged.</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>0</code></td>
+            <td>4.0</td>
           </tr>
           <tr>
             <td>errorLimit</td>
             <td>Controls the maximum number of errors before the check will abort.</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>100</code></td>
+            <td>4.0</td>
           </tr>
           <tr>
             <td>ignoreComments</td>
             <td>Controls whether to ignore matches found within comments.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>4.0</td>
           </tr>
         </table>
       </subsection>
@@ -500,12 +507,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>illegal pattern</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>&quot;$.&quot;</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>message</td>
@@ -513,30 +522,35 @@
             if empty then default(hard-coded) message is used.</td>
             <td><a href="property_types.html#string">String</a></td>
             <td><code>&quot;&quot;</code>(empty)</td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>ignoreCase</td>
             <td>Controls whether to ignore case when searching.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>minimum</td>
             <td>The minimum number of matches required in each file.</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>0</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>maximum</td>
             <td>The maximum number of matches required in each file.</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>0</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>fileExtensions</td>
             <td>file type extension of files to process</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>{}</code></td>
+            <td>5.0</td>
           </tr>
         </table>
       </subsection>
@@ -649,18 +663,21 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>folderPattern</td>
             <td>Regular expression to match the folder path against.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>null</code></td>
+            <td>6.15</td>
           </tr>
           <tr>
             <td>fileNamePattern</td>
             <td>Regular expression to match the file name against.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>null</code></td>
+            <td>6.15</td>
           </tr>
           <tr>
             <td>match</td>
@@ -668,12 +685,14 @@
             fileNamePattern is supplied, otherwise it is applied on the folderPattern.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>6.15</td>
           </tr>
           <tr>
             <td>ignoreFileNameExtensions</td>
             <td>Whether to ignore the file extension for the file name match.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>6.15</td>
           </tr>
           <tr>
             <td>fileExtensions</td>
@@ -681,6 +700,7 @@
             only files that match these types are examined with the other patterns.</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>{}</code></td>
+            <td>6.15</td>
           </tr>
         </table>
       </subsection>
@@ -813,12 +833,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>illegal pattern</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>&quot;$.&quot;</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>message</td>
@@ -826,30 +848,35 @@
             if empty then default(hard-coded) message is used.</td>
             <td><a href="property_types.html#string">String</a></td>
             <td><code>&quot;&quot;</code>(empty)</td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>ignoreCase</td>
             <td>Controls whether to ignore case when searching.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>minimum</td>
             <td>The minimum number of matches required in each file.</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>0</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>maximum</td>
             <td>The maximum number of matches required in each file.</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>0</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>fileExtensions</td>
             <td>file type extension of files to process</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>{}</code></td>
+            <td>5.0</td>
           </tr>
         </table>
       </subsection>
@@ -955,12 +982,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>format</td>
             <td>illegal pattern</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>&quot;$.&quot;</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>message</td>
@@ -968,30 +997,35 @@
             if empty then default(hard-coded) message is used.</td>
             <td><a href="property_types.html#string">String</a></td>
             <td><code>&quot;&quot;</code>(empty)</td>
+            <td>6.0</td>
           </tr>
           <tr>
             <td>ignoreCase</td>
             <td>Controls whether to ignore case when searching.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>minimum</td>
             <td>The minimum number of matches required in each file.</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>0</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>maximum</td>
             <td>The maximum number of matches required in each file.</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>0</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>ignoreComments</td>
             <td>Controls whether to ignore text in comments when searching.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.0</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -43,12 +43,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>maximum allowable number of lines</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>20</td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -113,12 +115,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>the maximum threshold allowed</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>30</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -136,6 +140,7 @@
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">INSTANCE_INIT</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">STATIC_INIT</a>.
             </td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -215,18 +220,21 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>maximum allowable number of lines</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>2000</td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>fileExtensions</td>
             <td>file type extension of files to process</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>{}</code></td>
+            <td>5.0</td>
           </tr>
         </table>
       </subsection>
@@ -302,18 +310,21 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>ignorePattern</td>
             <td>pattern for lines to ignore</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td>"^$"</td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>max</td>
             <td>maximum allowable line length</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>80</td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -415,36 +426,42 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>maxTotal</td>
             <td>maximum allowable number of methods at all scope levels</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>100</td>
+            <td>5.3</td>
           </tr>
           <tr>
             <td>maxPrivate</td>
             <td>maximum allowable number of <code>private</code> methods</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>100</td>
+            <td>5.3</td>
           </tr>
           <tr>
             <td>maxPackage</td>
             <td>maximum allowable number of <code>package</code> methods</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>100</td>
+            <td>5.3</td>
           </tr>
           <tr>
             <td>maxProtected</td>
             <td>maximum allowable number of <code>protected</code> methods</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>100</td>
+            <td>5.3</td>
           </tr>
           <tr>
             <td>maxPublic</td>
             <td>maximum allowable number of <code>public</code> methods</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>100</td>
+            <td>5.3</td>
           </tr>
 
           <tr>
@@ -465,6 +482,7 @@
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>.
             </td>
+            <td>5.3</td>
           </tr>
         </table>
       </subsection>
@@ -559,12 +577,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>maximum allowable number of lines</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>150</td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>countEmpty</td>
@@ -574,6 +594,7 @@
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>3.2</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -592,6 +613,7 @@
                <a
                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -687,12 +709,14 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>maximum allowable number of outer types</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>1</td>
+            <td>5.0</td>
           </tr>
         </table>
       </subsection>
@@ -765,18 +789,21 @@
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>max</td>
             <td>maximum allowable number of parameters</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>7</td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>ignoreOverriddenMethods</td>
             <td>Ignore number of parameters for methods with @Override annotation</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>6.2</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -795,6 +822,7 @@
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -43,12 +43,14 @@ for (
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>option</td>
             <td>policy on how to pad an empty for iterator</td>
             <td><a href="property_types.html#parenPad">pad policy</a></td>
             <td><code>nospace</code></td>
+            <td>3.4</td>
           </tr>
         </table>
       </subsection>
@@ -135,12 +137,14 @@ for (Iterator foo = very.long.line.iterator();
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>option</td>
             <td>policy on how to pad an empty for iterator</td>
             <td><a href="property_types.html#parenPad">pad policy</a></td>
             <td><code>nospace</code></td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -228,24 +232,28 @@ for (Iterator foo = very.long.line.iterator();
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>allowNoEmptyLineBetweenFields</td>
             <td>Allow no empty line between fields</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
+            <td>5.8</td>
           </tr>
           <tr>
              <td>allowMultipleEmptyLines</td>
              <td>Allow multiple empty lines between class members</td>
              <td><a href="property_types.html#boolean">Boolean</a></td>
              <td>true</td>
+             <td>6.3</td>
           </tr>
             <tr>
                 <td>allowMultipleEmptyLinesInsideClassMembers</td>
                 <td>Allow multiple empty lines inside class members</td>
                 <td><a href="property_types.html#boolean">Boolean</a></td>
                 <td>true</td>
+                <td>6.18</td>
             </tr>
           <tr>
             <td>tokens</td>
@@ -274,6 +282,7 @@ for (Iterator foo = very.long.line.iterator();
             <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">CTOR_DEF</a>,
             <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>.
           </td>
+          <td>5.8</td>
           </tr>
         </table>
       </subsection>
@@ -460,18 +469,21 @@ class Foo
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>eachLine</td>
             <td>whether to report on each line containing a tab, or just the first instance</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.0</td>
           </tr>
           <tr>
             <td>fileExtensions</td>
             <td>file type extension of files to process</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>{}</code></td>
+            <td>5.0</td>
           </tr>
         </table>
       </subsection>
@@ -664,6 +676,7 @@ sort(list, Comparable::&lt;String&gt;compareTo);             // Method reference
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>allowLineBreaks</td>
@@ -673,6 +686,7 @@ sort(list, Comparable::&lt;String&gt;compareTo);             // Method reference
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>option</td>
@@ -681,6 +695,7 @@ sort(list, Comparable::&lt;String&gt;compareTo);             // Method reference
               <a href="property_types.html#parenPad">pad policy</a>
             </td>
             <td><code>nospace</code></td>
+            <td>3.4</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -715,6 +730,7 @@ sort(list, Comparable::&lt;String&gt;compareTo);             // Method reference
                  <a
                   href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>.
             </td>
+            <td>3.4</td>
           </tr>
         </table>
       </subsection>
@@ -808,6 +824,7 @@ sort(list, Comparable::&lt;String&gt;compareTo);             // Method reference
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>tokens</td>
@@ -836,6 +853,7 @@ sort(list, Comparable::&lt;String&gt;compareTo);             // Method reference
              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">IMPORT</a>,
             <a
             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">STATIC_IMPORT</a>.</td>
+            <td>5.8</td>
           </tr>
         </table>
       </subsection>
@@ -946,6 +964,7 @@ import static java.math.BigInteger.ZERO;
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>allowLineBreaks</td>
@@ -954,6 +973,7 @@ import static java.math.BigInteger.ZERO;
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -1010,6 +1030,7 @@ import static java.math.BigInteger.ZERO;
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP">INDEX_OP</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -1090,6 +1111,7 @@ import static java.math.BigInteger.ZERO;
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>allowLineBreaks</td>
@@ -1098,6 +1120,7 @@ import static java.math.BigInteger.ZERO;
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -1122,6 +1145,7 @@ import static java.math.BigInteger.ZERO;
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_DEC">POST_DEC</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELLIPSIS">ELLIPSIS</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -1198,6 +1222,7 @@ import static java.math.BigInteger.ZERO;
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>option</td>
@@ -1206,6 +1231,7 @@ import static java.math.BigInteger.ZERO;
               <a href="property_types.html#wrapOp">wrap operator policy</a>
             </td>
             <td><code>nl</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -1276,6 +1302,7 @@ import static java.math.BigInteger.ZERO;
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">TYPE_EXTENSION_AND</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">LITERAL_INSTANCEOF</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -1373,12 +1400,14 @@ import static java.math.BigInteger.ZERO;
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>option</td>
             <td>policy on how to pad parentheses</td>
             <td><a href="property_types.html#parenPad">pad policy</a></td>
             <td><code>nospace</code></td>
+            <td>3.0</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -1473,6 +1502,7 @@ import static java.math.BigInteger.ZERO;
               <a
               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">LAMBDA</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -1567,6 +1597,7 @@ import static java.math.BigInteger.ZERO;
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>option</td>
@@ -1575,6 +1606,7 @@ import static java.math.BigInteger.ZERO;
               <a href="property_types.html#wrapOp">wrap operator policy</a>
             </td>
             <td><code>eol</code></td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -1609,6 +1641,7 @@ import static java.math.BigInteger.ZERO;
               <a
                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">COMMA</a>.
             </td>
+            <td>5.8</td>
           </tr>
         </table>
       </subsection>
@@ -1750,12 +1783,14 @@ public long toMicros(long d) { return d / (C1 / C0); }
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>validateComments</td>
             <td>If set to true, whitespaces surrounding comments will be ignored.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>6.19</td>
           </tr>
         </table>
       </subsection>
@@ -1831,12 +1866,14 @@ public long toMicros(long d) { return d / (C1 / C0); }
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>option</td>
             <td>policy on how to pad parentheses</td>
             <td><a href="property_types.html#parenPad">pad policy</a></td>
             <td><code>nospace</code></td>
+            <td>3.2</td>
           </tr>
         </table>
       </subsection>
@@ -1924,6 +1961,7 @@ public long toMicros(long d) { return d / (C1 / C0); }
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>tokens</td>
@@ -1970,6 +2008,7 @@ public long toMicros(long d) { return d / (C1 / C0); }
                 <a
                 href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">DO_WHILE</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>
@@ -2091,48 +2130,56 @@ try {
             <th>description</th>
             <th>type</th>
             <th>default value</th>
+            <th>since</th>
           </tr>
           <tr>
             <td>allowEmptyConstructors</td>
             <td>allow empty constructor bodies</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>4.0</td>
           </tr>
           <tr>
             <td>allowEmptyMethods</td>
             <td>allow empty method bodies</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>4.0</td>
           </tr>
           <tr>
             <td>allowEmptyTypes</td>
             <td>allow empty class, interface and enum bodies</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>allowEmptyLoops</td>
             <td>allow empty loop bodies</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>5.8</td>
           </tr>
           <tr>
             <td>allowEmptyLambdas</td>
             <td>allow empty lambda bodies</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>6.14</td>
           </tr>
           <tr>
             <td>allowEmptyCatches</td>
             <td>allow empty catch bodies</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
+            <td>7.6</td>
           </tr>
           <tr>
             <td>ignoreEnhancedForColon</td>
             <td>ignore whitespace around colon in for-each loops</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>
+            <td>5.5</td>
           </tr>
           <tr>
             <td>tokens</td>
@@ -2249,6 +2296,7 @@ try {
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ASSERT">LITERAL_ASSERT</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">TYPE_EXTENSION_AND</a>.
             </td>
+            <td>3.0</td>
           </tr>
         </table>
       </subsection>


### PR DESCRIPTION
Issue #4475

Just adding version to properties in this PR. Next PR will do module version.
I will not add version to Javadoc as there is no way to cross check them without a specialized JUnit, and this seems like this will be done with https://groups.google.com/forum/?hl=en#!topic/checkstyle-devel/lsNF6Dj90lo .

I added a temporary junit method to verify version numbers from extract file matched what I wrote in the xdocs.
I manually confirmed versions 3.0 and 6.7 because of limitations of the extract utility and small issues in CS at those times.
No modules were before 3.0 as they were internal, didn't use a configuration, and used System properties to control their settings.