### PR TITLE
Issue #4592: Added AbstractPathTestSupport and CheckstyleAntTaskTest, SuppressionsLoaderTest now extends from it

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractPathTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractPathTestSupport.java
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.io.File;
+import java.io.IOException;
+
+public abstract class AbstractPathTestSupport {
+    /**
+     * Returns the exact location for the package where the file is present.
+     * @return path for the package name for the file.
+     */
+    protected abstract String getPackageLocation();
+
+    /**
+     * Returns canonical path for the file with the given file name.
+     * The path is formed base on the root location.
+     * This implementation uses 'src/test/resources/'
+     * as a root location.
+     * @param filename file name.
+     * @return canonical path for the file name.
+     * @throws IOException if I/O exception occurs while forming the path.
+     */
+    protected String getPath(String filename) throws IOException {
+        return new File("src/test/resources/" + getPackageLocation() + "/" + filename)
+                .getCanonicalPath();
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -58,7 +58,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.google.common.io.Closeables;
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
 import com.puppycrawl.tools.checkstyle.CheckerStub;
 import com.puppycrawl.tools.checkstyle.DefaultLogger;
 import com.puppycrawl.tools.checkstyle.Definitions;
@@ -70,21 +70,25 @@ import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({CheckstyleAntTask.class, Closeables.class})
-public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
+public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
 
     private static final String FLAWLESS_INPUT =
-            "/ant/checkstyleanttask/InputCheckstyleAntTaskFlawless.java";
+            "InputCheckstyleAntTaskFlawless.java";
     private static final String VIOLATED_INPUT =
-        "ant/checkstyleanttask/InputCheckstyleAntTaskError.java";
+            "InputCheckstyleAntTaskError.java";
     private static final String WARNING_INPUT =
-        "ant/checkstyleanttask/InputCheckstyleAntTaskWarning.java";
+            "InputCheckstyleAntTaskWarning.java";
     private static final String CONFIG_FILE =
-            "ant/checkstyleanttask/InputCheckstyleAntTaskTestChecks.xml";
-    private static final String CONFIG_RESOURCE = "/com/puppycrawl/tools/checkstyle/" + CONFIG_FILE;
+            "InputCheckstyleAntTaskTestChecks.xml";
     private static final String CUSTOM_ROOT_CONFIG_FILE =
-        "ant/checkstyleanttask/InputCheckstyleAntTaskConfigCustomRootModule.xml";
+            "InputCheckstyleAntTaskConfigCustomRootModule.xml";
     private static final String NOT_EXISTING_FILE = "target/not_existing.xml";
     private static final String FAILURE_PROPERTY_VALUE = "myValue";
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/ant/checkstyleanttask/";
+    }
 
     private CheckstyleAntTask getCheckstyleAntTask() throws IOException {
         return getCheckstyleAntTask(CONFIG_FILE);
@@ -181,7 +185,7 @@ public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
         antTask.setProject(new Project());
 
         final FileResource fileResource = new FileResource(
-            antTask.getProject(), getPath("ant/checkstyleanttask/"));
+            antTask.getProject(), getPath(""));
         final Path sourcePath = new Path(antTask.getProject());
         sourcePath.add(fileResource);
         antTask.addPath(sourcePath);
@@ -265,7 +269,7 @@ public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
     @Test
     public final void testEmptyConfigFile() throws IOException {
         final CheckstyleAntTask antTask = new CheckstyleAntTask();
-        antTask.setConfig(getPath("ant/InputCheckstyleAntTaskEmptyConfig.xml"));
+        antTask.setConfig(getPath("InputCheckstyleAntTaskEmptyConfig.xml"));
         antTask.setProject(new Project());
         antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
         try {
@@ -430,7 +434,7 @@ public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
     public final void testConfigurationByResource() throws IOException {
         final CheckstyleAntTask antTask = new CheckstyleAntTask();
         antTask.setProject(new Project());
-        antTask.setConfig(CONFIG_RESOURCE);
+        antTask.setConfig(getPath(CONFIG_FILE));
         antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
 
         final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
@@ -477,8 +481,8 @@ public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
 
         final CheckstyleAntTask antTask = getCheckstyleAntTask(CUSTOM_ROOT_CONFIG_FILE);
         antTask.setFile(new File(getPath(VIOLATED_INPUT)));
-        antTask.setProperties(new File(getPath("ant/checkstyleanttask/"
-                + "InputCheckstyleAntTaskCheckstyleAntTest.properties")));
+        antTask.setProperties(new File(getPath(
+                "InputCheckstyleAntTaskCheckstyleAntTest.properties")));
         antTask.execute();
 
         assertEquals("Property is not set",
@@ -517,7 +521,7 @@ public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
         antTask.execute();
 
         final List<String> expected = FileUtils.readLines(
-                new File(getPath("ant/checkstyleanttask/InputCheckstyleAntTaskXmlOutput.xml")));
+                new File(getPath("InputCheckstyleAntTaskXmlOutput.xml")));
         final List<String> actual = FileUtils.readLines(outputFile);
         for (int i = 0; i < expected.size(); i++) {
             final String line = expected.get(i);
@@ -591,7 +595,7 @@ public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
 
     @Test
     public void testSetFileValueByFile() throws IOException {
-        final String filename = getPath("ant/InputCheckstyleAntTaskCheckstyleAntTest.properties");
+        final String filename = getPath("InputCheckstyleAntTaskCheckstyleAntTest.properties");
         final CheckstyleAntTask.Property property = new CheckstyleAntTask.Property();
         property.setFile(new File(filename));
         assertEquals("File path is unexpected",
@@ -727,8 +731,8 @@ public class CheckstyleAntTaskTest extends BaseCheckTestSupport {
         CheckerStub.reset();
 
         final CheckstyleAntTask antTask =
-                getCheckstyleAntTask("ant/checkstyleanttask/"
-                        + "InputCheckstyleAntTaskConfigCustomCheckerRootModule.xml");
+                getCheckstyleAntTask(
+                        "InputCheckstyleAntTaskConfigCustomCheckerRootModule.xml");
         antTask.setFile(new File(getPath(VIOLATED_INPUT)));
 
         antTask.execute();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -36,7 +36,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.xml.sax.InputSource;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FilterSet;
 
@@ -47,18 +47,17 @@ import com.puppycrawl.tools.checkstyle.api.FilterSet;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ SuppressionsLoader.class, SuppressionsLoaderTest.class })
-public class SuppressionsLoaderTest extends BaseCheckTestSupport {
+public class SuppressionsLoaderTest extends AbstractPathTestSupport {
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 
     @Override
-    protected String getPath(String filename) {
-        return "src/test/resources/com/puppycrawl/tools/checkstyle/filters/" + filename;
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/filters";
     }
 
     @Test
-    public void testNoSuppressions()
-            throws CheckstyleException {
+    public void testNoSuppressions() throws Exception {
         final FilterSet fc =
             SuppressionsLoader.loadSuppressions(getPath("suppressions_none.xml"));
         final FilterSet fc2 = new FilterSet();
@@ -114,8 +113,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testMultipleSuppression()
-            throws CheckstyleException {
+    public void testMultipleSuppression() throws Exception {
         final FilterSet fc =
             SuppressionsLoader.loadSuppressions(getPath("suppressions_multiple.xml"));
         final FilterSet fc2 = new FilterSet();
@@ -139,7 +137,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testNoFile() {
+    public void testNoFile() throws IOException {
         final String fn = getPath("suppressions_no_file.xml");
         try {
             SuppressionsLoader.loadSuppressions(fn);
@@ -156,7 +154,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testNoCheck() {
+    public void testNoCheck() throws IOException {
         final String fn = getPath("suppressions_no_check.xml");
         try {
             SuppressionsLoader.loadSuppressions(fn);
@@ -173,7 +171,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testBadInt() {
+    public void testBadInt() throws IOException {
         final String fn = getPath("suppressions_bad_int.xml");
         try {
             SuppressionsLoader.loadSuppressions(fn);
@@ -259,7 +257,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testNoCheckNoId() {
+    public void testNoCheckNoId() throws IOException {
         final String fn = getPath("suppressions_no_check_and_id.xml");
         try {
             SuppressionsLoader.loadSuppressions(fn);
@@ -280,7 +278,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testInvalidFileFormat() {
+    public void testInvalidFileFormat() throws IOException {
         final String fn = getPath("suppressions_invalid_file.xml");
         try {
             SuppressionsLoader.loadSuppressions(fn);
@@ -293,8 +291,7 @@ public class SuppressionsLoaderTest extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testLoadFromClasspath()
-            throws CheckstyleException {
+    public void testLoadFromClasspath() throws Exception {
         final FilterSet fc =
             SuppressionsLoader.loadSuppressions(getPath("suppressions_none.xml"));
         final FilterSet fc2 = new FilterSet();


### PR DESCRIPTION
Issue #4592 

This PR adds a new class `AbstractPathTestSupport` which contains two methods `getPath(String filename)` and `abstract getPackageLocation()`. `CheckstyleAntTaskTest` and `SuppressionsLoaderTest` no longer extends BaseCheckTestSupport but instead uses this abstract class. This removes the file from the hierarchy.