### PR TITLE
Issue #4700: Remove redundant sync for synchronizedMap (Intelllij inspection violations)

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -2054,7 +2054,7 @@
         <option name="reportLocalVariables" value="true" />
         <option name="reportMethodParameters" value="true" />
     </inspection_tool>
-    <inspection_tool class="SynchronizationOnStaticField" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="SynchronizationOnStaticField" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="SynchronizeOnLock" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SynchronizeOnNonFinalField" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="SynchronizeOnThis" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -239,9 +239,7 @@ public final class LocalizedMessage
 
     /** Clears the cache. */
     public static void clearCache() {
-        synchronized (BUNDLE_CACHE) {
-            BUNDLE_CACHE.clear();
-        }
+        BUNDLE_CACHE.clear();
     }
 
     /**
@@ -295,16 +293,8 @@ public final class LocalizedMessage
      * @return a ResourceBundle
      */
     private ResourceBundle getBundle(String bundleName) {
-        synchronized (BUNDLE_CACHE) {
-            ResourceBundle resourceBundle = BUNDLE_CACHE
-                    .get(bundleName);
-            if (resourceBundle == null) {
-                resourceBundle = ResourceBundle.getBundle(bundleName, sLocale,
-                        sourceClass.getClassLoader(), new Utf8Control());
-                BUNDLE_CACHE.put(bundleName, resourceBundle);
-            }
-            return resourceBundle;
-        }
+        return BUNDLE_CACHE.computeIfAbsent(bundleName, name -> ResourceBundle.getBundle(
+                name, sLocale, sourceClass.getClassLoader(), new Utf8Control()));
     }
 
     /**


### PR DESCRIPTION
 #4700 

The `BUNDLE_CACHE` is defined as follows:

    private static final Map<String, ResourceBundle> BUNDLE_CACHE =
        Collections.synchronizedMap(new HashMap<>());

Therefore, additional `synchronized` blocks are redundant as long as we're doing all work inside the same method (see `getBundle` changes).