### PR TITLE
Issue #4769: Control coverage of JavadocParser and JavadocLexer

### DIFF
--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -196,9 +196,9 @@ cobertura-check)
   xmlstarlet sel -t -m "//class" -v "@name" -n target/site/cobertura/coverage.xml | sed "s/\./\//g" | sed "/^$/d" | sort | uniq > cobertura_classes.log
   find target/classes -type f -name "*.class" | grep -vE ".*\\$.*" | sed "s/target\/classes\///g" | sed "s/.class//g" | sed "/^$/d" | sort | uniq > target_classes.log
   xmlstarlet sel -N pom=http://maven.apache.org/POM/4.0.0 -t -m "//pom:instrumentation/pom:excludes" -v "pom:exclude" -n pom.xml | sed "s/*//g" | sed "s/.class//g" | sed "/^$/d" | sort | uniq > cobertura_excluded_classes.log
-  # xmlstarlet has an issue. It concatenates these two lines and removes new line character,
+  # xmlstarlet has an issue. It concatenates this line with the previous one and removes new line character,
   # so we need to split them apart. We use the command till update of xmlstarlet to higher version.
-  sed -i'' "s/com\/puppycrawl\/tools\/checkstyle\/grammars\/javadoc\/com\/puppycrawl\/tools\/checkstyle\/gui\/BaseCellEditor/com\/puppycrawl\/tools\/checkstyle\/grammars\/javadoc\/\ncom\/puppycrawl\/tools\/checkstyle\/gui\/BaseCellEditor/" cobertura_excluded_classes.log
+  sed -i'' "s/com\/puppycrawl\/tools\/checkstyle\/gui\/BaseCellEditor/\ncom\/puppycrawl\/tools\/checkstyle\/gui\/BaseCellEditor/" cobertura_excluded_classes.log
   grep -Fxvf cobertura_classes.log target_classes.log > missed_classes_with_excludes.log
   grep -Fvf cobertura_excluded_classes.log missed_classes_with_excludes.log > missed_classes_without_excludes.log | cat > output.log
   echo "output.log"

--- a/pom.xml
+++ b/pom.xml
@@ -1512,8 +1512,8 @@
                 <haltOnFailure>true</haltOnFailure>
                 <branchRate>100</branchRate>
                 <lineRate>100</lineRate>
-                <totalBranchRate>92</totalBranchRate>
-                <totalLineRate>99</totalLineRate>
+                <totalBranchRate>81</totalBranchRate>
+                <totalLineRate>84</totalLineRate>
                 <regexes>
                   <regex>
                     <pattern>com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaRecognizer</pattern>
@@ -1525,11 +1525,28 @@
                     <branchRate>79</branchRate>
                     <lineRate>97</lineRate>
                   </regex>
+                  <regex>
+                    <pattern>com.puppycrawl.tools.checkstyle.grammars.javadoc.JavadocParser</pattern>
+                    <branchRate>23</branchRate>
+                    <lineRate>27</lineRate>
+                  </regex>
+                  <regex>
+                    <pattern>com.puppycrawl.tools.checkstyle.grammars.javadoc.JavadocLexer</pattern>
+                    <branchRate>41</branchRate>
+                    <lineRate>55</lineRate>
+                  </regex>
                 </regexes>
               </check>
               <instrumentation>
                 <excludes>
-                  <exclude>com/puppycrawl/tools/checkstyle/grammars/javadoc/*.class</exclude>
+                  <!-- Terence Parr, The Definitive ANTLR 4 Reference, 2.4 Building Language Applications Using Parse Trees:
+                       "To better support access to the elements within specific nodes, ANTLR generates
+                       a RuleNode subclass for each rule. ... Given this description of the concrete types, we could write
+                       code by hand to perform a depth-first walk of the tree. We could perform whatever actions we
+                       wanted as we discovered and finished nodes. Typical operations are things such as
+                       computing results, updating data structures, or generating output."
+                       We don't need these classes as we use only ParseTree methods for walking. -->
+                  <exclude>com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParser$*.class</exclude>
                   <!-- Swing related classes -->
                   <exclude>com/puppycrawl/tools/checkstyle/gui/BaseCellEditor*.class</exclude>
                   <exclude>com/puppycrawl/tools/checkstyle/gui/CodeSelector.class</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -757,7 +757,8 @@
         <artifactId>antlr4-maven-plugin</artifactId>
         <version>${antlr4.version}</version>
         <configuration>
-          <visitor>true</visitor>
+          <visitor>false</visitor>
+          <listener>false</listener>
           <sourceDirectory>${basedir}/src/main/resources/</sourceDirectory>
           <outputDirectory>${project.build.directory}/generated-sources/antlr/</outputDirectory>
           <includes>


### PR DESCRIPTION
#4769
JavadocParserListener and JavadocParserVisitor are excluded from generation as they are not used at all.