### PR TITLE
minor: Added 'final' to getPath in AbstractPathTestSupport and '/' to getNonCompilablePath in AbstractTreeTestSupport

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractPathTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractPathTestSupport.java
@@ -38,7 +38,7 @@ public abstract class AbstractPathTestSupport {
      * @return canonical path for the file name.
      * @throws IOException if I/O exception occurs while forming the path.
      */
-    protected String getPath(String filename) throws IOException {
+    protected final String getPath(String filename) throws IOException {
         return new File("src/test/resources/" + getPackageLocation() + "/" + filename)
                 .getCanonicalPath();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractTreeTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractTreeTestSupport.java
@@ -43,7 +43,7 @@ public abstract class AbstractTreeTestSupport extends AbstractPathTestSupport {
      * @throws IOException if I/O exception occurs while forming the path.
      */
     protected final String getNonCompilablePath(String filename) throws IOException {
-        return new File("src/test/resources-noncompilable/" + getPackageLocation()
+        return new File("src/test/resources-noncompilable/" + getPackageLocation() + "/"
                 + filename).getCanonicalPath();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
@@ -37,7 +37,7 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
 
     @Override
     protected String getPackageLocation() {
-        return "com/puppycrawl/tools/checkstyle/astprinter/";
+        return "com/puppycrawl/tools/checkstyle/astprinter";
     }
 
     @Test


### PR DESCRIPTION
This PR adds `final` to the `getPath()` method in AbstractPathTestSupport and `/` to the `getNonCompilablePath()` method and the resulting changes because of that.