### PR TITLE
Issue #4399: increase coverage of pitest-checkstyle-main profile to 99%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2032,7 +2032,24 @@
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.MainTest</param>
               </targetTests>
-              <mutationThreshold>93</mutationThreshold>
+              <excludedMethods>
+                <!-- till https://github.com/checkstyle/checkstyle/issues/4399 -->
+                <param>main</param>
+                <!-- till https://github.com/checkstyle/checkstyle/issues/4399 -->
+                <param>createListener</param>
+              </excludedMethods>
+              <avoidCallsTo>
+                <!-- till https://github.com/checkstyle/checkstyle/issues/4399 -->
+                <avoidCallsTo>com.google.common.io.Closeables</avoidCallsTo>
+                <!-- till https://github.com/checkstyle/checkstyle/issues/4399 -->
+                <avoidCallsTo>com.puppycrawl.tools.checkstyle.utils.CommonUtils</avoidCallsTo>
+                <!-- till https://github.com/checkstyle/checkstyle/issues/4399 -->
+                <avoidCallsTo>com.puppycrawl.tools.checkstyle.api.RootModule</avoidCallsTo>
+                <!-- add default suppressions -->
+                <avoidCallsTo>org.apache.commons.logging</avoidCallsTo>
+                <avoidCallsTo>java.util.logging</avoidCallsTo>
+              </avoidCallsTo>
+              <mutationThreshold>100</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>
@@ -2113,7 +2130,7 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheckTest</param>
               </targetTests>
-              <mutationThreshold>84</mutationThreshold>
+              <mutationThreshold>90</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION
Issue #4399
Futher to out conversation with @romani, this pull request suppresses all mutations (that can be suppressed) for pitest-checkstyle-main profile, so that later fix and remove suppressions.

Now the situation with main profile is as follows: [report](https://nimfadora.github.io/issue4399.html)

problems: 
1) [here](https://nimfadora.github.io/pr/com.puppycrawl.tools.checkstyle/Main.java.html#org.pitest.mutationtest.report.html.SourceFile@15e7538c_213) 
Original:
errorCounter != 0 && !cliViolations
I have tried many variants: 
errorCounter == 0 && !cliViolations
errorCounter == 0 && cliViolations
errorCounter != 0 && cliViolations
!(errorCounter != 0 && !cliViolations)
!(errorCounter == 0 && !cliViolations)
!(errorCounter == 0 && cliViolations)
!(errorCounter != 0 && cliViolations)
All of them were killed by our tests, so I don't understand why in pitest they are survived. 
2) All other cases except [this one](https://nimfadora.github.io/pr/com.puppycrawl.tools.checkstyle/Main.java.html#org.pitest.mutationtest.report.html.SourceFile@15e7538c_493) are connected to different ways of closing IO streams. I can test them with PowerMock, but as it uses reflection it is in a conflict with [this](https://github.com/checkstyle/checkstyle/blob/master/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java#L150) Main test. They cannot coexist, one of them fails when I try to fix another.


