### PR TITLE
Issue #5127: Fixed NPE in JavadocPackageCheck when relative path is used to run checkstyle CLI

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
@@ -20,10 +20,12 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 
 /**
@@ -67,9 +69,16 @@ public class JavadocPackageCheck extends AbstractFileSetCheck {
     }
 
     @Override
-    protected void processFiltered(File file, FileText fileText) {
+    protected void processFiltered(File file, FileText fileText) throws CheckstyleException {
         // Check if already processed directory
-        final File dir = file.getParentFile();
+        final File dir;
+        try {
+            dir = file.getCanonicalFile().getParentFile();
+        }
+        catch (IOException ex) {
+            throw new CheckstyleException(
+                    "Exception while getting canonical path to file " + file.getPath(), ex);
+        }
         final boolean isDirChecked = !directoriesChecked.add(dir);
         if (!isDirChecked) {
             // Check for the preferred file.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/noparentfile/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/noparentfile/package-info.java
@@ -1,0 +1,1 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.noparentfile;


### PR DESCRIPTION
Fix for issue #5127.
