### PR TITLE
Issue #3453: UnusedImportsCheck: handle qualified names in javadoc

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -300,8 +300,27 @@ public class UnusedImportsCheck extends AbstractCheck {
         final Set<String> references = new HashSet<>();
         final Matcher matcher = pattern.matcher(identifier);
         while (matcher.find()) {
-            references.add(matcher.group(1));
+            references.add(topLevelType(matcher.group(1)));
         }
         return references;
+    }
+
+    /**
+     * If the given type string contains "." (e.g. "Map.Entry"), returns the
+     * top level type (e.g. "Map"), as that is what must be imported for the
+     * type to resolve. Otherwise, returns the type as-is.
+     * @param type A possibly qualified type name
+     * @return The simple name of the top level type
+     */
+    private static String topLevelType(String type) {
+        final String topLevelType;
+        final int dotIndex = type.indexOf('.');
+        if (dotIndex == -1) {
+            topLevelType = type;
+        }
+        else {
+            topLevelType = type.substring(0, dotIndex);
+        }
+        return topLevelType;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -238,4 +238,13 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
         };
         verify(checkConfig, getPath("InputUnusedImportsFromJavaLang.java"), expected);
     }
+
+    @Test
+    public void testImportsJavadocQualifiedName() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(UnusedImportsCheck.class);
+        final String[] expected = {
+            "4:8: " + getCheckMessage(MSG_KEY, "java.util.List"),
+        };
+        verify(checkConfig, getPath("InputUnusedImportsJavadocQualifiedName.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsJavadocQualifiedName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsJavadocQualifiedName.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.util.Map; // OK
+import java.util.List; // VIOLATION
+
+/**
+ * Use {@link Map.Entry} in this javadoc.
+ */
+public class InputUnusedImportsJavadocQualifiedName {}


### PR DESCRIPTION
Issue #3453: UnusedImportsCheck: handle qualified names in javadoc