### PR TITLE
Pull #5033: made XMLLogger writer final

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -74,7 +74,7 @@ public class XMLLogger
     /**
      * Helper writer that allows easy encoding and printing.
      */
-    private PrintWriter writer;
+    private final PrintWriter writer;
 
     /**
      * Creates a new {@code XMLLogger} instance.
@@ -86,7 +86,7 @@ public class XMLLogger
      */
     @Deprecated
     public XMLLogger(OutputStream outputStream, boolean closeStream) {
-        setOutputStream(outputStream);
+        writer = new PrintWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
         this.closeStream = closeStream;
     }
 
@@ -97,17 +97,8 @@ public class XMLLogger
      * @param outputStreamOptions if {@code CLOSE} stream should be closed in auditFinished()
      */
     public XMLLogger(OutputStream outputStream, OutputStreamOptions outputStreamOptions) {
-        setOutputStream(outputStream);
+        writer = new PrintWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
         closeStream = outputStreamOptions == OutputStreamOptions.CLOSE;
-    }
-
-    /**
-     * Sets the OutputStream.
-     * @param outputStream the OutputStream to use
-     **/
-    private void setOutputStream(OutputStream outputStream) {
-        final OutputStreamWriter osw = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
-        writer = new PrintWriter(osw);
     }
 
     @Override


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/5025#discussion_r136051605 ,

We don't support swapping writers during mid-execution of Checkstyle, so we should remove `setOutputStream` to prevent people from mistaking this. Identified PR was going to make it `public` by mistake.

I wanted to make 1 constructor call another but I ran into some issues preventing that.

One constructor is deprecated so I don't think the good constructor should be calling the deprecated one.
There is no conversion from boolean to `OutputStreamOptions` that I can do in one line as required by a constructor call in a constructor unless I make a new method in `OutputStreamOptions` which would only be used for this purpose.

Eventually deprecated constructor will be removed, so I think this way is ok. If you wish for me to change, let me know.