### PR TITLE
Issue #4908: Remove thread-unsafe context from AbstractCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
@@ -39,14 +39,14 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
     /** Default tab width for column reporting. */
     private static final int DEFAULT_TAB_WIDTH = 8;
 
+    /**
+     * The check context.
+     * @noinspection ThreadLocalNotStaticFinal
+     */
+    private final ThreadLocal<FileContext> context = ThreadLocal.withInitial(FileContext::new);
+
     /** The tokens the check is interested in. */
     private final Set<String> tokens = new HashSet<>();
-
-    /** The sorted set for collecting messages. */
-    private final SortedSet<LocalizedMessage> messages = new TreeSet<>();
-
-    /** The current file contents. */
-    private FileContents fileContents;
 
     /** The tab width for column reporting. */
     private int tabWidth = DEFAULT_TAB_WIDTH;
@@ -111,14 +111,14 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
      * @return the sorted set of {@link LocalizedMessage}.
      */
     public SortedSet<LocalizedMessage> getMessages() {
-        return new TreeSet<>(messages);
+        return new TreeSet<>(context.get().messages);
     }
 
     /**
      * Clears the sorted set of {@link LocalizedMessage} of the check.
      */
     public final void clearMessages() {
-        messages.clear();
+        context.get().messages.clear();
     }
 
     /**
@@ -175,7 +175,7 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
      * @return the file contents
      */
     public final String[] getLines() {
-        return fileContents.getLines();
+        return context.get().fileContents.getLines();
     }
 
     /**
@@ -184,7 +184,7 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
      * @return the line from the file contents
      */
     public final String getLine(int index) {
-        return fileContents.getLine(index);
+        return context.get().fileContents.getLine(index);
     }
 
     /**
@@ -192,7 +192,7 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
      * @param contents the manager
      */
     public final void setFileContents(FileContents contents) {
-        fileContents = contents;
+        context.get().fileContents = contents;
     }
 
     /**
@@ -200,7 +200,7 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
      * @return the file contents
      */
     public final FileContents getFileContents() {
-        return fileContents;
+        return context.get().fileContents;
     }
 
     /**
@@ -249,7 +249,7 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
 
     @Override
     public final void log(int line, String key, Object... args) {
-        messages.add(
+        context.get().messages.add(
             new LocalizedMessage(
                 line,
                 getMessageBundle(),
@@ -266,7 +266,7 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
             Object... args) {
         final int col = 1 + CommonUtils.lengthExpandedTabs(
             getLines()[lineNo - 1], colNo, tabWidth);
-        messages.add(
+        context.get().messages.add(
             new LocalizedMessage(
                 lineNo,
                 col,
@@ -277,5 +277,16 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
                 getId(),
                 getClass(),
                 getCustomMessages().get(key)));
+    }
+
+    /**
+     * The actual context holder.
+     */
+    private static class FileContext {
+        /** The sorted set for collecting messages. */
+        private final SortedSet<LocalizedMessage> messages = new TreeSet<>();
+
+        /** The current file contents. */
+        private FileContents fileContents;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
@@ -26,13 +26,11 @@ import static org.mockito.Mockito.verify;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.internal.util.reflection.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
@@ -215,16 +213,13 @@ public class AbstractCheckTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testClearMessages() {
         final AbstractCheck check = new DummyAbstractCheck();
 
         check.log(0, "key", "args");
-        final Collection<LocalizedMessage> messages =
-                (Collection<LocalizedMessage>) Whitebox.getInternalState(check, "messages");
-        Assert.assertEquals("Invalid message size", 1, messages.size());
+        Assert.assertEquals("Invalid message size", 1, check.getMessages().size());
         check.clearMessages();
-        Assert.assertEquals("Invalid message size", 0, messages.size());
+        Assert.assertEquals("Invalid message size", 0, check.getMessages().size());
     }
 
     private static final class DummyAbstractCheck extends AbstractCheck {


### PR DESCRIPTION
Issue #4908

Moved all thread-unsafe `AbstractCheck` state to a thread-local state holder