### PR TITLE
minor: modified eclipse compiler to not execute without arguments

### DIFF
--- a/.ci/eclipse-compiler-javac.sh
+++ b/.ci/eclipse-compiler-javac.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+if [ -z "$1" ]; then
+    echo "No parameters supplied!"
+    echo "      The classpath of the project and it's libraries to compile must be supplied."
+    exit 1
+fi
+
 ECJ_JAR="ecj-4.7.jar"
 ECJ_MAVEN_VERSION="R-4.7-201706120950"
 ECJ_PATH=~/.m2/repository/$ECJ_MAVEN_VERSION/$ECJ_JAR


### PR DESCRIPTION
As I am new to this file, if i executed it as is it printed out 2000+ errors about couldn't be able to find classes.
It turns out that this is a required parameter that is passed by maven. Some of our other scripts can be executed as is, so it was not clear that this couldn't be.

I only modified it slightly to fail if no parameters were passed.
It doesn't affect the maven process any.