### PR TITLE
Issue #4725: add inspections passed without violations

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -75,7 +75,7 @@
     <inspection_tool class="AssertEqualsBetweenInconvertibleTypesTestNG" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="AssertEqualsCalledOnArray" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="AssertEqualsMayBeAssertSame" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AssertMessageNotString" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="AssertMessageNotString" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="AssertStatement" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="AssertWithSideEffects" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="AssertsWithoutMessages" enabled="false" level="ERROR" enabled_by_default="false" />
@@ -273,7 +273,7 @@
     </inspection_tool>
     <inspection_tool class="CheckImageSize" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="CheckNodeTest" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CheckStyle" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CheckStyle" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CheckTagEmptyBody" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="CheckValidXmlInScriptTagBody" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CheckXmlFileWithXercesValidator" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -373,7 +373,7 @@
     <inspection_tool class="CoffeeScriptSwitchStatementWithNoDefaultBranch" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="CoffeeScriptUnnecessaryReturn" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="CoffeeScriptUnusedLocalSymbols" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="CollectionAddAllCanBeReplacedWithConstructor" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="CollectionAddAllCanBeReplacedWithConstructor" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="CollectionAddedToSelf" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="CollectionContainsUrl" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CollectionsFieldAccessReplaceableByMethodCall" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -460,6 +460,7 @@
     <inspection_tool class="CovariantEquals" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CriteriaApiResolveInspection" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="CssConvertColorToHexInspection" enabled="true" level="ERROR" enabled_by_default="true" />
+    <!-- we like hex format of color -->
     <inspection_tool class="CssConvertColorToRgbInspection" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="CssFloatPxLength" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="CssInvalidAtRule" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -489,6 +490,7 @@
         </option>
     </inspection_tool>
     <inspection_tool class="CssUnknownTarget" enabled="true" level="WARNING" enabled_by_default="true" />
+    <!-- most found cases are used in xml files that are source for html pages -->
     <inspection_tool class="CssUnusedSymbol" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="CucumberExamplesColon" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CucumberJavaStepDefClassInDefaultPackage" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -510,7 +512,7 @@
     <inspection_tool class="CyclomaticComplexityJS" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="m_limit" value="10" />
     </inspection_tool>
-    <inspection_tool class="DanglingJavadoc" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="DanglingJavadoc" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="DataProviderReturnType" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DateToString" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="DebuggerStatementJS" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -683,7 +685,7 @@
     <inspection_tool class="ExtendsConcreteCollection" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="ExtendsObject" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ExtendsThread" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ExtendsThrowable" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="ExtendsThrowable" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ExtendsUtilityClass" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ExternalizableWithSerializationMethods" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ExternalizableWithoutPublicNoArgConstructor" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -694,7 +696,7 @@
         <option name="ignoreTestCases" value="false" />
     </inspection_tool>
     <inspection_tool class="FieldAccessNotGuarded" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="FieldAccessedSynchronizedAndUnsynchronized" enabled="false" level="ERROR" enabled_by_default="false">
+    <inspection_tool class="FieldAccessedSynchronizedAndUnsynchronized" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="countGettersAndSetters" value="false" />
     </inspection_tool>
     <inspection_tool class="FieldCanBeLocal" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -713,7 +715,7 @@
     <inspection_tool class="FieldMayBeFinal" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="FieldMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="FieldNotUsedInToString" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="FieldRepeatedlyAccessed" enabled="false" level="ERROR" enabled_by_default="false">
+    <inspection_tool class="FieldRepeatedlyAccessed" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="m_ignoreFinalFields" value="false" />
     </inspection_tool>
     <!-- we are library - we do this on purpose as clear signal to users -->
@@ -764,6 +766,7 @@
         <option name="m_maxLength" value="32" />
     </inspection_tool>
     <inspection_tool class="FunctionWithInconsistentReturnsJS" enabled="true" level="ERROR" enabled_by_default="true" />
+    <!-- we do not see a harm from such style -->
     <inspection_tool class="FunctionWithMultipleLoopsJS" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="FunctionWithMultipleReturnPointsJS" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="GherkinBrokenTableInspection" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -949,8 +952,8 @@
     <inspection_tool class="GroovyWhileLoopSpinsOnField" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="ignoreNonEmtpyLoops" value="false" />
     </inspection_tool>
-    <inspection_tool class="Guava" enabled="true" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="GuavaFluentIterable" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="Guava" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="GuavaFluentIterable" enabled="true" level="ERROR" enabled_by_default="true" />
     <!-- we like it, it is not performance issue for us -->
     <inspection_tool class="HardCodedStringLiteral" enabled="false" level="ERROR" enabled_by_default="false" />
     <!-- there are too much false positives in RegExps and javadoc start/end symbols in paths from classpath etc. -->
@@ -997,7 +1000,7 @@
         </option>
         <option name="myCustomValuesEnabled" value="true" />
     </inspection_tool>
-    <inspection_tool class="HtmlUnknownTarget" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="HtmlUnknownTarget" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="IOResource" enabled="true" level="WARNING" enabled_by_default="true">
         <scope name="Production" level="WARNING" enabled="false">
             <option name="ignoredTypesString" value="java.io.ByteArrayOutputStream,java.io.ByteArrayInputStream,java.io.StringBufferInputStream,java.io.CharArrayWriter,java.io.CharArrayReader,java.io.StringWriter,java.io.StringReader" />
@@ -1022,15 +1025,15 @@
     <inspection_tool class="IfThenToElvis" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="IfThenToSafeAccess" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="IgnoreCoverEntry" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="IgnoreDuplicateEntry" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="IgnoreDuplicateEntry" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="IgnoreIncorrectEntry" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="IgnoreRelativeEntry" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="IgnoreRelativeEntry" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="IgnoreResultOfCall" enabled="true" level="WARNING" enabled_by_default="true">
         <option name="m_reportAllNonLibraryCalls" value="false" />
         <option name="callCheckString" value="java.io.InputStream,read|skip|available|markSupported,java.io.Writer,read|skip|ready|markSupported,java.lang.Boolean,.*,java.lang.Byte,.*,java.lang.Character,.*,java.lang.Double,.*,java.lang.Float,.*,java.lang.Long,.*,java.lang.Math,.*,java.lang.Object,equals|hashCode|toString,java.lang.Short,.*,java.lang.StrictMath,.*,java.lang.String,.*,java.math.BigInteger,.*,java.math.BigDecimal,.*,java.net.InetAddress,.*,java.net.URI,.*,java.util.UUID,.*" />
     </inspection_tool>
     <inspection_tool class="IgnoreSyntaxEntry" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="IgnoreUnusedEntry" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="IgnoreUnusedEntry" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="IgnoredJUnitTest" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ImplicitArrayToString" enabled="true" level="ERROR" enabled_by_default="true" />
     <!-- we do not like this style, but we could change our mind in future -->
@@ -1145,6 +1148,7 @@
     <inspection_tool class="JSComparisonWithNaN" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="JSConsecutiveCommasInArrayLiteral" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="JSConstructorReturnsPrimitive" enabled="true" level="ERROR" enabled_by_default="true" />
+    <!-- we like the style when declaration comes close to first usage -->
     <inspection_tool class="JSDeclarationsAtScopeStart" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="JSDeprecatedSymbols" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="JSDuplicatedDeclaration" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -1377,7 +1381,7 @@
         <option name="m_includeLibraryClasses" value="false" />
         <option name="m_limit" value="25" />
     </inspection_tool>
-    <inspection_tool class="MethodMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true">
+    <inspection_tool class="MethodMayBeStatic" enabled="false" level="WARNING" enabled_by_default="false">
         <scope name="Production" level="WARNING" enabled="false">
             <option name="m_onlyPrivateOrFinal" value="false" />
             <option name="m_ignoreEmptyMethods" value="true" />
@@ -1388,8 +1392,8 @@
     <inspection_tool class="MethodMayBeSynchronized" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="MethodNameSameAsClassName" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="MethodNameSameAsParentName" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MethodNamesDifferOnlyByCase" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="MethodOnlyUsedFromInnerClass" enabled="false" level="ERROR" enabled_by_default="false">
+    <inspection_tool class="MethodNamesDifferOnlyByCase" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="MethodOnlyUsedFromInnerClass" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="ignoreMethodsAccessedFromAnonymousClass" value="false" />
         <option name="ignoreStaticMethodsFromNonStaticInnerClass" value="false" />
         <option name="onlyReportStaticMethods" value="false" />
@@ -1617,12 +1621,12 @@
     <inspection_tool class="PackageDotHtmlMayBePackageInfo" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="PackageInMultipleModules" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="PackageInfoWithoutPackage" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PackageNamingConvention" enabled="true" level="WARNING" enabled_by_default="false">
+    <inspection_tool class="PackageNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
         <option name="m_regex" value="[a-z0-9\.]*" />
         <option name="m_minLength" value="3" />
         <option name="m_maxLength" value="100" />
     </inspection_tool>
-    <inspection_tool class="PackageVisibleField" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="PackageVisibleField" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="PackageVisibleInnerClass" enabled="true" level="WARNING" enabled_by_default="true">
         <option name="ignoreEnums" value="false" />
         <option name="ignoreInterfaces" value="false" />
@@ -1755,7 +1759,7 @@
         <option name="ignoreSerializable" value="false" />
         <option name="ignoreCloneable" value="false" />
     </inspection_tool>
-    <inspection_tool class="RedundantMethodOverride" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="RedundantMethodOverride" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="RedundantScopeBinding" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="RedundantStringFormatCall" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="RedundantSuppression" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -1790,7 +1794,7 @@
     <inspection_tool class="RequiredBeanTypeInspection" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ReservedWordUsedAsNameJS" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="RestWrongDefaultValueInspection" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="false" level="WARNING" enabled_by_default="true">
+    <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
         <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
     <inspection_tool class="ResultSetIndexZero" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -1980,7 +1984,7 @@
     </inspection_tool>
     <!-- we are a library, not used by us heavily does not mean that is not required -->
     <inspection_tool class="StaticMethodOnlyUsedInOneClass" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="StaticNonFinalField" enabled="false" level="WARNING" enabled_by_default="true">
+    <inspection_tool class="StaticNonFinalField" enabled="true" level="WARNING" enabled_by_default="true">
         <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
     <inspection_tool class="StaticPseudoFunctionalStyleMethod" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -2347,7 +2351,7 @@
     <inspection_tool class="UnusedLabel" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="UnusedMessageFormatParameter" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="UnusedParameters" enabled="true" level="WARNING" enabled_by_default="true">
-        <scope name="Production" level="WARNING" enabled="false" />
+        <scope name="Production" level="WARNING" enabled="true" />
     </inspection_tool>
     <inspection_tool class="UnusedProperty" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="UnusedReceiverParameter" enabled="true" level="ERROR" enabled_by_default="true" />


### PR DESCRIPTION
Issue #4725

enabled such inspections:
AssertMessageNotString
CheckStyle
CollectionAddAllCanBeReplacedWithConstructor
CssConvertColorToRgbInspection
CssUnusedSymbol
DanglingJavadoc
ExtendsThrowable
FieldAccessedSynchronizedAndUnsynchronized
FieldRepeatedlyAccessed
FunctionWithMultipleLoopsJS
Guava
GuavaFluentIterable
HtmlUnknownTarget
IgnoreDuplicateEntry
IgnoreRelativeEntry
IgnoreUnusedEntry
JSDeclarationsAtScopeStart
MethodNamesDifferOnlyByCase
MethodOnlyUsedFromInnerClass
PackageNamingConvention
PackageVisibleField
RedundantMethodOverride
ResultOfObjectAllocationIgnored
StaticNonFinalField
UnusedParameters
