### PR TITLE
Issue #4885: fixed list of packages when module can't be found

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -270,9 +270,9 @@ public class PackageObjectFactory implements ModuleFactory {
      * @return a string which is obtained by joining package names with a class name.
      */
     private static String joinPackageNamesWithClassName(String className, Set<String> packages) {
-        return packages.stream()
-            .collect(Collectors.joining(
-                    className + STRING_SEPARATOR, "", PACKAGE_SEPARATOR + className));
+        return packages.stream().collect(
+            Collectors.joining(PACKAGE_SEPARATOR + className + STRING_SEPARATOR, "",
+                    PACKAGE_SEPARATOR + className));
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -169,7 +169,7 @@ public class PackageObjectFactoryTest {
     }
 
     @Test
-    public void testCreateObjectFromFullModuleNamesWithException() throws Exception {
+    public void testCreateObjectFromFullModuleNamesWithAmbiguousException() throws Exception {
         final String barPackage = BASE_PACKAGE + ".packageobjectfactory.bar";
         final String fooPackage = BASE_PACKAGE + ".packageobjectfactory.foo";
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
@@ -186,6 +186,33 @@ public class PackageObjectFactoryTest {
             final LocalizedMessage exceptionMessage = new LocalizedMessage(0,
                     Definitions.CHECKSTYLE_BUNDLE, AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE,
                     new String[] {name, optionalNames}, null, getClass(), null);
+            assertEquals("Invalid exception message",
+                    exceptionMessage.getMessage(), ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateObjectFromFullModuleNamesWithCantInstantiateException() {
+        final String package1 = BASE_PACKAGE + ".wrong1";
+        final String package2 = BASE_PACKAGE + ".wrong2";
+        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        final PackageObjectFactory objectFactory = new PackageObjectFactory(
+                new LinkedHashSet<>(Arrays.asList(package1, package2)), classLoader);
+        final String name = "FooCheck";
+        final String checkName = name + CHECK_SUFFIX;
+        try {
+            objectFactory.createModule(name);
+            fail("Exception is expected");
+        }
+        catch (CheckstyleException ex) {
+            final String attemptedNames = package1 + PACKAGE_SEPARATOR + name + STRING_SEPARATOR
+                    + package2 + PACKAGE_SEPARATOR + name + STRING_SEPARATOR
+                    + checkName + STRING_SEPARATOR
+                    + package1 + PACKAGE_SEPARATOR + checkName + STRING_SEPARATOR
+                    + package2 + PACKAGE_SEPARATOR + checkName;
+            final LocalizedMessage exceptionMessage = new LocalizedMessage(0,
+                    Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
+                    new String[] {name, attemptedNames}, null, getClass(), null);
             assertEquals("Invalid exception message",
                     exceptionMessage.getMessage(), ex.getMessage());
         }


### PR DESCRIPTION
Issue #4885

Problem went unnoticed because we didn't have a test failing with multiple packages defined.
I assume coverage didn't catch anything missing because we inlined work using `Collectors.joining`.