### PR TITLE
Issue #4870: Mark TranslationCheck with GlobalStatefulCheck annotation

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -99,6 +99,8 @@
     <allow class="java.nio.file.NoSuchFileException" local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.Definitions" local-only="true"/>
 
+    <allow class="com.puppycrawl.tools.checkstyle.GlobalStatefulCheck" local-only="true"/>
+
     <subpackage name="imports">
       <allow class="com.puppycrawl.tools.checkstyle.XmlLoader" local-only="true"/>
     </subpackage>

--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -3379,6 +3379,10 @@
                        In this case, there will be a warning "AutoCloseableResource", which need
                        to be suppressed. -->
                 <option value="resource"/>
+                <!-- till https://github.com/checkstyle/checkstyle/issues/5338 -->
+                <option value="AbstractClassExtendsConcreteClass" />
+                <!-- till #4869, after that the GlobalStatefulCheck will be used in UTs -->
+                <option value="ClassOnlyUsedInOnePackage" />
             </list>
         </option>
     </inspection_tool>

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -335,7 +335,7 @@
            CheckstyleAntTask integrates Checkstyle with Ant.
            Checker collects external resource locations and sets up the configuration. -->
       <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='Main'
-        or @Image='Checker' or @Image='CheckstyleAntTask']"/>
+        or @Image='Checker' or @Image='CheckstyleAntTask'] or @Image='TranslationCheck'"/>
     </properties>
   </rule>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -36,6 +36,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -44,6 +45,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.puppycrawl.tools.checkstyle.Definitions;
+import com.puppycrawl.tools.checkstyle.GlobalStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
@@ -98,6 +100,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <br>
  *
  */
+@GlobalStatefulCheck
 public class TranslationCheck extends AbstractFileSetCheck {
 
     /**
@@ -163,7 +166,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
     private final Log log;
 
     /** The files to process. */
-    private final Set<File> filesToProcess = new HashSet<>();
+    private final Set<File> filesToProcess = ConcurrentHashMap.newKeySet();
 
     /** The base name regexp pattern. */
     private Pattern baseName;


### PR DESCRIPTION
Issue #4870

Marks TranslationCheck with `GlobalStatefulCheck` annotation. Also changes `filesToProcess` to support MT access