### PR TITLE
Issue #5005: increase coverage of pitest-checks-metrics to 97%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1923,7 +1923,7 @@
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.checks.metrics.*</param>
               </targetTests>
-              <mutationThreshold>91</mutationThreshold>
+              <mutationThreshold>97</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -132,7 +132,6 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
      * @param from array representing regular expressions of classes to ignore.
      */
     public void setExcludeClassesRegexps(String... from) {
-        excludeClassesRegexps.clear();
         excludeClassesRegexps.addAll(Arrays.stream(from.clone())
                 .map(CommonUtils::createPattern)
                 .collect(Collectors.toSet()));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
@@ -43,7 +43,6 @@ public final class ClassDataAbstractionCouplingCheck
     /** Creates bew instance of the check. */
     public ClassDataAbstractionCouplingCheck() {
         super(DEFAULT_MAX);
-        setTokens("LITERAL_NEW");
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheckTest.java
@@ -65,6 +65,17 @@ public class CyclomaticComplexityCheckTest
     }
 
     @Test
+    public void testEqualsMaxComplexity() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(CyclomaticComplexityCheck.class);
+        checkConfig.addAttribute("max", "5");
+
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig, getPath("InputCyclomaticComplexitySwitchBlocks.java"), expected);
+    }
+
+    @Test
     public void test() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(CyclomaticComplexityCheck.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckTest.java
@@ -71,6 +71,19 @@ public class JavaNCSSCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testEqualToMax() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(JavaNCSSCheck.class);
+
+        checkConfig.addAttribute("methodMaximum", "12");
+        checkConfig.addAttribute("classMaximum", "22");
+        checkConfig.addAttribute("fileMaximum", "39");
+
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig, getPath("InputJavaNCSS.java"), expected);
+    }
+
+    @Test
     public void testDefaultConfiguration() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(JavaNCSSCheck.class);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.metrics;
 
 import static com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck.MSG_KEY;
 
+import java.util.Collection;
 import java.util.SortedSet;
 
 import org.junit.Assert;
@@ -29,9 +30,11 @@ import org.junit.Test;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.Context;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.TestUtils;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 // -@cs[AbbreviationAsWordInName] Can't change check name
@@ -102,6 +105,37 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
         };
 
         verify(checkConfig, getPath("InputNPathComplexityOverflow.java"), expected);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testStatefulFieldsClearedOnBeginTree1() throws Exception {
+        final DetailAST ast = new DetailAST();
+        ast.setType(TokenTypes.LITERAL_ELSE);
+
+        final NPathComplexityCheck check = new NPathComplexityCheck();
+        Assert.assertTrue("Stateful field is not cleared after beginTree",
+            TestUtils.isStatefulFieldClearedDuringBeginTree(check, ast, "rangeValues",
+                rangeValues -> ((Collection<Context>) rangeValues).isEmpty()));
+        Assert.assertTrue("Stateful field is not cleared after beginTree",
+            TestUtils.isStatefulFieldClearedDuringBeginTree(check, ast, "expressionValues",
+                expressionValues -> ((Collection<Context>) expressionValues).isEmpty()));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testStatefulFieldsClearedOnBeginTree2() throws Exception {
+        final DetailAST ast = new DetailAST();
+        ast.setType(TokenTypes.LITERAL_RETURN);
+        ast.setLineNo(5);
+        final DetailAST child = new DetailAST();
+        child.setType(TokenTypes.SEMI);
+        ast.addChild(child);
+
+        final NPathComplexityCheck check = new NPathComplexityCheck();
+        Assert.assertTrue("Stateful field is not cleared after beginTree",
+            TestUtils.isStatefulFieldClearedDuringBeginTree(check, ast, "isAfterValues",
+                isAfterValues -> ((Collection<Context>) isAfterValues).isEmpty()));
     }
 
     @Test


### PR DESCRIPTION
Issue #5005

[report before changes](https://nimfadora.github.io/pr/com.puppycrawl.tools.checkstyle.checks.metrics/)

increased coverage of pitest-checks-metrics by 4%
current threshold 97%