### PR TITLE
Issue #4993: increased coverage of pitest-checks-sizes to 100%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2017,7 +2017,7 @@
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.checks.sizes.*</param>
               </targetTests>
-              <mutationThreshold>94</mutationThreshold>
+              <mutationThreshold>100</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java
@@ -113,7 +113,10 @@ public class MethodLengthCheck extends AbstractCheck {
         if (!countEmpty) {
             final FileContents contents = getFileContents();
             final int lastLine = closingBrace.getLineNo();
-            for (int i = openingBrace.getLineNo() - 1; i < lastLine; i++) {
+            // lastLine - 1 is actual last line index. Last line is line with curly brace,
+            // which is always not empty. So, we make it lastLine - 2 to cover last line that
+            // actually may be empty.
+            for (int i = openingBrace.getLineNo() - 1; i <= lastLine - 2; i++) {
                 if (contents.lineIsBlank(i) || contents.lineIsComment(i)) {
                     length--;
                 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
@@ -23,13 +23,18 @@ import static com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCo
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.util.Collection;
+
+import org.junit.Assert;
 import org.junit.Test;
 
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.Context;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.TestUtils;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class ExecutableStatementCountCheckTest
@@ -37,6 +42,17 @@ public class ExecutableStatementCountCheckTest
     @Override
     protected String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount";
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testStatefulFieldsClearedOnBeginTree() throws Exception {
+        final DetailAST ast = new DetailAST();
+        ast.setType(TokenTypes.STATIC_INIT);
+        final ExecutableStatementCountCheck check = new ExecutableStatementCountCheck();
+        Assert.assertTrue("Stateful field is not cleared after beginTree",
+                TestUtils.isStatefulFieldClearedDuringBeginTree(check, ast, "contextStack",
+                    contextStack -> ((Collection<Context>) contextStack).isEmpty()));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
@@ -51,10 +51,21 @@ public class FileLengthCheckTest
     }
 
     @Test
+    public void testFileLengthEqualToMaxLength() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(FileLengthCheck.class);
+        checkConfig.addAttribute("max", "225");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(createChecker(checkConfig),
+                getPath("InputFileLength.java"),
+                getPath("InputFileLength.java"), expected);
+    }
+
+    @Test
     public void testOk() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(FileLengthCheck.class);
-        checkConfig.addAttribute("max", "2000");
+        checkConfig.addAttribute("max", "1000");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(createChecker(checkConfig),
                 getPath("InputFileLength.java"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
@@ -78,6 +78,18 @@ public class MethodLengthCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testWithComments() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(MethodLengthCheck.class);
+        checkConfig.addAttribute("max", "7");
+        checkConfig.addAttribute("countEmpty", "false");
+        final String[] expected = {
+            "18:5: " + getCheckMessage(MSG_KEY, 8, 7),
+        };
+        verify(checkConfig, getPath("InputMethodLengthComments.java"), expected);
+    }
+
+    @Test
     public void testAbstract() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(MethodLengthCheck.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
@@ -82,6 +82,16 @@ public class ParameterNumberCheckTest
     }
 
     @Test
+    public void testMaxParam()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(ParameterNumberCheck.class);
+        checkConfig.addAttribute("max", "9");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputParameterNumberSimple.java"), expected);
+    }
+
+    @Test
     public void shouldLogActualParameterNumber()
             throws Exception {
         final DefaultConfiguration checkConfig =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/TestUtils.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/TestUtils.java
@@ -24,6 +24,7 @@ import static com.puppycrawl.tools.checkstyle.TreeWalker.parseWithComments;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Optional;
 import java.util.Set;
@@ -34,6 +35,7 @@ import org.junit.Assert;
 import antlr.ANTLRException;
 import com.puppycrawl.tools.checkstyle.PackageNamesLoader;
 import com.puppycrawl.tools.checkstyle.PackageObjectFactory;
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
@@ -61,6 +63,31 @@ public final class TestUtils {
         }
         constructor.setAccessible(true);
         constructor.newInstance();
+    }
+
+    /**
+     * Checks if stateful field is cleared during {@link AbstractCheck#beginTree} in check.
+     *
+     * @param check      check object which field is to be verified
+     * @param astToVisit ast to pass into check methods
+     * @param fieldName  name of the field to be checked
+     * @param isClear    function for checking field state
+     * @return {@code true} if state of the field is cleared
+     * @throws NoSuchFieldException   if there is no field with the
+     *                                {@code fieldName} in the {@code check}
+     * @throws IllegalAccessException if the field is inaccessible
+     */
+    public static boolean isStatefulFieldClearedDuringBeginTree(AbstractCheck check,
+                                                                DetailAST astToVisit,
+                                                                String fieldName,
+                                                                Predicate<Object> isClear)
+            throws NoSuchFieldException, IllegalAccessException {
+        check.beginTree(null);
+        check.visitToken(astToVisit);
+        check.beginTree(null);
+        final Field field = check.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return isClear.test(field.get(check));
     }
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthComments.java
@@ -1,0 +1,27 @@
+package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+public class InputMethodLengthComments {
+    public void visitToken(DetailAST ast) {
+
+        final DetailAST openingBrace = ast.findFirstToken(TokenTypes.SLIST);
+
+        if (openingBrace != null) {
+            final DetailAST closingBrace =
+                    openingBrace.findFirstToken(TokenTypes.RCURLY);
+        }
+
+    }
+
+    public DetailAST visit(DetailAST ast) {
+        final DetailAST openingBrace = ast.findFirstToken(TokenTypes.SLIST);
+        DetailAST closingBrace = null;
+
+        if (openingBrace != null) {
+            closingBrace = openingBrace.findFirstToken(TokenTypes.RCURLY);
+        }
+        return closingBrace;
+    }
+}


### PR DESCRIPTION
Issue #4993

[report before changes](https://nimfadora.github.io/pr/com.puppycrawl.tools.checkstyle.checks.sizes/index.html)

coverage of pitest-checks-sizes was increased by 6%
current threshold: 100%