### PR TITLE
Issue #4586: Moved resources for the JavadocStyle check test

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -42,7 +42,8 @@ public class JavadocStyleCheckTest
     @Override
     protected String getPath(String filename) throws IOException {
         return super.getPath("checks" + File.separator
-                + "javadoc" + File.separator + filename);
+                + "javadoc" + File.separator
+                + "javadocstyle" + File.separator + filename);
     }
 
     @Test
@@ -198,7 +199,7 @@ public class JavadocStyleCheckTest
         final DefaultConfiguration checkConfig = createCheckConfig(JavadocStyleCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputNoJavadoc.java"), expected);
+        verify(checkConfig, getPath("InputJavadocStyleNoJavadoc.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/bothfiles/InputIgnored.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/bothfiles/InputIgnored.java
@@ -1,5 +1,0 @@
-package com.puppycrawl.tools.checkstyle.checks.javadoc.bothfiles;
-
-class InputIgnored
-{
-}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/bothfiles/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/bothfiles/package-info.java
@@ -1,1 +1,0 @@
-package com.puppycrawl.tools.checkstyle.checks.javadoc.bothfiles;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/bothfiles/package.html
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/bothfiles/package.html
@@ -1,1 +1,0 @@
-Ignored

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyle.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyle.java
@@ -3,7 +3,7 @@
 // Created: 2003
 ////////////////////////////////////////////////////////////////////////////////
 
-package com.puppycrawl.tools.checkstyle.checks.javadoc;
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle;
 
 /**
  * Test input for the JavadocStyleCheck.  This check is used to perform 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleHtmlComment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleHtmlComment.java
@@ -3,7 +3,7 @@
 // Created: 2014
 ////////////////////////////////////////////////////////////////////////////////
 
-package com.puppycrawl.tools.checkstyle.checks.javadoc;
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle;
 
 /**
  * Test input for the JavadocStyleCheck.  This check is used to perform 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleNoJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleNoJavadoc.java
@@ -1,0 +1,120 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle;
+
+public class InputJavadocStyleNoJavadoc //comment test
+{
+    public int i1;
+    protected int i2;
+    int i3;
+    private int i4;
+
+    public void foo1() {}
+    protected void foo2() {}
+    void foo3() {}
+    private void foo4() {}
+
+    protected class ProtectedInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    class PackageInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    private class PrivateInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+}
+
+class PackageClass {
+    public int i1;
+    protected int i2;
+    int i3;
+    private int i4;
+
+    public void foo1() {}
+    protected void foo2() {}
+    void foo3() {}
+    private void foo4() {}
+
+    public class PublicInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    protected class ProtectedInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    class PackageInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    private class PrivateInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {}
+        protected void foo2() {}
+        void foo3() {}
+        private void foo4() {}
+    }
+
+    class IgnoredName {
+        // ignore by name
+        private int logger;
+        // no warning, 'serialVersionUID' fields do not require Javadoc
+        private static final long serialVersionUID = 0;
+    }
+
+    /**/
+    void methodWithTwoStarComment() {}
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/bothfiles/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/bothfiles/package-info.java
@@ -1,0 +1,1 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle.bothfiles;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/pkginfo/annotation/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/pkginfo/annotation/package-info.java
@@ -1,11 +1,12 @@
 /**
  * This is a valid package documentation.  <--- See the period after the
  * first sentence.
- * 
+ *
  * <p>
  * hurray for javadocs in html
  * <br>
  * with a legacy non-closed br element
  * </p>
  */
-package com.puppycrawl.tools.checkstyle.checks.javadoc.pkginfo.valid;
+@Deprecated
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle.pkginfo.annotation;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/pkginfo/invalidformat/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/pkginfo/invalidformat/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * blah blah
+ */
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle.pkginfo.invalidformat;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/pkginfo/invalidinherit/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/pkginfo/invalidinherit/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * {@inheritDoc} Where are we inheriting from
+ */
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle.pkginfo.invalidinherit;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/pkginfo/valid/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/pkginfo/valid/package-info.java
@@ -1,12 +1,11 @@
 /**
  * This is a valid package documentation.  <--- See the period after the
  * first sentence.
- *
+ * 
  * <p>
  * hurray for javadocs in html
  * <br>
  * with a legacy non-closed br element
  * </p>
  */
-@Deprecated
-package com.puppycrawl.tools.checkstyle.checks.javadoc.pkginfo.annotation;
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle.pkginfo.valid;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/pkginfo/invalidformat/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/pkginfo/invalidformat/package-info.java
@@ -1,4 +1,0 @@
-/**
- * blah blah
- */
-package com.puppycrawl.tools.checkstyle.checks.javadoc.pkginfo.invalidformat;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/pkginfo/invalidinherit/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/pkginfo/invalidinherit/package-info.java
@@ -1,4 +1,0 @@
-/**
- * {@inheritDoc} Where are we inheriting from
- */
-package com.puppycrawl.tools.checkstyle.checks.javadoc.pkginfo.invalidinherit;


### PR DESCRIPTION
Issue #4586 :
1.Copied&Renamed `InputNojavadoc` to the javadocstyle subdirectory.Because it was used by the other check test.

2.Moved&Renamed the remianing resources for JavadocStyleCheck to the javadocstyle subdirectory.