### PR TITLE
Issue #4592: Tests from filefilters, filters, grammars now extend AbstractModuleTestSupport and AbstractTreeTestSupport

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractTreeTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractTreeTestSupport.java
@@ -66,6 +66,19 @@ public abstract class AbstractTreeTestSupport extends AbstractPathTestSupport {
     }
 
     /**
+     * Performs verification of the given text ast tree representation.
+     * This implementation uses {@link BaseCheckTestSupport#verifyAst(String, String, boolean)}
+     * method inside.
+     * @param expectedTextPrintFileName expected text ast tree representation.
+     * @param actualJavaFileName actual text ast tree representation.
+     * @throws Exception if exception occurs during verification.
+     */
+    protected static void verifyAst(String expectedTextPrintFileName, String actualJavaFileName)
+            throws Exception {
+        verifyAst(expectedTextPrintFileName, actualJavaFileName, false);
+    }
+
+    /**
      * Verifies the java and javadoc AST generated for the supplied java file against
      * the expected AST in supplied text file.
      * @param expectedTextPrintFilename name of the file having the expected ast.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filefilters/ExclusionBeforeExecutionFileFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filefilters/ExclusionBeforeExecutionFileFilterTest.java
@@ -22,21 +22,19 @@ package com.puppycrawl.tools.checkstyle.filefilters;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.regex.Pattern;
 
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-public class ExclusionBeforeExecutionFileFilterTest extends BaseCheckTestSupport {
+public class ExclusionBeforeExecutionFileFilterTest extends AbstractModuleTestSupport {
     @Override
-    protected String getNonCompilablePath(String filename) throws IOException {
-        return super.getNonCompilablePath("filefilters" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/filefilters";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -19,8 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
@@ -28,7 +26,7 @@ import java.util.stream.Collectors;
 
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
@@ -43,7 +41,7 @@ import com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class SuppressWarningsFilterTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
     private static final String[] ALL_MESSAGES = {
         "16: Missing a Javadoc comment.",
         "17: Missing a Javadoc comment.",
@@ -70,8 +68,8 @@ public class SuppressWarningsFilterTest
     };
 
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("filters" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/filters";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -22,8 +22,6 @@ package com.puppycrawl.tools.checkstyle.filters;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -33,7 +31,7 @@ import java.util.stream.Collectors;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
@@ -50,7 +48,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class SuppressWithNearbyCommentFilterTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
     private static final String[] ALL_MESSAGES = {
         "14:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         "15:17: Name 'A2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
@@ -81,8 +79,8 @@ public class SuppressWithNearbyCommentFilterTest
     };
 
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("filters" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/filters";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -22,8 +22,6 @@ package com.puppycrawl.tools.checkstyle.filters;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -34,7 +32,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
@@ -51,7 +49,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class SuppressionCommentFilterTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
     private static final String[] ALL_MESSAGES = {
         "13:17: Name 'I' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         "16:17: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
@@ -73,8 +71,8 @@ public class SuppressionCommentFilterTest
     };
 
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("filters" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/filters";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -41,7 +40,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.google.common.io.Closeables;
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
@@ -52,14 +51,14 @@ import nl.jqno.equalsverifier.Warning;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({SuppressionFilter.class, CommonUtils.class})
-public class SuppressionFilterTest extends BaseCheckTestSupport {
+public class SuppressionFilterTest extends AbstractModuleTestSupport {
 
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("filters" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/filters";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/AstRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/AstRegressionTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -38,19 +37,14 @@ import antlr.NoViableAltForCharException;
 import antlr.ParserSharedInputState;
 import antlr.SemanticException;
 import antlr.TokenBuffer;
+import com.puppycrawl.tools.checkstyle.AbstractTreeTestSupport;
 import com.puppycrawl.tools.checkstyle.AstTreeStringPrinter;
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 
-public class AstRegressionTest extends BaseCheckTestSupport {
+public class AstRegressionTest extends AbstractTreeTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator + filename);
-    }
-
-    @Override
-    protected String getNonCompilablePath(String filename) throws IOException {
-        return super.getNonCompilablePath("grammars" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/EmbeddedNullCharTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/EmbeddedNullCharTest.java
@@ -19,12 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.grammars;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -34,10 +31,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Michael Studman
  */
 public class EmbeddedNullCharTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/GeneratedJava14LexerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/GeneratedJava14LexerTest.java
@@ -21,13 +21,10 @@ package com.puppycrawl.tools.checkstyle.grammars;
 
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Assume;
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -37,7 +34,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Rick Giles
  */
 public class GeneratedJava14LexerTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
 
     /**
      * <p>Is {@code true} if this is Windows.</p>
@@ -47,13 +44,8 @@ public class GeneratedJava14LexerTest
     private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
 
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator + filename);
-    }
-
-    @Override
-    protected String getNonCompilablePath(String filename) throws IOException {
-        return super.getNonCompilablePath("grammars" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/HexFloatsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/HexFloatsTest.java
@@ -19,12 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.grammars;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -34,10 +31,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Michael Studman
  */
 public class HexFloatsTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7DiamondTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7DiamondTest.java
@@ -19,12 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.grammars;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -34,10 +31,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Dinesh Bolkensteyn (SonarSource)
  */
 public class Java7DiamondTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7MultiCatchTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7MultiCatchTest.java
@@ -19,12 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.grammars;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -34,10 +31,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Dinesh Bolkensteyn (SonarSource)
  */
 public class Java7MultiCatchTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7NumericalLiteralsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7NumericalLiteralsTest.java
@@ -19,12 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.grammars;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -34,10 +31,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Dinesh Bolkensteyn (SonarSource)
  */
 public class Java7NumericalLiteralsTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7StringSwitchTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7StringSwitchTest.java
@@ -19,12 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.grammars;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -34,10 +31,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Dinesh Bolkensteyn (SonarSource)
  */
 public class Java7StringSwitchTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7TryWithResourcesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java7TryWithResourcesTest.java
@@ -19,12 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.grammars;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -34,10 +31,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Dinesh Bolkensteyn (SonarSource)
  */
 public class Java7TryWithResourcesTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java9TryWithResourcesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/Java9TryWithResourcesTest.java
@@ -19,12 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.grammars;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -33,12 +30,11 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * Tests Java 9 try-with-resources can be parsed.
  * @author checkstyle team
  */
-public class Java9TryWithResourcesTest extends BaseCheckTestSupport {
+public class Java9TryWithResourcesTest extends AbstractModuleTestSupport {
 
     @Override
-    protected String getNonCompilablePath(String filename) throws IOException {
-        return super.getNonCompilablePath("grammars" + File.separator
-                + "java9" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars/java9";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/LineCommentAtTheEndOfFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/LineCommentAtTheEndOfFileTest.java
@@ -19,12 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.grammars;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -36,10 +33,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Evgeny Mandrikov
  */
 public class LineCommentAtTheEndOfFileTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/MultiDimensionalArraysInGenericsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/MultiDimensionalArraysInGenericsTest.java
@@ -19,21 +19,18 @@
 
 package com.puppycrawl.tools.checkstyle.grammars;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class MultiDimensionalArraysInGenericsTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/UnicodeEscapeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/UnicodeEscapeTest.java
@@ -19,12 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.grammars;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -34,10 +31,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Dinesh Bolkensteyn (SonarSource)
  */
 public class UnicodeEscapeTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/VarargTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/VarargTest.java
@@ -19,12 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.grammars;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -34,10 +31,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Michael Studman
  */
 public class VarargTest
-    extends BaseCheckTestSupport {
+    extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
@@ -19,20 +19,16 @@
 
 package com.puppycrawl.tools.checkstyle.grammars.comments;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractTreeTestSupport;
 import com.puppycrawl.tools.checkstyle.api.Comment;
 
-public class CommentsTest extends BaseCheckTestSupport {
+public class CommentsTest extends AbstractTreeTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator
-                + "comments" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars/comments";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/AnnotationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/AnnotationTest.java
@@ -19,27 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-public class AnnotationTest extends BaseCheckTestSupport {
+public class AnnotationTest extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator
-                + "java8" + File.separator + filename);
-    }
-
-    @Override
-    protected String getNonCompilablePath(String filename) throws IOException {
-        return super.getNonCompilablePath("grammars" + File.separator
-                + "java8" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars/java8";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/AnnotationsOnArrayTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/AnnotationsOnArrayTest.java
@@ -19,21 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-public class AnnotationsOnArrayTest extends BaseCheckTestSupport {
+public class AnnotationsOnArrayTest extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator
-                + "java8" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars/java8";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/DefaultMethodsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/DefaultMethodsTest.java
@@ -19,27 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-public class DefaultMethodsTest extends BaseCheckTestSupport {
+public class DefaultMethodsTest extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator
-                + "java8" + File.separator + filename);
-    }
-
-    @Override
-    protected String getNonCompilablePath(String filename) throws IOException {
-        return super.getNonCompilablePath("grammars" + File.separator
-                + "java8" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars/java8";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/LambdaTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/LambdaTest.java
@@ -19,21 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-public class LambdaTest extends BaseCheckTestSupport {
+public class LambdaTest extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator
-                + "java8" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars/java8";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/MethodReferencesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/MethodReferencesTest.java
@@ -19,21 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-public class MethodReferencesTest extends BaseCheckTestSupport {
+public class MethodReferencesTest extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator
-                + "java8" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars/java8";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/ReceiverParameterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/ReceiverParameterTest.java
@@ -19,21 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-public class ReceiverParameterTest extends BaseCheckTestSupport {
+public class ReceiverParameterTest extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator
-                + "java8" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars/java8";
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/TypeUseAnnotationsOnQualifiedTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/java8/TypeUseAnnotationsOnQualifiedTypesTest.java
@@ -19,21 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.grammars.java8;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-public class TypeUseAnnotationsOnQualifiedTypesTest extends BaseCheckTestSupport {
+public class TypeUseAnnotationsOnQualifiedTypesTest extends AbstractModuleTestSupport {
     @Override
-    protected String getPath(String filename) throws IOException {
-        return super.getPath("grammars" + File.separator
-                + "java8" + File.separator + filename);
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/grammars/java8";
     }
 
     @Test


### PR DESCRIPTION
Issue #4592

This PR extends the tests in filefilters, filters, grammars packages from `AbstractModuleTestSupport` and `AbstractTreeTestSupport`.