### PR TITLE
Issue #4592: Added AbstractTreeTestSupport and JavadocParseTreeTest, AstTreeStringPrinterTest now extend from it

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractTreeTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractTreeTestSupport.java
@@ -1,0 +1,116 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public abstract class AbstractTreeTestSupport extends AbstractPathTestSupport {
+
+    protected static final String LF_REGEX = "\\\\n";
+
+    protected static final String CLRF_REGEX = "\\\\r\\\\n";
+
+    /**
+     * Returns canonical path for the file with the given file name.
+     * The path is formed base on the non-compilable resources location.
+     * This implementation uses 'src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/'
+     * as a non-compilable resource location.
+     * @param filename file name.
+     * @return canonical path for the file with the given file name.
+     * @throws IOException if I/O exception occurs while forming the path.
+     */
+    protected final String getNonCompilablePath(String filename) throws IOException {
+        return new File("src/test/resources-noncompilable/" + getPackageLocation()
+                + filename).getCanonicalPath();
+    }
+
+    /**
+     * Performs verification of the given text ast tree representation.
+     * @param expectedTextPrintFileName expected text ast tree representation.
+     * @param actualJavaFileName actual text ast tree representation.
+     * @param withComments whether to perform verification of comment nodes in tree.
+     * @throws Exception if exception occurs during verification.
+     */
+    protected static void verifyAst(String expectedTextPrintFileName, String actualJavaFileName,
+                                    boolean withComments) throws Exception {
+        final String expectedContents = readFile(expectedTextPrintFileName);
+
+        final String actualContents = AstTreeStringPrinter.printFileAst(
+                new File(actualJavaFileName), withComments).replaceAll(CLRF_REGEX, LF_REGEX);
+
+        assertEquals("Generated AST from Java file should match pre-defined AST", expectedContents,
+                actualContents);
+    }
+
+    /**
+     * Verifies the java and javadoc AST generated for the supplied java file against
+     * the expected AST in supplied text file.
+     * @param expectedTextPrintFilename name of the file having the expected ast.
+     * @param actualJavaFilename name of the java file.
+     * @throws Exception if exception occurs during verification.
+     */
+    protected static void verifyJavaAndJavadocAst(String expectedTextPrintFilename,
+                                                  String actualJavaFilename) throws Exception {
+
+        final String expectedContents = readFile(expectedTextPrintFilename);
+
+        final String actualContents = AstTreeStringPrinter.printJavaAndJavadocTree(
+                new File(actualJavaFilename)).replaceAll(CLRF_REGEX, LF_REGEX);
+
+        assertEquals("Generated AST from the java file should match the pre-defined AST",
+                expectedContents, actualContents);
+    }
+
+    /**
+     * Verifies the javadoc tree generated for the supplied javadoc file against the expected tree
+     * in the supplied text file.
+     * @param expectedTextPrintFilename name of the text file having the expected tree.
+     * @param actualJavadocFilename name of the file containing the javadoc.
+     * @throws Exception if exception occurs during verification.
+     */
+    protected static void verifyJavadocTree(String expectedTextPrintFilename,
+                                            String actualJavadocFilename) throws Exception {
+
+        final String expectedContents = readFile(expectedTextPrintFilename);
+
+        final String actualContents = DetailNodeTreeStringPrinter.printFileAst(
+                new File(actualJavadocFilename)).replaceAll(CLRF_REGEX, LF_REGEX);
+
+        assertEquals("Generated tree from the javadoc file should match the pre-defined tree",
+                expectedContents, actualContents);
+    }
+
+    /** Reads the contents of a file.
+     * @param filename the name of the file whose contents are to be read
+     * @return contents of the file with all {@code \r\n} replaced by {@code \n}
+     * @throws IOException if I/O exception occurs while reading
+     */
+    protected static String readFile(String filename) throws IOException {
+        return new String(Files.readAllBytes(
+                Paths.get(filename)), StandardCharsets.UTF_8)
+                .replaceAll(CLRF_REGEX, LF_REGEX);
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle;
 import static com.puppycrawl.tools.checkstyle.internal.TestUtils.assertUtilsClassHasPrivateConstructor;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -34,16 +33,11 @@ import antlr.NoViableAltException;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 
-public class AstTreeStringPrinterTest extends BaseCheckTestSupport {
+public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
 
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("astprinter" + File.separator + filename);
-    }
-
-    @Override
-    protected String getNonCompilablePath(String filename) throws IOException {
-        return super.getNonCompilablePath("astprinter" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/astprinter/";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParseTreeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParseTreeTest.java
@@ -24,13 +24,13 @@ import java.io.IOException;
 
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractTreeTestSupport;
 
-public class JavadocParseTreeTest extends BaseCheckTestSupport {
+public class JavadocParseTreeTest extends AbstractTreeTestSupport {
 
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator + "javadoc" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars/javadoc/";
     }
 
     private String getHtmlPath(String filename) throws IOException {


### PR DESCRIPTION
Issue #4592

This PR adds a new class AbstractTreeTestSupport which contains methods necessary for processing UTs for Tree tests. JavadocParseTreeTest and AstTreeStringPrinterTest no longer extends BaseCheckTestSupport but instead uses this abstract class. This removes the file from the hierarchy.