### PR TITLE
Issue #4567: fix AccessorClassGeneration and JUnitTestsShouldIncludeAssert violations

### DIFF
--- a/config/pmd-test.xml
+++ b/config/pmd-test.xml
@@ -40,9 +40,7 @@
         <exclude name="NPathComplexity"/>
         <!--conflicts with checkstyle rule-->
         <exclude name="JUnitUseExpected"/>
-        <!--tentative-->
-        <exclude name="AccessorClassGeneration"/>
-        <!--tentative-->
+        <!--will be addressed in https://github.com/checkstyle/checkstyle/projects/5-->
         <exclude name="NonThreadSafeSingleton"/>
     </rule>
 
@@ -77,7 +75,7 @@
             <!-- in ImportControlCheckTest pmd does not find asserts in private methods of the test class called from the test method -->
             <!-- in AstRegressionTest pmd does not find asserts in inner classes methods called from the test method -->
             <!-- in AllChecksTest pmd does not find asserts in lambdas -->
-            <!-- Starting from CheckstyleAntTaskTest tests should be rewrited-->
+            <!-- TreeWalkerTest should be rewrited-->
             <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='SuppressionFilterTest']//MethodDeclarator[@Image='testEqualsAndHashCode']
             | //ClassOrInterfaceDeclaration[@Image='SuppressionCommentFilterTest']//MethodDeclarator[@Image='testEqualsAndHashCodeOfTagClass']
             | //ClassOrInterfaceDeclaration[@Image='SuppressWithNearbyCommentFilterTest']//MethodDeclarator[@Image='testEqualsAndHashCodeOfTagClass']
@@ -88,8 +86,6 @@
             | /ClassOrInterfaceDeclaration[@Image='AstRegressionTest']//MethodDeclarator[@Image='testImpossibleExceptions']
             | //ClassOrInterfaceDeclaration[@Image='AstRegressionTest']//MethodDeclarator[@Image='testImpossibleValid']
             | //ClassOrInterfaceDeclaration[@Image='AllChecksTest']//MethodDeclarator[@Image='testAllModulesAreReferencedInConfigFile']
-            | //ClassOrInterfaceDeclaration[@Image='CheckstyleAntTaskTest']//MethodDeclarator[@Image='testConfigurationByUrl']
-            | //ClassOrInterfaceDeclaration[@Image='CheckstyleAntTaskTest']//MethodDeclarator[@Image='testConfigurationByResource']
             | //ClassOrInterfaceDeclaration[@Image='TreeWalkerTest']//MethodDeclarator[@Image='testProcessNonJavaFiles']
             "/>
         </properties>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -362,7 +362,21 @@ public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
         final URL url = new File(getPath(CONFIG_FILE)).toURI().toURL();
         antTask.setConfig(url.toString());
         antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
+
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        final File outputFile = new File("target/ant_task_config_by_url.txt");
+        formatter.setTofile(outputFile);
+        final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
+        formatterType.setValue("plain");
+        formatter.setType(formatterType);
+        formatter.createListener(null);
+        antTask.addFormatter(formatter);
+
         antTask.execute();
+
+        final List<String> output = FileUtils.readLines(outputFile);
+        final int sizeOfOutputWithNoViolations = 2;
+        assertEquals("No violations expected", sizeOfOutputWithNoViolations, output.size());
     }
 
     @Test
@@ -371,7 +385,21 @@ public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
         antTask.setProject(new Project());
         antTask.setConfig(CONFIG_RESOURCE);
         antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
+
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        final File outputFile = new File("target/ant_task_config_by_url.txt");
+        formatter.setTofile(outputFile);
+        final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
+        formatterType.setValue("plain");
+        formatter.setType(formatterType);
+        formatter.createListener(null);
+        antTask.addFormatter(formatter);
+
         antTask.execute();
+
+        final List<String> output = FileUtils.readLines(outputFile);
+        final int sizeOfOutputWithNoViolations = 2;
+        assertEquals("No violations expected", sizeOfOutputWithNoViolations, output.size());
     }
 
     @Test
@@ -671,7 +699,7 @@ public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
         private final String msg;
         private final int level;
 
-        private MessageLevelPair(String msg, int level) {
+        MessageLevelPair(String msg, int level) {
             this.msg = msg;
             this.level = level;
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1917,7 +1917,7 @@ public class IndentationCheckTest extends BaseCheckTestSupport {
         private final String expectedWarning;
         private final boolean warning;
 
-        private IndentComment(Matcher match, int lineNumber) {
+        IndentComment(Matcher match, int lineNumber) {
             this.lineNumber = lineNumber;
             indent = Integer.parseInt(match.group(1));
             if (match.group(2) == null) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
@@ -93,7 +93,7 @@ public class BlockCommentPositionTest {
         private final Function<DetailAST, Boolean> assertion;
         private final int matchesNum;
 
-        private BlockCommentPositionTestMetadata(String fileName, Function<DetailAST,
+        BlockCommentPositionTestMetadata(String fileName, Function<DetailAST,
                 Boolean> assertion, int matchesNum) {
             this.fileName = fileName;
             this.assertion = assertion;


### PR DESCRIPTION
Issue #4567 

subtask of #877 

fixed AccessorClassGeneration violations and JUnitTestsShouldIncludeAssert  in CheckstyleAntTask