### PR TITLE
Issue #5148: added module JavadocType

### DIFF
--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -212,6 +212,7 @@
             <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
             <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
+        <module name="JavadocType"/>
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>


### PR DESCRIPTION
Issue #5148: added module JavadocType

Public Class and Interface javadoc is not checked at the moment.

Excerpt:

~~~
7.3 Where Javadoc is used

At the minimum, Javadoc is present for every public class, and every public or protected member of such a class, with a few exceptions noted below.
~~~
