### PR TITLE
Issue #4805: fix HtmlTagCanBeJavadocTag in TokenTypes

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
@@ -73,7 +73,11 @@ public final class TokenTypesDoclet {
             for (final FieldDoc field : fields) {
                 if (field.isStatic() && field.isPublic() && field.isFinal()
                     && "int".equals(field.type().qualifiedTypeName())) {
-                    if (field.firstSentenceTags().length != 1) {
+                    // We have to filter "Text" tags because of jdk parsing bug
+                    // till Oracle reference id: 9050448
+                    if (field.firstSentenceTags().length != 1
+                            && Arrays.stream(field.firstSentenceTags())
+                            .filter(tag -> !"Text".equals(tag.name())).count() != 1) {
                         final List<Tag> tags = Arrays.asList(field.firstSentenceTags());
                         final String joinedTags = tags
                             .stream()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDocletTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDocletTest.java
@@ -158,6 +158,22 @@ public class TokenTypesDocletTest extends AbstractPathTestSupport {
 
     }
 
+    @Test
+    public void testJavadocTagPassValidation() throws Exception {
+        final ListBuffer<String[]> options = new ListBuffer<>();
+        options.add(new String[] {"-destfile", "target/tokentypes.properties"});
+
+        final ListBuffer<String> names = new ListBuffer<>();
+        names.add(getPath("InputTokenTypesDocletJavadocParseError.java"));
+
+        final Context context = new Context();
+        new TestMessager(context);
+        final JavadocTool javadocTool = JavadocTool.make0(context);
+        final RootDoc rootDoc = getRootDoc(javadocTool, options, names);
+
+        assertTrue("Should process valid root doc", TokenTypesDoclet.start(rootDoc));
+    }
+
     private static RootDoc getRootDoc(JavadocTool javadocTool, ListBuffer<String[]> options,
             ListBuffer<String> names) throws Exception {
         final Method getRootDocImpl = getMethodGetRootDocImplByReflection();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/doclets/InputTokenTypesDocletJavadocParseError.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/doclets/InputTokenTypesDocletJavadocParseError.java
@@ -1,0 +1,22 @@
+package com.puppycrawl.tools.checkstyle.doclets;
+
+public final class InputTokenTypesDocletJavadocParseError {
+
+    private InputTokenTypesDocletJavadocParseError() {
+    }
+
+    /**
+     * The <code>+</code> (unary plus) operator.
+     **/
+    public static final int CONSTANT1 = 1;
+
+    /**
+     * The {@code ++} (postfix increment) operator.
+     */
+    public static final int CONSTANT2 = 2;
+
+    /**
+     * Here you can see sentence without html or javadoc tags.
+     **/
+    public static final int CONSTANT3 = 3;
+}


### PR DESCRIPTION
Issue #4805

here are the changes in TokenTypes which cause build to fail