### PR TITLE
Issue #4724: fix FieldNotUsedInToString IDEA violations

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -720,7 +720,7 @@
     </inspection_tool>
     <inspection_tool class="FieldMayBeFinal" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="FieldMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="FieldNotUsedInToString" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="FieldNotUsedInToString" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="FieldRepeatedlyAccessed" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="m_ignoreFinalFields" value="false" />
     </inspection_tool>
@@ -2113,6 +2113,8 @@
                 <option value="NonFinalFieldReferencedInHashCode" />
                 <!-- FileContentsHolder#getContence() getter is deprecated -->
                 <option value="CallToSimpleGetterFromWithinClass" />
+                <!-- violations in DetailAST will be addressed further -->
+                <option value="FieldNotUsedInToString" />
             </list>
         </option>
     </inspection_tool>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Comment.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Comment.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
+import java.util.Arrays;
+
 /**
  * Representation of the comment block.
  *
@@ -98,8 +100,10 @@ public class Comment implements TextBlock {
 
     @Override
     public String toString() {
-        final String separator = ":";
-        return "Comment[" + startLineNo + separator + startColNo + "-"
-            + endLineNo + separator + endColNo + "]";
+        return "Comment[text=" + Arrays.toString(text)
+                + ", startLineNo=" + startLineNo
+                + ", endLineNo=" + endLineNo
+                + ", startColNo=" + startColNo
+                + ", endColNo=" + endColNo + ']';
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -32,6 +32,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
  * @author Oliver Burn
  * @author lkuehne
  * @see <a href="http://www.antlr.org/">ANTLR Website</a>
+ * @noinspection FieldNotUsedInToString
  */
 public final class DetailAST extends CommonASTWithHiddenTokens {
     private static final long serialVersionUID = -2580884815577559874L;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
@@ -95,7 +95,7 @@ public final class FullIdent {
 
     @Override
     public String toString() {
-        return getText() + "[" + lineNo + "x" + columnNo + "]";
+        return String.join("", elements) + "[" + lineNo + "x" + columnNo + "]";
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AbstractTypeAwareCheck.java
@@ -476,9 +476,11 @@ public abstract class AbstractTypeAwareCheck extends AbstractCheck {
         @Override
         public String toString() {
             return "RegularClass[name=" + getName()
-                + ", in class=" + surroundingClass
-                + ", loadable=" + loadable
-                + ", class=" + classObj + "]";
+                    + ", in class='" + surroundingClass + '\''
+                    + ", check=" + check.hashCode()
+                    + ", loadable=" + loadable
+                    + ", class=" + classObj
+                    + ']';
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineSet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineSet.java
@@ -93,6 +93,6 @@ public class LineSet {
 
     @Override
     public String toString() {
-        return "LineSet[firstLine=" + firstLine() + ", lastLine=" + lastLine() + "]";
+        return "LineSet[firstLine=" + lines.firstKey() + ", lastLine=" + lines.lastKey() + "]";
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java
@@ -117,9 +117,21 @@ class HtmlTag {
 
     @Override
     public String toString() {
+        return "HtmlTag[id='" + id + '\''
+                + ", lineNo=" + lineNo
+                + ", position=" + position
+                + ", text='" + text + '\''
+                + ", closedTag=" + closedTag
+                + ", incompleteTag=" + incompleteTag + ']';
+    }
+
+    /**
+     * Returns the comment line of text where this tag appears.
+     * @return text of the tag
+     */
+    public String getText() {
         final int startOfText = position;
-        final int endOfText =
-            Math.min(startOfText + MAX_TEXT_LEN, text.length());
+        final int endOfText = Math.min(startOfText + MAX_TEXT_LEN, text.length());
         return text.substring(startOfText, endOfText);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtils;
@@ -169,7 +170,13 @@ public class JavadocNodeImpl implements DetailNode {
 
     @Override
     public String toString() {
-        return JavadocUtils.getTokenName(type)
-                + "[" + lineNumber + "x" + columnNumber + "]";
+        return "JavadocNodeImpl["
+                + "index=" + index
+                + ", type=" + JavadocUtils.getTokenName(type)
+                + ", text='" + text + '\''
+                + ", lineNumber=" + lineNumber
+                + ", columnNumber=" + columnNumber
+                + ", children=" + Objects.hashCode(children)
+                + ", parent=" + parent + ']';
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -370,7 +370,7 @@ public class JavadocStyleCheck
                     log(tag.getLineNo(),
                         tag.getPosition(),
                         MSG_EXTRA_HTML,
-                        tag);
+                        tag.getText());
                 }
                 else {
                     // See if there are any unclosed tags that were opened
@@ -394,7 +394,8 @@ public class JavadocStyleCheck
             if (!isSingleTag(htmlTag)
                 && !htmlTag.getId().equals(lastFound)
                 && !typeParameters.contains(htmlTag.getId())) {
-                log(htmlTag.getLineNo(), htmlTag.getPosition(), MSG_UNCLOSED_HTML, htmlTag);
+                log(htmlTag.getLineNo(), htmlTag.getPosition(),
+                        MSG_UNCLOSED_HTML, htmlTag.getText());
                 lastFound = htmlTag.getId();
             }
         }
@@ -436,7 +437,7 @@ public class JavadocStyleCheck
             log(lastOpenTag.getLineNo(),
                 lastOpenTag.getPosition(),
                 MSG_UNCLOSED_HTML,
-                lastOpenTag);
+                lastOpenTag.getText());
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java
@@ -91,8 +91,10 @@ public class JavadocTag {
 
     @Override
     public String toString() {
-        return "JavadocTag{tag='" + getTagName() + "' lineNo=" + lineNo + ", columnNo=" + columnNo
-                + ", firstArg='" + firstArg + "'}";
+        return "JavadocTag[tag='" + tagInfo.getName()
+                + "' lineNo=" + lineNo
+                + ", columnNo=" + columnNo
+                + ", firstArg='" + firstArg + "']";
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -411,9 +411,13 @@ public class SuppressWithNearbyCommentFilter
         }
 
         @Override
-        public final String toString() {
-            return "Tag[lines=[" + firstLine + " to " + lastLine
-                + "]; text='" + text + "']";
+        public String toString() {
+            return "Tag[text='" + text + '\''
+                    + ", firstLine=" + firstLine
+                    + ", lastLine=" + lastLine
+                    + ", tagCheckRegexp=" + tagCheckRegexp
+                    + ", tagMessageRegexp=" + tagMessageRegexp
+                    + ']';
         }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -450,9 +450,13 @@ public class SuppressionCommentFilter
         }
 
         @Override
-        public final String toString() {
-            return "Tag[line=" + line + "; col=" + column
-                + "; on=" + reportingOn + "; text='" + text + "']";
+        public String toString() {
+            return "Tag[text='" + text + '\''
+                    + ", line=" + line
+                    + ", column=" + column
+                    + ", on=" + reportingOn
+                    + ", tagCheckRegexp=" + tagCheckRegexp
+                    + ", tagMessageRegexp=" + tagMessageRegexp + ']';
         }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
@@ -74,7 +74,7 @@ public class FileContentsTest {
         fileContents.reportCppComment(1, 2);
         final Map<Integer, TextBlock> cppComments = fileContents.getCppComments();
 
-        assertEquals(new Comment(new String[] {"// "}, 2, 1, 6).toString(),
+        assertEquals(new Comment(new String[] {" //  "}, 2, 1, 6).toString(),
                 cppComments.get(1).toString());
     }
 
@@ -95,7 +95,7 @@ public class FileContentsTest {
         fileContents.reportCComment(1, 2, 1, 2);
         final ImmutableMap<Integer, List<TextBlock>> comments = fileContents.getCComments();
 
-        assertEquals(new Comment(new String[] {"// "}, 2, 1, 2).toString(),
+        assertEquals(new Comment(new String[] {"/"}, 2, 1, 2).toString(),
                 comments.get(1).get(0).toString());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractTypeAwareCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractTypeAwareCheckTest.java
@@ -100,15 +100,17 @@ public class AbstractTypeAwareCheckTest extends AbstractModuleTestSupport {
                 int.class, int.class);
         final Object token = tokenConstructor.newInstance("blablabla", 1, 1);
 
+        final JavadocMethodCheck methodCheck = new JavadocMethodCheck();
         final Object regularClass = regularClassConstructor.newInstance(token, "sur",
-                new JavadocMethodCheck());
+                methodCheck);
 
         final Method toString = regularClass.getClass().getDeclaredMethod("toString");
         toString.setAccessible(true);
         final String result = (String) toString.invoke(regularClass);
-        assertEquals("Invalid toString result",
-            "RegularClass[name=Token[blablabla(1x1)], in class=sur, loadable=true, class=null]",
-            result);
+        final String expected = "RegularClass[name=Token[blablabla(1x1)], in class='sur', check="
+                + methodCheck.hashCode() + "," + " loadable=true, class=null]";
+
+        assertEquals("Invalid toString result", expected, result);
 
         final Method setClazz = regularClass.getClass().getDeclaredMethod("setClazz", Class.class);
         setClazz.setAccessible(true);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImplTest.java
@@ -36,7 +36,8 @@ public class JavadocNodeImplTest {
 
         final String result = javadocNode.toString();
 
-        assertEquals("CODE_LITERAL[1x2]", result);
+        assertEquals("JavadocNodeImpl[index=0, type=CODE_LITERAL, text='null', lineNumber=1,"
+                + " columnNumber=2, children=0, parent=null]", result);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -26,6 +26,7 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.M
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.MSG_NO_PERIOD;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.MSG_UNCLOSED_HTML;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 
@@ -411,5 +412,12 @@ public class JavadocStyleCheckTest
             "418: " + getCheckMessage(MSG_NO_PERIOD),
         };
         verify(checkConfig, getPath("InputJavadocStyle.java"), expected);
+    }
+
+    @Test
+    public void testHtmlTagToString() {
+        final HtmlTag tag = new HtmlTag("id", 3, 5, true, false, "<a href=\"URL\"/>");
+        assertEquals("HtmlTag[id='id', lineNo=3, position=5, text='<a href=\"URL\"/>', "
+                + "closedTag=true, incompleteTag=false]", tag.toString());
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagTest.java
@@ -61,6 +61,6 @@ public class JavadocTagTest {
 
         final String result = javadocTag.toString();
 
-        assertEquals("JavadocTag{tag='author' lineNo=0, columnNo=1, firstArg='firstArg'}", result);
+        assertEquals("JavadocTag[tag='author' lineNo=0, columnNo=1, firstArg='firstArg']", result);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -310,7 +310,8 @@ public class SuppressWithNearbyCommentFilterTest
                 "text", 7, new SuppressWithNearbyCommentFilter()
         );
         assertEquals("Invalid toString result",
-            "Tag[lines=[7 to 7]; text='text']", tag.toString());
+            "Tag[text='text', firstLine=7, lastLine=7, "
+                    + "tagCheckRegexp=.*, tagMessageRegexp=null]", tag.toString());
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -257,7 +257,8 @@ public class SuppressionCommentFilterTest
         );
 
         assertEquals("Invalid toString result",
-            "Tag[line=0; col=1; on=false; text='text']", tag.toString());
+            "Tag[text='text', line=0, column=1, on=false,"
+                    + " tagCheckRegexp=.*, tagMessageRegexp=null]", tag.toString());
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
@@ -48,7 +48,9 @@ public class CommentsTest extends BaseCheckTestSupport {
     @Test
     public void testToString() {
         final Comment comment = new Comment(new String[] {"value"}, 1, 2, 3);
-        Assert.assertEquals("Comment[2:1-2:3]", comment.toString());
+        Assert.assertEquals(
+                "Comment[text=[value], startLineNo=2, endLineNo=2, startColNo=1, endColNo=3]",
+                comment.toString());
     }
 
     @Test


### PR DESCRIPTION
Issue #4724

I think it is not very good idea to rewrite toString, as in JavadocNodeImpl, for e.z. we have such fields as [children and parent](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java#L68), in HtmlTag toString method [performs some calculations](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java#L121). What should I do with such cases?