### PR TITLE
Issue #4394: increase coverage of pitest-checkstyle-api profile to 100%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2206,7 +2206,7 @@
                 <!--cause of https://github.com/checkstyle/checkstyle/issues/3605-->
                 <avoidCallsTo>com.puppycrawl.tools.checkstyle.api.AbstractLoader$FeaturesForVerySecureJavaInstallations</avoidCallsTo>
               </avoidCallsTo>
-              <mutationThreshold>96</mutationThreshold>
+              <mutationThreshold>100</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
@@ -19,13 +19,22 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import com.google.common.collect.ImmutableMap;
 
 public class FileContentsTest {
 
@@ -56,6 +65,91 @@ public class FileContentsTest {
                 new FileText(new File("filename"), Collections.singletonList("  //   ")));
         fileContents.reportSingleLineComment(1, 2);
         assertTrue(fileContents.hasIntersectionWithComment(1, 5, 1, 6));
+    }
 
+    @Test
+    public void testReportCppComment() {
+        final FileContents fileContents = new FileContents(
+                new FileText(new File("filename"), Collections.singletonList("   //  ")));
+        fileContents.reportCppComment(1, 2);
+        final Map<Integer, TextBlock> cppComments = fileContents.getCppComments();
+
+        assertEquals(new Comment(new String[] {"// "}, 2, 1, 6).toString(),
+                cppComments.get(1).toString());
+    }
+
+    @Test
+    public void testHasIntersectionWithSingleLineComment() {
+        final FileContents fileContents = new FileContents(
+                new FileText(new File("filename"), Arrays.asList("     ", "  //test   ",
+                        "  //test   ", "  //test   ")));
+        fileContents.reportCppComment(4, 4);
+
+        assertTrue(fileContents.hasIntersectionWithComment(1, 3, 4, 6));
+    }
+
+    @Test
+    public void testReportComment() {
+        final FileContents fileContents = new FileContents(
+                new FileText(new File("filename"), Collections.singletonList("  //   ")));
+        fileContents.reportCComment(1, 2, 1, 2);
+        final ImmutableMap<Integer, List<TextBlock>> comments = fileContents.getCComments();
+
+        assertEquals(new Comment(new String[] {"// "}, 2, 1, 2).toString(),
+                comments.get(1).get(0).toString());
+    }
+
+    @Test
+    public void testHasIntersectionWithBlockComment() {
+        final FileContents fileContents = new FileContents(new FileText(new File("filename"),
+                        Arrays.asList("  /* */    ", "    ", "  /* test   ", "  */  ", "   ")));
+        fileContents.reportCComment(1, 2, 1, 5);
+        fileContents.reportCComment(3, 2, 4, 2);
+
+        assertTrue(fileContents.hasIntersectionWithComment(2, 2, 3, 6));
+    }
+
+    @Test
+    public void testHasIntersectionWithBlockComment2() {
+        final FileContents fileContents = new FileContents(
+                new FileText(new File("filename"), Arrays.asList("  /* */    ", "    ", " ")));
+        fileContents.reportCComment(1, 2, 1, 5);
+
+        assertFalse(fileContents.hasIntersectionWithComment(2, 2, 3, 6));
+    }
+
+    @Test
+    public void testInPackageInfo() {
+        final FileContents fileContents = new FileContents(new FileText(
+                new File("filename.package-info.java"),
+                Collections.singletonList("  //   ")));
+
+        assertTrue(fileContents.inPackageInfo());
+    }
+
+    @Test
+    public void testGetJavadocBefore() {
+        final FileContents fileContents = new FileContents(
+                new FileText(new File("filename"), Collections.singletonList("    ")));
+        final Map<Integer, TextBlock> javadoc = new HashMap<>();
+        javadoc.put(0, new Comment(new String[] {"// "}, 2, 1, 2));
+        Whitebox.setInternalState(fileContents, "javadocComments", javadoc);
+        final TextBlock javadocBefore = fileContents.getJavadocBefore(2);
+
+        assertEquals(new Comment(new String[] {"// "}, 2, 1, 2).toString(),
+                javadocBefore.toString());
+    }
+
+    @Test
+    public void testExtractBlockComment() {
+        final FileContents fileContents = new FileContents(
+                new FileText(new File("filename"), Arrays.asList("   ", "    ", "  /* test   ",
+                        "  */  ", "   ")));
+        fileContents.reportCComment(3, 2, 4, 2);
+        final ImmutableMap<Integer, List<TextBlock>> blockComments =
+            fileContents.getBlockComments();
+        final String[] text = blockComments.get(3).get(0).getText();
+
+        assertArrayEquals(new String[] {"/* test   ", "  *"}, text);
     }
 }


### PR DESCRIPTION
Issue #4394

[pitest-checkstyle-api profile before changes](https://nimfadora.github.io/issue4394.html)

increased mutation threshold for pitest-checkstyle-api profile by 4%
current threshold: 100%
execution time: 3:31 min

one mutation left: [I have no idea how to test it](https://nimfadora.github.io/pr/com.puppycrawl.tools.checkstyle.api/FileText.java.html#org.pitest.mutationtest.report.html.SourceFile@76e17762_175)