### PR TITLE
Issue #5228: removed unnecessary create module config methods

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilterTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class BeforeExecutionExclusionFileFilterTest extends AbstractModuleTestSupport {
@@ -67,7 +66,7 @@ public class BeforeExecutionExclusionFileFilterTest extends AbstractModuleTestSu
     @Test
     public void testRejectBadFile() throws Exception {
         final DefaultConfiguration filterConfig =
-                createBeforeExecutionFileFilterConfig(BeforeExecutionExclusionFileFilter.class);
+                createModuleConfig(BeforeExecutionExclusionFileFilter.class);
         filterConfig.addAttribute("fileNamePattern", "IncorrectClass\\.java");
 
         final String[] violations = CommonUtils.EMPTY_STRING_ARRAY;
@@ -84,17 +83,5 @@ public class BeforeExecutionExclusionFileFilterTest extends AbstractModuleTestSu
             exclusionBeforeExecutionFileFilter.setFileNamePattern(Pattern.compile(fileName));
         }
         return exclusionBeforeExecutionFileFilter;
-    }
-
-    private static DefaultConfiguration createBeforeExecutionFileFilterConfig(Class<?> aClass) {
-        return new DefaultConfiguration(aClass.getName());
-    }
-
-    @Override
-    protected DefaultConfiguration createTreeWalkerConfig(Configuration config) {
-        final DefaultConfiguration dc =
-                new DefaultConfiguration("configuration");
-        dc.addChild(config);
-        return dc;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -82,7 +82,7 @@ public class SuppressWarningsFilterTest
     @Test
     public void testDefault() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressWarningsFilter.class);
+            createModuleConfig(SuppressWarningsFilter.class);
         final String[] suppressed = {
             "24:17: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "29:17: Name 'L' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
@@ -96,10 +96,6 @@ public class SuppressWarningsFilterTest
             "97: Missing a Javadoc comment.",
         };
         verifySuppressed(filterConfig, suppressed);
-    }
-
-    private static DefaultConfiguration createFilterConfig(Class<?> classObj) {
-        return new DefaultConfiguration(classObj.getName());
     }
 
     private void verifySuppressed(Configuration aFilterConfig,
@@ -161,7 +157,7 @@ public class SuppressWarningsFilterTest
     @Test
     public void testSuppressById() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressWarningsFilter.class);
+            createModuleConfig(SuppressWarningsFilter.class);
         final String[] suppressedViolationMessages = {
             "6:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "8: Uncommented main method found.",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -92,7 +92,7 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testDefault() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressWithNearbyCommentFilter.class);
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
         final String[] suppressed = {
             "14:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "15:17: Name 'A2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
@@ -108,7 +108,7 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testCheckC() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressWithNearbyCommentFilter.class);
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("checkC", "false");
         final String[] suppressed = {
             "14:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
@@ -120,7 +120,7 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testCheckCpp() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressWithNearbyCommentFilter.class);
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("checkCPP", "false");
         final String[] suppressed = {
             "15:17: Name 'A2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
@@ -135,7 +135,7 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testUsingVariableMessage() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressWithNearbyCommentFilter.class);
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("commentFormat", "ALLOW CATCH (\\w+) BECAUSE");
         filterConfig.addAttribute("checkFormat", "IllegalCatchCheck");
         filterConfig.addAttribute("messageFormat", "$1");
@@ -150,7 +150,7 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testUsingVariableCheckOnNextLine() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressWithNearbyCommentFilter.class);
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("commentFormat", "ALLOW (\\w+) ON NEXT LINE");
         filterConfig.addAttribute("checkFormat", "$1");
         filterConfig.addAttribute("influenceFormat", "1");
@@ -163,7 +163,7 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testUsingVariableCheckOnPreviousLine() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressWithNearbyCommentFilter.class);
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("commentFormat", "ALLOW (\\w+) ON PREVIOUS LINE");
         filterConfig.addAttribute("checkFormat", "$1");
         filterConfig.addAttribute("influenceFormat", "-1");
@@ -176,7 +176,7 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testVariableCheckOnVariableNumberOfLines() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressWithNearbyCommentFilter.class);
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("commentFormat", "ALLOW (\\w+) UNTIL THIS LINE([+-]\\d+)");
         filterConfig.addAttribute("checkFormat", "$1");
         filterConfig.addAttribute("influenceFormat", "$2");
@@ -192,10 +192,6 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testEqualsAndHashCodeOfTagClass() {
         EqualsVerifier.forClass(SuppressWithNearbyCommentFilter.Tag.class).usingGetClass().verify();
-    }
-
-    private static DefaultConfiguration createFilterConfig(Class<?> classObj) {
-        return new DefaultConfiguration(classObj.getName());
     }
 
     private void verifySuppressed(Configuration filterConfig,
@@ -244,7 +240,7 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testInvalidInfluenceFormat() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressWithNearbyCommentFilter.class);
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("influenceFormat", "a");
 
         try {
@@ -261,7 +257,7 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testInfluenceFormat() throws Exception {
         final DefaultConfiguration filterConfig =
-                createFilterConfig(SuppressWithNearbyCommentFilter.class);
+                createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("influenceFormat", "1");
 
         final String[] suppressed = {
@@ -280,7 +276,7 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testInvalidCheckFormat() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressWithNearbyCommentFilter.class);
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("checkFormat", "a[l");
 
         try {
@@ -314,7 +310,7 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testUsingTagMessageRegexp() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressWithNearbyCommentFilter.class);
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("commentFormat", "SUPPRESS CHECKSTYLE (\\w+)");
         filterConfig.addAttribute("checkFormat", "IllegalCatchCheck");
         filterConfig.addAttribute("messageFormat", "^$1 ololo*$");
@@ -325,7 +321,7 @@ public class SuppressWithNearbyCommentFilterTest
     @Test
     public void testSuppressById() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressWithNearbyCommentFilter.class);
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("commentFormat", "@cs-: (\\w+) \\(\\w+\\)");
         filterConfig.addAttribute("checkFormat", "$1");
         filterConfig.addAttribute("influenceFormat", "0");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -85,7 +85,7 @@ public class SuppressionCommentFilterTest
     @Test
     public void testDefault() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressionCommentFilter.class);
+            createModuleConfig(SuppressionCommentFilter.class);
         final String[] suppressed = {
             "16:17: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "43:17: Name 'T' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
@@ -99,7 +99,7 @@ public class SuppressionCommentFilterTest
     @Test
     public void testCheckC() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressionCommentFilter.class);
+            createModuleConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("checkC", "false");
         final String[] suppressed = {
             "43:17: Name 'T' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
@@ -112,7 +112,7 @@ public class SuppressionCommentFilterTest
     @Test
     public void testCheckCpp() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressionCommentFilter.class);
+            createModuleConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("checkCPP", "false");
         final String[] suppressed = {
             "16:17: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
@@ -125,7 +125,7 @@ public class SuppressionCommentFilterTest
     @Test
     public void testOffFormat() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressionCommentFilter.class);
+            createModuleConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("offCommentFormat", "CS_OFF");
         filterConfig.addAttribute("onCommentFormat", "CS_ON");
         final String[] suppressed = {
@@ -142,7 +142,7 @@ public class SuppressionCommentFilterTest
     @Test
     public void testOffFormatCheck() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressionCommentFilter.class);
+            createModuleConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("offCommentFormat", "CS_OFF");
         filterConfig.addAttribute("onCommentFormat", "CS_ON");
         filterConfig.addAttribute("checkFormat", "ConstantNameCheck");
@@ -155,7 +155,7 @@ public class SuppressionCommentFilterTest
     @Test
     public void testArgumentSuppression() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressionCommentFilter.class);
+            createModuleConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("offCommentFormat", "IllegalCatchCheck OFF\\: (\\w+)");
         filterConfig.addAttribute("onCommentFormat", "IllegalCatchCheck ON\\: (\\w+)");
         filterConfig.addAttribute("checkFormat", "IllegalCatchCheck");
@@ -169,7 +169,7 @@ public class SuppressionCommentFilterTest
     @Test
     public void testExpansion() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressionCommentFilter.class);
+            createModuleConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("offCommentFormat", "CSOFF\\: ([\\w\\|]+)");
         filterConfig.addAttribute("onCommentFormat", "CSON\\: ([\\w\\|]+)");
         filterConfig.addAttribute("checkFormat", "$1");
@@ -184,7 +184,7 @@ public class SuppressionCommentFilterTest
     @Test
     public void testMessage() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressionCommentFilter.class);
+            createModuleConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("onCommentFormat", "UNUSED ON\\: (\\w+)");
         filterConfig.addAttribute("offCommentFormat", "UNUSED OFF\\: (\\w+)");
         filterConfig.addAttribute("checkFormat", "Unused");
@@ -193,10 +193,6 @@ public class SuppressionCommentFilterTest
             "47:34: Unused parameter 'aInt'.",
         };
         verifySuppressed(filterConfig, suppressed);
-    }
-
-    private static DefaultConfiguration createFilterConfig(Class<?> aClass) {
-        return new DefaultConfiguration(aClass.getName());
     }
 
     private void verifySuppressed(Configuration aFilterConfig,
@@ -262,7 +258,7 @@ public class SuppressionCommentFilterTest
     @Test
     public void testInvalidCheckFormat() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressionCommentFilter.class);
+            createModuleConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("checkFormat", "e[l");
 
         try {
@@ -279,7 +275,7 @@ public class SuppressionCommentFilterTest
     @Test
     public void testInvalidMessageFormat() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressionCommentFilter.class);
+            createModuleConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("messageFormat", "e[l");
 
         try {
@@ -305,7 +301,7 @@ public class SuppressionCommentFilterTest
     @Test
     public void testSuppressById() throws Exception {
         final DefaultConfiguration filterConfig =
-            createFilterConfig(SuppressionCommentFilter.class);
+            createModuleConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("offCommentFormat", "CSOFF (\\w+) \\(\\w+\\)");
         filterConfig.addAttribute("onCommentFormat", "CSON (\\w+)");
         filterConfig.addAttribute("checkFormat", "$1");


### PR DESCRIPTION
Issue #5228

Removed unnecessary `create*Config` methods and replaced them with `createModuleConfig`.