### PR TITLE
Issue #4169: Javadoc on annotation fields support

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPosition.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPosition.java
@@ -98,7 +98,10 @@ public final class BlockCommentPosition {
     public static boolean isOnField(DetailAST blockComment) {
         return isOnPlainClassMember(blockComment, TokenTypes.VARIABLE_DEF)
                 || isOnTokenWithModifiers(blockComment, TokenTypes.VARIABLE_DEF)
-                || isOnTokenWithAnnotation(blockComment, TokenTypes.VARIABLE_DEF);
+                || isOnTokenWithAnnotation(blockComment, TokenTypes.VARIABLE_DEF)
+                || isOnPlainClassMember(blockComment, TokenTypes.ANNOTATION_FIELD_DEF)
+                || isOnTokenWithModifiers(blockComment, TokenTypes.ANNOTATION_FIELD_DEF)
+                || isOnTokenWithAnnotation(blockComment, TokenTypes.ANNOTATION_FIELD_DEF);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -184,7 +184,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputAbstractJavadocPosition.java"), expected);
         assertEquals("Invalid number of javadocs",
-            58, JavadocCatchCheck.javadocsNumber);
+            62, JavadocCatchCheck.javadocsNumber);
     }
 
     @Test
@@ -196,7 +196,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig,
             getPath("InputAbstractJavadocPositionWithSinglelineComments.java"), expected);
         assertEquals("Invalid number of javadocs",
-                58, JavadocCatchCheck.javadocsNumber);
+                62, JavadocCatchCheck.javadocsNumber);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocPosition.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocPosition.java
@@ -230,6 +230,12 @@ enum CCCCCCC {
 
 /**Javadoc*/
 @interface/**nope*/ MyAnnotation/**nope*/ {/**nope*/
+	/**Javadoc*/
+	@Component/**nope*/ abstract/**nope*/ String/**nope*/ val1()/**nope*/ default/**nope*/ "";
+	/**Javadoc*/
+	abstract/**nope*/ String/**nope*/ val2()/**nope*/;
+	/**Javadoc*/
+	String/**nope*/ val3()/**nope*/;
 }
 
 class MyTemp1 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocPositionWithSinglelineComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocPositionWithSinglelineComments.java
@@ -231,6 +231,12 @@ enum XXXXXXX {
 
 /**Javadoc*/ //noise
 @interface/**nope*/ MyAnnotation2/**nope*/ {/**nope*/
+	/**Javadoc*/ //noise
+	@Component2/**nope*/ abstract/**nope*/ String/**nope*/ val1()/**nope*/ default/**nope*/ "";
+	/**Javadoc*/ //noise
+	abstract/**nope*/ String/**nope*/ val2()/**nope*/;
+	/**Javadoc*/ //noise
+	String/**nope*/ val3()/**nope*/;
 }
 
 class MyTemp2 {


### PR DESCRIPTION
Issue #4169

Checkstyle ignores javadoc that placed over Annotation type elements 