### PR TITLE
Issue #4630: fixed exception in ModifiedControlVariable for enhanced for

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -330,8 +330,10 @@ public final class ModifiedControlVariableCheck extends AbstractCheck {
     private void leaveForDef(DetailAST ast) {
         final DetailAST forInitAST = ast.findFirstToken(TokenTypes.FOR_INIT);
         if (forInitAST == null) {
-            // this is for-each loop, just pop variables
-            getCurrentVariables().pop();
+            if (!skipEnhancedForLoopVariable) {
+                // this is for-each loop, just pop variables
+                getCurrentVariables().pop();
+            }
         }
         else {
             final Set<String> variablesManagedByForLoop = getVariablesManagedByForLoop(ast);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
@@ -78,6 +78,19 @@ public class ModifiedControlVariableCheckTest
     }
 
     @Test
+    public void testEnhancedForLoopVariable2() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(ModifiedControlVariableCheck.class);
+        checkConfig.addAttribute("skipEnhancedForLoopVariable", "true");
+
+        final String[] expected = {
+            "14:18: " + getCheckMessage(MSG_KEY, "i"),
+        };
+        verify(checkConfig, getPath("InputModifiedControlVariableEnhancedForLoopVariable2.java"),
+            expected);
+    }
+
+    @Test
     public void testTokensNotNull() {
         final ModifiedControlVariableCheck check = new ModifiedControlVariableCheck();
         Assert.assertNotNull("Acceptable tokens should not be null", check.getAcceptableTokens());

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableEnhancedForLoopVariable2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableEnhancedForLoopVariable2.java
@@ -1,0 +1,18 @@
+package com.puppycrawl.tools.checkstyle.checks.coding.modifiedcontrolvariable;
+
+public class InputModifiedControlVariableEnhancedForLoopVariable2 {
+    void m(int[] a) {
+        for (int i = 0, j = 1; ; i++, j++) {
+            for (int k : a) {
+            }
+        }
+    }
+
+    void m2(int[] a) {
+        for (int i = 0, j = 1; ; i++, j++) {
+            for (int k : a) {
+                i++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue #4630

We skip over `FOR_EACH_CLAUSE` in `leaveToken` but we don't do the same when we reach `LITERAL_FOR` which is a parent of `FOR_EACH_CLAUSE`.

Regression to come.