### PR TITLE
Issue #4402: increase coverage of pitest-checks-annotation to 100

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1660,7 +1660,7 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.annotation.PackageAnnotationCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheckTest</param>
               </targetTests>
-              <mutationThreshold>99</mutationThreshold>
+              <mutationThreshold>100</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
@@ -242,7 +242,7 @@ public final class MissingDeprecatedCheck extends AbstractCheck {
 
         boolean found = false;
         int reindex = index + 1;
-        while (reindex < lines.length) {
+        while (reindex <= lines.length - 1) {
             final Matcher multilineCont = MATCH_DEPRECATED_MULTILINE_CONT.matcher(lines[reindex]);
 
             if (multilineCont.find()) {


### PR DESCRIPTION
Issue #4402

[report before changes](https://nimfadora.github.io/pr/com.puppycrawl.tools.checkstyle.checks.annotation/index.html)

increased coverage of pitest-checks-annotation by 1%
current threshold: 100%
execution time: 01:39 