### PR TITLE
config: add distribution for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 sudo: false
+dist: precise
 
 cache:
   apt: true


### PR DESCRIPTION
Update for travis to older distribution until fixed.

#4847 - show all problems that are happening with trusty.
#4848 - will upgrade to "trusty"