### PR TITLE
Issue #4988: increased coverage of pitest-checks-regexp to 100%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1990,7 +1990,7 @@
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.checks.regexp.*</param>
               </targetTests>
-              <mutationThreshold>93</mutationThreshold>
+              <mutationThreshold>100</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
@@ -228,7 +228,7 @@ public class RegexpCheck extends AbstractCheck {
      * @return true is we can continue
      */
     private boolean canContinueValidation(boolean ignore) {
-        return errorCount < errorLimit
+        return errorCount <= errorLimit - 1
                 && (ignore || illegalPattern || checkForDuplicates);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheck.java
@@ -48,7 +48,6 @@ public class RegexpMultilineCheck extends AbstractFileSetCheck {
 
     @Override
     public void beginProcessing(String charset) {
-        super.beginProcessing(charset);
         final DetectorOptions options = DetectorOptions.newBuilder()
             .reporter(this)
             .compileFlags(Pattern.MULTILINE)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java
@@ -46,7 +46,6 @@ public class RegexpSinglelineCheck extends AbstractFileSetCheck {
 
     @Override
     public void beginProcessing(String charset) {
-        super.beginProcessing(charset);
         final DetectorOptions options = DetectorOptions.newBuilder()
             .reporter(this)
             .compileFlags(0)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java
@@ -108,10 +108,7 @@ class SinglelineDetector {
             // So we need to use (endCol - 1) here.
             if (options.getSuppressor()
                     .shouldSuppress(lineNo, startCol, lineNo, endCol - 1)) {
-                if (endCol < line.length()) {
-                    // check if the expression is on the rest of the line
-                    checkLine(lineNo, line, matcher, endCol);
-                }
+                checkLine(lineNo, line, matcher, endCol);
             }
             else {
                 currentMatches++;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TestLoggingReporter.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TestLoggingReporter.java
@@ -1,0 +1,43 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2017 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractViolationReporter;
+
+/**
+ * @noinspection ClassOnlyUsedInOnePackage
+ */
+public final class TestLoggingReporter extends AbstractViolationReporter {
+    private int logCount;
+
+    @Override
+    public void log(int line, String key, Object... args) {
+        logCount++;
+    }
+
+    @Override
+    public void log(int line, int col, String key, Object... args) {
+        logCount++;
+    }
+
+    public int getLogCount() {
+        return logCount;
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheckTest.java
@@ -134,13 +134,12 @@ public class RegexpCheckTest extends AbstractModuleTestSupport {
             createModuleConfig(RegexpCheck.class);
         checkConfig.addAttribute("format", illegal);
         checkConfig.addAttribute("illegalPattern", "true");
-        checkConfig.addAttribute("errorLimit", "3");
+        checkConfig.addAttribute("errorLimit", "2");
         final String error = "The error limit has been exceeded, "
                 + "the check is aborting, there may be more unreported errors.";
         final String[] expected = {
             "7: " + getCheckMessage(MSG_ILLEGAL_REGEXP, illegal),
-            "8: " + getCheckMessage(MSG_ILLEGAL_REGEXP, illegal),
-            "9: " + getCheckMessage(MSG_ILLEGAL_REGEXP, error + illegal),
+            "8: " + getCheckMessage(MSG_ILLEGAL_REGEXP, error + illegal),
         };
         verify(checkConfig, getPath("InputRegexpSemantic.java"), expected);
     }
@@ -348,5 +347,20 @@ public class RegexpCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(RegexpCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputRegexpStartingWithEmptyLine.java"), expected);
+    }
+
+    @Test
+    public void testIgnoreCommentsCppStyleWithIllegalPatternFalse() throws Exception {
+        // See if the comment is removed properly
+        final String illegal = "don't use trailing comments";
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(RegexpCheck.class);
+        checkConfig.addAttribute("format", illegal);
+        checkConfig.addAttribute("illegalPattern", "false");
+        checkConfig.addAttribute("ignoreComments", "true");
+        final String[] expected = {
+            "0: " + getCheckMessage(MSG_REQUIRED_REGEXP, illegal),
+        };
+        verify(checkConfig, getPath("InputRegexpTrailingComment.java"), expected);
     }
 }


### PR DESCRIPTION
Issue #4988

[report before changes](https://nimfadora.github.io/pr/com.puppycrawl.tools.checkstyle.checks.regexp/index.html)

pitest-checks-regexp coverage was increased by 7%
current threshould: 100
