### PR TITLE
Issue #5004: increase coverage of pitest-checks-imports to 96%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1828,7 +1828,7 @@
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.checks.imports.*</param>
               </targetTests>
-              <mutationThreshold>94</mutationThreshold>
+              <mutationThreshold>96</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
@@ -114,8 +114,6 @@ public class AvoidStarImportCheck
      *     where star imports are ok.
      */
     public void setExcludes(String... excludesParam) {
-        excludes.clear();
-
         for (final String exclude : excludesParam) {
             if (exclude.endsWith(STAR_IMPORT_SUFFIX)) {
                 excludes.add(exclude);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
@@ -115,7 +115,6 @@ public class IllegalImportCheck
      */
     public void setIllegalClasses(String... from) {
         illegalClasses = from.clone();
-        illegalClassesRegexps.clear();
         for (String illegalClass : illegalClasses) {
             illegalClassesRegexps.add(CommonUtils.createPattern(illegalClass));
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckTest.java
@@ -24,11 +24,17 @@ import static com.puppycrawl.tools.checkstyle.checks.imports.RedundantImportChec
 import static com.puppycrawl.tools.checkstyle.checks.imports.RedundantImportCheck.MSG_SAME;
 import static org.junit.Assert.assertArrayEquals;
 
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class RedundantImportCheckTest
     extends AbstractModuleTestSupport {
@@ -47,6 +53,24 @@ public class RedundantImportCheckTest
         };
         assertArrayEquals("Default required tokens are invalid",
             expected, checkObj.getRequiredTokens());
+    }
+
+    @Test
+    public void testStateIsClearedOnBeginTree1()
+            throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RedundantImportCheck.class);
+        final String inputWithWarnings = getPath("InputRedundantImportCheckClearState.java");
+        final String inputWithoutWarnings = getPath("InputRedundantImportWithoutWarnings.java");
+        final List<String> expectedFirstInput = Arrays.asList(
+            "4:1: " + getCheckMessage(MSG_DUPLICATE, 3, "java.util.Arrays.asList"),
+            "7:1: " + getCheckMessage(MSG_DUPLICATE, 6, "java.util.List")
+        );
+        final List<String> expectedSecondInput = Arrays.asList(CommonUtils.EMPTY_STRING_ARRAY);
+        final File[] inputs = {new File(inputWithWarnings), new File(inputWithoutWarnings)};
+
+        verify(createChecker(checkConfig), inputs, ImmutableMap.of(
+            inputWithWarnings, expectedFirstInput,
+            inputWithoutWarnings, expectedSecondInput));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -22,8 +22,13 @@ package com.puppycrawl.tools.checkstyle.checks.imports;
 import static com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck.MSG_KEY;
 import static org.junit.Assert.assertArrayEquals;
 
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -33,6 +38,31 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
     @Override
     protected String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/imports/unusedimports";
+    }
+
+    @Test
+    public void testReferencedStateIsCleared() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(UnusedImportsCheck.class);
+        final String inputWithoutWarnings = getPath("InputUnusedImportWithoutWarnings.java");
+        final String inputWithWarnings = getPath("InputUnusedImportCheckClearState.java");
+        final List<String> expectedFirstInput = Arrays.asList(CommonUtils.EMPTY_STRING_ARRAY);
+        final List<String> expectedSecondInput = Arrays.asList(
+                "3:8: " + getCheckMessage(MSG_KEY, "java.util.Arrays"),
+                "4:8: " + getCheckMessage(MSG_KEY, "java.util.List"),
+                "5:8: " + getCheckMessage(MSG_KEY, "java.util.Set")
+        );
+        final File[] inputsWithWarningsFirst =
+            {new File(inputWithWarnings), new File(inputWithoutWarnings)};
+        final File[] inputsWithoutWarningFirst =
+            {new File(inputWithoutWarnings), new File(inputWithWarnings)};
+
+        verify(createChecker(checkConfig), inputsWithWarningsFirst, ImmutableMap.of(
+                inputWithoutWarnings, expectedFirstInput,
+                inputWithWarnings, expectedSecondInput));
+        verify(createChecker(checkConfig), inputsWithoutWarningFirst, ImmutableMap.of(
+                inputWithoutWarnings, expectedFirstInput,
+                inputWithWarnings, expectedSecondInput));
+
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/InputRedundantImportCheckClearState.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/InputRedundantImportCheckClearState.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.redundantimport;
+
+import static java.util.Arrays.asList;
+import static java.util.Arrays.asList;
+
+import java.util.List;
+import java.util.List;
+
+public class InputRedundantImportCheckClearState {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/InputRedundantImportWithoutWarnings.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/InputRedundantImportWithoutWarnings.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.redundantimport;
+
+import static java.util.Arrays.asList;
+
+import java.util.List;
+
+public class InputRedundantImportWithoutWarnings {
+    private static final List<String> CONSTANTS = asList("a", "b");
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportCheckClearState.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportCheckClearState.java
@@ -1,0 +1,7 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+public class InputUnusedImportCheckClearState {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportWithoutWarnings.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportWithoutWarnings.java
@@ -1,0 +1,8 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class InputUnusedImportWithoutWarnings {
+    private static final List<String> CONSTANTS = Arrays.asList("a", "b");
+}


### PR DESCRIPTION
Issue #5004

[report before changes](https://nimfadora.github.io/pr/com.puppycrawl.tools.checkstyle.checks.imports/index.html)

coverage of pitest-checks-imports was increased by 2%
current threshold: 96