### PR TITLE
Issue #5003: remove ParenPad#processExpression call where it seems useless

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
@@ -121,7 +121,6 @@ public class ParenPadCheck extends AbstractParenPadCheck {
             case TokenTypes.METHOD_CALL:
                 processLeft(ast);
                 processRight(ast.findFirstToken(TokenTypes.RPAREN));
-                processExpression(ast);
                 break;
             case TokenTypes.DOT:
             case TokenTypes.EXPR:
@@ -209,7 +208,6 @@ public class ParenPadCheck extends AbstractParenPadCheck {
             while (childAst != null) {
                 if (childAst.getType() == TokenTypes.LPAREN) {
                     processLeft(childAst);
-                    processExpression(childAst);
                 }
                 else if (childAst.getType() == TokenTypes.RPAREN && !isInTypecast(childAst)) {
                     processRight(childAst);


### PR DESCRIPTION
Issue #5003 

remove calls to [processExpression](https://github.com/checkstyle/checkstyle/issues/5003#issuecomment-338330949), as pitest claims ([here](https://nimfadora.github.io/pr/com.puppycrawl.tools.checkstyle.checks.whitespace/ParenPadCheck.java.html#org.pitest.mutationtest.report.html.SourceFile@4f473a20_123) and [here](https://nimfadora.github.io/pr/com.puppycrawl.tools.checkstyle.checks.whitespace/ParenPadCheck.java.html#org.pitest.mutationtest.report.html.SourceFile@4f473a20_187)) that they are useless

[regression report](https://nimfadora.github.io/diff5003-paren-pad/index.html)