### PR TITLE
Issue #3752: Added tokens to SeparatorWrapCheck in google style

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/SeparatorWrapTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/SeparatorWrapTest.java
@@ -79,4 +79,31 @@ public class SeparatorWrapTest extends BaseCheckTestSupport {
         final Integer[] warnList = getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }
+
+    @Test
+    public void testEllipsis() throws Exception {
+        final String[] expected = {
+            "11:13: " + getCheckMessage(SeparatorWrapCheck.class, "line.previous", "..."),
+        };
+
+        final Configuration checkConfig = getCheckConfig("SeparatorWrap", "SeparatorWrapEllipsis");
+        final String filePath = getPath("InputSeparatorWrapEllipsis.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void testArrayDeclarator() throws Exception {
+        final String[] expected = {
+            "9:13: " + getCheckMessage(SeparatorWrapCheck.class, "line.previous", "["),
+        };
+        final Configuration checkConfig = getCheckConfig("SeparatorWrap",
+                "SeparatorWrapArrayDeclarator");
+        final String filePath = getPath("InputSeparatorWrapArrayDeclarator.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapArrayDeclarator.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapArrayDeclarator.java
@@ -1,0 +1,12 @@
+package com.google.checkstyle.test.chapter4formatting.rule451wheretobreak;
+
+class InputSeparatorWrapArrayDeclarator {
+
+    protected int[] arrayDeclarationWithGoodWrapping = new int[
+            ] {1, 2}; // ok
+
+    protected int[] arrayDeclarationWithBadWrapping = new int
+            [] {1, 2}; // warn
+
+}
+

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapEllipsis.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapEllipsis.java
@@ -1,0 +1,16 @@
+package com.google.checkstyle.test.chapter4formatting.rule451wheretobreak;
+
+class InputSeparatorWrapEllipsis {
+
+    public void testMethodWithGoodWrapping(String... // ok
+            parameters) {
+
+    }
+
+    public void testMethodWithBadWrapping(String
+            ...parameters) { // warn
+
+    }
+
+}
+

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -94,6 +94,18 @@
             <property name="option" value="EOL"/>
         </module>
         <module name="SeparatorWrap">
+            <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/258 -->
+            <property name="id" value="SeparatorWrapEllipsis"/>
+            <property name="tokens" value="ELLIPSIS"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/259 -->
+            <property name="id" value="SeparatorWrapArrayDeclarator"/>
+            <property name="tokens" value="ARRAY_DECLARATOR"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
             <property name="id" value="SeparatorWrapMethodRef"/>
             <property name="tokens" value="METHOD_REF"/>
             <property name="option" value="nl"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
@@ -112,4 +112,25 @@ public class SeparatorWrapCheckTest
                 ex.getMessage().startsWith(messageStart));
         }
     }
+
+    @Test
+    public void testEllipsis() throws Exception {
+        checkConfig.addAttribute("option", "EOL");
+        checkConfig.addAttribute("tokens", "ELLIPSIS");
+        final String[] expected = {
+            "11:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "..."),
+        };
+        verify(checkConfig, getPath("InputSeparatorWrapForEllipsis.java"), expected);
+    }
+
+    @Test
+    public void testArrayDeclarator() throws Exception {
+        checkConfig.addAttribute("option", "EOL");
+        checkConfig.addAttribute("tokens", "ARRAY_DECLARATOR");
+        final String[] expected = {
+            "9:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "["),
+        };
+        verify(checkConfig, getPath("InputSeparatorWrapForArrayDeclarator.java"), expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -179,9 +179,15 @@ public class AllChecksTest extends BaseCheckTestSupport {
                 "METHOD_DEF", "CTOR_DEF", "CLASS_DEF", "ENUM_DEF", "INTERFACE_DEF")
                 .collect(Collectors.toSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("SeparatorWrap", Stream.of(
-                // state of configuration until
-                // https://github.com/checkstyle/checkstyle/issues/3752
-                "RBRACK", "AT", "ELLIPSIS", "SEMI", "ARRAY_DECLARATOR",
+                // location could be any to allow writing expressions for indexes evaluation
+                // on new line, see https://github.com/checkstyle/checkstyle/issues/3752
+                "RBRACK",
+                // for some targets annotations can be used without wrapping, as described
+                // in https://google.github.io/styleguide/javaguide.html#s4.8.5-annotations
+                "AT",
+                // location could be any to allow using for line separation in enum values,
+                // see https://github.com/checkstyle/checkstyle/issues/3752
+                "SEMI",
                 // needs context to decide what type of parentheses should be separated or not
                 // which this check does not provide
                 "LPAREN", "RPAREN").collect(Collectors.toSet()));

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapForArrayDeclarator.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapForArrayDeclarator.java
@@ -1,0 +1,12 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.separatorwrap;
+
+class InputSeparatorWrapTestArrayDeclarator {
+
+    protected int[] arrayDeclarationWithGoodWrapping = new int[
+            ] {1, 2};
+
+    protected int[] arrayDeclarationWithBadWrapping = new int
+            [] {1, 2};
+
+}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapForEllipsis.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapForEllipsis.java
@@ -1,0 +1,16 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.separatorwrap;
+
+class InputSeparatorWrapTestEllipsis {
+
+    public void testMethodWithGoodWrapping(String...
+            parameters) {
+
+    }
+
+    public void testMethodWithBadWrapping(String
+            ...parameters) {
+
+    }
+
+}
+


### PR DESCRIPTION
Issue #3752 
According to https://github.com/checkstyle/checkstyle/issues/3752#issuecomment-310446430 ARRAY_DECLARATOR and ELLIPSIS updated to EOL in google style check config.
Tests updated. Links to issues opened on google style added to comments.