### PR TITLE
Issue #4607: Added moduleId to violation messages

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -332,7 +332,7 @@
     </inspection_tool>
     <inspection_tool class="ClassWithOnlyPrivateConstructors" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ClassWithTooManyDependencies" enabled="true" level="ERROR" enabled_by_default="true">
-        <option name="limit" value="34" />
+        <option name="limit" value="36" />
     </inspection_tool>
     <inspection_tool class="ClassWithTooManyDependents" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="limit" value="300" />

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatter.java
@@ -26,7 +26,10 @@ import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 
 /**
  * Represents the default formatter for log message.
- * Default log message format is: [SEVERITY LEVEL] filePath:lineNo:columnNo: message. [CheckName]
+ * Default log message format is:
+ * [SEVERITY LEVEL] filePath:lineNo:columnNo: message. [CheckName]
+ * When the module id of the message has been set, the format is:
+ * [SEVERITY LEVEL] filePath:lineNo:columnNo: message. [ModuleId]
  * @author Andrei Selkin
  */
 public class AuditEventDefaultFormatter implements AuditEventFormatter {
@@ -62,9 +65,15 @@ public class AuditEventDefaultFormatter implements AuditEventFormatter {
         if (event.getColumn() > 0) {
             sb.append(':').append(event.getColumn());
         }
-        sb.append(": ").append(message);
-        final String checkShortName = getCheckShortName(event);
-        sb.append(" [").append(checkShortName).append(']');
+        sb.append(": ").append(message).append(" [");
+        if (event.getModuleId() == null) {
+            final String checkShortName = getCheckShortName(event);
+            sb.append(checkShortName);
+        }
+        else {
+            sb.append(event.getModuleId());
+        }
+        sb.append(']');
 
         return sb.toString();
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -129,9 +129,14 @@ public class XMLLogger
             writer.print(" message=\""
                 + encode(event.getMessage())
                 + "\"");
-            writer.println(" source=\""
-                + encode(event.getSourceName())
-                + "\"/>");
+            writer.print(" source=\"");
+            if (event.getModuleId() == null) {
+                writer.print(encode(event.getSourceName()));
+            }
+            else {
+                writer.print(encode(event.getModuleId()));
+            }
+            writer.println("\"/>");
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -411,15 +411,29 @@ public final class LocalizedMessage
 
     @Override
     public int compareTo(LocalizedMessage other) {
-        int result = Integer.compare(lineNo, other.lineNo);
+        final int result;
 
         if (lineNo == other.lineNo) {
             if (columnNo == other.columnNo) {
-                result = getMessage().compareTo(other.getMessage());
+                if (Objects.equals(moduleId, other.moduleId)) {
+                    result = getMessage().compareTo(other.getMessage());
+                }
+                else if (moduleId == null) {
+                    result = -1;
+                }
+                else if (other.moduleId == null) {
+                    result = 1;
+                }
+                else {
+                    result = moduleId.compareTo(other.moduleId);
+                }
             }
             else {
                 result = Integer.compare(columnNo, other.columnNo);
             }
+        }
+        else {
+            result = Integer.compare(lineNo, other.lineNo);
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatterTest.java
@@ -104,6 +104,23 @@ public class AuditEventDefaultFormatterTest {
     }
 
     @Test
+    public void testFormatModuleWithModuleId() {
+        final AuditEvent mock = PowerMockito.mock(AuditEvent.class);
+        when(mock.getSourceName()).thenReturn("TestModule");
+        when(mock.getSeverityLevel()).thenReturn(SeverityLevel.WARNING);
+        when(mock.getLine()).thenReturn(1);
+        when(mock.getColumn()).thenReturn(1);
+        when(mock.getMessage()).thenReturn("Mocked message.");
+        when(mock.getFileName()).thenReturn("InputMockFile.java");
+        when(mock.getModuleId()).thenReturn("ModuleId");
+        final AuditEventFormatter formatter = new AuditEventDefaultFormatter();
+
+        final String expected = "[WARN] InputMockFile.java:1:1: Mocked message. [ModuleId]";
+
+        assertEquals("Invalid format", expected, formatter.format(mock));
+    }
+
+    @Test
     public void testCalculateBufferLength() throws Exception {
         final Method calculateBufferLengthMethod =
                 Whitebox.getMethod(AuditEventDefaultFormatter.class,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -166,6 +166,24 @@ public class XMLLoggerTest {
     }
 
     @Test
+    public void testAddErrorModuleId() throws IOException {
+        final XMLLogger logger = new XMLLogger(outStream, true);
+        logger.auditStarted(null);
+        final LocalizedMessage message =
+            new LocalizedMessage(1, 1,
+                "messages.properties", "key", null, SeverityLevel.ERROR, "module",
+                    getClass(), null);
+        final AuditEvent ev = new AuditEvent(this, "Test.java", message);
+        logger.addError(ev);
+        logger.auditFinished(null);
+        final String[] expectedLines = {
+            "<error line=\"1\" column=\"1\" severity=\"error\" message=\"key\""
+                + " source=\"module\"/>",
+        };
+        verifyLines(expectedLines);
+    }
+
+    @Test
     public void testAddErrorOnZeroColumns() throws IOException {
         final XMLLogger logger = new XMLLogger(outStream, true);
         logger.auditStarted(null);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
@@ -23,6 +23,7 @@ import static com.puppycrawl.tools.checkstyle.utils.CommonUtils.EMPTY_BYTE_ARRAY
 import static com.puppycrawl.tools.checkstyle.utils.CommonUtils.EMPTY_OBJECT_ARRAY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.times;
@@ -222,9 +223,24 @@ public class LocalizedMessageTest {
         assertEquals("Invalid token type", TokenTypes.OBJBLOCK, localizedMessage2.getTokenType());
     }
 
+    @Test
+    public void testCompareToWithDifferentModuleId() {
+        final LocalizedMessage message1 = createSampleLocalizedMessageWithId("module1");
+        final LocalizedMessage message2 = createSampleLocalizedMessageWithId("module2");
+        final LocalizedMessage messageNull = createSampleLocalizedMessageWithId(null);
+
+        assertTrue("Invalid comparing result", message1.compareTo(messageNull) > 0);
+        assertTrue("Invalid comparing result", messageNull.compareTo(message1) < 0);
+        assertTrue("Invalid comparing result", message1.compareTo(message2) < 0);
+    }
+
     private static LocalizedMessage createSampleLocalizedMessage() {
+        return createSampleLocalizedMessageWithId("module");
+    }
+
+    private static LocalizedMessage createSampleLocalizedMessageWithId(String id) {
         return new LocalizedMessage(0, "com.puppycrawl.tools.checkstyle.checks.coding.messages",
-                "empty.statement", EMPTY_OBJECT_ARRAY, "module", LocalizedMessage.class, null);
+                "empty.statement", EMPTY_OBJECT_ARRAY, id, LocalizedMessage.class, null);
     }
 
     @After


### PR DESCRIPTION
#4607 

In XMLLogger, there would be an `id="..."` if the module id is set. (and no `source="..."`)

Log message would be `[SEVERITY LEVEL] filePath:lineNo:columnNo: message. [ModuleId]`, if module id is set.

I was stuck before for I didn't realize that I need to modify `compareTo` in LocalizedMessage.
