### PR TITLE
Issue #4563: fixed stackoverflow with DetailAST.setParent

### DIFF
--- a/config/pmd-test.xml
+++ b/config/pmd-test.xml
@@ -72,9 +72,11 @@
             <!-- in SuppressionCommentFilterTest, SuppressWithNearbyCommentFilterTest, SuppressionFilterTest
             pmd does not accept nl.jqno.equalsverifier.EqualsVerifier#.verify() as correctness check method -->
             <!-- in AbstractJavadocCheckTest pmd does not find asserts in another class methods called from the test method -->
-            <!-- in ImportControlCheckTest pmd does not find asserts in private methods of the test class called from the test method -->
+            <!-- in ImportControlCheckTest, DetailASTTest
+                 pmd does not find asserts in private methods of the test class called from the test method -->
             <!-- in AstRegressionTest pmd does not find asserts in inner classes methods called from the test method -->
             <!-- in AllChecksTest pmd does not find asserts in lambdas -->
+            <!-- in DetailASTTest pmd does not find asserts in lambdas -->
             <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='SuppressionFilterTest']//MethodDeclarator[@Image='testEqualsAndHashCode']
             | //ClassOrInterfaceDeclaration[@Image='SuppressionCommentFilterTest']//MethodDeclarator[@Image='testEqualsAndHashCodeOfTagClass']
             | //ClassOrInterfaceDeclaration[@Image='SuppressWithNearbyCommentFilterTest']//MethodDeclarator[@Image='testEqualsAndHashCodeOfTagClass']
@@ -85,6 +87,7 @@
             | /ClassOrInterfaceDeclaration[@Image='AstRegressionTest']//MethodDeclarator[@Image='testImpossibleExceptions']
             | //ClassOrInterfaceDeclaration[@Image='AstRegressionTest']//MethodDeclarator[@Image='testImpossibleValid']
             | //ClassOrInterfaceDeclaration[@Image='AllChecksTest']//MethodDeclarator[@Image='testAllModulesAreReferencedInConfigFile']
+            | //ClassOrInterfaceDeclaration[@Image='DetailASTTest']//MethodDeclarator[@Image='testTreeStructure']
             "/>
         </properties>
     </rule>

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -31,4 +31,8 @@
     and do not have coverage problems due to imports from java.util.stream. -->
     <suppress id="ForbidInterfacesImportFromJavaUtilStream"
               files=".*[\\/]src[\\/](test|it)[\\/]"/>
+
+    <!-- Tone down the checking for test code -->
+    <suppress checks="ForbidCertainImports"
+              files="DetailASTTest\.java"/>
 </suppressions>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -32,7 +32,7 @@
     <suppress checks="Javadoc" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="MagicNumber" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="AvoidStaticImport" files=".*[\\/]src[\\/](test|it)[\\/]"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="[\\/]IndentationCheckTest.java$|[\\/]SuppressWithNearbyCommentFilterTest.java$|[\\/]SuppressionCommentFilterTest.java$"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="[\\/]IndentationCheckTest.java$|[\\/]SuppressWithNearbyCommentFilterTest.java$|[\\/]SuppressionCommentFilterTest.java|[\\/]DetailASTTest.java$"/>
     <suppress checks="EqualsAvoidNull" files="[\\/]Int.*FilterTest.java$"/>
     <suppress checks="VisibilityModifier" files="[\\/]BaseCheckTestSupport.java$|[\\/]AbstractModuleTestSupport.java$"/>
     <suppress checks="WriteTag" files=".*[\\/]src[\\/](test|it)[\\/]"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -199,13 +199,17 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
      * @param parent the parent token
      */
     private void setParent(DetailAST parent) {
-        clearBranchTokenTypes();
-        this.parent = parent;
-        final DetailAST nextSibling = getNextSibling();
-        if (nextSibling != null) {
-            nextSibling.setParent(parent);
-            nextSibling.previousSibling = this;
-        }
+        DetailAST instance = this;
+        do {
+            instance.clearBranchTokenTypes();
+            instance.parent = parent;
+            final DetailAST nextSibling = instance.getNextSibling();
+            if (nextSibling != null) {
+                nextSibling.previousSibling = instance;
+            }
+
+            instance = nextSibling;
+        } while (instance != null);
     }
 
     /**


### PR DESCRIPTION
Issue #4563

Rewrote `setParent` to not do a recursive call but to use a loop instead.

`testManyComments` was written in a way to avoid putting a 300kb input file into our repository.
It added 9 seconds runtime on my local PC.

i assume we don't need regression.