### PR TITLE
Issue #4540: fixed wrong MethodCount with new nested interface def

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
@@ -120,10 +120,7 @@ public final class MethodCountCheck extends AbstractCheck {
 
     @Override
     public void leaveToken(DetailAST ast) {
-        if (ast.getType() == TokenTypes.CLASS_DEF
-            || ast.getType() == TokenTypes.INTERFACE_DEF
-            || ast.getType() == TokenTypes.ENUM_CONSTANT_DEF
-            || ast.getType() == TokenTypes.ENUM_DEF) {
+        if (ast.getType() != TokenTypes.METHOD_DEF) {
             final MethodCounter counter = counters.pop();
             checkCounters(counter, ast);
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheckTest.java
@@ -142,4 +142,16 @@ public class MethodCountCheckTest extends BaseCheckTestSupport {
 
         verify(checkConfig, getPath("InputMethodCount4.java"), expected);
     }
+
+    @Test
+    public void testWithInterfaceDefinitionInClass() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(MethodCountCheck.class);
+        checkConfig.addAttribute("maxTotal", "1");
+
+        final String[] expected = {
+            "1: " + getCheckMessage(MSG_MANY_METHODS, 2, 1),
+        };
+
+        verify(checkConfig, getPath("InputMethodCount5.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCount5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCount5.java
@@ -1,0 +1,9 @@
+public class InputMethodCount5 {
+    void method1() {
+    }
+
+    private @interface Generates {}
+
+    void method2() {
+    }
+}


### PR DESCRIPTION
Issue #4540

The reason to drop all the class definitions for a 'not method definition' condition is so [the change inversely mirrors exactly what is in `visitToken`](https://github.com/checkstyle/checkstyle/blob/7956f0b8d846d8f8ded1e9871e4bb58bf351fbb1/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java#L112-L118). We should be less likely to have issues again if we add more tokens this way.

I will provide regression for just this change, and run regression against commit before bad PR to see if I can verify no more bad results exist.