### PR TITLE
Issue #4744: ignore starting inheritDoc in SummaryJavadocCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -92,9 +92,6 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
     /** Period literal. */
     private static final String PERIOD = ".";
 
-    /** Inherit doc literal. */
-    private static final String INHERIT_DOC = "{@inheritDoc}";
-
     /** Set of allowed Tokens tags in summary java doc. */
     private static final Set<Integer> ALLOWED_TYPES = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(JavadocTokenTypes.TEXT,
@@ -137,23 +134,48 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
 
     @Override
     public void visitJavadocToken(DetailNode ast) {
-        String firstSentence = getFirstSentence(ast);
-        final int endOfSentence = firstSentence.lastIndexOf(period);
-        final String summaryDoc = getSummarySentence(ast);
-        if (summaryDoc.isEmpty()) {
-            log(ast.getLineNumber(), MSG_SUMMARY_JAVADOC_MISSING);
-        }
-        else if (!period.isEmpty()
-                && !summaryDoc.contains(period)
-                && !summaryDoc.equals(INHERIT_DOC)) {
-            log(ast.getLineNumber(), MSG_SUMMARY_FIRST_SENTENCE);
-        }
-        if (endOfSentence != -1) {
-            firstSentence = firstSentence.substring(0, endOfSentence);
-            if (containsForbiddenFragment(firstSentence)) {
-                log(ast.getLineNumber(), MSG_SUMMARY_JAVADOC);
+        if (!startsWithInheritDoc(ast)) {
+            String firstSentence = getFirstSentence(ast);
+            final int endOfSentence = firstSentence.lastIndexOf(period);
+            final String summaryDoc = getSummarySentence(ast);
+            if (summaryDoc.isEmpty()) {
+                log(ast.getLineNumber(), MSG_SUMMARY_JAVADOC_MISSING);
+            }
+            else if (!period.isEmpty()
+                    && !summaryDoc.contains(period)) {
+                log(ast.getLineNumber(), MSG_SUMMARY_FIRST_SENTENCE);
+            }
+            if (endOfSentence != -1) {
+                firstSentence = firstSentence.substring(0, endOfSentence);
+                if (containsForbiddenFragment(firstSentence)) {
+                    log(ast.getLineNumber(), MSG_SUMMARY_JAVADOC);
+                }
             }
         }
+    }
+
+    /**
+     * Checks if the node starts with an {&#64;inheritDoc}.
+     * @param root The root node to examine.
+     * @return {@code true} if the javadoc starts with an {&#64;inheritDoc}.
+     */
+    private static boolean startsWithInheritDoc(DetailNode root) {
+        boolean found = false;
+        final DetailNode[] children = root.getChildren();
+
+        for (int i = 0; !found && i < children.length - 1; i++) {
+            final DetailNode child = children[i];
+            if (child.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG
+                    && child.getChildren()[1].getType() == JavadocTokenTypes.INHERIT_DOC_LITERAL) {
+                found = true;
+            }
+            else if (child.getType() != JavadocTokenTypes.LEADING_ASTERISK
+                    && !CommonUtils.isBlank(child.getText())) {
+                break;
+            }
+        }
+
+        return found;
     }
 
     /**
@@ -168,10 +190,6 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
             if (ALLOWED_TYPES.contains(child.getType())) {
                 result.append(child.getText());
             }
-            else if (child.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG
-                    && getContentOfChild(child).equals(INHERIT_DOC)) {
-                result.append(INHERIT_DOC);
-            }
             else if (child.getType() == JavadocTokenTypes.HTML_ELEMENT
                     && CommonUtils.isBlank(result.toString().trim())) {
                 result.append(getStringInsideTag(result.toString(),
@@ -185,19 +203,6 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
             }
         }
         return result.toString().trim();
-    }
-
-    /**
-     * Returns content when token type is javadoc inline tag.
-     * @param child javadoc inline tag ast.
-     * @return content of child nodes as string.
-     */
-    private static String getContentOfChild(DetailNode child) {
-        final StringBuilder contents = new StringBuilder(256);
-        for (DetailNode node : child.getChildren()) {
-            contents.append(node.getText().trim());
-        }
-        return contents.toString();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -78,9 +78,9 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
             "83: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
             "103: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
             "116: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
-            "121: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+            "121: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
             "126: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "131: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "132: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
         };
         verify(checkConfig, getPath("InputSummaryJavadocIncorrect.java"), expected);
     }
@@ -115,9 +115,9 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
             "69: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
             "103: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
             "116: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
-            "121: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+            "121: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
             "126: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "131: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "132: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
         };
 
         createChecker(checkConfig);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocCorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocCorrect.java
@@ -50,6 +50,36 @@ class InputSummaryJavadocCorrect {
     void foo10() {}
 
     /**
+     * {@inheritDoc}mm
+     */
+    void foo9a() {}
+
+    /**
+     * {@inheritDoc}mm.
+     */
+    void foo11() {}
+
+    /**
+     * {@inheritDoc} M m m m
+     */
+    void foo12() {}
+
+    /**
+     * {@inheritDoc} M m m m.
+     */
+    void foo13() {}
+
+    /**
+     * mm. {@inheritDoc}
+     */
+    void foo14() {}
+
+    /**
+     * M m m m. {@inheritDoc}
+     */
+    void foo15() {}
+
+    /**
      * This is summary java doc.
      * <a href="mailto:vlad@htmlbook.ru"/>
      */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocIncorrect.java
@@ -119,11 +119,6 @@ class InputSummaryJavadocIncorrect {
          void foo7() {}
 
          /**
-          * {@inheritDoc}mm
-          */
-         void foo9() {}
-
-         /**
           * {@link #setBounds(int,int,int,int)}
           */
          void foo8() {}
@@ -133,4 +128,9 @@ class InputSummaryJavadocIncorrect {
           */
          void foo10() {}
     };
+
+    /**
+     * M m m m {@inheritDoc}
+     */
+    void foo7() {}
 }


### PR DESCRIPTION
Issue #4744

This will also cover https://github.com/checkstyle/checkstyle/issues/4800 .
Changed in inputs is moving correct case out of incorrect input file. All changes in test are from that, not from change in code.

Regression will come, but it will be slow because of javadoc parsing.