### PR TITLE
minor: Added links to new test supports in BaseCheckTestSupport

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/BaseCheckTestSupport.java
@@ -44,8 +44,8 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 /**
  * @deprecated BaseCheckTestSupport is no longer used. All checks
- * now extend AbstractPathTestSupport, AbstractModuleTestSupport,
- * AbstractTreeTestSupport
+ * now extend {@link AbstractPathTestSupport}, {@link AbstractModuleTestSupport},
+ * {@link AbstractTreeTestSupport}.
  */
 @Deprecated
 public class BaseCheckTestSupport {


### PR DESCRIPTION
Adds links to new tests supports `AbstractPathTestSupport`, `AbstractModuleTestSupport` and `AbstractTreeTestSupport` in `BaseCheckTestSupport` as it no longer supported and has become deprecated.