### PR TITLE
Issue #4456: Disallowing user to use incomplete fully qualified Check…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -170,14 +170,14 @@ public class PackageObjectFactory implements ModuleFactory {
         if (instance == null) {
             instance = createObject(name);
         }
-        final String nameCheck = name + CHECK_SUFFIX;
         if (instance == null) {
-            instance = createObject(nameCheck);
-        }
-        if (instance == null) {
-            final String attemptedNames = joinPackageNamesWithClassName(name, packages)
-                    + STRING_SEPARATOR + nameCheck + STRING_SEPARATOR
-                    + joinPackageNamesWithClassName(nameCheck, packages);
+            String attemptedNames = null;
+            if (!name.contains(PACKAGE_SEPARATOR)) {
+                final String nameCheck = name + CHECK_SUFFIX;
+                attemptedNames = joinPackageNamesWithClassName(name, packages)
+                        + STRING_SEPARATOR + nameCheck + STRING_SEPARATOR
+                        + joinPackageNamesWithClassName(nameCheck, packages);
+            }
             final LocalizedMessage exceptionMessage = new LocalizedMessage(0,
                 Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
                 new String[] {name, attemptedNames}, null, getClass(), null);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -53,7 +53,6 @@ import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
-import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
 
 /**
@@ -122,12 +121,19 @@ public class PackageObjectFactoryTest {
     }
 
     @Test
-    public void testMakeCheckFromName()
-            throws CheckstyleException {
-        final ConstantNameCheck check =
-                (ConstantNameCheck) factory.createModule(
-                        "com.puppycrawl.tools.checkstyle.checks.naming.ConstantName");
-        assertNotNull("Checker should not be null when creating module from name", check);
+    public void testMakeCheckFromName() {
+        final String name = "com.puppycrawl.tools.checkstyle.checks.naming.ConstantName";
+        try {
+            factory.createModule(name);
+            fail("Exception is expected");
+        }
+        catch (CheckstyleException ex) {
+            final LocalizedMessage exceptionMessage = new LocalizedMessage(0,
+                    Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
+                    new String[] {name, null}, null, factory.getClass(), null);
+            assertEquals("Invalid exception message",
+                    exceptionMessage.getMessage(), ex.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
Issue #4456
It seems that some class information are not in  `NAME_TO_FULL_MODULE_NAME` or `thirdPartyNameToFullModuleNames`.
For example，`com.puppycrawl.tools.checkstyle.CheckerTest`.
And my idea is:
1.Add information to `NAME_TO_FULL_MODULE_NAME`  or `TEST_MODULE_NAME`(New)
2.Change method of refactor
Please correct me if I misunderstood.