### PR TITLE
Issue #929: Use private final loggers instead of private static final in Checkstyle codebase

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -194,6 +194,7 @@
           <property name="forbiddenClassesRegexpProtected" value="Logger"/>
           <property name="forbiddenClassesRegexpPublic" value="Logger"/>
           <property name="forbiddenClassesRegexpPackagePrivate" value="Logger"/>
+          <property name="forbiddenClassesRegexpStatic" value="Logger"/>
         </module>
         <module name="ConstructorWithoutParamsCheck">
           <property name="classNameFormat" value=".*Exception$"/>

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -35,4 +35,9 @@
     <!-- Tone down the checking for test code -->
     <suppress checks="ForbidCertainImports"
               files="DetailASTTest\.java"/>
+
+    <!-- Main and MainTest are technically not part of the checkstyle library,
+    so static Loggers are okay there. -->
+    <suppress checks="AvoidModifiersForTypesCheck"
+              files="Main\.java|MainTest\.java"/>
 </suppressions>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -69,7 +69,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher, RootMod
     public static final String EXCEPTION_MSG = "general.exception";
 
     /** Logger for Checker. */
-    private static final Log LOG = LogFactory.getLog(Checker.class);
+    private final Log log;
 
     /** Maintains error count. */
     private final SeverityLevelCounter counter = new SeverityLevelCounter(
@@ -139,6 +139,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher, RootMod
      */
     public Checker() {
         addListener(counter);
+        log = LogFactory.getLog(Checker.class);
     }
 
     /**
@@ -318,7 +319,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher, RootMod
             }
         }
         catch (final IOException ioe) {
-            LOG.debug("IOException occurred.", ioe);
+            log.debug("IOException occurred.", ioe);
             fileMessages.add(new LocalizedMessage(0,
                     Definitions.CHECKSTYLE_BUNDLE, EXCEPTION_MSG,
                     new String[] {ioe.getMessage()}, null, getClass(), null));
@@ -329,7 +330,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher, RootMod
                 throw ex;
             }
 
-            LOG.debug("Exception occurred.", ex);
+            log.debug("Exception occurred.", ex);
 
             final StringWriter sw = new StringWriter();
             final PrintWriter pw = new PrintWriter(sw, true);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -125,9 +125,6 @@ public class TranslationCheck extends AbstractFileSetCheck {
      */
     private static final String WRONG_LANGUAGE_CODE_KEY = "translation.wrongLanguageCode";
 
-    /** Logger for TranslationCheck. */
-    private static final Log LOG = LogFactory.getLog(TranslationCheck.class);
-
     /**
      * Regexp string for default translation files.
      * For example, messages.properties.
@@ -164,6 +161,9 @@ public class TranslationCheck extends AbstractFileSetCheck {
     /** Formatting string to form regexp to validate default translations file names. */
     private static final String REGEXP_FORMAT_TO_CHECK_DEFAULT_TRANSLATIONS = "^%s\\.%s$";
 
+    /** Logger for TranslationCheck. */
+    private final Log log;
+
     /** The files to process. */
     private final Set<File> filesToProcess = new HashSet<>();
 
@@ -181,6 +181,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
     public TranslationCheck() {
         setFileExtensions("properties");
         baseName = CommonUtils.createPattern("^messages.*$");
+        log = LogFactory.getLog(TranslationCheck.class);
     }
 
     /**
@@ -513,7 +514,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
         final SortedSet<LocalizedMessage> messages = new TreeSet<>();
         messages.add(message);
         getMessageDispatcher().fireErrors(file.getPath(), messages);
-        LOG.debug("IOException occurred.", exception);
+        log.debug("IOException occurred.", exception);
     }
 
     /** Class which represents a resource bundle. */


### PR DESCRIPTION
Issue #929

There is also an (abandoned and closed) PR for this issue: #4076

I have tried to take both the discussion from the issue and the incomplete PR into consideration.

Changes:
- Using private final loggers instead of private static final, except in the Main.java class
- Added sventu check to prevent static Loggers in the future
- Added exception to above rule for the Main.java class (for reasons see discussion in #4076)