### PR TITLE
Issue #4785: DetailNodeTreeStringPrinter#createFakeBlockComment move …

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
-import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtils;
 
 /**
@@ -41,9 +41,6 @@ public final class DetailNodeTreeStringPrinter {
 
     /** OS specific line separator. */
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
-
-    /** Symbols with which javadoc starts. */
-    private static final String JAVADOC_START = "/**";
 
     /** Prevent instances. */
     private DetailNodeTreeStringPrinter() {
@@ -80,7 +77,7 @@ public final class DetailNodeTreeStringPrinter {
      * @return tree
      */
     private static DetailNode parseJavadocAsDetailNode(String javadocComment) {
-        final DetailAST blockComment = createFakeBlockComment(javadocComment);
+        final DetailAST blockComment = CommonUtils.createBlockCommentNode(javadocComment);
         return parseJavadocAsDetailNode(blockComment);
     }
 
@@ -172,35 +169,6 @@ public final class DetailNodeTreeStringPrinter {
         final FileText text = new FileText(file.getAbsoluteFile(),
             System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
         return parseJavadocAsDetailNode(text.getFullText().toString());
-    }
-
-    /**
-     * Creates DetailAST block comment to pass it to the Javadoc parser.
-     * @param content comment content.
-     * @return DetailAST block comment
-     */
-    private static DetailAST createFakeBlockComment(String content) {
-        final DetailAST blockCommentBegin = new DetailAST();
-        blockCommentBegin.setType(TokenTypes.BLOCK_COMMENT_BEGIN);
-        blockCommentBegin.setText("/*");
-        blockCommentBegin.setLineNo(0);
-        blockCommentBegin.setColumnNo(-JAVADOC_START.length());
-
-        final DetailAST commentContent = new DetailAST();
-        commentContent.setType(TokenTypes.COMMENT_CONTENT);
-        commentContent.setText("*" + content);
-        commentContent.setLineNo(0);
-        // javadoc should starts at 0 column, so COMMENT_CONTENT node
-        // that contains javadoc identificator has -1 column
-        commentContent.setColumnNo(-1);
-
-        final DetailAST blockCommentEnd = new DetailAST();
-        blockCommentEnd.setType(TokenTypes.BLOCK_COMMENT_END);
-        blockCommentEnd.setText("*/");
-
-        blockCommentBegin.setFirstChild(commentContent);
-        commentContent.setNextSibling(blockCommentEnd);
-        return blockCommentBegin;
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -22,12 +22,10 @@ package com.puppycrawl.tools.checkstyle;
 import java.io.File;
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Locale;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -681,7 +679,7 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
             commentAst = createSlCommentNode(token);
         }
         else {
-            commentAst = createBlockCommentNode(token);
+            commentAst = CommonUtils.createBlockCommentNode(token);
         }
         return commentAst;
     }
@@ -712,83 +710,6 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
 
         slComment.addChild(slCommentContent);
         return slComment;
-    }
-
-    /**
-     * Create block comment from token.
-     * @param token
-     *        Token object.
-     * @return DetailAST with BLOCK_COMMENT type.
-     */
-    private static DetailAST createBlockCommentNode(Token token) {
-        final DetailAST blockComment = new DetailAST();
-        blockComment.initialize(TokenTypes.BLOCK_COMMENT_BEGIN, "/*");
-
-        // column counting begins from 0
-        blockComment.setColumnNo(token.getColumn() - 1);
-        blockComment.setLineNo(token.getLine());
-
-        final DetailAST blockCommentContent = new DetailAST();
-        blockCommentContent.setType(TokenTypes.COMMENT_CONTENT);
-
-        // column counting begins from 0
-        // plus length of '/*'
-        blockCommentContent.setColumnNo(token.getColumn() - 1 + 2);
-        blockCommentContent.setLineNo(token.getLine());
-        blockCommentContent.setText(token.getText());
-
-        final DetailAST blockCommentClose = new DetailAST();
-        blockCommentClose.initialize(TokenTypes.BLOCK_COMMENT_END, "*/");
-
-        final Entry<Integer, Integer> linesColumns = countLinesColumns(
-                token.getText(), token.getLine(), token.getColumn());
-        blockCommentClose.setLineNo(linesColumns.getKey());
-        blockCommentClose.setColumnNo(linesColumns.getValue());
-
-        blockComment.addChild(blockCommentContent);
-        blockComment.addChild(blockCommentClose);
-        return blockComment;
-    }
-
-    /**
-     * Count lines and columns (in last line) in text.
-     * @param text
-     *        String.
-     * @param initialLinesCnt
-     *        initial value of lines counter.
-     * @param initialColumnsCnt
-     *        initial value of columns counter.
-     * @return entry(pair), first element is lines counter, second - columns
-     *         counter.
-     */
-    private static Entry<Integer, Integer> countLinesColumns(
-            String text, int initialLinesCnt, int initialColumnsCnt) {
-        int lines = initialLinesCnt;
-        int columns = initialColumnsCnt;
-        boolean foundCr = false;
-        for (char c : text.toCharArray()) {
-            if (c == '\n') {
-                foundCr = false;
-                lines++;
-                columns = 0;
-            }
-            else {
-                if (foundCr) {
-                    foundCr = false;
-                    lines++;
-                    columns = 0;
-                }
-                if (c == '\r') {
-                    foundCr = true;
-                }
-                columns++;
-            }
-        }
-        if (foundCr) {
-            lines++;
-            columns = 0;
-        }
-        return new SimpleEntry<>(lines, columns);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -34,9 +34,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
-import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
 
@@ -76,31 +74,6 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             assertEquals("Generated and expected parse error messages don't match",
                     expected, ex.getMessage());
         }
-    }
-
-    @Test
-    public void testCreationOfFakeCommentBlock() throws Exception {
-        final Method createFakeBlockComment =
-                Whitebox.getMethod(DetailNodeTreeStringPrinter.class,
-                        "createFakeBlockComment", String.class);
-
-        final DetailAST testCommentBlock =
-                (DetailAST) createFakeBlockComment.invoke(null, "test_comment");
-        assertEquals("Invalid token type",
-                TokenTypes.BLOCK_COMMENT_BEGIN, testCommentBlock.getType());
-        assertEquals("Invalid text", "/*", testCommentBlock.getText());
-        assertEquals("Invalid line number", 0, testCommentBlock.getLineNo());
-
-        final DetailAST contentCommentBlock = testCommentBlock.getFirstChild();
-        assertEquals("Invalid tiken type",
-                TokenTypes.COMMENT_CONTENT, contentCommentBlock.getType());
-        assertEquals("Invalid text", "*test_comment", contentCommentBlock.getText());
-        assertEquals("Invalid line number", 0, contentCommentBlock.getLineNo());
-        assertEquals("Invalid column number", -1, contentCommentBlock.getColumnNo());
-
-        final DetailAST endCommentBlock = contentCommentBlock.getNextSibling();
-        assertEquals("Invalid tiken type", TokenTypes.BLOCK_COMMENT_END, endCommentBlock.getType());
-        assertEquals("Invalid text", "*/", endCommentBlock.getText());
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
@@ -45,6 +45,8 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 @RunWith(PowerMockRunner.class)
 public class CommonUtilsTest {
@@ -111,6 +113,27 @@ public class CommonUtilsTest {
             assertEquals("Invalid exception message",
                 "Failed to initialise regular expression [", ex.getMessage());
         }
+    }
+
+    @Test
+    public void testCreationOfFakeCommentBlock() {
+        final DetailAST testCommentBlock =
+                CommonUtils.createBlockCommentNode("test_comment");
+        assertEquals("Invalid token type",
+                TokenTypes.BLOCK_COMMENT_BEGIN, testCommentBlock.getType());
+        assertEquals("Invalid text", "/*", testCommentBlock.getText());
+        assertEquals("Invalid line number", 0, testCommentBlock.getLineNo());
+
+        final DetailAST contentCommentBlock = testCommentBlock.getFirstChild();
+        assertEquals("Invalid tiken type",
+                TokenTypes.COMMENT_CONTENT, contentCommentBlock.getType());
+        assertEquals("Invalid text", "*test_comment", contentCommentBlock.getText());
+        assertEquals("Invalid line number", 0, contentCommentBlock.getLineNo());
+        assertEquals("Invalid column number", -1, contentCommentBlock.getColumnNo());
+
+        final DetailAST endCommentBlock = contentCommentBlock.getNextSibling();
+        assertEquals("Invalid tiken type", TokenTypes.BLOCK_COMMENT_END, endCommentBlock.getType());
+        assertEquals("Invalid text", "*/", endCommentBlock.getText());
     }
 
     @Test


### PR DESCRIPTION
Issue #4785

Methods DetailNodeTreeStringPrinter#createFakeBlockComment and TreeWalker#createBlockCommentNode were moved to CommonUtils. Test for DetailNodeTreeStringPrinter#createFakeBlockComment also was moved to CommonUtilsTest class.