### PR TITLE
Issue #4883: Add MT check markers

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -40,6 +40,11 @@
   <allow pkg="org.antlr.v4.runtime" local-only="true"/>
   <allow class="com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.+"
           local-only="true" regex="true"/>
+  <allow class="java.lang.annotation.ElementType" local-only="true"/>
+  <allow class="java.lang.annotation.Inherited" local-only="true"/>
+  <allow class="java.lang.annotation.Retention" local-only="true"/>
+  <allow class="java.lang.annotation.RetentionPolicy" local-only="true"/>
+  <allow class="java.lang.annotation.Target" local-only="true"/>
 
   <!-- allowed till https://github.com/checkstyle/checkstyle/issues/3455 -->
   <allow class="com.google.common.base.CaseFormat" local-only="true"/>

--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -2144,6 +2144,12 @@ isolated classes and we cannot put them to separate package as it will affect us
                 <option value="ThisEscapedInObjectConstruction" />
                 <!-- it will makes code too complicated in some cases -->
                 <option value="MultipleReturnPointsPerMethod" />
+                <!-- MT check markers are annotations -->
+                <option value="AnnotationClass" />
+                <!-- till #4870, used in MT check markers -->
+                <option value="ClassIndependentOfModule" />
+                <!-- till #4870, used in MT check markers -->
+                <option value="unused" />
             </list>
         </option>
     </inspection_tool>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/FileStatefulCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/FileStatefulCheck.java
@@ -1,0 +1,53 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation means that the check contains file-related context and therefore
+ * cannot be used from the others threads at the same time.
+ * This annotation should be used when the check holds a thread-unsafe state.
+ * Checker guarantees that the whole file processed inside the same thread.
+ * Checker guarantees that the whole file processed with the same check instance.
+ * Checker guarantees that each check instance processes only one file at the same time.
+ * Checker guarantees that all check instances have equal (but not the same) configuration.
+ * It means, that if a check holds a property of type "array of strings",
+ * the property value will not be shared accross check instances.
+ * Instead, each check instance will hold its own array instance.
+ * Checker does not guarantee that each file will have it's own thread -
+ * there might be a list of files, which will be executed on the same thread.
+ * Checker does not guarantee that each file will have it's own check instance -
+ * there might be a list of files, which will be checked by the same instance.
+ * Note: Checks with such annotation will be executed in mode how all Checks worked
+ * before MT mode is introduced.
+ * @author Andrew Kuchev
+ * @noinspection AnnotationClass, ClassIndependentOfModule, unused
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface FileStatefulCheck {
+    // this annotation does not have properties
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/GlobalStatefulCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/GlobalStatefulCheck.java
@@ -1,0 +1,48 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation means that the check contains global context,
+ * which will be updated while Checkstyle processes files. This also means,
+ * that all files will be processed by the same check instance.
+ * This annotation should be used, if a check accumulates some information during the audit,
+ * and processed only once at the end of the audit (however, the check still
+ * can produce some messages, while collecting information).
+ * The check methods and fields should be thread safe, because they may be accessed from others
+ * threads at the same time.
+ * Checker guarantees that there will be exactly one check instance
+ * This is simular to multi-file validation, which checkstyle does not support fully yet.
+ * Please refer to https://github.com/checkstyle/checkstyle/issues/3540 for details.
+ * @author Andrew Kuchev
+ * @noinspection AnnotationClass, ClassIndependentOfModule, unused
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface GlobalStatefulCheck {
+    // this annotation does not have properties
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/StatelessCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/StatelessCheck.java
@@ -1,0 +1,43 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation means that the check does not contain mutable state and
+ * may be safely used from others threads at the same time.
+ * The check does not contain mutable state, if it does not change any field values at the
+ * execution stage (but it still can set properties at the initialization stage).
+ * Checker guarantees that there will be exactly one check instance during the audit.
+ * This also means, that all files will be processed by the same check instance.
+ * @author Andrew Kuchev
+ * @noinspection AnnotationClass, ClassIndependentOfModule, unused
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface StatelessCheck {
+    // this annotation does not have properties
+}


### PR DESCRIPTION
Issue #4883 

This PR adds the following marker interfaces:

1. ~~`OneModuleInstancePerApplication` - for stateless and global-stateful checks~~
1. ~~`OneModuleInstancePerThread` - for file-stateful checks~~
1. `GlobalStatefulModule` - for global-stateful checks
1. `FileStatefulModule` - for file-stateful checks
1. `StatelessModule` - for stateless checks

This PR is a base PR for https://github.com/checkstyle/checkstyle/pull/4892 and https://github.com/checkstyle/checkstyle/pull/4882