### PR TITLE
Issue #4395: kill last mutation in pitest-checkstyle-utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2278,10 +2278,6 @@
                 <param>com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyCommentFilterTest</param>
                 <param>com.puppycrawl.tools.checkstyle.internal.AllChecksTest</param>
               </targetTests>
-              <excludedMethods>
-                <!-- till https://github.com/checkstyle/checkstyle/issues/4395 -->
-                <param>getTokenName</param>
-              </excludedMethods>
               <mutationThreshold>100</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
@@ -343,7 +343,7 @@ public final class JavadocUtils {
         if (id == JavadocTokenTypes.EOF) {
             name = "EOF";
         }
-        else if (id > TOKEN_VALUE_TO_NAME.length - 1) {
+        else if (id >= TOKEN_VALUE_TO_NAME.length) {
             throw new IllegalArgumentException(UNKNOWN_JAVADOC_TOKEN_ID_EXCEPTION_MESSAGE + id);
         }
         else {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java
@@ -279,6 +279,18 @@ public class JavadocUtilsTest {
     }
 
     @Test
+    public void testGetTokenNameForLowerBoundInvalidId() {
+        try {
+            JavadocUtils.getTokenName(20079);
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException ex) {
+            assertEquals("Invalid exception message",
+                    "Unknown javadoc token id. Given id: 20079", ex.getMessage());
+        }
+    }
+
+    @Test
     public void testGetTokenIdThatIsUnknown() {
         try {
             JavadocUtils.getTokenId("");


### PR DESCRIPTION
Issue #4395

original: `id > TOKEN_VALUE_TO_NAME.length - 1`
mutated: `id > TOKEN_VALUE_TO_NAME.length + 1`
fixed: `id >= TOKEN_VALUE_TO_NAME.length`

and added one more test on the lower bound of invalid token id