### PR TITLE
Issue #5023. Prohibited the usage of hardcoded encoding in Checkstyle sources.

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -257,7 +257,11 @@
         <property name="tokens" value="LITERAL_VOLATILE"/>
         <property name="tokens" value="LITERAL_ASSERT"/>
     </module>
-    <module name="IllegalTokenText"/>
+    <module name="IllegalTokenText">
+      <property name="tokens" value="STRING_LITERAL"/>
+      <property name="format" value="^(US-ASCII|ISO-8859-1|UTF-8|UTF-16BE|UTF-16LE|UTF-16)$"/>
+      <property name="ignoreCase" value="true"/>
+    </module>
     <module name="IllegalType"/>
     <module name="InnerAssignment"/>
     <module name="MagicNumber"/>

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -123,7 +123,7 @@
     </subpackage>
     <subpackage name="header">
       <allow class="java.nio.charset.Charset" local-only="true"/>
-
+      <allow class="java.nio.charset.StandardCharsets" local-only="true" />
       <!-- allowed till https://github.com/checkstyle/checkstyle/issues/3455 -->
       <allow class="com.google.common.io.Closeables" local-only="true"/>
     </subpackage>
@@ -170,6 +170,7 @@
            local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser" local-only="true"/>
     <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
+    <allow class="java.nio.charset.StandardCharsets" local-only="true" />
   </subpackage>
 
   <subpackage name="xpath">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
@@ -234,7 +235,7 @@ public final class AstTreeStringPrinter {
     private static DetailAST parseFile(File file, PrintOptions withComments)
             throws IOException, CheckstyleException {
         final FileText text = new FileText(file.getAbsoluteFile(),
-            System.getProperty("file.encoding", "UTF-8"));
+            System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
         return parseFileText(text, withComments);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -25,6 +25,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -124,7 +125,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher, RootMod
     private SeverityLevel severityLevel = SeverityLevel.ERROR;
 
     /** Name of a charset. */
-    private String charset = System.getProperty("file.encoding", "UTF-8");
+    private String charset = System.getProperty("file.encoding", StandardCharsets.UTF_8.name());
 
     /** Cache file. **/
     private PropertyCacheFile cache;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseErrorMessage;
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseStatus;
@@ -169,7 +170,7 @@ public final class DetailNodeTreeStringPrinter {
      */
     private static DetailNode parseFile(File file) throws IOException {
         final FileText text = new FileText(file.getAbsoluteFile(),
-            System.getProperty("file.encoding", "UTF-8"));
+            System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
         return parseJavadocAsDetailNode(text.getFullText().toString());
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -26,6 +26,7 @@ import java.io.Reader;
 import java.io.Serializable;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Collections;
@@ -519,7 +520,8 @@ public final class LocalizedMessage
             }
             ResourceBundle resourceBundle = null;
             if (stream != null) {
-                final Reader streamReader = new InputStreamReader(stream, "UTF-8");
+                final Reader streamReader = new InputStreamReader(stream,
+                        StandardCharsets.UTF_8.name());
                 try {
                     // Only this line is changed to make it to read properties files as UTF-8.
                     resourceBundle = new PropertyResourceBundle(streamReader);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -28,6 +28,7 @@ import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -57,7 +58,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
     private URI headerFile;
 
     /** Name of a charset to use for loading the header from a file. */
-    private String charset = System.getProperty("file.encoding", "UTF-8");
+    private String charset = System.getProperty("file.encoding", StandardCharsets.UTF_8.name());
 
     /**
      * Hook method for post processing header lines.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.gui;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -267,6 +268,6 @@ public class MainFrameModel {
      */
     private static FileText getFileText(File file) throws IOException {
         return new FileText(file.getAbsoluteFile(),
-                System.getProperty("file.encoding", "UTF-8"));
+                System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -150,7 +150,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
                 new DefaultConfiguration("configuration");
         final DefaultConfiguration twConf = createModuleConfig(TreeWalker.class);
         // make sure that the tests always run with this charset
-        dc.addAttribute("charset", "UTF-8");
+        dc.addAttribute("charset", StandardCharsets.UTF_8.name());
         dc.addChild(twConf);
         twConf.addChild(config);
         return dc;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
@@ -75,7 +75,7 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
     public void testPrintAst() throws Exception {
         final FileText text = new FileText(
                 new File(getPath("InputAstTreeStringPrinterComments.java")).getAbsoluteFile(),
-                System.getProperty("file.encoding", "UTF-8"));
+                System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
         final String actual = AstTreeStringPrinter.printAst(text,
                 AstTreeStringPrinter.PrintOptions.WITHOUT_COMMENTS);
         final String expected = new String(Files.readAllBytes(Paths.get(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -272,7 +272,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
     @Test
     public void testFileExtensions() throws Exception {
         final DefaultConfiguration checkerConfig = new DefaultConfiguration("configuration");
-        checkerConfig.addAttribute("charset", "UTF-8");
+        checkerConfig.addAttribute("charset", StandardCharsets.UTF_8.name());
         checkerConfig.addAttribute("cacheFile", temporaryFolder.newFile().getPath());
 
         final Checker checker = new Checker();
@@ -309,7 +309,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
     @Test
     public void testIgnoredFileExtensions() throws Exception {
         final DefaultConfiguration checkerConfig = new DefaultConfiguration("configuration");
-        checkerConfig.addAttribute("charset", "UTF-8");
+        checkerConfig.addAttribute("charset", StandardCharsets.UTF_8.name());
         checkerConfig.addAttribute("cacheFile", temporaryFolder.newFile().getPath());
 
         final Checker checker = new Checker();
@@ -406,7 +406,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         final Context context = (Context) Whitebox.getInternalState(checker, "childContext");
         assertEquals("Charset was different than expected",
-                System.getProperty("file.encoding", "UTF-8"), context.get("charset"));
+                System.getProperty("file.encoding", StandardCharsets.UTF_8.name()),
+                context.get("charset"));
         assertEquals("Was used unsufficient classloader",
                 contextClassLoader, context.get("classLoader"));
         assertEquals("Severity is set to unexpected value",
@@ -493,7 +494,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         treeWalkerConfig.addChild(checkConfig);
 
         final DefaultConfiguration checkerConfig = new DefaultConfiguration("checkstyleConfig");
-        checkerConfig.addAttribute("charset", "UTF-8");
+        checkerConfig.addAttribute("charset", StandardCharsets.UTF_8.name());
         checkerConfig.addChild(treeWalkerConfig);
 
         final File cacheFile = temporaryFolder.newFile();
@@ -562,7 +563,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
     @Test
     public void testClearExistingCache() throws Exception {
         final DefaultConfiguration checkerConfig = new DefaultConfiguration("myConfig");
-        checkerConfig.addAttribute("charset", "UTF-8");
+        checkerConfig.addAttribute("charset", StandardCharsets.UTF_8.name());
         final File cacheFile = temporaryFolder.newFile();
         checkerConfig.addAttribute("cacheFile", cacheFile.getPath());
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
@@ -44,7 +45,7 @@ public class DefaultLoggerTest {
         final DefaultLogger dl = new DefaultLogger(infoStream, true, errorStream, true);
         dl.addException(new AuditEvent(5000, "myfile"), new IllegalStateException("upsss"));
         dl.auditFinished(new AuditEvent(6000, "myfile"));
-        final String output = errorStream.toString("UTF-8");
+        final String output = errorStream.toString(StandardCharsets.UTF_8.name());
         final LocalizedMessage addExceptionMessage = new LocalizedMessage(0,
                 Definitions.CHECKSTYLE_BUNDLE, DefaultLogger.ADD_EXCEPTION_MESSAGE,
                 new String[] {"myfile"}, null,
@@ -76,7 +77,7 @@ public class DefaultLoggerTest {
         dl.auditStarted(null);
         dl.addException(new AuditEvent(5000, "myfile"), new IllegalStateException("upsss"));
         dl.auditFinished(new AuditEvent(6000, "myfile"));
-        final String output = errorStream.toString("UTF-8");
+        final String output = errorStream.toString(StandardCharsets.UTF_8.name());
         final LocalizedMessage addExceptionMessage = new LocalizedMessage(0,
                 Definitions.CHECKSTYLE_BUNDLE, DefaultLogger.ADD_EXCEPTION_MESSAGE,
                 new String[] {"myfile"}, null,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -31,7 +31,6 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.reflect.Method;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -572,7 +571,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
 
         assertTrue("External resource is not present in cache",
                 new String(Files.readAllBytes(cacheFile.toPath()),
-                        Charset.forName("UTF-8")).contains(
+                        StandardCharsets.UTF_8).contains(
                                 "InputTreeWalkerSuppressionXpathFilter.xml"));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
@@ -272,7 +272,7 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     private static void checkFile(String filename) throws Exception {
         final FileText text = new FileText(new File(filename),
-                           System.getProperty("file.encoding", "UTF-8"));
+                           System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
         final FileContents contents = new FileContents(text);
         final DetailAST rootAST = TreeWalker.parse(contents);
         if (rootAST != null) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -30,6 +30,7 @@ import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 import org.junit.Test;
@@ -70,7 +71,7 @@ public class FileTextTest extends AbstractPathTestSupport {
         doNothing().when(Closeables.class);
         Closeables.closeQuietly(any(Reader.class));
 
-        final String charsetName = "ISO-8859-1";
+        final String charsetName = StandardCharsets.ISO_8859_1.name();
         final FileText fileText = new FileText(new File(getPath("InputFileTextImportControl.xml")),
                 charsetName);
         assertEquals("Invalid charset name", charsetName, fileText.getCharset().name());
@@ -81,7 +82,7 @@ public class FileTextTest extends AbstractPathTestSupport {
 
     @Test
     public void testLineColumnBeforeCopyConstructor() throws IOException {
-        final String charsetName = "ISO-8859-1";
+        final String charsetName = StandardCharsets.ISO_8859_1.name();
         final FileText fileText = new FileText(new File(getPath("InputFileTextImportControl.xml")),
                 charsetName);
         final LineColumn lineColumn = fileText.lineColumn(100);
@@ -91,7 +92,7 @@ public class FileTextTest extends AbstractPathTestSupport {
 
     @Test
     public void testLineColumnAfterCopyConstructor() throws IOException {
-        final String charsetName = "ISO-8859-1";
+        final String charsetName = StandardCharsets.ISO_8859_1.name();
         final FileText fileText = new FileText(new File(getPath("InputFileTextImportControl.xml")),
                 charsetName);
         final FileText copy = new FileText(fileText);
@@ -107,7 +108,7 @@ public class FileTextTest extends AbstractPathTestSupport {
 
     @Test
     public void testLineColumnAtTheStartOfFile() throws IOException {
-        final String charsetName = "ISO-8859-1";
+        final String charsetName = StandardCharsets.ISO_8859_1.name();
         final FileText fileText = new FileText(new File(getPath("InputFileTextImportControl.xml")),
                 charsetName);
         final FileText copy = new FileText(fileText);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import static com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck.MSG_KEY;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.SortedSet;
 
 import org.junit.Assert;
@@ -152,7 +153,8 @@ public class IllegalInstantiationCheckTest
 
         final IllegalInstantiationCheck check = new IllegalInstantiationCheck();
         final File inputFile = new File(getNonCompilablePath("InputIllegalInstantiationLang.java"));
-        check.setFileContents(new FileContents(new FileText(inputFile, "UTF-8")));
+        check.setFileContents(new FileContents(new FileText(inputFile,
+                StandardCharsets.UTF_8.name())));
         check.configure(createModuleConfig(IllegalInstantiationCheck.class));
         check.setClasses("java.lang.Boolean");
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import org.junit.Rule;
@@ -351,7 +351,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
 
         assertTrue("External resourse is not present in cache",
                 new String(Files.readAllBytes(cacheFile.toPath()),
-                Charset.forName("UTF-8")).contains("InputImportControlOneRegExp.xml"));
+                        StandardCharsets.UTF_8).contains("InputImportControlOneRegExp.xml"));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDocletTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDocletTest.java
@@ -185,7 +185,8 @@ public class TokenTypesDocletTest extends AbstractPathTestSupport {
         final Method getRootDocImpl = getMethodGetRootDocImplByReflection();
         final RootDoc rootDoc;
         if (System.getProperty("java.version").startsWith("1.7.")) {
-            rootDoc = (RootDoc) getRootDocImpl.invoke(javadocTool, "", "UTF-8",
+            rootDoc = (RootDoc) getRootDocImpl.invoke(javadocTool, "",
+                    StandardCharsets.UTF_8.name(),
                     new ModifierFilter(ModifierFilter.ALL_ACCESS),
                     names.toList(),
                     options.toList(),
@@ -195,7 +196,8 @@ public class TokenTypesDocletTest extends AbstractPathTestSupport {
                     false, false, false);
         }
         else {
-            rootDoc = (RootDoc) getRootDocImpl.invoke(javadocTool, "", "UTF-8",
+            rootDoc = (RootDoc) getRootDocImpl.invoke(javadocTool, "",
+                    StandardCharsets.UTF_8.name(),
                     new ModifierFilter(ModifierFilter.ALL_ACCESS),
                     names.toList(),
                     options.toList(),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/AstRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/AstRegressionTest.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.junit.Test;
@@ -217,7 +218,8 @@ public class AstRegressionTest extends AbstractTreeTestSupport {
             AstTreeStringPrinter.PrintOptions withComments) throws Exception {
         final File expectedFile = new File(expectedTextPrintFileName);
         final String expectedContents = new FileText(expectedFile, System.getProperty(
-                "file.encoding", "UTF-8")).getFullText().toString().replace("\r", "");
+                "file.encoding", StandardCharsets.UTF_8.name()))
+                .getFullText().toString().replace("\r", "");
 
         final FileText actualFileContents = new FileText(new File(""),
                 Arrays.asList(actualJava.split("\\n|\\r\\n?")));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.gui;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -48,7 +49,9 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
 
     private static DetailAST parseFile(File file) throws Exception {
         final FileContents contents = new FileContents(
-                new FileText(file.getAbsoluteFile(), System.getProperty("file.encoding", "UTF-8")));
+                new FileText(file.getAbsoluteFile(),
+                        System.getProperty("file.encoding",
+                        StandardCharsets.UTF_8.name())));
         return TreeWalker.parseWithComments(contents);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
@@ -151,7 +152,7 @@ public final class TestUtil {
      * @throws ANTLRException       if parser or lexer failed
      */
     public static DetailAST parseFile(File file) throws IOException, ANTLRException {
-        final FileText text = new FileText(file.getAbsoluteFile(), "UTF-8");
+        final FileText text = new FileText(file.getAbsoluteFile(), StandardCharsets.UTF_8.name());
         final FileContents contents = new FileContents(text);
         return parseWithComments(contents);
     }


### PR DESCRIPTION
Issue #5023. Changes:

Prohibited the usage of hardcoded encoding in Checkstyle sources
Fixed existing hardcoded encodings to match new rule
Allowed import of java.nio.charset.StandardCharsets for packages where it needed