### PR TITLE
config: remove gist patch for contribution/checkstyle-tester

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -179,8 +179,6 @@ build:
           cd contribution/checkstyle-tester
           sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
           sed -i'' 's/#apache-struts/apache-struts/' projects-for-wercker.properties
-          wget https://gist.githubusercontent.com/timurt/dedda143b7a4984006af4731f3a236ec/raw/fc1da9dbdd34be15621082435f27a35492594bbc/checkstyle-tester.patch
-          git apply checkstyle-tester.patch
           groovy ./launch.groovy --listOfProjects projects-for-wercker.properties --config checks-nonjavadoc-error.xml
           cd ../../
           rm -rf contribution
@@ -199,8 +197,6 @@ build:
           sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
           sed -i'' 's/#checkstyle/checkstyle/' projects-for-wercker.properties
           sed -i'' 's/#sevntu-checkstyle/sevntu-checkstyle/' projects-for-wercker.properties
-          wget https://gist.githubusercontent.com/timurt/dedda143b7a4984006af4731f3a236ec/raw/fc1da9dbdd34be15621082435f27a35492594bbc/checkstyle-tester.patch
-          git apply checkstyle-tester.patch
           groovy ./launch.groovy --listOfProjects projects-for-wercker.properties --config checks-nonjavadoc-error.xml
           cd ../../
           rm -rf contribution
@@ -218,8 +214,6 @@ build:
           cd contribution/checkstyle-tester
           sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
           sed -i'' 's/#guava/guava/' projects-for-wercker.properties
-          wget https://gist.githubusercontent.com/timurt/dedda143b7a4984006af4731f3a236ec/raw/fc1da9dbdd34be15621082435f27a35492594bbc/checkstyle-tester.patch
-          git apply checkstyle-tester.patch
           groovy ./launch.groovy --listOfProjects projects-for-wercker.properties --config checks-nonjavadoc-error.xml
           cd ../../
           rm -rf contribution
@@ -237,8 +231,6 @@ build:
           cd contribution/checkstyle-tester
           sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
           sed -i'' 's/#hibernate-orm/hibernate-orm/' projects-for-wercker.properties
-          wget https://gist.githubusercontent.com/timurt/dedda143b7a4984006af4731f3a236ec/raw/fc1da9dbdd34be15621082435f27a35492594bbc/checkstyle-tester.patch
-          git apply checkstyle-tester.patch
           groovy ./launch.groovy --listOfProjects projects-for-wercker.properties --config checks-nonjavadoc-error.xml
           cd ../../
           rm -rf contribution
@@ -257,8 +249,6 @@ build:
           cd contribution/checkstyle-tester
           sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
           sed -i'' 's/#findbugs/findbugs/' projects-for-wercker.properties
-          wget https://gist.githubusercontent.com/timurt/dedda143b7a4984006af4731f3a236ec/raw/fc1da9dbdd34be15621082435f27a35492594bbc/checkstyle-tester.patch
-          git apply checkstyle-tester.patch
           groovy ./launch.groovy --listOfProjects projects-for-wercker.properties --config checks-nonjavadoc-error.xml
           cd ../../
           rm -rf contribution
@@ -276,8 +266,6 @@ build:
           cd contribution/checkstyle-tester
           sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
           sed -i'' 's/#spring-framework/spring-framework/' projects-for-wercker.properties
-          wget https://gist.githubusercontent.com/timurt/dedda143b7a4984006af4731f3a236ec/raw/fc1da9dbdd34be15621082435f27a35492594bbc/checkstyle-tester.patch
-          git apply checkstyle-tester.patch
           groovy ./launch.groovy --listOfProjects projects-for-wercker.properties --config checks-nonjavadoc-error.xml
           cd ../../
           rm -rf contribution
@@ -295,8 +283,6 @@ build:
           cd contribution/checkstyle-tester
           sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
           sed -i'' 's/#Hbase/Hbase/' projects-for-wercker.properties
-          wget https://gist.githubusercontent.com/timurt/dedda143b7a4984006af4731f3a236ec/raw/fc1da9dbdd34be15621082435f27a35492594bbc/checkstyle-tester.patch
-          git apply checkstyle-tester.patch
           groovy ./launch.groovy --listOfProjects projects-for-wercker.properties --config checks-nonjavadoc-error.xml
           cd ../../
           rm -rf contribution
@@ -316,8 +302,6 @@ build:
           sed -i'' 's/#pmd/pmd/' projects-for-wercker.properties
           sed -i'' 's/#elasticsearch/elasticsearch/' projects-for-wercker.properties
           sed -i'' 's/#lombok-ast/lombok-ast/' projects-for-wercker.properties
-          wget https://gist.githubusercontent.com/timurt/dedda143b7a4984006af4731f3a236ec/raw/fc1da9dbdd34be15621082435f27a35492594bbc/checkstyle-tester.patch
-          git apply checkstyle-tester.patch
           groovy ./launch.groovy --listOfProjects projects-for-wercker.properties --config checks-nonjavadoc-error.xml
           cd ../../
           rm -rf contribution
@@ -341,8 +325,6 @@ build:
           sed -i'' 's/#apache-ant/apache-ant/' projects-for-wercker.properties
           sed -i'' 's/#apache-jsecurity/apache-jsecurity/' projects-for-wercker.properties
           sed -i'' 's/#android-launcher/android-launcher/' projects-for-wercker.properties
-          wget https://gist.githubusercontent.com/timurt/dedda143b7a4984006af4731f3a236ec/raw/fc1da9dbdd34be15621082435f27a35492594bbc/checkstyle-tester.patch
-          git apply checkstyle-tester.patch
           groovy ./launch.groovy --listOfProjects projects-for-wercker.properties --config checks-nonjavadoc-error.xml
           cd ../../
           rm -rf contribution


### PR DESCRIPTION
In PR for [4714](https://github.com/checkstyle/checkstyle/issues/4714), `wercker.yml` was patched to pass checks. Project [chekstyle-tester](https://github.com/checkstyle/contribution/tree/master/checkstyle-tester) was updated recently, `SuppressionCommentFilter` and `SuppressWithNearbyCommentFilter` modules were moved to `TreeWalker` and there is no need to patch [checks-nonjavadoc-error.xml](https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/checks-nonjavadoc-error.xml) now. This PR removes redundant commands from `wecker.yml` responsible for patching `checks-nonjavadoc-error.xml`