### PR TITLE
Update HideUtilityClassConstructorCheck.java

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -25,7 +25,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * Make sure that utility classes (classes that contain only static methods)
- * do not have a public constructor.
+ * do not have a public constructor. If all constructors are private,
+ * consider declaring the class as final.
  * <p>
  * Rationale: Instantiating utility classes does not make sense.
  * A common mistake is forgetting to hide the default constructor.


### PR DESCRIPTION
minor: save people from hitting FinalClassCheck after addressing this

It's annoying to follow the suggestion of making the constructor private, only to turn around and get hit by the FinalClassCheck warning on the next checkstyle run. We should give people a heads up that the recommended change likely necessitates a second, related change. 