### PR TITLE
Issue #5027: remove use of javax.xml.bind.DatatypeConverter

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -34,7 +34,6 @@
   <allow pkg="java.nio" local-only="true" />
   <allow class="java.security.MessageDigest" local-only="true"/>
   <allow class="java.security.NoSuchAlgorithmException" local-only="true"/>
-  <allow class="javax.xml.bind.DatatypeConverter" local-only="true"/>
   <allow pkg="com.puppycrawl.tools.checkstyle.utils" local-only="true"/>
   <allow pkg="com.puppycrawl.tools.checkstyle.grammars" local-only="true"/>
   <allow pkg="org.apache.commons.cli" local-only="true"/>
@@ -44,6 +43,7 @@
 
   <!-- allowed till https://github.com/checkstyle/checkstyle/issues/3455 -->
   <allow class="com.google.common.base.CaseFormat" local-only="true"/>
+  <allow class="com.google.common.io.BaseEncoding" local-only="true"/>
   <allow class="com.google.common.io.Closeables" local-only="true"/>
   <allow class="com.google.common.io.Flushables" local-only="true"/>
   <allow class="com.google.common.collect.HashMultimap" local-only="true"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -39,8 +39,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 
-import javax.xml.bind.DatatypeConverter;
-
+import com.google.common.io.BaseEncoding;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closeables;
 import com.google.common.io.Flushables;
@@ -230,7 +229,7 @@ final class PropertyCacheFile {
             final MessageDigest digest = MessageDigest.getInstance("SHA-1");
             digest.update(outputStream.toByteArray());
 
-            return DatatypeConverter.printHexBinary(digest.digest());
+            return BaseEncoding.base16().upperCase().encode(digest.digest());
         }
         catch (final IOException | NoSuchAlgorithmException ex) {
             // rethrow as unchecked exception

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -53,8 +53,6 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -63,6 +61,7 @@ import org.mockito.Matchers;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.google.common.io.BaseEncoding;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closeables;
 import com.google.common.io.Flushables;
@@ -232,7 +231,7 @@ public class PropertyCacheFileTest {
             oos.writeObject(input);
         }
         digest.update(out.toByteArray());
-        final String expected = DatatypeConverter.printHexBinary(digest.digest());
+        final String expected = BaseEncoding.base16().upperCase().encode(digest.digest());
 
         assertEquals("Hashes are not equal", expected,
                 cache.get("module-resource*?:" + pathToResource));


### PR DESCRIPTION
Issue #5027

This change replaces javax.xml.bind.DatatypeConverter with com.google.common.io.BaseEncoding
