### PR TITLE
Issue #4398: increase coverage of pitest-checkstyle-tree-walker profile to 94%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2078,7 +2078,13 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.sizes.*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.whitespace.*</param>
               </targetTests>
-              <mutationThreshold>89</mutationThreshold>
+              <excludedMethods>
+                <!-- destroy in TreeWalker was added in case module had to free up resources before ending,
+                but currently it does nothing, so we cannot check it. If we remove this destroy we would have
+                to remove all of them as they are chained together, so we just exclude it from pitest check. -->
+                <param>destroy</param>
+              </excludedMethods>
+              <mutationThreshold>94</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -628,7 +628,6 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
         slComment.setLineNo(token.getLine());
 
         final DetailAST slCommentContent = new DetailAST();
-        slCommentContent.initialize(token);
         slCommentContent.setType(TokenTypes.COMMENT_CONTENT);
 
         // column counting begins from 0
@@ -656,7 +655,6 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
         blockComment.setLineNo(token.getLine());
 
         final DetailAST blockCommentContent = new DetailAST();
-        blockCommentContent.initialize(token);
         blockCommentContent.setType(TokenTypes.COMMENT_CONTENT);
 
         // column counting begins from 0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/InputTreeWalkerHiddenComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/InputTreeWalkerHiddenComments.java
@@ -1,0 +1,13 @@
+package com.puppycrawl.tools.checkstyle;
+
+/**
+ * Some Javadoc.
+ *
+ * <p>{@code function} will never be invoked with a null value.
+ *
+ * @since 8.0
+ */
+public class InputTreeWalkerHiddenComments {
+
+}
+// inline comment


### PR DESCRIPTION
Issue #4398

increased mutation threshold for pitest-checkstyle-tree-walker by 5%
threshold: 94%
execution time: 10:31 min

[pitest report before changes for package](https://nimfadora.github.io/issue4398.html)