### PR TITLE
Issue #4856: fixed NPE in RequireThisCheck for methods from base class

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -803,11 +803,13 @@ public class RequireThisCheck extends AbstractCheck {
      */
     private AbstractFrame getMethodWithoutThis(DetailAST ast) {
         AbstractFrame result = null;
-        final AbstractFrame frame = findFrame(ast, true);
-        if (!validateOnlyOverlapping
-                && ((ClassFrame) frame).hasInstanceMethod(ast)
-                && !((ClassFrame) frame).hasStaticMethod(ast)) {
-            result = frame;
+        if (!validateOnlyOverlapping) {
+            final AbstractFrame frame = findFrame(ast, true);
+            if (frame != null
+                    && ((ClassFrame) frame).hasInstanceMethod(ast)
+                    && !((ClassFrame) frame).hasStaticMethod(ast)) {
+                result = frame;
+            }
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -299,4 +299,12 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputRequireThisCaseGroup.java"), expected);
     }
+
+    @Test
+    public void testExtendedMethod() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RequireThisCheck.class);
+        checkConfig.addAttribute("validateOnlyOverlapping", "false");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputRequireThisExtendedMethod.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisExtendedMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisExtendedMethod.java
@@ -1,0 +1,10 @@
+package com.github.sevntu.checkstyle.checks.coding;
+
+import java.util.logging.Logger;
+
+public class InputRequireThisExtendedMethod
+{
+    public class Check {
+        private Logger log1 = Logger.getLogger(getClass().getName());
+    }
+}


### PR DESCRIPTION
Issue #4856

This is a simple NPE fix.
The method being searched for in issue, `getClass`, can't be found because it is declared in `Object` and we can only look at the declarations in the current file. There is nothing we can do for the method except to skip over it.

Code was slightly modified so call to `findFrame` wasn't always being executed, regardless of `validateOnlyOverlapping` definition.