### PR TITLE
Issue #4842: make test for creating listener with location clean temp file

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -60,6 +60,7 @@ import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -573,12 +574,14 @@ public class MainTest {
                     ex.getCause() instanceof IllegalStateException);
         }
         finally {
+            verifyStatic(times(1));
+            final ArgumentCaptor<OutputStream> out =
+                    ArgumentCaptor.forClass(OutputStream.class);
+            CommonUtils.close(out.capture());
+            out.getValue().close();
             // method creates output folder
             FileUtils.deleteQuietly(new File(outDir));
         }
-
-        verifyStatic(times(1));
-        CommonUtils.close(any(OutputStream.class));
     }
 
     @Test


### PR DESCRIPTION
Issue #4842 

MainTest.testCreateListenerWithLocationIllegalStateException tests method Main.createListener. This method opens output stream for specified output location and passes created output stream to appropriate audit listener constructor. When specified format of the audit listener is not appropriate  it closes the stream with CommonUtils.close and throws exception.

Test MainTest.testCreateListenerWithLocationIllegalStateException mocks CommonUtils.close and in the result the output stream is not closed after invocation of Main.createListener.

At the end of the test it tried to remove the output location for which the output stream was not closed.
In Windows the file cannot be deleted where there is stream opened for file. The attempt to do this leads to the following error:

```
java.nio.file.FileSystemException: The process cannot access the file because it is being used by another process
```

This exception was silenced because the deletion of the file was done with FileUtils.deleteQuietly. In Unix-like system you can remove file even when there is stream opened for this file.

The most basic test reproducing this behaviour is the following:

```java
    @Test
    public void test() throws Exception {
        String path = "myfolder1234";
        FileOutputStream file = new FileOutputStream(path);
        Files.delete(new File(path).toPath());
    }
```

In Windows this throws java.nio.file.FileSystemException exception, in FreeBSD 11.0 the file is removed as expected.

To delete output location in Windows the output stream must be closed before file is deleted. It is done by intercepting argument passed to CommonUtils.close and closing this stream manually. In Unix-like systems this should not harm the test.