### PR TITLE
Issue #5124: removed usage of branchContains for modifiers

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
@@ -143,8 +143,8 @@ public class FinalParametersCheck extends AbstractCheck {
 
         if (method.branchContains(TokenTypes.PARAMETER_DEF)
                 // ignore abstract and native methods
-                && !modifiers.branchContains(TokenTypes.ABSTRACT)
-                && !modifiers.branchContains(TokenTypes.LITERAL_NATIVE)) {
+                && modifiers.findFirstToken(TokenTypes.ABSTRACT) == null
+                && modifiers.findFirstToken(TokenTypes.LITERAL_NATIVE) == null) {
             // we can now be sure that there is at least one parameter
             final DetailAST parameters =
                 method.findFirstToken(TokenTypes.PARAMETERS);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -183,8 +183,8 @@ public class UncommentedMainCheck
         final DetailAST modifiers =
             method.findFirstToken(TokenTypes.MODIFIERS);
 
-        return modifiers.branchContains(TokenTypes.LITERAL_PUBLIC)
-            && modifiers.branchContains(TokenTypes.LITERAL_STATIC);
+        return modifiers.findFirstToken(TokenTypes.LITERAL_PUBLIC) != null
+            && modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -188,7 +188,7 @@ public abstract class AbstractSuperCheck
             final DetailAST modifiersAST = ast.findFirstToken(TokenTypes.MODIFIERS);
 
             if (getMethodName().equals(name)
-                    && !modifiersAST.branchContains(TokenTypes.LITERAL_NATIVE)) {
+                    && modifiersAST.findFirstToken(TokenTypes.LITERAL_NATIVE) == null) {
                 final DetailAST params = ast.findFirstToken(TokenTypes.PARAMETERS);
                 overridingMethod = params.getChildCount() == 0;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
@@ -116,10 +116,10 @@ public class EqualsHashCodeCheck
         final DetailAST parameters = ast.findFirstToken(TokenTypes.PARAMETERS);
 
         return CheckUtils.isEqualsMethod(ast)
-                && modifiers.branchContains(TokenTypes.LITERAL_PUBLIC)
+                && modifiers.findFirstToken(TokenTypes.LITERAL_PUBLIC) != null
                 && isObjectParam(parameters.getFirstChild())
                 && (ast.branchContains(TokenTypes.SLIST)
-                        || modifiers.branchContains(TokenTypes.LITERAL_NATIVE));
+                        || modifiers.findFirstToken(TokenTypes.LITERAL_NATIVE) != null);
     }
 
     /**
@@ -136,11 +136,11 @@ public class EqualsHashCodeCheck
 
         return type.getFirstChild().getType() == TokenTypes.LITERAL_INT
                 && "hashCode".equals(methodName.getText())
-                && modifiers.branchContains(TokenTypes.LITERAL_PUBLIC)
-                && !modifiers.branchContains(TokenTypes.LITERAL_STATIC)
+                && modifiers.findFirstToken(TokenTypes.LITERAL_PUBLIC) != null
+                && modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) == null
                 && parameters.getFirstChild() == null
                 && (ast.branchContains(TokenTypes.SLIST)
-                        || modifiers.branchContains(TokenTypes.LITERAL_NATIVE));
+                        || modifiers.findFirstToken(TokenTypes.LITERAL_NATIVE) != null);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -152,7 +152,7 @@ public class ExplicitInitializationCheck extends AbstractCheck {
 
             if (assign != null) {
                 final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
-                skipCase = modifiers.branchContains(TokenTypes.FINAL);
+                skipCase = modifiers.findFirstToken(TokenTypes.FINAL) != null;
             }
         }
         return skipCase;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -612,8 +612,8 @@ public class FinalLocalVariableCheck extends AbstractCheck {
             if (parent.getType() == TokenTypes.METHOD_DEF) {
                 final DetailAST modifiers =
                     parent.findFirstToken(TokenTypes.MODIFIERS);
-                abstractOrNative = modifiers.branchContains(TokenTypes.ABSTRACT)
-                        || modifiers.branchContains(TokenTypes.LITERAL_NATIVE);
+                abstractOrNative = modifiers.findFirstToken(TokenTypes.ABSTRACT) != null
+                        || modifiers.findFirstToken(TokenTypes.LITERAL_NATIVE) != null;
             }
             parent = parent.getParent();
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -246,7 +246,7 @@ public class HiddenFieldCheck
         final DetailAST typeMods = ast.findFirstToken(TokenTypes.MODIFIERS);
         final boolean isStaticInnerType =
                 typeMods != null
-                        && typeMods.branchContains(TokenTypes.LITERAL_STATIC);
+                        && typeMods.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
         final String frameName;
 
         if (type == TokenTypes.CLASS_DEF || type == TokenTypes.ENUM_DEF) {
@@ -268,11 +268,11 @@ public class HiddenFieldCheck
                         child.findFirstToken(TokenTypes.IDENT).getText();
                     final DetailAST mods =
                         child.findFirstToken(TokenTypes.MODIFIERS);
-                    if (mods.branchContains(TokenTypes.LITERAL_STATIC)) {
-                        newFrame.addStaticField(name);
+                    if (mods.findFirstToken(TokenTypes.LITERAL_STATIC) == null) {
+                        newFrame.addInstanceField(name);
                     }
                     else {
-                        newFrame.addInstanceField(name);
+                        newFrame.addStaticField(name);
                     }
                 }
                 child = child.getNextSibling();
@@ -365,7 +365,7 @@ public class HiddenFieldCheck
                         || parent.getType() == TokenTypes.VARIABLE_DEF) {
                 final DetailAST mods =
                     parent.findFirstToken(TokenTypes.MODIFIERS);
-                inStatic = mods.branchContains(TokenTypes.LITERAL_STATIC);
+                inStatic = mods.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
                 break;
             }
             else {
@@ -423,7 +423,7 @@ public class HiddenFieldCheck
             // therefore this method is potentially a setter
             final DetailAST typeAST = aMethodAST.findFirstToken(TokenTypes.TYPE);
             final String returnType = typeAST.getFirstChild().getText();
-            if (typeAST.branchContains(TokenTypes.LITERAL_VOID)
+            if (typeAST.findFirstToken(TokenTypes.LITERAL_VOID) != null
                     || setterCanReturnItsClass && frame.isEmbeddedIn(returnType)) {
                 // this method has signature
                 //
@@ -492,7 +492,7 @@ public class HiddenFieldCheck
             final DetailAST method = ast.getParent().getParent();
             if (method.getType() == TokenTypes.METHOD_DEF) {
                 final DetailAST mods = method.findFirstToken(TokenTypes.MODIFIERS);
-                result = mods.branchContains(TokenTypes.ABSTRACT);
+                result = mods.findFirstToken(TokenTypes.ABSTRACT) != null;
             }
         }
         return result;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -271,7 +271,7 @@ public class MagicNumberCheck extends AbstractCheck {
                 // explicit constant
                 final DetailAST modifiersAST = varDefAST.findFirstToken(TokenTypes.MODIFIERS);
 
-                if (modifiersAST.branchContains(TokenTypes.FINAL)) {
+                if (modifiersAST.findFirstToken(TokenTypes.FINAL) != null) {
                     constantDef = varDefAST;
                 }
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheck.java
@@ -63,7 +63,7 @@ public class MissingCtorCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
-        if (!modifiers.branchContains(TokenTypes.ABSTRACT)
+        if (modifiers.findFirstToken(TokenTypes.ABSTRACT) == null
                 && ast.findFirstToken(TokenTypes.OBJBLOCK)
                     .findFirstToken(TokenTypes.CTOR_DEF) == null) {
             log(ast.getLineNo(), MSG_KEY);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheck.java
@@ -148,7 +148,7 @@ public class NoCloneCheck extends AbstractCheck {
 
             final DetailAST params = aAST.findFirstToken(TokenTypes.PARAMETERS);
             final boolean hasEmptyParamList =
-                !params.branchContains(TokenTypes.PARAMETER_DEF);
+                params.findFirstToken(TokenTypes.PARAMETER_DEF) == null;
 
             if (hasEmptyParamList) {
                 log(aAST.getLineNo(), MSG_KEY);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoFinalizerCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoFinalizerCheck.java
@@ -63,7 +63,7 @@ public class NoFinalizerCheck extends AbstractCheck {
 
             final DetailAST params = aAST.findFirstToken(TokenTypes.PARAMETERS);
             final boolean hasEmptyParamList =
-                !params.branchContains(TokenTypes.PARAMETER_DEF);
+                params.findFirstToken(TokenTypes.PARAMETER_DEF) == null;
 
             if (hasEmptyParamList) {
                 log(aAST.getLineNo(), MSG_KEY);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -352,11 +352,11 @@ public class RequireThisCheck extends AbstractCheck {
             case TokenTypes.METHOD_DEF :
                 final DetailAST methodFrameNameIdent = ast.findFirstToken(TokenTypes.IDENT);
                 final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
-                if (mods.branchContains(TokenTypes.LITERAL_STATIC)) {
-                    ((ClassFrame) frame).addStaticMethod(methodFrameNameIdent);
+                if (mods.findFirstToken(TokenTypes.LITERAL_STATIC) == null) {
+                    ((ClassFrame) frame).addInstanceMethod(methodFrameNameIdent);
                 }
                 else {
-                    ((ClassFrame) frame).addInstanceMethod(methodFrameNameIdent);
+                    ((ClassFrame) frame).addStaticMethod(methodFrameNameIdent);
                 }
                 frameStack.addFirst(new MethodFrame(frame, methodFrameNameIdent));
                 break;
@@ -386,7 +386,7 @@ public class RequireThisCheck extends AbstractCheck {
             final DetailAST mods =
                     ast.findFirstToken(TokenTypes.MODIFIERS);
             if (ScopeUtils.isInInterfaceBlock(ast)
-                    || mods.branchContains(TokenTypes.LITERAL_STATIC)) {
+                    || mods.findFirstToken(TokenTypes.LITERAL_STATIC) != null) {
                 ((ClassFrame) frame).addStaticMember(ident);
             }
             else {
@@ -599,7 +599,7 @@ public class RequireThisCheck extends AbstractCheck {
                 if (codeBlockDefinition != null) {
                     final DetailAST modifiers = codeBlockDefinition.getFirstChild();
                     staticContext = codeBlockDefinition.getType() == TokenTypes.STATIC_INIT
-                        || modifiers.branchContains(TokenTypes.LITERAL_STATIC);
+                        || modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
                 }
             }
             else {
@@ -1226,7 +1226,7 @@ public class RequireThisCheck extends AbstractCheck {
             boolean result = false;
             for (DetailAST member : instanceMembers) {
                 final DetailAST mods = member.getParent().findFirstToken(TokenTypes.MODIFIERS);
-                final boolean finalMod = mods.branchContains(TokenTypes.FINAL);
+                final boolean finalMod = mods.findFirstToken(TokenTypes.FINAL) != null;
                 if (finalMod && member.equals(instanceMember)) {
                     result = true;
                     break;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -258,7 +258,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
         final DetailAST modifiers = ast.getFirstChild();
 
         if (parentType != TokenTypes.OBJBLOCK
-                && (!ignoreFinal || !modifiers.branchContains(TokenTypes.FINAL))) {
+                && (!ignoreFinal || modifiers.findFirstToken(TokenTypes.FINAL) == null)) {
             final DetailAST variable = ast.findFirstToken(TokenTypes.IDENT);
 
             if (!isVariableMatchesIgnorePattern(variable.getText())) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -169,7 +169,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
      */
     private static boolean isNativeMethod(DetailAST ast) {
         final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
-        return mods.branchContains(TokenTypes.LITERAL_NATIVE);
+        return mods.findFirstToken(TokenTypes.LITERAL_NATIVE) != null;
     }
 
     /**
@@ -205,10 +205,10 @@ public class DesignForExtensionCheck extends AbstractCheck {
         final DetailAST modifiers = methodDef.findFirstToken(TokenTypes.MODIFIERS);
         return ScopeUtils.getSurroundingScope(methodDef).isIn(Scope.PROTECTED)
             && !ScopeUtils.isInInterfaceOrAnnotationBlock(methodDef)
-            && !modifiers.branchContains(TokenTypes.LITERAL_PRIVATE)
-            && !modifiers.branchContains(TokenTypes.ABSTRACT)
-            && !modifiers.branchContains(TokenTypes.FINAL)
-            && !modifiers.branchContains(TokenTypes.LITERAL_STATIC);
+            && modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) == null
+            && modifiers.findFirstToken(TokenTypes.ABSTRACT) == null
+            && modifiers.findFirstToken(TokenTypes.FINAL) == null
+            && modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) == null;
     }
 
     /**
@@ -220,7 +220,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
     private static boolean hasIgnoredAnnotation(DetailAST methodDef, Set<String> annotations) {
         final DetailAST modifiers = methodDef.findFirstToken(TokenTypes.MODIFIERS);
         boolean hasIgnoredAnnotation = false;
-        if (modifiers.branchContains(TokenTypes.ANNOTATION)) {
+        if (modifiers.findFirstToken(TokenTypes.ANNOTATION) != null) {
             final Optional<DetailAST> annotation = TokenUtils.findFirstTokenByPredicate(modifiers,
                 currentToken -> {
                     return currentToken.getType() == TokenTypes.ANNOTATION
@@ -273,7 +273,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
     private static boolean canBeSubclassed(DetailAST classDef) {
         final DetailAST modifiers = classDef.findFirstToken(TokenTypes.MODIFIERS);
         return classDef.getType() != TokenTypes.ENUM_DEF
-            && !modifiers.branchContains(TokenTypes.FINAL)
+            && modifiers.findFirstToken(TokenTypes.FINAL) == null
             && hasDefaultOrExplicitNonPrivateCtor(classDef);
     }
 
@@ -297,7 +297,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
 
                 final DetailAST ctorMods =
                         candidate.findFirstToken(TokenTypes.MODIFIERS);
-                if (!ctorMods.branchContains(TokenTypes.LITERAL_PRIVATE)) {
+                if (ctorMods.findFirstToken(TokenTypes.LITERAL_PRIVATE) == null) {
                     hasExplicitNonPrivateCtor = true;
                     break;
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -97,8 +97,8 @@ public class FinalClassCheck
             case TokenTypes.CLASS_DEF:
                 registerNestedSubclassToOuterSuperClasses(ast);
 
-                final boolean isFinal = modifiers.branchContains(TokenTypes.FINAL);
-                final boolean isAbstract = modifiers.branchContains(TokenTypes.ABSTRACT);
+                final boolean isFinal = modifiers.findFirstToken(TokenTypes.FINAL) != null;
+                final boolean isAbstract = modifiers.findFirstToken(TokenTypes.ABSTRACT) != null;
 
                 final String qualifiedClassName = getQualifiedClassName(ast);
                 classes.push(new ClassDesc(qualifiedClassName, isFinal, isAbstract));
@@ -107,11 +107,11 @@ public class FinalClassCheck
             case TokenTypes.CTOR_DEF:
                 if (!ScopeUtils.isInEnumBlock(ast)) {
                     final ClassDesc desc = classes.peek();
-                    if (modifiers.branchContains(TokenTypes.LITERAL_PRIVATE)) {
-                        desc.registerPrivateCtor();
+                    if (modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) == null) {
+                        desc.registerNonPrivateCtor();
                     }
                     else {
-                        desc.registerNonPrivateCtor();
+                        desc.registerPrivateCtor();
                     }
                 }
                 break;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -95,7 +95,7 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
      */
     private static boolean isAbstract(DetailAST ast) {
         return ast.findFirstToken(TokenTypes.MODIFIERS)
-            .branchContains(TokenTypes.ABSTRACT);
+            .findFirstToken(TokenTypes.ABSTRACT) != null;
     }
 
     /**
@@ -105,7 +105,7 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
      */
     private static boolean isStatic(DetailAST ast) {
         return ast.findFirstToken(TokenTypes.MODIFIERS)
-            .branchContains(TokenTypes.LITERAL_STATIC);
+            .findFirstToken(TokenTypes.LITERAL_STATIC) != null;
     }
 
     /**
@@ -193,9 +193,9 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
                     final DetailAST modifiers =
                         child.findFirstToken(TokenTypes.MODIFIERS);
                     final boolean isStatic =
-                        modifiers.branchContains(TokenTypes.LITERAL_STATIC);
+                        modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
                     final boolean isPrivate =
-                        modifiers.branchContains(TokenTypes.LITERAL_PRIVATE);
+                        modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) != null;
 
                     if (!isStatic) {
                         hasNonStaticMethodOrField = true;
@@ -208,8 +208,8 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
                     hasDefaultCtor = false;
                     final DetailAST modifiers =
                         child.findFirstToken(TokenTypes.MODIFIERS);
-                    if (!modifiers.branchContains(TokenTypes.LITERAL_PRIVATE)
-                        && !modifiers.branchContains(TokenTypes.LITERAL_PROTECTED)) {
+                    if (modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) == null
+                        && modifiers.findFirstToken(TokenTypes.LITERAL_PROTECTED) == null) {
                         // treat package visible as public
                         // for the purpose of this Check
                         hasPublicCtor = true;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
@@ -143,7 +143,7 @@ public final class ThrowsCountCheck extends AbstractCheck {
     private static boolean isOverriding(DetailAST ast) {
         final DetailAST modifiers = ast.getParent().findFirstToken(TokenTypes.MODIFIERS);
         boolean isOverriding = false;
-        if (modifiers.branchContains(TokenTypes.ANNOTATION)) {
+        if (modifiers.findFirstToken(TokenTypes.ANNOTATION) != null) {
             DetailAST child = modifiers.getFirstChild();
             while (child != null) {
                 if (child.getType() == TokenTypes.ANNOTATION

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -736,7 +736,7 @@ public class VisibilityModifierCheck
      */
     private static boolean isFinalField(DetailAST variableDef) {
         final DetailAST modifiers = variableDef.findFirstToken(TokenTypes.MODIFIERS);
-        return modifiers.branchContains(TokenTypes.FINAL);
+        return modifiers.findFirstToken(TokenTypes.FINAL) != null;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
@@ -284,14 +284,14 @@ public class RedundantModifierCheck
                         ast.findFirstToken(TokenTypes.MODIFIERS);
         // private method?
         boolean checkFinal =
-            modifiers.branchContains(TokenTypes.LITERAL_PRIVATE);
+            modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) != null;
         // declared in a final class?
         DetailAST parent = ast.getParent();
         while (parent != null) {
             if (parent.getType() == TokenTypes.CLASS_DEF) {
                 final DetailAST classModifiers =
                     parent.findFirstToken(TokenTypes.MODIFIERS);
-                checkFinal = checkFinal || classModifiers.branchContains(TokenTypes.FINAL);
+                checkFinal = checkFinal || classModifiers.findFirstToken(TokenTypes.FINAL) != null;
                 parent = null;
             }
             else if (parent.getType() == TokenTypes.LITERAL_NEW
@@ -372,7 +372,7 @@ public class RedundantModifierCheck
     private static boolean isClassProtected(DetailAST classDef) {
         final DetailAST classModifiers =
                 classDef.findFirstToken(TokenTypes.MODIFIERS);
-        return classModifiers.branchContains(TokenTypes.LITERAL_PROTECTED);
+        return classModifiers.findFirstToken(TokenTypes.LITERAL_PROTECTED) != null;
     }
 
     /**
@@ -384,7 +384,8 @@ public class RedundantModifierCheck
         boolean isAccessibleFromPublic = false;
         final boolean isMostOuterScope = ast.getParent() == null;
         final DetailAST modifiersAst = ast.findFirstToken(TokenTypes.MODIFIERS);
-        final boolean hasPublicModifier = modifiersAst.branchContains(TokenTypes.LITERAL_PUBLIC);
+        final boolean hasPublicModifier =
+                modifiersAst.findFirstToken(TokenTypes.LITERAL_PUBLIC) != null;
 
         if (isMostOuterScope) {
             isAccessibleFromPublic = hasPublicModifier;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -244,9 +244,9 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
             }
             else {
                 result = ignoreFinal
-                          && modifiers.branchContains(TokenTypes.FINAL)
+                          && modifiers.findFirstToken(TokenTypes.FINAL) != null
                     || ignoreStatic
-                        && modifiers.branchContains(TokenTypes.LITERAL_STATIC);
+                        && modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
             }
         }
         else if (ast.getType() == TokenTypes.METHOD_DEF) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractAccessControlNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractAccessControlNameCheck.java
@@ -70,7 +70,7 @@ public abstract class AbstractAccessControlNameCheck
 
     @Override
     protected boolean mustCheckName(DetailAST ast) {
-        return shouldCheckInScope(ast);
+        return shouldCheckInScope(ast.findFirstToken(TokenTypes.MODIFIERS));
     }
 
     /**
@@ -82,11 +82,11 @@ public abstract class AbstractAccessControlNameCheck
      */
     protected boolean shouldCheckInScope(DetailAST modifiers) {
         final boolean isPublic = modifiers
-                .branchContains(TokenTypes.LITERAL_PUBLIC);
+                .findFirstToken(TokenTypes.LITERAL_PUBLIC) != null;
         final boolean isProtected = modifiers
-                .branchContains(TokenTypes.LITERAL_PROTECTED);
+                .findFirstToken(TokenTypes.LITERAL_PROTECTED) != null;
         final boolean isPrivate = modifiers
-                .branchContains(TokenTypes.LITERAL_PRIVATE);
+                .findFirstToken(TokenTypes.LITERAL_PRIVATE) != null;
         final boolean isPackage = !(isPublic || isProtected || isPrivate);
 
         return applyToPublic && isPublic

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
@@ -81,8 +81,8 @@ public class ConstantNameCheck
 
         final DetailAST modifiersAST =
             ast.findFirstToken(TokenTypes.MODIFIERS);
-        final boolean isStatic = modifiersAST.branchContains(TokenTypes.LITERAL_STATIC);
-        final boolean isFinal = modifiersAST.branchContains(TokenTypes.FINAL);
+        final boolean isStatic = modifiersAST.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
+        final boolean isFinal = modifiersAST.findFirstToken(TokenTypes.FINAL) != null;
 
         if (isStatic && isFinal && shouldCheckInScope(modifiersAST)
                 || ScopeUtils.isInAnnotationBlock(ast)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheck.java
@@ -81,7 +81,7 @@ public class LocalFinalVariableNameCheck
         final DetailAST modifiersAST =
             ast.findFirstToken(TokenTypes.MODIFIERS);
         final boolean isFinal = ast.getType() == TokenTypes.RESOURCE
-            || modifiersAST.branchContains(TokenTypes.FINAL);
+            || modifiersAST.findFirstToken(TokenTypes.FINAL) != null;
         return isFinal && ScopeUtils.isLocalVariableDef(ast);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheck.java
@@ -120,7 +120,7 @@ public class LocalVariableNameCheck
         }
         else {
             final DetailAST modifiersAST = ast.findFirstToken(TokenTypes.MODIFIERS);
-            final boolean isFinal = modifiersAST.branchContains(TokenTypes.FINAL);
+            final boolean isFinal = modifiersAST.findFirstToken(TokenTypes.FINAL) != null;
             result = !isFinal && ScopeUtils.isLocalVariableDef(ast);
         }
         return result;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheck.java
@@ -75,7 +75,7 @@ public class MemberNameCheck
     protected final boolean mustCheckName(DetailAST ast) {
         final DetailAST modifiersAST =
             ast.findFirstToken(TokenTypes.MODIFIERS);
-        final boolean isStatic = modifiersAST.branchContains(TokenTypes.LITERAL_STATIC);
+        final boolean isStatic = modifiersAST.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
 
         return !isStatic && !ScopeUtils.isInInterfaceOrAnnotationBlock(ast)
             && !ScopeUtils.isLocalVariableDef(ast)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheck.java
@@ -73,8 +73,8 @@ public class StaticVariableNameCheck
     protected final boolean mustCheckName(DetailAST ast) {
         final DetailAST modifiersAST =
             ast.findFirstToken(TokenTypes.MODIFIERS);
-        final boolean isStatic = modifiersAST.branchContains(TokenTypes.LITERAL_STATIC);
-        final boolean isFinal = modifiersAST.branchContains(TokenTypes.FINAL);
+        final boolean isStatic = modifiersAST.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
+        final boolean isFinal = modifiersAST.findFirstToken(TokenTypes.FINAL) != null;
 
         return isStatic
                 && !isFinal

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtils.java
@@ -98,8 +98,9 @@ public final class CheckUtils {
 
         if (ast.getType() == TokenTypes.METHOD_DEF) {
             final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
-            final boolean staticOrAbstract = modifiers.branchContains(TokenTypes.LITERAL_STATIC)
-                    || modifiers.branchContains(TokenTypes.ABSTRACT);
+            final boolean staticOrAbstract =
+                    modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null
+                    || modifiers.findFirstToken(TokenTypes.ABSTRACT) != null;
 
             if (!staticOrAbstract) {
                 final DetailAST nameNode = ast.findFirstToken(TokenTypes.IDENT);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/explicitinitialization/InputExplicitInitialization.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/explicitinitialization/InputExplicitInitialization.java
@@ -79,4 +79,5 @@ class Chars {
     char b = a;
     byte c = 1;
     short d = 1;
+    final long e = 0; 
 }


### PR DESCRIPTION
Issue #5124

This is the first PR.
This removes 64 of the 91 uses of `branchContains`.
I focused on all variables that were using `modifiers`.

I ran into 1 issue with this in `DesignForExtensionCheck` where a comment wasn't found in the modifier. I just undid the change and will look into it more later.


I ran into another issue with `AbstractAccessControlNameCheck` where the method said it was receiving the modifiers AST but in fact ti was not. I fixed this in the method call to it.