### PR TITLE
Issue #5022: Fixed pitest coverage

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -24,7 +24,7 @@ env:
     - PROFILE="-Ppitest-checks-naming,no-validations"; POST_ACTION=check_survived
     - PROFILE="-Ppitest-checks-indentation,no-validations"
     - PROFILE="-Ppitest-checkstyle-tree-walker,no-validations"; POST_ACTION=check_survived
-    - PROFILE="-Ppitest-checkstyle-common,no-validations"; POST_ACTION=till_#5022
+    - PROFILE="-Ppitest-checkstyle-common,no-validations"; POST_ACTION=check_survived
     - PROFILE="-Ppitest-checkstyle-main,no-validations"; POST_ACTION=check_survived
     - PROFILE="-Ppitest-checkstyle-api,no-validations"; POST_ACTION=off_till_resolved
     - PROFILE="-Ppitest-checkstyle-utils,no-validations"; POST_ACTION=off_till_resolved

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -125,7 +125,6 @@ public class XMLLogger
     @Override
     public void auditFinished(AuditEvent event) {
         fileMessages.forEach(this::writeFileMessages);
-        fileMessages.clear();
 
         writer.println("</checkstyle>");
         if (closeStream) {


### PR DESCRIPTION
Issue #5022 

Not sure if shippable build is unstable, but I am able to reproduce the failure locally and the root of the problem is the following line:

    fileMessages.clear();

Called inside `auditFinished`

Fixed coverage by adding a test for this behavior