### PR TITLE
Issue #4798: refactored SummaryJavadoc messages and logic

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/SummaryJavadocTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/SummaryJavadocTest.java
@@ -61,7 +61,6 @@ public class SummaryJavadocTest extends AbstractModuleTestSupport {
             "37: " + msgFirstSentence,
             "47: " + msgForbiddenFragment,
             "53: " + msgMissingDoc,
-            "58: " + msgForbiddenFragment,
             "58: " + msgMissingDoc,
             "69: " + msgMissingDoc,
             "83: " + msgForbiddenFragment,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -135,19 +135,18 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
     @Override
     public void visitJavadocToken(DetailNode ast) {
         if (!startsWithInheritDoc(ast)) {
-            String firstSentence = getFirstSentence(ast);
-            final int endOfSentence = firstSentence.lastIndexOf(period);
             final String summaryDoc = getSummarySentence(ast);
             if (summaryDoc.isEmpty()) {
                 log(ast.getLineNumber(), MSG_SUMMARY_JAVADOC_MISSING);
             }
-            else if (!period.isEmpty()
-                    && !summaryDoc.contains(period)) {
-                log(ast.getLineNumber(), MSG_SUMMARY_FIRST_SENTENCE);
-            }
-            if (endOfSentence != -1) {
-                firstSentence = firstSentence.substring(0, endOfSentence);
-                if (containsForbiddenFragment(firstSentence)) {
+            else if (!period.isEmpty()) {
+                final String firstSentence = getFirstSentence(ast);
+                final int endOfSentence = firstSentence.lastIndexOf(period);
+                if (!summaryDoc.contains(period)) {
+                    log(ast.getLineNumber(), MSG_SUMMARY_FIRST_SENTENCE);
+                }
+                if (endOfSentence != -1
+                        && containsForbiddenFragment(firstSentence.substring(0, endOfSentence))) {
                     log(ast.getLineNumber(), MSG_SUMMARY_JAVADOC);
                 }
             }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -26,7 +26,7 @@ javadoc.writeTag={0}={1}
 javadoc.wrong.singleton.html.tag=Javadoc comment at column {0} has parse error. It is forbidden to close singleton HTML tags. Tag: {1}.
 non.empty.atclause=At-clause should have a non-empty description.
 singleline.javadoc=Single-line Javadoc comment should be multi-line.
-summary.first.sentence=First sentence of Javadoc is incomplete (period is missing) or not present.
+summary.first.sentence=First sentence of Javadoc is missing an ending period.
 summary.javaDoc=Forbidden summary fragment.
 summary.javaDoc.missing=Summary javadoc is missing.
 tag.continuation.indent=Line continuation have incorrect indentation level, expected level should be {0}.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
@@ -26,7 +26,7 @@ javadoc.writeTag={0}={1}
 javadoc.wrong.singleton.html.tag=Der Javadoc-Kommentar an Position {0} führt zu einem Parserfehler. Singleton-HTML-Tags dürfen nicht geschlossen werden. Tag: {1}
 non.empty.atclause=@-Klausel sollte eine nicht-leere Beschreibung haben.
 singleline.javadoc=Einzeiliger Javadoc-Kommentar sollte auf mehrere Zeilen verteilt sein.
-summary.first.sentence=Erster Javadoc-Satz ist unvollständig (Punkt fehlt) oder nicht vorhanden.
+summary.first.sentence=Der erste Satz von Javadoc fehlt eine Endperiode.
 summary.javaDoc=Verbotener Ausdruck im ersten Javadoc-Satz.
 summary.javaDoc.missing=Zusammenfassung javadoc fehlt.
 tag.continuation.indent=Fortsetzung der Zeile hat falsche Einrückungstiefe (erwartet: {0}).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
@@ -26,7 +26,7 @@ javadoc.writeTag={0}={1}
 javadoc.wrong.singleton.html.tag=Javadoc comentario en la columna {0} tiene parse error. Está prohibido cerrar etiquetas HTML únicos. Tag: {1}
 non.empty.atclause=Al cláusula debe tener una descripción que no esté vacía.
 singleline.javadoc=Una sola línea Javadoc comentario debe ser de varias líneas.
-summary.first.sentence=Primera frase del Javadoc es incompleta (período de falta) o no está presente.
+summary.first.sentence=Primera frase de Javadoc falta un período final.
 summary.javaDoc=Resumen fragmento Prohibida.
 summary.javaDoc.missing=Resumen javadoc falta.
 tag.continuation.indent=Línea continuación tiene nivel de sangría incorrecta, nivel esperado debería ser {0}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
@@ -26,7 +26,7 @@ javadoc.writeTag={0}={1}
 javadoc.wrong.singleton.html.tag=Javadoc kommentti sarakkeessa {0} on Jäsennysvirhe. On kiellettyä sulkea yksittäiseksi HTML tageja. Tag: {1} .
 non.empty.atclause=At-lauseke tulisi olla ei-tyhjä kuvaus.
 singleline.javadoc=Yksilinjainen Javadoc kommentti pitäisi olla multi-line.
-summary.first.sentence=Ensimmäinen virke Javadoc on epätäydellinen (ajanjakso puuttuu) tai ole läsnä.
+summary.first.sentence=Javadocin ensimmäinen lause puuttuu päättymisajasta.
 summary.javaDoc=Kielletty yhteenveto fragmentti.
 summary.javaDoc.missing=Yhteenveto javadoc puuttuu.
 tag.continuation.indent=Jatkorivin on väärä sisennystason, odotettu taso olisi {0} .

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
@@ -26,7 +26,7 @@ javadoc.writeTag={0}={1}
 javadoc.wrong.singleton.html.tag=Le commentaire Javadoc à la colonne {0} ne peut être analysé. Il est interdit de fermer les balises HTML singleton. Balise : {1}
 non.empty.atclause=La balise javadoc doit avoir une description non-vide.
 singleline.javadoc=Le commentaire Javadoc sur une seule ligne doit être sur plusieurs lignes.
-summary.first.sentence=La première phrase de la javadoc est incomplète (le point est manquant) ou non présente.
+summary.first.sentence=La première phrase de Javadoc manque d'une période de fin.
 summary.javaDoc=Fragment de résumé interdit.
 summary.javaDoc.missing=Résumé javadoc est manquant.
 tag.continuation.indent=La continuation de la ligne a un niveau d''indentation incorrect, le niveau attendu doit être {0}.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
@@ -26,7 +26,7 @@ javadoc.writeTag={0}={1}
 javadoc.wrong.singleton.html.tag={0} 桁目の Javadoc コメントでパースエラーが発生しました。空要素の閉じタグは禁止されています。タグ: {1}。
 non.empty.atclause=Javadoc タグには空でない説明文が必要です。
 singleline.javadoc=単一行のJavadocコメントは、複数行にする必要があります。
-summary.first.sentence=Javadoc の​​最初の文が不完全（ピリオドがない）か、または文がありません。
+summary.first.sentence=Javadocの最初の文には終了時がありません。
 summary.javaDoc=禁止された文言が概要に含まれています。
 summary.javaDoc.missing=要約javadocがありません。
 tag.continuation.indent=行継続のインデントのレベルが間違っています。期待されるレベルは {0} です。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
@@ -26,7 +26,7 @@ javadoc.writeTag={0}={1}
 javadoc.wrong.singleton.html.tag=Javadoc comentário na coluna {0} tem analisar erro. É proibido fechar tags HTML únicas. Tag: {1}
 non.empty.atclause=Na cláusula deve ter uma descrição não-vazia.
 singleline.javadoc=De linha única Javadoc comentário deve ser multi-line.
-summary.first.sentence=Primeira frase do Javadoc está incompleta (período está faltando) ou não está presente.
+summary.first.sentence=A primeira frase de Javadoc falta um período final.
 summary.javaDoc=Fragmento resumo Proibida.
 summary.javaDoc.missing=Sumário javadoc está ausente.
 tag.continuation.indent=Continuação de linha têm nível de recuo incorreto, nível esperado deve ser {0}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
@@ -26,7 +26,7 @@ javadoc.writeTag={0}={1}
 javadoc.wrong.singleton.html.tag=Sütununda Javadoc comment {0} hatası ayrıştırmak vardır. Bu singleton HTML etiketleri kapatmak için yasaktır. Etiket: {1}
 non.empty.atclause=At-fıkra boş olmayan bir tanım olması gerekir.
 singleline.javadoc=Tek satır Javadoc comment multi-line olmalıdır.
-summary.first.sentence=Javadoc ilk cümlesi (dönem eksik) veya mevcut eksik.
+summary.first.sentence=Javadoc'un ilk cümlesi biten bir süre eksik.
 summary.javaDoc=Yasak özeti fragmanı.
 summary.javaDoc.missing=Özet javadoc eksik.
 tag.continuation.indent=Çizgi devamı yanlış girinti düzeyine sahip, beklenen seviyede olmalıdır {0}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
@@ -26,7 +26,7 @@ javadoc.writeTag={0}={1}
 javadoc.wrong.singleton.html.tag=Javadoc 第 {0} 个字符解析错误。HTML 标签： {1} 不需要闭合。
 non.empty.atclause=@标签应有非空说明。
 singleline.javadoc=该Javadoc注释应为多行的。
-summary.first.sentence=Javadoc 首句应以句号结尾。
+summary.first.sentence=Javadoc的第一句缺少一个结束时期。
 summary.javaDoc=禁止出现的首行内容。
 summary.javaDoc.missing=缺少摘要javadoc。
 tag.continuation.indent=Javadoc 缩进级别错误，应为 {0} 个缩进符。

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -73,7 +73,6 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
             "47: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
             "53: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
             "58: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "58: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
             "69: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
             "83: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
             "103: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),


### PR DESCRIPTION
Issue #4798

`summary.first.sentence` was rewritten to specify only an ending period was missing, as a missing first sentence is part of `summary.javaDoc.missing`.

Logic was rewritten to not show violations on missing summary and forbidden fragement at the same time for default module.
Changes in Tests were because of this.

Inlining `firstSentence = firstSentence.substring(0, endOfSentence);` is because nested `if`s were getting too deep and caused a violation. I didn't want to move `log`s outside of main visit.

Regression to come.