### PR TITLE
Issue #4606: Support parameter imports for block-level javadoc tags

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -248,15 +249,15 @@ public class UnusedImportsCheck extends AbstractCheck {
      */
     private static Set<String> collectReferencesFromJavadoc(TextBlock textBlock) {
         final Set<String> references = new HashSet<>();
-        // process all the @link type tags
+        final List<JavadocTag> tags = new ArrayList<>();
+        // gather all the inline tags, like @link
         // INLINE tags inside BLOCKs get hidden when using ALL
-        getValidTags(textBlock, JavadocUtils.JavadocTagType.INLINE).stream()
+        tags.addAll(getValidTags(textBlock, JavadocUtils.JavadocTagType.INLINE));
+        // gather all the block-level tags, like @throws and @see
+        tags.addAll(getValidTags(textBlock, JavadocUtils.JavadocTagType.BLOCK));
+        tags.stream()
             .filter(JavadocTag::canReferenceImports)
             .forEach(tag -> references.addAll(processJavadocTag(tag)));
-        // process all the @throws type tags
-        getValidTags(textBlock, JavadocUtils.JavadocTagType.BLOCK).stream()
-            .filter(JavadocTag::canReferenceImports)
-            .forEach(tag -> references.addAll(matchPattern(tag.getFirstArg(), FIRST_CLASS_NAME)));
         return references;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -114,6 +114,13 @@ public class UnusedImportsCheckTest extends BaseCheckTestSupport {
     }
 
     @Test
+    public void testProcessJavadocWithBlockTagContainingMethodParameters() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(UnusedImportsCheck.class);
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputUnusedImportWithBlockMethodParameters.java"), expected);
+    }
+
+    @Test
     public void testAnnotations() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(UnusedImportsCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportWithBlockMethodParameters.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportWithBlockMethodParameters.java
@@ -1,0 +1,15 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.util.Collection;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class InputUnusedImportWithBlockMethodParameters {
+
+/**
+ * @see ExecutorService#invokeAll(Collection, long, TimeUnit)
+ */
+    public int calculate() {
+        return 0;
+    }
+}


### PR DESCRIPTION
This fixes issue #4606. 

I understand that `UnusedImportsCheck` needs to be rewritten to parse javadoc correctly. However, this fix is small and there is an included test that can be used to verify the rewrite.

I created a new input test file and test method in `UnusedImportsCheckTest`. If you prefer, I can just add the problem `@see` tag into `InputUnusedImports.java`.