### PR TITLE
Issue #4472: Fix EmptyBlockCheck NPE with annotation default keyword

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
@@ -243,6 +243,7 @@ public class EmptyBlockCheck
         if ((ast.getType() == TokenTypes.LITERAL_CASE
                 || ast.getType() == TokenTypes.LITERAL_DEFAULT)
                 && ast.getNextSibling() != null
+                && ast.getNextSibling().getFirstChild() != null
                 && ast.getNextSibling().getFirstChild().getType() == TokenTypes.SLIST) {
             leftCurly = ast.getNextSibling().getFirstChild();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
@@ -229,4 +229,14 @@ public class EmptyBlockCheckTest
         };
         verify(checkConfig, getPath("InputEmptyBlockDefault.java"), expected);
     }
+
+    @Test
+    public void testAnnotationDefaultKeyword() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(EmptyBlockCheck.class);
+        checkConfig.addAttribute("option", BlockOption.STATEMENT.toString());
+        checkConfig.addAttribute("tokens", "LITERAL_DEFAULT");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        final String path = getPath("InputEmptyBlockAnnotationDefaultKeyword.java");
+        verify(checkConfig, path, expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/InputEmptyBlockAnnotationDefaultKeyword.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/InputEmptyBlockAnnotationDefaultKeyword.java
@@ -1,0 +1,5 @@
+package com.puppycrawl.tools.checkstyle.checks.blocks.emptyblock;
+
+public @interface InputEmptyBlockAnnotationDefaultKeyword {
+    String name() default "";
+}


### PR DESCRIPTION
Issue #4472 

---------

Diffs with `LITERAL_DEFAULT`: https://soon-checkstyle-diffs.github.io/issue-4472-npe/index.html

Diffs with default module properties: https://soon-checkstyle-diffs.github.io/issue-4472/index.html