### PR TITLE
minor: restored AllChecksTest.testAllModulesWithDefaultConfiguration

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -82,7 +82,8 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
 
         try {
             final Class<?> moduleClass = Class.forName(moduleConfig.getName());
-            if (ModuleReflectionUtils.isCheckstyleCheck(moduleClass)) {
+            if (ModuleReflectionUtils.isCheckstyleCheck(moduleClass)
+                    || ModuleReflectionUtils.isTreeWalkerFilterModule(moduleClass)) {
                 addTreeWalker = true;
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -47,6 +47,7 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+import com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtils;
 
 public class AllChecksTest extends AbstractModuleTestSupport {
     private static final Locale[] ALL_LOCALES = {
@@ -236,20 +237,24 @@ public class AllChecksTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testAllChecksWithDefaultConfiguration() throws Exception {
+    public void testAllModulesWithDefaultConfiguration() throws Exception {
         final String inputFilePath = getPath("InputAllChecksDefaultConfig.java");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        for (Class<?> check : CheckUtil.getCheckstyleChecks()) {
-            final DefaultConfiguration checkConfig = createModuleConfig(check);
+        for (Class<?> module : CheckUtil.getCheckstyleModules()) {
+            if (ModuleReflectionUtils.isRootModule(module)) {
+                continue;
+            }
+
+            final DefaultConfiguration moduleConfig = createModuleConfig(module);
             final Checker checker;
-            if (check.equals(ImportControlCheck.class)) {
+            if (module.equals(ImportControlCheck.class)) {
                 // ImportControlCheck must have the import control configuration file to avoid
                 // violation.
-                checkConfig.addAttribute("file", getPath(
+                moduleConfig.addAttribute("file", getPath(
                         "InputAllChecksImport-control_complete.xml"));
             }
-            checker = createChecker(checkConfig);
+            checker = createChecker(moduleConfig);
             verify(checker, inputFilePath, expected);
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/internal/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/internal/package-info.java
@@ -1,0 +1,1 @@
+package com.puppycrawl.tools.checkstyle.internal;


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/4855#discussion_r130225340 ,
this PR restores `AllChecksTest.testAllModulesWithDefaultConfiguration` to its working, original condition.

Changes in `AbstractModuleTestSupport` were needed to support `TreeWalkerFilterModule`s. This is what prompted me to create Issue #4843 .

`package-info.java` was added to quiet error from `testAllModulesWithDefaultConfiguration` when `JavadocPackageCheck` was run.