### PR TITLE
Issue #4394: increase coverage of pitest-checkstyle-api-filters profile to 90%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2106,6 +2106,10 @@
                 <param>com.puppycrawl.tools.checkstyle.grammars.comments.CommentsTest</param>
                 <param>com.puppycrawl.tools.checkstyle.filefilters.*</param>
                 <param>com.puppycrawl.tools.checkstyle.filters.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheckTest</param>
               </targetTests>
               <mutationThreshold>84</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -28,7 +28,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 
 import org.apache.commons.beanutils.ConversionException;
+import org.apache.commons.beanutils.ConvertUtilsBean;
+import org.apache.commons.beanutils.Converter;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DefaultContext;
@@ -131,6 +134,29 @@ public class AutomaticBeanTest {
         }
         catch (IllegalStateException ex) {
             assertEquals("null,wrongVal,0,someValue", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testRegisterIntegralTypes() throws Exception {
+        final ConvertUtilsBeanStub convertUtilsBean = new ConvertUtilsBeanStub();
+        Whitebox.invokeMethod(AutomaticBean.class, "registerIntegralTypes", convertUtilsBean);
+        assertEquals("Number of converters registered differs from expected",
+                81, convertUtilsBean.getRegisterCount());
+    }
+
+    private static class ConvertUtilsBeanStub extends ConvertUtilsBean {
+
+        private int registerCount;
+
+        @Override
+        public void register(Converter converter, Class<?> clazz) {
+            super.register(converter, clazz);
+            registerCount++;
+        }
+
+        public int getRegisterCount() {
+            return registerCount;
         }
     }
 


### PR DESCRIPTION
Issue #4394

[pitest-checkstyle-api-filters profile before changes](https://nimfadora.github.io/issue4394.html)

increased mutation threshold for pitest-checkstyle-api-filters profile by 6%
current threshold: 90%
execution time: 18:23 min