### PR TITLE
Issue #4575: Modified ClassDataAbstractionCouplingCheckTest.java and moved its input files to the classdataabstractioncoupling subdirectory

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
@@ -41,7 +41,8 @@ public class ClassDataAbstractionCouplingCheckTest extends BaseCheckTestSupport 
     @Override
     protected String getPath(String filename) throws IOException {
         return super.getPath("checks" + File.separator
-                + "metrics" + File.separator + filename);
+                + "metrics" + File.separator + "classdataabstractioncoupling" + File.separator
+                + filename);
     }
 
     @Test
@@ -58,7 +59,7 @@ public class ClassDataAbstractionCouplingCheckTest extends BaseCheckTestSupport 
             "27:1: " + getCheckMessage(MSG_KEY, 2, 0, "[HashMap, HashSet]"),
         };
 
-        verify(checkConfig, getPath("InputClassCoupling.java"), expected);
+        verify(checkConfig, getPath("InputClassDataAbstractionCoupling.java"), expected);
     }
 
     @Test
@@ -76,7 +77,8 @@ public class ClassDataAbstractionCouplingCheckTest extends BaseCheckTestSupport 
         };
 
         verify(checkConfig,
-            getPath("InputClassCouplingExcludedPackagesDirectPackages.java"), expected);
+            getPath("InputClassDataAbstractionCouplingExcludedPackagesDirectPackages.java"),
+                expected);
     }
 
     @Test
@@ -94,7 +96,8 @@ public class ClassDataAbstractionCouplingCheckTest extends BaseCheckTestSupport 
             "18:1: " + getCheckMessage(MSG_KEY, 1, 0, "[CClass]"),
         };
         verify(checkConfig,
-            getPath("InputClassCouplingExcludedPackagesCommonPackage.java"), expected);
+            getPath("InputClassDataAbstractionCouplingExcludedPackagesCommonPackage.java"),
+                expected);
     }
 
     @Test
@@ -136,7 +139,8 @@ public class ClassDataAbstractionCouplingCheckTest extends BaseCheckTestSupport 
                 + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c");
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("InputClassCouplingExcludedPackagesAllIgnored.java"), expected);
+        verify(checkConfig,
+            getPath("InputClassDataAbstractionCouplingExcludedPackagesAllIgnored.java"), expected);
     }
 
     @Test
@@ -146,7 +150,7 @@ public class ClassDataAbstractionCouplingCheckTest extends BaseCheckTestSupport 
 
         createChecker(checkConfig);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("InputClassCoupling.java"), expected);
+        verify(checkConfig, getPath("InputClassDataAbstractionCoupling.java"), expected);
     }
 
     @Test
@@ -179,7 +183,7 @@ public class ClassDataAbstractionCouplingCheckTest extends BaseCheckTestSupport 
             "7:5: " + getCheckMessage(MSG_KEY, 1, 0, "[ArrayList]"),
         };
 
-        verify(checkConfig, getPath("InputClassCoupling.java"), expected);
+        verify(checkConfig, getPath("InputClassDataAbstractionCoupling.java"), expected);
     }
 
     @Test
@@ -197,6 +201,6 @@ public class ClassDataAbstractionCouplingCheckTest extends BaseCheckTestSupport 
             "27:1: " + getCheckMessage(MSG_KEY, 2, 0, "[HashMap, HashSet]"),
         };
 
-        verify(checkConfig, getPath("InputClassCoupling.java"), expected);
+        verify(checkConfig, getPath("InputClassDataAbstractionCoupling.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCoupling.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCoupling.java
@@ -1,0 +1,43 @@
+package com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling;
+
+import javax.naming.NamingException;
+import java.util.*;
+
+public class InputClassDataAbstractionCoupling {
+    private class InnerClass { //singleline comment
+        public List _list = new ArrayList();
+    }
+
+    private class AnotherInnerClass {
+        public String _string = "";
+    }
+
+    public Set _set = /*block comment*/new HashSet();
+    public Map _map = new HashMap();
+    public String _string = "";
+    public int[] _intArray = new int[0];
+    public InnerClass _innerClass = new InnerClass();
+    public AnotherInnerClass _anotherInnerClass = new AnotherInnerClass();
+
+    public void foo() throws NamingException {
+    }
+
+}
+
+enum InnerEnum {
+    VALUE1;
+
+    private InnerEnum()
+    {
+        map2 = new HashMap();
+    }
+    private Set map1 = new HashSet();
+    private Map map2;
+}
+
+class InputThrows {
+
+    public void get() throws NamingException, IllegalArgumentException {
+        new java.lang.ref.ReferenceQueue<Integer>();
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingExcludedPackagesAllIgnored.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingExcludedPackagesAllIgnored.java
@@ -1,11 +1,11 @@
-package com.puppycrawl.tools.checkstyle.checks.metrics;
+package com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling;
 
 import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.aa.AAClass;
 import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.ab.ABClass;
 import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.b.BClass;
 import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c.CClass;
 
-public class InputClassCouplingExcludedPackagesAllIgnored { // total: ok
+public class InputClassDataAbstractionCouplingExcludedPackagesAllIgnored { // total: ok
     public AAClass aa = new AAClass(); // ok
     public ABClass ab = new ABClass(); // ok
 
@@ -15,7 +15,7 @@ public class InputClassCouplingExcludedPackagesAllIgnored { // total: ok
     }
 }
 
-class InputClassCouplingExcludedPackagesAllIgnoredHidden { // total: ok
+class InputClassDataAbstractionCouplingExcludedPackagesAllIgnoredHidden { // total: ok
     public CClass c = new CClass(); // ok
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingExcludedPackagesCommonPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingExcludedPackagesCommonPackage.java
@@ -1,0 +1,20 @@
+package com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling;
+
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.aa.AAClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.ab.ABClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.b.BClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c.CClass;
+
+public class InputClassDataAbstractionCouplingExcludedPackagesCommonPackage { // total: ok
+    public AAClass aa = new AAClass(); // ok
+    public ABClass ab = new ABClass(); // ok
+
+    class Inner { // total: 2 violations
+        public BClass b = new BClass(); // violation
+        public CClass c = new CClass(); // violation
+    }
+}
+
+class InputClassDataAbstractionCouplingExcludedPackagesCommonPackageHidden { // total: 1 violation
+    public CClass c = new CClass(); // violation
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingExcludedPackagesDirectPackages.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingExcludedPackagesDirectPackages.java
@@ -1,0 +1,20 @@
+package com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling;
+
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.aa.AAClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.ab.ABClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.b.BClass;
+import com.puppycrawl.tools.checkstyle.checks.metrics.inputs.c.CClass;
+
+public class InputClassDataAbstractionCouplingExcludedPackagesDirectPackages { // total: 2 violations
+    public AAClass aa = new AAClass(); // violation
+    public ABClass ab = new ABClass(); // violation
+
+    class Inner { // total: ok
+        public BClass b = new BClass(); // ok
+        public CClass c = new CClass(); // ok
+    }
+}
+
+class InputClassDataAbstractionCouplingExcludedPackagesDirectPackagesHidden { // total: ok
+    public CClass c = new CClass(); // ok
+}


### PR DESCRIPTION

Issue #4575

This PR moves all inputs of ClassDataAbstractionCouplingCheckTest of the metrics package to a new subdirectory 'classdataabstractioncoupling'.