### PR TITLE
Pull #4907: disallow java.util.Comparator in import-control

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -27,6 +27,7 @@
   <disallow class="java.util.stream.LongStream.Builder"/>
   <disallow class="java.util.stream.BaseStream"/>
   <disallow class="java.util.stream.Collector"/>
+  <disallow class="java.util.Comparator"/>
 
   <!-- The local ones -->
   <allow pkg="java.lang.reflect" local-only="true" />


### PR DESCRIPTION
Taken from https://github.com/checkstyle/checkstyle/pull/4899#discussion_r131524446
