### PR TITLE
Issue #4294: ParenPad: handle trailing semi-colons in try-with-resources

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/ParenPadTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/ParenPadTest.java
@@ -158,6 +158,8 @@ public class ParenPadTest extends AbstractModuleTestSupport {
             "212:49: " + getCheckMessage(clazz, messageKeyFollowed, "("),
             "212:51: " + getCheckMessage(clazz, messageKeyPreceded, ")"),
             "212:53: " + getCheckMessage(clazz, messageKeyPreceded, ")"),
+            "220:36: " + getCheckMessage(clazz, messageKeyPreceded, ")"),
+            "221:60: " + getCheckMessage(clazz, messageKeyPreceded, ")"),
         };
         final Configuration checkConfig = getModuleConfig("ParenPad");
         final String filePath = getPath("InputParenPad.java");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputParenPad.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputParenPad.java
@@ -211,4 +211,13 @@ enum MyEnum {
         org.junit.Assert.assertThat( "Help! Integers don't work", // warning
                 0, org.hamcrest.CoreMatchers.is( 1 ) ); // warning
     }
+
+    private void tryWithResources() throws Exception {
+        try (AutoCloseable a = null) {} // ok
+        try (AutoCloseable a = null; AutoCloseable b = null) {} // ok
+        try (AutoCloseable a = null; AutoCloseable b = null; ) {} // ok
+        try (AutoCloseable a = null; AutoCloseable b = null; ) {} // ok
+        try (AutoCloseable a = null ) {} // warning
+        try (AutoCloseable a = null; AutoCloseable b = null ) {} // warning
+    }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
@@ -28,9 +28,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 /**
  * <p>Checks the padding of parentheses; that is whether a space is required
  * after a left parenthesis and before a right parenthesis, or such spaces are
- * forbidden, with the exception that it does
- * not check for padding of the right parenthesis at an empty for iterator and
- * empty for initializer.
+ * forbidden. No check occurs at the right parenthesis after an empty for
+ * iterator, at the left parenthesis before an empty for initialization, or at
+ * the right parenthesis of a try-with-resources resource specification where
+ * the last resource variable has a trailing semi-colon.
  * Use Check {@link EmptyForIteratorPadCheck EmptyForIteratorPad} to validate
  * empty for iterators and {@link EmptyForInitializerPadCheck EmptyForInitializerPad}
  * to validate empty for initializers. Typecasts are also not checked, as there is
@@ -137,6 +138,9 @@ public class ParenPadCheck extends AbstractParenPadCheck {
             case TokenTypes.LAMBDA:
                 visitTokenWithOptionalParentheses(ast);
                 break;
+            case TokenTypes.RESOURCE_SPECIFICATION:
+                visitResourceSpecification(ast);
+                break;
             default:
                 processLeft(ast.findFirstToken(TokenTypes.LPAREN));
                 processRight(ast.findFirstToken(TokenTypes.RPAREN));
@@ -156,6 +160,27 @@ public class ParenPadCheck extends AbstractParenPadCheck {
             processLeft(parenAst);
             processRight(ast.findFirstToken(TokenTypes.RPAREN));
         }
+    }
+
+    /**
+     * Checks parens in {@link TokenTypes#RESOURCE_SPECIFICATION}.
+     * @param ast the token to check.
+     */
+    private void visitResourceSpecification(DetailAST ast) {
+        processLeft(ast.findFirstToken(TokenTypes.LPAREN));
+        final DetailAST rparen = ast.findFirstToken(TokenTypes.RPAREN);
+        if (!hasPrecedingSemiColon(rparen)) {
+            processRight(rparen);
+        }
+    }
+
+    /**
+     * Checks that a token is preceded by a semi-colon.
+     * @param ast the token to check
+     * @return whether a token is preceded by a semi-colon
+     */
+    private static boolean hasPrecedingSemiColon(DetailAST ast) {
+        return ast.getPreviousSibling().getType() == TokenTypes.SEMI;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
@@ -445,4 +445,14 @@ public class ParenPadCheckTest
         };
         verify(checkConfig, getPath("InputParenPadStartOfTheLine.java"), expected);
     }
+
+    @Test
+    public void testTryWithResources() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(ParenPadCheck.class);
+        final String[] expected = {
+            "9:36: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
+            "10:60: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
+        };
+        verify(checkConfig, getPath("InputParenPadTryWithResources.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadTryWithResources.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadTryWithResources.java
@@ -1,0 +1,12 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.parenpad;
+
+class InputParenPadTryWithResources {
+    private void tryWithResources() throws Exception {
+        try (AutoCloseable a = null) {} // ok
+        try (AutoCloseable a = null; AutoCloseable b = null) {} // ok
+        try (AutoCloseable a = null; AutoCloseable b = null; ) {} // ok
+        try (AutoCloseable a = null; AutoCloseable b = null; ) {} // ok
+        try (AutoCloseable a = null ) {} // warning
+        try (AutoCloseable a = null; AutoCloseable b = null ) {} // warning
+    }
+}

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1396,9 +1396,11 @@ import static java.math.BigInteger.ZERO;
         <p>
           Checks the policy on the padding of parentheses; i.e. whether a
           space is required after a left parenthesis and before a right
-          parenthesis, or such spaces are forbidden, with the exception that it does
-          not check for padding of the right parenthesis at an empty for iterator and
-          empty for initializer.
+          parenthesis, or such spaces are forbidden. No check occurs at
+          the right parenthesis after an empty for iterator, at the left
+          parenthesis before an empty for initialization, or at the right
+          parenthesis of a try-with-resources resource specification where
+          the last resource variable has a trailing semi-colon.
           Use Check <a
           href="config_whitespace.html#EmptyForIteratorPad">EmptyForIteratorPad</a>
           to validate empty for iterators and <a
@@ -1542,6 +1544,16 @@ import static java.math.BigInteger.ZERO;
     &lt;property name=&quot;option&quot; value=&quot;space&quot;/&gt;
 &lt;/module&gt;
         </source>
+
+        <p>
+          The following cases not checked:
+        </p>
+        <source>
+for ( ; i &lt; j; i++, j--) // no check after left parenthesis
+for (Iterator it = xs.iterator(); it.hasNext(); ) // no check before right parenthesis
+try (Closeable resource = acquire(); ) // no check before right parenthesis
+        </source>
+
       </subsection>
 
       <subsection name="Example of Usage">


### PR DESCRIPTION
Issue #4294: ParenPad: handle trailing semi-colons in try-with-resources