### PR TITLE
Issue #3891: reorganized xpath package inputs

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/ElementNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/ElementNodeTest.java
@@ -29,20 +29,25 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.TestUtils;
 import net.sf.saxon.om.Item;
 import net.sf.saxon.om.NodeInfo;
 
-public class ElementNodeTest {
+public class ElementNodeTest extends AbstractPathTestSupport {
 
     private static RootNode rootNode;
 
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/xpath/xpathmapper";
+    }
+
     @Before
     public void init() throws Exception {
-        final File file = new File("src/test/resources/com/puppycrawl/tools/"
-                + "checkstyle/xpath/InputXpathMapperAst.java");
+        final File file = new File(getPath("InputXpathMapperAst.java"));
         final DetailAST rootAst = TestUtils.parseFile(file);
         rootNode = new RootNode(rootAst);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.xpath;
 
 import static com.puppycrawl.tools.checkstyle.internal.XpathUtil.getXpathItems;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -32,6 +31,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.TestUtils;
@@ -40,14 +40,18 @@ import net.sf.saxon.om.Item;
 import net.sf.saxon.om.NamespaceBinding;
 import net.sf.saxon.tree.iter.EmptyIterator;
 
-public class RootNodeTest {
+public class RootNodeTest extends AbstractPathTestSupport {
 
     private static RootNode rootNode;
 
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/xpath/xpathmapper";
+    }
+
     @Before
     public void init() throws Exception {
-        final File file = new File("src/test/resources/com/puppycrawl/tools/"
-                + "checkstyle/xpath/InputXpathMapperAst.java");
+        final File file = new File(getPath("InputXpathMapperAst.java"));
         final DetailAST rootAst = TestUtils.parseFile(file);
         rootNode = new RootNode(rootAst);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.TestUtils;
@@ -39,7 +40,12 @@ import net.sf.saxon.om.Item;
 import net.sf.saxon.trans.XPathException;
 import net.sf.saxon.tree.iter.EmptyIterator;
 
-public class XpathMapperTest {
+public class XpathMapperTest extends AbstractPathTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/xpath/xpathmapper";
+    }
 
     @Test
     public void testFullPath() throws Exception {
@@ -138,7 +144,7 @@ public class XpathMapperTest {
         final String xpath = "//*[@text]";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<Item> nodes = getXpathItems(xpath, rootNode);
-        assertEquals("Invalid number of nodes", 17, nodes.size());
+        assertEquals("Invalid number of nodes", 18, nodes.size());
     }
 
     @Test
@@ -433,7 +439,7 @@ public class XpathMapperTest {
     @Test
     public void testQueryAnnotation() throws Exception {
         final String xpath = "//ANNOTATION[@text='SuppressWarnings']";
-        final RootNode rootNode = getRootNode("InputXpathAnnotation.java");
+        final RootNode rootNode = getRootNode("InputXpathMapperAnnotation.java");
         final DetailAST[] actual = convertToArray(getXpathItems(xpath, rootNode));
         final DetailAST expectedAnnotationNode = getSiblingByType(rootNode.getUnderlyingNode(),
                 TokenTypes.CLASS_DEF)
@@ -446,7 +452,7 @@ public class XpathMapperTest {
     @Test
     public void testQueryNonExistingAnnotation() throws Exception {
         final String xpath = "//ANNOTATION[@text='SpringBootApplication']";
-        final RootNode rootNode = getRootNode("InputXpathAnnotation.java");
+        final RootNode rootNode = getRootNode("InputXpathMapperAnnotation.java");
         final List<Item> nodes = getXpathItems(xpath, rootNode);
         assertEquals("Invalid number of nodes", 0, nodes.size());
     }
@@ -454,7 +460,7 @@ public class XpathMapperTest {
     @Test
     public void testQueryEnumDef() throws Exception {
         final String xpath = "/ENUM_DEF";
-        final RootNode enumRootNode = getRootNode("InputXpathEnum.java");
+        final RootNode enumRootNode = getRootNode("InputXpathMapperEnum.java");
         final DetailAST[] actual = convertToArray(getXpathItems(xpath, enumRootNode));
         final DetailAST expectedEnumDefNode = getSiblingByType(enumRootNode.getUnderlyingNode(),
                 TokenTypes.ENUM_DEF);
@@ -465,7 +471,7 @@ public class XpathMapperTest {
     @Test
     public void testQueryEnumElementsNumber() throws Exception {
         final String xpath = "/ENUM_DEF/OBJBLOCK/ENUM_CONSTANT_DEF";
-        final RootNode enumRootNode = getRootNode("InputXpathEnum.java");
+        final RootNode enumRootNode = getRootNode("InputXpathMapperEnum.java");
         final List<Item> nodes = getXpathItems(xpath, enumRootNode);
         assertEquals("Invalid number of nodes", 3, nodes.size());
     }
@@ -473,7 +479,7 @@ public class XpathMapperTest {
     @Test
     public void testQueryEnumElementByName() throws Exception {
         final String xpath = "//*[@text='TWO']";
-        final RootNode enumRootNode = getRootNode("InputXpathEnum.java");
+        final RootNode enumRootNode = getRootNode("InputXpathMapperEnum.java");
         final DetailAST[] actual = convertToArray(getXpathItems(xpath, enumRootNode));
         final DetailAST expectedEnumConstantDefNode = getSiblingByType(
                 enumRootNode.getUnderlyingNode(),
@@ -489,7 +495,7 @@ public class XpathMapperTest {
     @Test
     public void testQueryInterfaceDef() throws Exception {
         final String xpath = "/INTERFACE_DEF";
-        final RootNode interfaceRootNode = getRootNode("InputXpathInterface.java");
+        final RootNode interfaceRootNode = getRootNode("InputXpathMapperInterface.java");
         final DetailAST[] actual = convertToArray(getXpathItems(xpath, interfaceRootNode));
         final DetailAST expectedInterfaceDefNode = getSiblingByType(
                 interfaceRootNode.getUnderlyingNode(),
@@ -501,7 +507,7 @@ public class XpathMapperTest {
     @Test
     public void testQueryInterfaceMethodDefNumber() throws Exception {
         final String xpath = "/INTERFACE_DEF/OBJBLOCK/METHOD_DEF";
-        final RootNode interfaceRootNode = getRootNode("InputXpathInterface.java");
+        final RootNode interfaceRootNode = getRootNode("InputXpathMapperInterface.java");
         final List<Item> nodes = getXpathItems(xpath, interfaceRootNode);
         assertEquals("Invalid number of nodes", 4, nodes.size());
     }
@@ -509,7 +515,7 @@ public class XpathMapperTest {
     @Test
     public void testQueryInterfaceParameterDef() throws Exception {
         final String xpath = "//PARAMETER_DEF[@text='someVariable']/../..";
-        final RootNode interfaceRootNode = getRootNode("InputXpathInterface.java");
+        final RootNode interfaceRootNode = getRootNode("InputXpathMapperInterface.java");
         final DetailAST[] actual = convertToArray(getXpathItems(xpath, interfaceRootNode));
         final DetailAST expectedMethodDefNode = getSiblingByType(
                 interfaceRootNode.getUnderlyingNode(),
@@ -521,9 +527,8 @@ public class XpathMapperTest {
         assertArrayEquals("Result nodes differ from expected", expected, actual);
     }
 
-    private static RootNode getRootNode(String fileName) throws Exception {
-        final File file = new File("src/test/resources/com/puppycrawl/tools/"
-                + "checkstyle/xpath/" + fileName);
+    private RootNode getRootNode(String fileName) throws Exception {
+        final File file = new File(getPath(fileName));
         final DetailAST rootAst = TestUtils.parseFile(file);
         return new RootNode(rootAst);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/InputXpathAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/InputXpathAnnotation.java
@@ -1,6 +1,0 @@
-package com.puppycrawl.tools.checkstyle.xpath;
-
-@SuppressWarnings("test")
-public class InputXpathAnnotation {
-
-}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/InputXpathEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/InputXpathEnum.java
@@ -1,7 +1,0 @@
-package com.puppycrawl.tools.checkstyle.xpath;
-
-public enum InputXpathEnum {
-    ONE,
-    TWO,
-    THREE
-}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathmapper/InputXpathMapperAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathmapper/InputXpathMapperAnnotation.java
@@ -1,0 +1,6 @@
+package com.puppycrawl.tools.checkstyle.xpath.xpathmapper;
+
+@SuppressWarnings("test")
+public class InputXpathMapperAnnotation {
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathmapper/InputXpathMapperAst.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathmapper/InputXpathMapperAst.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.xpath;
+package com.puppycrawl.tools.checkstyle.xpath.xpathmapper;
 
 public class InputXpathMapperAst {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathmapper/InputXpathMapperEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathmapper/InputXpathMapperEnum.java
@@ -1,0 +1,7 @@
+package com.puppycrawl.tools.checkstyle.xpath.xpathmapper;
+
+public enum InputXpathMapperEnum {
+    ONE,
+    TWO,
+    THREE
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathmapper/InputXpathMapperInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathmapper/InputXpathMapperInterface.java
@@ -1,6 +1,6 @@
-package com.puppycrawl.tools.checkstyle.xpath;
+package com.puppycrawl.tools.checkstyle.xpath.xpathmapper;
 
-public interface InputXpathInterface {
+public interface InputXpathMapperInterface {
     int sum(int a, int b);
     void init(String someVariable, int age);
     String getName();


### PR DESCRIPTION
Issue #3891 

No inputs in main directory. https://github.com/rnveach/checkstyle/tree/issue_3891_6/src/test/resources/com/puppycrawl/tools/checkstyle/xpath

All deleted files were renamed and had their package change.

@romani Please note import change in `RootNodeTest` and how our checks don't complain either way. Eclipse made the change when I re-organized imports.