### PR TITLE
Issue #4592: merged module test support and fileset test support

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule21filename/OuterTypeFilenameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule21filename/OuterTypeFilenameTest.java
@@ -40,7 +40,7 @@ public class OuterTypeFilenameTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("OuterTypeFilename");
+        final Configuration checkConfig = getModuleConfig("OuterTypeFilename");
         final String filePath = getPath("InputOuterTypeFilename1.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -52,7 +52,7 @@ public class OuterTypeFilenameTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("OuterTypeFilename");
+        final Configuration checkConfig = getModuleConfig("OuterTypeFilename");
         final String filePath = getPath("InputOuterTypeFilename2.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -66,7 +66,7 @@ public class OuterTypeFilenameTest extends AbstractModuleTestSupport {
             "3: " + getCheckMessage(OuterTypeFilenameCheck.class, MSG_KEY),
         };
 
-        final Configuration checkConfig = getCheckConfig("OuterTypeFilename");
+        final Configuration checkConfig = getModuleConfig("OuterTypeFilename");
         final String filePath = getPath("InputOuterTypeFilename3.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule231filetab/FileTabCharacterTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule231filetab/FileTabCharacterTest.java
@@ -22,7 +22,6 @@ package com.google.checkstyle.test.chapter2filebasic.rule231filetab;
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.AbstractModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck;
 
@@ -31,13 +30,6 @@ public class FileTabCharacterTest extends AbstractModuleTestSupport {
     @Override
     protected String getPackageLocation() {
         return "com/google/checkstyle/test/chapter2filebasic/rule231filetab";
-    }
-
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        final DefaultConfiguration dc = new DefaultConfiguration("root");
-        dc.addChild(config);
-        return dc;
     }
 
     @Test
@@ -55,7 +47,7 @@ public class FileTabCharacterTest extends AbstractModuleTestSupport {
             "134:3: " + getCheckMessage(FileTabCharacterCheck.class, "containsTab"),
         };
 
-        final Configuration checkConfig = getCheckConfig("FileTabCharacter");
+        final Configuration checkConfig = getModuleConfig("FileTabCharacter");
         final String filePath = getPath("InputFileTabCharacter.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/IllegalTokenTextTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/IllegalTokenTextTest.java
@@ -99,7 +99,7 @@ public class IllegalTokenTextTest extends AbstractModuleTestSupport {
             "162:29: " + message,
         };
 
-        final Configuration checkConfig = getCheckConfig("IllegalTokenText");
+        final Configuration checkConfig = getModuleConfig("IllegalTokenText");
         final String filePath = getPath("InputIllegalTokenText.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule233nonascii/AvoidEscapedUnicodeCharactersTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule233nonascii/AvoidEscapedUnicodeCharactersTest.java
@@ -46,7 +46,7 @@ public class AvoidEscapedUnicodeCharactersTest extends AbstractModuleTestSupport
             "36: " + getCheckMessage(AvoidEscapedUnicodeCharactersCheck.class, MSG_KEY),
         };
 
-        final Configuration checkConfig = getCheckConfig("AvoidEscapedUnicodeCharacters");
+        final Configuration checkConfig = getModuleConfig("AvoidEscapedUnicodeCharacters");
         final String filePath = getPath("InputAvoidEscapedUnicodeCharacters.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java
@@ -46,7 +46,7 @@ public class LineLengthTest extends AbstractModuleTestSupport {
             "57: " + getCheckMessage(LineLengthCheck.class, "maxLineLen", 100, 116),
         };
 
-        final Configuration checkConfig = getCheckConfig("LineLength");
+        final Configuration checkConfig = getModuleConfig("LineLength");
         final String filePath = getPath("InputLineLength.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/AvoidStarImportTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/AvoidStarImportTest.java
@@ -41,7 +41,7 @@ public class AvoidStarImportTest extends AbstractModuleTestSupport {
             "19: Using the '.*' form of import should be avoided - javax.swing.WindowConstants.*.",
         };
 
-        final Configuration checkConfig = getCheckConfig("AvoidStarImport");
+        final Configuration checkConfig = getModuleConfig("AvoidStarImport");
         final String filePath = getPath("InputAvoidStarImport.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java
@@ -43,7 +43,7 @@ public class NoLineWrapTest extends AbstractModuleTestSupport {
             "10: " + getCheckMessage(NoLineWrapCheck.class, "no.line.wrap", "import"),
         };
 
-        final Configuration checkConfig = getCheckConfig("NoLineWrap");
+        final Configuration checkConfig = getModuleConfig("NoLineWrap");
         final String filePath = getPath("InputNoLineWrapBad.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -55,7 +55,7 @@ public class NoLineWrapTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("NoLineWrap");
+        final Configuration checkConfig = getModuleConfig("NoLineWrap");
         final String filePath = getPath("InputNoLineWrapGood.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -71,7 +71,7 @@ public class NoLineWrapTest extends AbstractModuleTestSupport {
             "29: " + getCheckMessage(LineLengthCheck.class, "maxLineLen", maxLineLength, 113),
         };
 
-        final Configuration checkConfig = getCheckConfig("LineLength");
+        final Configuration checkConfig = getModuleConfig("LineLength");
         final String filePath = getPath("InputLineLength.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/CustomImportOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/CustomImportOrderTest.java
@@ -59,7 +59,7 @@ public class CustomImportOrderTest extends AbstractModuleTestSupport {
                 "javax.swing.JTable"),
         };
 
-        final Configuration checkConfig = getCheckConfig("CustomImportOrder");
+        final Configuration checkConfig = getModuleConfig("CustomImportOrder");
         final String filePath = getPath("InputCustomImportOrder1.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -84,7 +84,7 @@ public class CustomImportOrderTest extends AbstractModuleTestSupport {
                 "java.util.concurrent.AbstractExecutorService"),
         };
 
-        final Configuration checkConfig = getCheckConfig("CustomImportOrder");
+        final Configuration checkConfig = getModuleConfig("CustomImportOrder");
         final String filePath = getPath("InputCustomImportOrder2.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -111,7 +111,7 @@ public class CustomImportOrderTest extends AbstractModuleTestSupport {
                 "java.util.concurrent.AbstractExecutorService"),
         };
 
-        final Configuration checkConfig = getCheckConfig("CustomImportOrder");
+        final Configuration checkConfig = getModuleConfig("CustomImportOrder");
         final String filePath = getPath("InputCustomImportOrder3.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -123,7 +123,7 @@ public class CustomImportOrderTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("CustomImportOrder");
+        final Configuration checkConfig = getModuleConfig("CustomImportOrder");
         final String filePath = getPath("InputCustomImportOrderValid.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -134,7 +134,7 @@ public class CustomImportOrderTest extends AbstractModuleTestSupport {
     public void testValidGoogleStyleOrderOfImports() throws Exception {
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("CustomImportOrder");
+        final Configuration checkConfig = getModuleConfig("CustomImportOrder");
         final String filePath = getPath("InputCustomImportOrderNoImports.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/OneTopLevelClassTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/OneTopLevelClassTest.java
@@ -48,7 +48,7 @@ public class OneTopLevelClassTest extends AbstractModuleTestSupport {
             "77: " + getCheckMessage(clazz, messageKey, "AnotherClass"),
         };
 
-        final Configuration checkConfig = getCheckConfig("OneTopLevelClass");
+        final Configuration checkConfig = getModuleConfig("OneTopLevelClass");
         final String filePath = getPath("InputOneTopLevelClassBasic.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -60,7 +60,7 @@ public class OneTopLevelClassTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("OneTopLevelClass");
+        final Configuration checkConfig = getModuleConfig("OneTopLevelClass");
         final String filePath = getPath("InputOneTopLevelClassGood.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -77,7 +77,7 @@ public class OneTopLevelClassTest extends AbstractModuleTestSupport {
             "4: " + getCheckMessage(clazz, messageKey, "FooEnum"),
         };
 
-        final Configuration checkConfig = getCheckConfig("OneTopLevelClass");
+        final Configuration checkConfig = getModuleConfig("OneTopLevelClass");
         final String filePath = getPath("InputOneTopLevelClassBad1.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -95,7 +95,7 @@ public class OneTopLevelClassTest extends AbstractModuleTestSupport {
             "7: " + getCheckMessage(clazz, messageKey, "FooClass"),
         };
 
-        final Configuration checkConfig = getCheckConfig("OneTopLevelClass");
+        final Configuration checkConfig = getModuleConfig("OneTopLevelClass");
         final String filePath = getPath("InputOneTopLevelClassBad2.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/OverloadMethodsDeclarationOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/OverloadMethodsDeclarationOrderTest.java
@@ -46,7 +46,7 @@ public class OverloadMethodsDeclarationOrderTest extends AbstractModuleTestSuppo
             "109: " + getCheckMessage(clazz, messageKey, 98),
         };
 
-        final Configuration checkConfig = getCheckConfig("OverloadMethodsDeclarationOrder");
+        final Configuration checkConfig = getModuleConfig("OverloadMethodsDeclarationOrder");
         final String filePath = getPath("InputOverloadMethodsDeclarationOrder.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3sourcefile/EmptyLineSeparatorTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3sourcefile/EmptyLineSeparatorTest.java
@@ -50,7 +50,7 @@ public class EmptyLineSeparatorTest extends AbstractModuleTestSupport {
             "119: " + getCheckMessage(clazz, messageKey, "VARIABLE_DEF"),
         };
 
-        final Configuration checkConfig = getCheckConfig("EmptyLineSeparator");
+        final Configuration checkConfig = getModuleConfig("EmptyLineSeparator");
         final String filePath = getPath("InputEmptyLineSeparator.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule411bracesareused/NeedBracesTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule411bracesareused/NeedBracesTest.java
@@ -79,7 +79,7 @@ public class NeedBracesTest extends AbstractModuleTestSupport {
             "210: " + getCheckMessage(clazz, messageKey, "for"),
         };
 
-        final Configuration checkConfig = getCheckConfig("NeedBraces");
+        final Configuration checkConfig = getModuleConfig("NeedBraces");
         final String filePath = getPath("InputNeedBraces.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyTest.java
@@ -47,7 +47,7 @@ public class LeftCurlyTest extends AbstractModuleTestSupport {
             "97:5: " + getCheckMessage(LeftCurlyCheck.class, MSG_KEY_LINE_PREVIOUS, "{", 5),
         };
 
-        final Configuration checkConfig = getCheckConfig("LeftCurly");
+        final Configuration checkConfig = getModuleConfig("LeftCurly");
         final String filePath = getPath("InputLeftCurlyBraces.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -65,7 +65,7 @@ public class LeftCurlyTest extends AbstractModuleTestSupport {
             "50:5: " + getCheckMessage(LeftCurlyCheck.class, MSG_KEY_LINE_PREVIOUS, "{", 5),
         };
 
-        final Configuration checkConfig = getCheckConfig("LeftCurly");
+        final Configuration checkConfig = getModuleConfig("LeftCurly");
         final String filePath = getPath("InputLeftCurlyAnnotations.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -93,7 +93,7 @@ public class LeftCurlyTest extends AbstractModuleTestSupport {
             "76:5: " + getCheckMessage(LeftCurlyCheck.class, MSG_KEY_LINE_PREVIOUS, "{", 5),
         };
 
-        final Configuration checkConfig = getCheckConfig("LeftCurly");
+        final Configuration checkConfig = getModuleConfig("LeftCurly");
         final String filePath = getPath("InputLeftCurlyMethod.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
@@ -46,7 +46,7 @@ public class RightCurlyTest extends AbstractModuleTestSupport {
             "79:27: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_BREAK_BEFORE, "}", 27),
         };
 
-        final Configuration checkConfig = getCheckConfig("RightCurly", "RightCurlySame");
+        final Configuration checkConfig = getModuleConfig("RightCurly", "RightCurlySame");
         final String filePath = getPath("InputRightCurlyOther.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -57,7 +57,7 @@ public class RightCurlyTest extends AbstractModuleTestSupport {
     public void testRightCurlySame() throws Exception {
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("RightCurly", "RightCurlySame");
+        final Configuration checkConfig = getModuleConfig("RightCurly", "RightCurlySame");
         final String filePath = getPath("InputRightCurlySame.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -72,7 +72,7 @@ public class RightCurlyTest extends AbstractModuleTestSupport {
             "83:9: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_SAME, "}", 9),
         };
 
-        final Configuration checkConfig = getCheckConfig("RightCurly", "RightCurlySame");
+        final Configuration checkConfig = getModuleConfig("RightCurly", "RightCurlySame");
         final String filePath = getPath("InputRightCurlyDoWhile.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -89,7 +89,7 @@ public class RightCurlyTest extends AbstractModuleTestSupport {
             "122:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_NEW, "}", 6),
         };
 
-        final Configuration checkConfig = getCheckConfig("RightCurly", "RightCurlyAlone");
+        final Configuration checkConfig = getModuleConfig("RightCurly", "RightCurlyAlone");
         final String filePath = getPath("InputRightCurlyOtherAlone.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -100,7 +100,7 @@ public class RightCurlyTest extends AbstractModuleTestSupport {
     public void testRightCurlyAloneSame() throws Exception {
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("RightCurly", "RightCurlyAlone");
+        final Configuration checkConfig = getModuleConfig("RightCurly", "RightCurlyAlone");
         final String filePath = getPath("InputRightCurlySame.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -111,7 +111,7 @@ public class RightCurlyTest extends AbstractModuleTestSupport {
     public void testRightCurlyAloneSameAndLiteralDo() throws Exception {
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("RightCurly", "RightCurlyAlone");
+        final Configuration checkConfig = getModuleConfig("RightCurly", "RightCurlyAlone");
         final String filePath = getPath("InputRightCurlyDoWhileAlone.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyBlockTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyBlockTest.java
@@ -71,7 +71,7 @@ public class EmptyBlockTest extends AbstractModuleTestSupport {
             "320:34: " + getCheckMessage(EmptyBlockCheck.class, "block.empty", "if"),
         };
 
-        final Configuration checkConfig = getCheckConfig("EmptyBlock");
+        final Configuration checkConfig = getModuleConfig("EmptyBlock");
         final String filePath = getPath("InputEmptyBlockBasic.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -87,7 +87,7 @@ public class EmptyBlockTest extends AbstractModuleTestSupport {
             "72:21: " + getCheckMessage(EmptyBlockCheck.class, "block.empty", "finally"),
         };
 
-        final Configuration checkConfig = getCheckConfig("EmptyBlock");
+        final Configuration checkConfig = getModuleConfig("EmptyBlock");
         final String filePath = getPath("InputEmptyBlock.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyCatchBlockTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyCatchBlockTest.java
@@ -44,7 +44,7 @@ public class EmptyCatchBlockTest extends AbstractModuleTestSupport {
             "83: " + getCheckMessage(EmptyCatchBlockCheck.class, "catch.block.empty"),
         };
 
-        final Configuration checkConfig = getCheckConfig("EmptyCatchBlock");
+        final Configuration checkConfig = getModuleConfig("EmptyCatchBlock");
         final String filePath = getPath("InputEmptyBlockCatch.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -56,7 +56,7 @@ public class EmptyCatchBlockTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("EmptyCatchBlock");
+        final Configuration checkConfig = getModuleConfig("EmptyCatchBlock");
         final String filePath = getPath("InputEmptyCatchBlockNoViolations.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -71,7 +71,7 @@ public class EmptyCatchBlockTest extends AbstractModuleTestSupport {
             "27: " + getCheckMessage(EmptyCatchBlockCheck.class, "catch.block.empty"),
         };
 
-        final Configuration checkConfig = getCheckConfig("EmptyCatchBlock");
+        final Configuration checkConfig = getModuleConfig("EmptyCatchBlock");
         final String filePath = getPath("InputEmptyCatchBlockViolationsByComment.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -87,7 +87,7 @@ public class EmptyCatchBlockTest extends AbstractModuleTestSupport {
             "58: " + getCheckMessage(EmptyCatchBlockCheck.class, "catch.block.empty"),
         };
 
-        final Configuration checkConfig = getCheckConfig("EmptyCatchBlock");
+        final Configuration checkConfig = getModuleConfig("EmptyCatchBlock");
         final String filePath = getPath("InputEmptyCatchBlockViolationsByVariableName.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineTest.java
@@ -64,7 +64,7 @@ public class OneStatementPerLineTest extends AbstractModuleTestSupport {
             "307:39: " + msg,
         };
 
-        final Configuration checkConfig = getCheckConfig("OneStatementPerLine");
+        final Configuration checkConfig = getModuleConfig("OneStatementPerLine");
         final String filePath = getPath("InputOneStatementPerLine.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -86,7 +86,7 @@ public class OneStatementPerLineTest extends AbstractModuleTestSupport {
             "43:91: " + msg,
         };
 
-        final Configuration checkConfig = getCheckConfig("OneStatementPerLine");
+        final Configuration checkConfig = getModuleConfig("OneStatementPerLine");
         final String filePath = new File("src/test/resources-noncompilable/"
             + "com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/"
             + "InputOneStatementPerLine.java").getCanonicalPath();

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/LineLengthTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/LineLengthTest.java
@@ -40,7 +40,7 @@ public class LineLengthTest extends AbstractModuleTestSupport {
             "29: " + getCheckMessage(LineLengthCheck.class, "maxLineLen", 100, 113),
         };
 
-        final Configuration checkConfig = getCheckConfig("LineLength");
+        final Configuration checkConfig = getModuleConfig("LineLength");
         final String filePath = getPath("InputLineLength.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/MethodParamPadTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/MethodParamPadTest.java
@@ -46,7 +46,7 @@ public class MethodParamPadTest extends AbstractModuleTestSupport {
             "353:15: " + getCheckMessage(clazz, messageKeyPreceded, "("),
             "358:13: " + getCheckMessage(clazz, messageKeyPrevious, "("),
         };
-        final Configuration checkConfig = getCheckConfig("MethodParamPad");
+        final Configuration checkConfig = getModuleConfig("MethodParamPad");
         final String filePath = getPath("InputMethodParamPad.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/OperatorWrapTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/OperatorWrapTest.java
@@ -60,7 +60,7 @@ public class OperatorWrapTest extends AbstractModuleTestSupport {
             "194:38: " + getCheckMessage(clazz, messageKey, "?"),
         };
 
-        final Configuration checkConfig = getCheckConfig("OperatorWrap");
+        final Configuration checkConfig = getModuleConfig("OperatorWrap");
         final String filePath = getPath("InputOperatorWrap.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/SeparatorWrapTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/SeparatorWrapTest.java
@@ -41,7 +41,7 @@ public class SeparatorWrapTest extends AbstractModuleTestSupport {
             "28:30: " + getCheckMessage(SeparatorWrapCheck.class, "line.new", "."),
         };
 
-        final Configuration checkConfig = getCheckConfig("SeparatorWrap", "SeparatorWrapDot");
+        final Configuration checkConfig = getModuleConfig("SeparatorWrap", "SeparatorWrapDot");
         final String filePath = getPath("InputSeparatorWrap.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -55,7 +55,7 @@ public class SeparatorWrapTest extends AbstractModuleTestSupport {
             "31:17: " + getCheckMessage(SeparatorWrapCheck.class, "line.previous", ","),
         };
 
-        final Configuration checkConfig = getCheckConfig("SeparatorWrap", "SeparatorWrapComma");
+        final Configuration checkConfig = getModuleConfig("SeparatorWrap", "SeparatorWrapComma");
         final String filePath = getPath("InputSeparatorWrapComma.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -69,7 +69,8 @@ public class SeparatorWrapTest extends AbstractModuleTestSupport {
             "17:49: " + getCheckMessage(SeparatorWrapCheck.class, MSG_LINE_NEW, "::"),
         };
 
-        final Configuration checkConfig = getCheckConfig("SeparatorWrap", "SeparatorWrapMethodRef");
+        final Configuration checkConfig = getModuleConfig("SeparatorWrap",
+                "SeparatorWrapMethodRef");
         final String filePath = getPath("InputSeparatorWrapMethodRef.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -82,7 +83,7 @@ public class SeparatorWrapTest extends AbstractModuleTestSupport {
             "11:13: " + getCheckMessage(SeparatorWrapCheck.class, "line.previous", "..."),
         };
 
-        final Configuration checkConfig = getCheckConfig("SeparatorWrap", "SeparatorWrapEllipsis");
+        final Configuration checkConfig = getModuleConfig("SeparatorWrap", "SeparatorWrapEllipsis");
         final String filePath = getPath("InputSeparatorWrapEllipsis.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -94,7 +95,7 @@ public class SeparatorWrapTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "9:13: " + getCheckMessage(SeparatorWrapCheck.class, "line.previous", "["),
         };
-        final Configuration checkConfig = getCheckConfig("SeparatorWrap",
+        final Configuration checkConfig = getModuleConfig("SeparatorWrap",
                 "SeparatorWrapArrayDeclarator");
         final String filePath = getPath("InputSeparatorWrapArrayDeclarator.java");
 

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java
@@ -50,7 +50,7 @@ public class EmptyLineSeparatorTest extends AbstractModuleTestSupport {
             "119: " + getCheckMessage(clazz, messageKey, "VARIABLE_DEF"),
         };
 
-        final Configuration checkConfig = getCheckConfig("EmptyLineSeparator");
+        final Configuration checkConfig = getModuleConfig("EmptyLineSeparator");
         final String filePath = getPath("InputEmptyLineSeparator.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/GenericWhitespaceTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/GenericWhitespaceTest.java
@@ -36,7 +36,7 @@ public class GenericWhitespaceTest extends AbstractModuleTestSupport {
 
         final String msgPreceded = "ws.preceded";
         final String msgFollowed = "ws.followed";
-        final Configuration checkConfig = getCheckConfig("GenericWhitespace");
+        final Configuration checkConfig = getModuleConfig("GenericWhitespace");
 
         final String[] expected = {
             "12:16: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
@@ -69,7 +69,7 @@ public class GenericWhitespaceTest extends AbstractModuleTestSupport {
         final String msgFollowed = "ws.followed";
         final String msgNotPreceded = "ws.notPreceded";
         final String msgIllegalFollow = "ws.illegalFollow";
-        final Configuration checkConfig = getCheckConfig("GenericWhitespace");
+        final Configuration checkConfig = getModuleConfig("GenericWhitespace");
 
         final String[] expected = {
             "16:13: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
@@ -108,7 +108,7 @@ public class GenericWhitespaceTest extends AbstractModuleTestSupport {
 
     @Test
     public void genericEndsTheLine() throws Exception {
-        final Configuration checkConfig = getCheckConfig("GenericWhitespace");
+        final Configuration checkConfig = getModuleConfig("GenericWhitespace");
         final String[] expected = {
         };
         verify(checkConfig, getPath("InputGenericWhitespaceEndsTheLine.java"),

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/MethodParamPadTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/MethodParamPadTest.java
@@ -48,7 +48,7 @@ public class MethodParamPadTest extends AbstractModuleTestSupport {
             "47:18: " + getCheckMessage(clazz, messageKeyPreceded, "("),
             "52:36: " + getCheckMessage(clazz, messageKeyPreceded, "("),
         };
-        final Configuration checkConfig = getCheckConfig("MethodParamPad");
+        final Configuration checkConfig = getModuleConfig("MethodParamPad");
         final String filePath = getPath("InputMethodParamPad.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/ParenPadTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/ParenPadTest.java
@@ -159,7 +159,7 @@ public class ParenPadTest extends AbstractModuleTestSupport {
             "212:51: " + getCheckMessage(clazz, messageKeyPreceded, ")"),
             "212:53: " + getCheckMessage(clazz, messageKeyPreceded, ")"),
         };
-        final Configuration checkConfig = getCheckConfig("ParenPad");
+        final Configuration checkConfig = getModuleConfig("ParenPad");
         final String filePath = getPath("InputParenPad.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
@@ -35,7 +35,7 @@ public class WhitespaceAroundTest extends AbstractModuleTestSupport {
     @Test
     public void testWhitespaceAroundBasic() throws Exception {
 
-        final Configuration checkConfig = getCheckConfig("WhitespaceAround");
+        final Configuration checkConfig = getModuleConfig("WhitespaceAround");
         final String msgPreceded = "ws.notPreceded";
         final String msgFollowed = "ws.notFollowed";
 
@@ -76,7 +76,7 @@ public class WhitespaceAroundTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("WhitespaceAround");
+        final Configuration checkConfig = getModuleConfig("WhitespaceAround");
         final String filePath = getPath("InputWhitespaceAroundEmptyTypesAndCycles.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4821onevariableperline/MultipleVariableDeclarationsTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4821onevariableperline/MultipleVariableDeclarationsTest.java
@@ -63,7 +63,7 @@ public class MultipleVariableDeclarationsTest extends AbstractModuleTestSupport 
             "89:5: " + msgComma,
         };
 
-        final Configuration checkConfig = getCheckConfig("MultipleVariableDeclarations");
+        final Configuration checkConfig = getModuleConfig("MultipleVariableDeclarations");
         final String filePath = getPath("InputMultipleVariableDeclarations.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4822variabledistance/VariableDeclarationUsageDistanceTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4822variabledistance/VariableDeclarationUsageDistanceTest.java
@@ -47,7 +47,7 @@ public class VariableDeclarationUsageDistanceTest extends AbstractModuleTestSupp
         };
 
         final Configuration checkConfig =
-            getCheckConfig("VariableDeclarationUsageDistance");
+            getModuleConfig("VariableDeclarationUsageDistance");
         final String filePath = getPath("InputVariableDeclarationUsageDistanceCheck.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/ArrayTypeStyleTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/ArrayTypeStyleTest.java
@@ -46,7 +46,7 @@ public class ArrayTypeStyleTest extends AbstractModuleTestSupport {
             "42:19: " + getCheckMessage(ArrayTypeStyleCheck.class, MSG_KEY),
         };
 
-        final Configuration checkConfig = getCheckConfig("ArrayTypeStyle");
+        final Configuration checkConfig = getModuleConfig("ArrayTypeStyle");
         final String filePath = getPath("InputArrayTypeStyle.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java
@@ -37,7 +37,7 @@ public class IndentationTest extends AbstractIndentationTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("Indentation");
+        final Configuration checkConfig = getModuleConfig("Indentation");
         final String filePath = getPath("InputIndentationCorrectClass.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -49,7 +49,7 @@ public class IndentationTest extends AbstractIndentationTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("Indentation");
+        final Configuration checkConfig = getModuleConfig("Indentation");
         final String filePath = getPath("InputIndentationCorrectFieldAndParameter.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -61,7 +61,7 @@ public class IndentationTest extends AbstractIndentationTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("Indentation");
+        final Configuration checkConfig = getModuleConfig("Indentation");
         final String filePath = getPath("InputIndentationCorrectForAndParameter.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -73,7 +73,7 @@ public class IndentationTest extends AbstractIndentationTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("Indentation");
+        final Configuration checkConfig = getModuleConfig("Indentation");
         final String filePath = getPath("InputIndentationCorrectIfAndParameter.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -85,7 +85,7 @@ public class IndentationTest extends AbstractIndentationTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("Indentation");
+        final Configuration checkConfig = getModuleConfig("Indentation");
         final String filePath = getPath("InputIndentationCorrect.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -97,7 +97,7 @@ public class IndentationTest extends AbstractIndentationTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("Indentation");
+        final Configuration checkConfig = getModuleConfig("Indentation");
         final String filePath = getPath("InputIndentationCorrectReturnAndParameter.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -109,7 +109,7 @@ public class IndentationTest extends AbstractIndentationTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("Indentation");
+        final Configuration checkConfig = getModuleConfig("Indentation");
         final String filePath = getPath("InputIndentationCorrectWhileDoWhileAndParameter.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4842fallthrough/FallThroughTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4842fallthrough/FallThroughTest.java
@@ -51,7 +51,7 @@ public class FallThroughTest extends AbstractModuleTestSupport {
             "374:41: " + msg,
         };
 
-        final Configuration checkConfig = getCheckConfig("FallThrough");
+        final Configuration checkConfig = getModuleConfig("FallThrough");
         final String filePath = getPath("InputFallThrough.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4843defaultcasepresent/MissingSwitchDefaultTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4843defaultcasepresent/MissingSwitchDefaultTest.java
@@ -47,7 +47,7 @@ public class MissingSwitchDefaultTest extends AbstractModuleTestSupport {
             "42: " + msg,
         };
 
-        final Configuration checkConfig = getCheckConfig("MissingSwitchDefault");
+        final Configuration checkConfig = getModuleConfig("MissingSwitchDefault");
         final String filePath = getPath("InputMissingSwitchDefault.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule485annotations/AnnotationLocationTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule485annotations/AnnotationLocationTest.java
@@ -37,7 +37,7 @@ public class AnnotationLocationTest extends AbstractModuleTestSupport {
 
         final Class<AnnotationLocationCheck> clazz = AnnotationLocationCheck.class;
         getCheckMessage(clazz, "annotation.location.alone");
-        final Configuration checkConfig = getCheckConfig("AnnotationLocation",
+        final Configuration checkConfig = getModuleConfig("AnnotationLocation",
                 "AnnotationLocationMostCases");
 
         final String msgLocationAlone = "annotation.location.alone";
@@ -67,7 +67,7 @@ public class AnnotationLocationTest extends AbstractModuleTestSupport {
 
         final Class<AnnotationLocationCheck> clazz = AnnotationLocationCheck.class;
         getCheckMessage(clazz, "annotation.location.alone");
-        final Configuration checkConfig = getCheckConfig("AnnotationLocation",
+        final Configuration checkConfig = getModuleConfig("AnnotationLocation",
                 "AnnotationLocationVariables");
 
         final String msgLocation = "annotation.location";

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/CommentsIndentationTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/CommentsIndentationTest.java
@@ -91,7 +91,7 @@ public class CommentsIndentationTest extends AbstractModuleTestSupport {
                 352, 9, 8),
             };
 
-        final Configuration checkConfig = getCheckConfig("CommentsIndentation");
+        final Configuration checkConfig = getModuleConfig("CommentsIndentation");
         final String filePath =
             getPath("InputCommentsIndentationCommentIsAtTheEndOfBlock.java");
 
@@ -138,7 +138,7 @@ public class CommentsIndentationTest extends AbstractModuleTestSupport {
                 "228, 230", 6, "12, 12"),
             };
 
-        final Configuration checkConfig = getCheckConfig("CommentsIndentation");
+        final Configuration checkConfig = getModuleConfig("CommentsIndentation");
         final String filePath =
             getPath("InputCommentsIndentationInSwitchBlock.java");
 
@@ -161,7 +161,7 @@ public class CommentsIndentationTest extends AbstractModuleTestSupport {
                 72, 0, 8),
             };
 
-        final Configuration checkConfig = getCheckConfig("CommentsIndentation");
+        final Configuration checkConfig = getModuleConfig("CommentsIndentation");
         final String filePath =
             getPath("InputCommentsIndentationInEmptyBlock.java");
 
@@ -192,7 +192,7 @@ public class CommentsIndentationTest extends AbstractModuleTestSupport {
                 109, 33, 8),
             };
 
-        final Configuration checkConfig = getCheckConfig("CommentsIndentation");
+        final Configuration checkConfig = getModuleConfig("CommentsIndentation");
         final String filePath =
             getPath("InputCommentsIndentationSurroundingCode.java");
 

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule487modifiers/ModifierOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule487modifiers/ModifierOrderTest.java
@@ -96,7 +96,7 @@ public class ModifierOrderTest extends AbstractModuleTestSupport {
             "245:14: " + getCheckMessage(clazz, msgMod, "default"),
         };
 
-        final Configuration checkConfig = getCheckConfig("ModifierOrder");
+        final Configuration checkConfig = getModuleConfig("ModifierOrder");
         final String filePath = getPath("InputModifierOrder.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule488numericliterals/UpperEllTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule488numericliterals/UpperEllTest.java
@@ -61,7 +61,7 @@ public class UpperEllTest extends AbstractModuleTestSupport {
             "100:22: Should use uppercase 'L'.",
         };
 
-        final Configuration checkConfig = getCheckConfig("UpperEll");
+        final Configuration checkConfig = getModuleConfig("UpperEll");
         final String filePath = getPath("InputUpperEll.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule51identifiernames/CatchParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule51identifiernames/CatchParameterNameTest.java
@@ -37,7 +37,7 @@ public class CatchParameterNameTest extends AbstractModuleTestSupport {
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException {
-        checkConfig = getCheckConfig("CatchParameterName");
+        checkConfig = getModuleConfig("CatchParameterName");
         format = checkConfig.getAttribute("format");
     }
 

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java
@@ -47,7 +47,7 @@ public class PackageNameTest extends AbstractModuleTestSupport {
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException {
-        checkConfig = getCheckConfig("PackageName");
+        checkConfig = getModuleConfig("PackageName");
         format = checkConfig.getAttribute("format");
     }
 

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule522typenames/TypeNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule522typenames/TypeNameTest.java
@@ -34,7 +34,7 @@ public class TypeNameTest extends AbstractModuleTestSupport {
     @Test
     public void testTypeName() throws Exception {
 
-        final Configuration checkConfig = getCheckConfig("TypeName");
+        final Configuration checkConfig = getModuleConfig("TypeName");
         final String msgKey = "name.invalidPattern";
         final String format = "^[A-Z][a-zA-Z0-9]*$";
 

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule523methodnames/MethodNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule523methodnames/MethodNameTest.java
@@ -34,7 +34,7 @@ public class MethodNameTest extends AbstractModuleTestSupport {
     @Test
     public void testMethodName() throws Exception {
 
-        final Configuration checkConfig = getCheckConfig("MethodName");
+        final Configuration checkConfig = getModuleConfig("MethodName");
         final String msgKey = "name.invalidPattern";
         final String format = "^[a-z][a-z0-9][a-zA-Z0-9_]*$";
 

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java
@@ -39,7 +39,7 @@ public class MemberNameTest extends AbstractModuleTestSupport {
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException {
-        checkConfig = getCheckConfig("MemberName");
+        checkConfig = getModuleConfig("MemberName");
         format = checkConfig.getAttribute("format");
     }
 

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java
@@ -42,7 +42,7 @@ public class ParameterNameTest extends AbstractModuleTestSupport {
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException {
-        final List<Configuration> configs = getCheckConfigs("ParameterName");
+        final List<Configuration> configs = getModuleConfigs("ParameterName");
 
         Assert.assertEquals("Invalid configs size", 1, configs.size());
 

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
@@ -39,7 +39,7 @@ public class LocalVariableNameTest extends AbstractModuleTestSupport {
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException {
-        checkConfig = getCheckConfig("LocalVariableName");
+        checkConfig = getModuleConfig("LocalVariableName");
         format = checkConfig.getAttribute("format");
     }
 

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassTypeParameterNameTest.java
@@ -35,7 +35,7 @@ public class ClassTypeParameterNameTest extends AbstractModuleTestSupport {
 
     @Test
     public void testClassDefault() throws Exception {
-        final Configuration configuration = getCheckConfig("ClassTypeParameterName");
+        final Configuration configuration = getModuleConfig("ClassTypeParameterName");
         final String format = configuration.getAttribute("format");
 
         final String[] expected = {

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InterfaceTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InterfaceTypeParameterNameTest.java
@@ -35,7 +35,7 @@ public class InterfaceTypeParameterNameTest extends AbstractModuleTestSupport {
 
     @Test
     public void testInterfaceDefault() throws Exception {
-        final Configuration configuration = getCheckConfig("InterfaceTypeParameterName");
+        final Configuration configuration = getModuleConfig("InterfaceTypeParameterName");
         final String format = configuration.getAttribute("format");
 
         final String[] expected = {

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/MethodTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/MethodTypeParameterNameTest.java
@@ -38,13 +38,13 @@ public class MethodTypeParameterNameTest extends AbstractModuleTestSupport {
 
     @BeforeClass
     public static void setConfigurationBuilder() throws CheckstyleException {
-        format = getCheckConfig("ClassTypeParameterName").getAttribute("format");
+        format = getModuleConfig("ClassTypeParameterName").getAttribute("format");
     }
 
     @Test
     public void testMethodDefault() throws Exception {
 
-        final Configuration checkConfig = getCheckConfig("MethodTypeParameterName");
+        final Configuration checkConfig = getModuleConfig("MethodTypeParameterName");
 
         final String[] expected = {
             "9:6: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "e_e", format),

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
@@ -54,7 +54,7 @@ public class AbbreviationAsWordInNameTest extends AbstractModuleTestSupport {
 
         final String filePath = getPath("InputAbbreviationAsWordInTypeNameCheck.java");
 
-        final Configuration checkConfig = getCheckConfig("AbbreviationAsWordInName");
+        final Configuration checkConfig = getModuleConfig("AbbreviationAsWordInName");
         final Integer[] warnList = getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);
     }

--- a/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule62donotignoreexceptions/EmptyBlockTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule62donotignoreexceptions/EmptyBlockTest.java
@@ -41,7 +41,7 @@ public class EmptyBlockTest extends AbstractModuleTestSupport {
             "72:21: " + getCheckMessage(EmptyBlockCheck.class, "block.empty", "finally"),
         };
 
-        final Configuration checkConfig = getCheckConfig("EmptyBlock");
+        final Configuration checkConfig = getModuleConfig("EmptyBlock");
         final String filePath = getPath("InputEmptyBlockCatch.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule64finalizers/NoFinalizerTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule64finalizers/NoFinalizerTest.java
@@ -41,7 +41,7 @@ public class NoFinalizerTest extends AbstractModuleTestSupport {
             "5: " + msg,
         };
 
-        final Configuration checkConfig = getCheckConfig("NoFinalizer");
+        final Configuration checkConfig = getModuleConfig("NoFinalizer");
         final String filePath = getPath("InputNoFinalizer.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -65,7 +65,7 @@ public class NoFinalizerTest extends AbstractModuleTestSupport {
             "136: " + msg,
         };
 
-        final Configuration checkConfig = getCheckConfig("NoFinalizer");
+        final Configuration checkConfig = getModuleConfig("NoFinalizer");
         final String filePath = getPath("InputNoFinalizeExtend.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/SingleLineJavadocTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/SingleLineJavadocTest.java
@@ -47,7 +47,7 @@ public class SingleLineJavadocTest extends AbstractModuleTestSupport {
             "41: " + msg,
         };
 
-        final Configuration checkConfig = getCheckConfig("SingleLineJavadoc");
+        final Configuration checkConfig = getModuleConfig("SingleLineJavadoc");
         final String filePath = getPath("InputSingleLineJavadocCheck.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/JavadocParagraphTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/JavadocParagraphTest.java
@@ -38,7 +38,7 @@ public class JavadocParagraphTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("JavadocParagraph");
+        final Configuration checkConfig = getModuleConfig("JavadocParagraph");
         final String filePath = getPath("InputCorrectJavadocParagraphCheck.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -88,7 +88,7 @@ public class JavadocParagraphTest extends AbstractModuleTestSupport {
             "73: " + msgBefore,
         };
 
-        final Configuration checkConfig = getCheckConfig("JavadocParagraph");
+        final Configuration checkConfig = getModuleConfig("JavadocParagraph");
         final String filePath = getPath("InputIncorrectJavadocParagraphCheck.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/AtclauseOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/AtclauseOrderTest.java
@@ -38,7 +38,7 @@ public class AtclauseOrderTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("AtclauseOrder");
+        final Configuration checkConfig = getModuleConfig("AtclauseOrder");
         final String filePath = getPath("InputCorrectAtClauseOrderCheck.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -80,7 +80,7 @@ public class AtclauseOrderTest extends AbstractModuleTestSupport {
             "261: " + msg,
         };
 
-        final Configuration checkConfig = getCheckConfig("AtclauseOrder");
+        final Configuration checkConfig = getModuleConfig("AtclauseOrder");
         final String filePath = getPath("InputIncorrectAtClauseOrderCheck.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/JavadocTagContinuationIndentationTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/JavadocTagContinuationIndentationTest.java
@@ -52,7 +52,7 @@ public class JavadocTagContinuationIndentationTest extends AbstractModuleTestSup
             "322: " + msg,
         };
 
-        final Configuration checkConfig = getCheckConfig("JavadocTagContinuationIndentation");
+        final Configuration checkConfig = getModuleConfig("JavadocTagContinuationIndentation");
         final String filePath = getPath("InputJavaDocTagContinuationIndentation.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/NonEmptyAtclauseDescriptionTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/NonEmptyAtclauseDescriptionTest.java
@@ -51,7 +51,7 @@ public class NonEmptyAtclauseDescriptionTest extends AbstractModuleTestSupport {
             "52: " + msg,
         };
 
-        final Configuration checkConfig = getCheckConfig("NonEmptyAtclauseDescription");
+        final Configuration checkConfig = getModuleConfig("NonEmptyAtclauseDescription");
         final String filePath = getPath("InputNonEmptyAtclauseDescriptionCheck.java");
 
         final Integer[] warnList = getLineNumbersFromExpected(expected);
@@ -72,7 +72,7 @@ public class NonEmptyAtclauseDescriptionTest extends AbstractModuleTestSupport {
             "40: " + msg,
         };
 
-        final Configuration checkConfig = getCheckConfig("NonEmptyAtclauseDescription");
+        final Configuration checkConfig = getModuleConfig("NonEmptyAtclauseDescription");
         final String filePath = getPath("InputNonEmptyAtclauseDescriptionCheckSpaceSeq.java");
 
         final Integer[] warnList = getLineNumbersFromExpected(expected);

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/SummaryJavadocTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/SummaryJavadocTest.java
@@ -38,7 +38,7 @@ public class SummaryJavadocTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        final Configuration checkConfig = getCheckConfig("SummaryJavadoc");
+        final Configuration checkConfig = getModuleConfig("SummaryJavadoc");
         final String filePath = getPath("InputCorrectSummaryJavaDocCheck.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
@@ -68,7 +68,7 @@ public class SummaryJavadocTest extends AbstractModuleTestSupport {
             "103: " + msgMissingDoc,
         };
 
-        final Configuration checkConfig = getCheckConfig("SummaryJavadoc");
+        final Configuration checkConfig = getModuleConfig("SummaryJavadoc");
         final String filePath = getPath("InputIncorrectSummaryJavaDocCheck.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/JavadocMethodTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/JavadocMethodTest.java
@@ -41,7 +41,7 @@ public class JavadocMethodTest extends AbstractModuleTestSupport {
             "57:5: " + msg,
         };
 
-        final Configuration checkConfig = getCheckConfig("JavadocMethod");
+        final Configuration checkConfig = getModuleConfig("JavadocMethod");
         final String filePath = getPath("InputJavadocMethodCheck.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);


### PR DESCRIPTION
Issue #4592

All major changes are in `AbstractModuleTestSupport` to mirror changes that were add in `test` folder.

`getCheckConfig(String checkName)` was rewritten to be an override of the method `getCheckConfig(String checkName, String checkId)`.