### PR TITLE
Issue #4396: increase coverage of pitest-checkstyle-filters profile to 100

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -32,7 +32,7 @@
     <suppress checks="Javadoc" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="MagicNumber" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="AvoidStaticImport" files=".*[\\/]src[\\/](test|it)[\\/]"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="[\\/]IndentationCheckTest.java$"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="[\\/]IndentationCheckTest.java$|[\\/]SuppressWithNearbyCommentFilterTest.java$|[\\/]SuppressionCommentFilterTest.java$"/>
     <suppress checks="EqualsAvoidNull" files="[\\/]Int.*FilterTest.java$"/>
     <suppress checks="VisibilityModifier" files="[\\/]BaseCheckTestSupport.java$|[\\/]AbstractModuleTestSupport.java$"/>
     <suppress checks="WriteTag" files=".*[\\/]src[\\/](test|it)[\\/]"/>

--- a/pom.xml
+++ b/pom.xml
@@ -2232,18 +2232,6 @@
                 <param>com.puppycrawl.tools.checkstyle.filefilters.*</param>
                 <param>com.puppycrawl.tools.checkstyle.filters.*</param>
               </targetTests>
-              <excludedMethods>
-                <!-- till https://github.com/checkstyle/checkstyle/issues/4396 -->
-                <param>compareTo</param>
-                <!-- till https://github.com/checkstyle/checkstyle/issues/4396 -->
-                <param>findNearestMatch</param>
-                <!-- till https://github.com/checkstyle/checkstyle/issues/4396 -->
-                <param>tagSuppressions</param>
-                <!-- till https://github.com/checkstyle/checkstyle/issues/4396 -->
-                <param>tagSuppressions</param>
-                <!-- till https://github.com/checkstyle/checkstyle/issues/4396 -->
-                <param>startElement</param>
-              </excludedMethods>
               <mutationThreshold>100</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.filters;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -234,7 +233,6 @@ public class SuppressWithNearbyCommentFilter
                 contents.getBlockComments().values();
             cComments.forEach(this::tagSuppressions);
         }
-        Collections.sort(tags);
     }
 
     /**
@@ -279,7 +277,7 @@ public class SuppressWithNearbyCommentFilter
     /**
      * A Tag holds a suppression comment and its location.
      */
-    public static class Tag implements Comparable<Tag> {
+    public static class Tag {
         /** The text of the tag. */
         private final String text;
 
@@ -346,26 +344,6 @@ public class SuppressWithNearbyCommentFilter
                 throw new IllegalArgumentException(
                     "unable to parse expanded comment " + format, ex);
             }
-        }
-
-        /**
-         * Compares the position of this tag in the file
-         * with the position of another tag.
-         * @param other the tag to compare with this one.
-         * @return a negative number if this tag is before the other tag,
-         *     0 if they are at the same position, and a positive number if this
-         *     tag is after the other tag.
-         */
-        @Override
-        public int compareTo(Tag other) {
-            final int result;
-            if (firstLine == other.firstLine) {
-                result = Integer.compare(lastLine, other.lastLine);
-            }
-            else {
-                result = Integer.compare(firstLine, other.firstLine);
-            }
-            return result;
         }
 
         @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -93,9 +93,7 @@ public final class SuppressionsLoader
             try {
                 final String files = attributes.getValue("files");
                 suppress = new SuppressElement(files);
-                if (modId != null) {
-                    suppress.setModuleId(modId);
-                }
+                suppress.setModuleId(modId);
                 if (checks != null) {
                     suppress.setChecks(checks);
                 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -34,6 +34,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 import org.xml.sax.InputSource;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
@@ -296,5 +297,15 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             SuppressionsLoader.loadSuppressions(getPath("suppressions_none.xml"));
         final FilterSet fc2 = new FilterSet();
         assertEquals("Suppressions were not loaded", fc2, fc);
+    }
+
+    @Test
+    public void testSettingModuleId() throws Exception {
+        final FilterSet fc =
+                SuppressionsLoader.loadSuppressions(getPath("suppressions_with_id.xml"));
+        final SuppressElement suppressElement = (SuppressElement) fc.getFilters().toArray()[0];
+
+        final String id = Whitebox.getInternalState(suppressElement, "moduleId");
+        assertEquals("Id has to be defined", "someId", id);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/InputSuppressByIdWithNearbyCommentFilter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/InputSuppressByIdWithNearbyCommentFilter.java
@@ -9,4 +9,6 @@ public class InputSuppressByIdWithNearbyCommentFilter {
     int line_length = 100; // Suppression @cs-: ignore (reason)
 
     private long ID = 1; // Suppression @cs-:
+    /*
+        Suppression @cs-: ignore (reason)*/private long ID3 = 1;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/InputSuppressionCommentFilter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/InputSuppressionCommentFilter.java
@@ -22,9 +22,9 @@ class InputSuppressionCommentFilter
     private int L;
     private static final int m = 0;
     /*
-     * CSON: MemberNameCheck
+     * CSON: MemberNameCheck|ConstantNameCheck
      */
-    private int M2;
+    private int M2;//CSOFF: ConstantNameCheck
     private static final int n = 0;
     //CSON: ConstantNameCheck
     

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_with_id.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressions_with_id.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd">
+<suppressions>
+    <suppress files="file0" checks="check0" id="someId"/>
+</suppressions>


### PR DESCRIPTION
Issue #4396

increased mutation threshold for pitest-checkstyle-filters by 5%
current threshold: 100%
execution time: 9:42 min

[pitest report before changes for package](https://nimfadora.github.io/issue4396.html)