### PR TITLE
Issue #2883: Remove `cache` field from TreeWalker in Checkstyle 8.0

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -106,19 +106,6 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
     }
 
     /**
-     * Sets cache file.
-     * @deprecated Use {@link Checker#setCacheFile} instead. It does not do anything now. We just
-     *             keep the setter for transition period to the same option in Checker. The
-     *             method will be completely removed in Checkstyle 8.0. See
-     *             <a href="https://github.com/checkstyle/checkstyle/issues/2883">issue#2883</a>
-     * @param fileName the cache file
-     */
-    @Deprecated
-    public void setCacheFile(String fileName) {
-        // Deprecated
-    }
-
-    /**
      * Sets classLoader to load class.
      * @param classLoader class loader to resolve classes with.
      */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -150,7 +150,6 @@ public class TreeWalkerTest extends BaseCheckTestSupport {
         final DefaultConfiguration config = new DefaultConfiguration("default config");
         treeWalker.setTabWidth(1);
         treeWalker.configure(config);
-        treeWalker.setCacheFile(temporaryFolder.newFile().getPath());
 
         assertEquals("Invalid setter result", 1,
             Whitebox.getInternalState(treeWalker, "tabWidth"));


### PR DESCRIPTION
#2883 