### PR TITLE
Issue #2804: allow suppression by message

### DIFF
--- a/config/catalog.xml
+++ b/config/catalog.xml
@@ -8,7 +8,9 @@
     <system systemId="http://checkstyle.sourceforge.net/dtds/packages_1_0.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/packages_1_0.dtd"/>
     <system systemId="http://checkstyle.sourceforge.net/dtds/suppressions_1_0.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_0.dtd"/>
     <system systemId="http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_1.dtd"/>
+    <system systemId="http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_2.dtd"/>
     <system systemId="http://checkstyle.sourceforge.net/dtds/suppressions_1_1_xpath_experimental.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_1_xpath_experimental.dtd"/>
+    <system systemId="http://checkstyle.sourceforge.net/dtds/suppressions_1_2_xpath_experimental.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_2_xpath_experimental.dtd"/>
     <system systemId="http://checkstyle.sourceforge.net/dtds/import_control_1_0.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_0.dtd"/>
     <system systemId="http://checkstyle.sourceforge.net/dtds/import_control_1_1.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_1.dtd"/>
     <system systemId="http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_2.dtd"/>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd">
+    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
 
 <suppressions>
     <suppress checks="FileLength"
@@ -28,7 +28,7 @@
     <suppress checks="NPathComplexity" files="[\\/]XdocsPagesTest\.java"/>
     <suppress checks="IllegalCatch" files="[\\/]internal[\\/].*[\\/]\w+Util\.java"/>
     <suppress checks="EmptyBlock" files=".*[\\/]src[\\/]test[\\/]"/>
-    <suppress checks="Javadoc" files=".*[\\/]src[\\/](test|it)[\\/]"/>
+    <suppress message="Missing a Javadoc comment|Missing package-info.java file|Expected @throws tag for|missing an @author tag" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="MagicNumber" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="AvoidStaticImport" files=".*[\\/]src[\\/](test|it)[\\/]"/>
     <suppress checks="ClassDataAbstractionCoupling" files="[\\/]IndentationCheckTest.java$|[\\/]SuppressWithNearbyCommentFilterTest.java$|[\\/]SuppressionCommentFilterTest.java|[\\/]DetailASTTest.java$"/>

--- a/src/it/java/com/google/checkstyle/test/base/AbstractModuleTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/AbstractModuleTestSupport.java
@@ -151,7 +151,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param moduleCreationOption {@code IN_TREEWALKER} if the {@code moduleConfig} should be added
      *                                                  under {@link TreeWalker}.
      * @return {@link Checker} instance.
-     * @throws CheckstyleException if an exception occurs during checker configuration.
+     * @throws Exception if an exception occurs during checker configuration.
      */
     protected final Checker createChecker(Configuration moduleConfig,
                                     ModuleCreationOption moduleCreationOption)
@@ -281,8 +281,10 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * Gets the check message 'as is' from appropriate 'messages.properties'
      * file.
      *
+     * @param aClass The package the message is located in.
      * @param messageKey the key of message in 'messages.properties' file.
      * @param arguments  the arguments of message in 'messages.properties' file.
+     * @return The message of the check with the arguments applied.
      */
     protected static String getCheckMessage(Class<? extends AbstractViolationReporter> aClass,
             String messageKey, Object... arguments) {
@@ -302,8 +304,10 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
 
     /**
      * Gets the check message 'as is' from appropriate 'messages.properties' file.
+     * @param messages The map of messages to scan.
      * @param messageKey the key of message in 'messages.properties' file.
      * @param arguments the arguments of message in 'messages.properties' file.
+     * @return The message of the check with the arguments applied.
      */
     protected static String getCheckMessage(Map<String, String> messages, String messageKey,
             Object... arguments) {
@@ -333,6 +337,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * Returns {@link Configuration} instance for the given module name.
      * This implementation uses {@link AbstractModuleTestSupport#getConfiguration()} method inside.
      * @param moduleName module name.
+     * @param moduleId module id.
      * @return {@link Configuration} instance for the given module name.
      * @throws CheckstyleException if exception occurs during configuration loading.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -76,7 +76,7 @@ public final class ConfigurationLoader {
         "-//Puppy Crawl//DTD Check Configuration 1.0//EN";
 
     /** The resource for version 1_0 of the configuration dtd. */
-    private static final String DTD_RESOURCE_NAME_1_0 =
+    private static final String DTD_CONFIGURATION_NAME_1_0 =
         "com/puppycrawl/tools/checkstyle/configuration_1_0.dtd";
 
     /** The public ID for version 1_1 of the configuration dtd. */
@@ -84,7 +84,7 @@ public final class ConfigurationLoader {
         "-//Puppy Crawl//DTD Check Configuration 1.1//EN";
 
     /** The resource for version 1_1 of the configuration dtd. */
-    private static final String DTD_RESOURCE_NAME_1_1 =
+    private static final String DTD_CONFIGURATION_NAME_1_1 =
         "com/puppycrawl/tools/checkstyle/configuration_1_1.dtd";
 
     /** The public ID for version 1_2 of the configuration dtd. */
@@ -92,7 +92,7 @@ public final class ConfigurationLoader {
         "-//Puppy Crawl//DTD Check Configuration 1.2//EN";
 
     /** The resource for version 1_2 of the configuration dtd. */
-    private static final String DTD_RESOURCE_NAME_1_2 =
+    private static final String DTD_CONFIGURATION_NAME_1_2 =
         "com/puppycrawl/tools/checkstyle/configuration_1_2.dtd";
 
     /** The public ID for version 1_3 of the configuration dtd. */
@@ -100,7 +100,7 @@ public final class ConfigurationLoader {
         "-//Puppy Crawl//DTD Check Configuration 1.3//EN";
 
     /** The resource for version 1_3 of the configuration dtd. */
-    private static final String DTD_RESOURCE_NAME_1_3 =
+    private static final String DTD_CONFIGURATION_NAME_1_3 =
         "com/puppycrawl/tools/checkstyle/configuration_1_3.dtd";
 
     /** Prefix for the exception when unable to parse resource. */
@@ -166,10 +166,10 @@ public final class ConfigurationLoader {
      */
     private static Map<String, String> createIdToResourceNameMap() {
         final Map<String, String> map = new HashMap<>();
-        map.put(DTD_PUBLIC_ID_1_0, DTD_RESOURCE_NAME_1_0);
-        map.put(DTD_PUBLIC_ID_1_1, DTD_RESOURCE_NAME_1_1);
-        map.put(DTD_PUBLIC_ID_1_2, DTD_RESOURCE_NAME_1_2);
-        map.put(DTD_PUBLIC_ID_1_3, DTD_RESOURCE_NAME_1_3);
+        map.put(DTD_PUBLIC_ID_1_0, DTD_CONFIGURATION_NAME_1_0);
+        map.put(DTD_PUBLIC_ID_1_1, DTD_CONFIGURATION_NAME_1_1);
+        map.put(DTD_PUBLIC_ID_1_2, DTD_CONFIGURATION_NAME_1_2);
+        map.put(DTD_PUBLIC_ID_1_3, DTD_CONFIGURATION_NAME_1_3);
         return map;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -60,17 +60,31 @@ public final class SuppressionsLoader
     private static final String DTD_SUPPRESSIONS_NAME_1_1 =
         "com/puppycrawl/tools/checkstyle/suppressions_1_1.dtd";
     /** The public ID for the configuration dtd. */
+    private static final String DTD_PUBLIC_ID_1_2 =
+        "-//Puppy Crawl//DTD Suppressions 1.2//EN";
+    /** The resource for the configuration dtd. */
+    private static final String DTD_SUPPRESSIONS_NAME_1_2 =
+        "com/puppycrawl/tools/checkstyle/suppressions_1_2.dtd";
+    /** The public ID for the configuration dtd. */
     private static final String DTD_PUBLIC_ID_1_1_XPATH =
             "-//Puppy Crawl//DTD Suppressions Xpath Experimental 1.1//EN";
     /** The resource for the configuration dtd. */
     private static final String DTD_SUPPRESSIONS_NAME_1_1_XPATH =
             "com/puppycrawl/tools/checkstyle/suppressions_1_1_xpath_experimental.dtd";
+    /** The public ID for the configuration dtd. */
+    private static final String DTD_PUBLIC_ID_1_2_XPATH =
+            "-//Puppy Crawl//DTD Suppressions Xpath Experimental 1.2//EN";
+    /** The resource for the configuration dtd. */
+    private static final String DTD_SUPPRESSIONS_NAME_1_2_XPATH =
+            "com/puppycrawl/tools/checkstyle/suppressions_1_2_xpath_experimental.dtd";
     /** File search error message. **/
     private static final String UNABLE_TO_FIND_ERROR_MESSAGE = "Unable to find: ";
     /** String literal for attribute name. **/
     private static final String ATTRIBUTE_NAME_FILES = "files";
     /** String literal for attribute name. **/
     private static final String ATTRIBUTE_NAME_CHECKS = "checks";
+    /** String literal for attribute name. **/
+    private static final String ATTRIBUTE_NAME_MESSAGE = "message";
     /** String literal for attribute name. **/
     private static final String ATTRIBUTE_NAME_ID = "id";
     /** String literal for attribute name. **/
@@ -128,20 +142,21 @@ public final class SuppressionsLoader
     private static SuppressElement getSuppressElement(Attributes attributes) throws SAXException {
         final String checks = attributes.getValue(ATTRIBUTE_NAME_CHECKS);
         final String modId = attributes.getValue(ATTRIBUTE_NAME_ID);
-        if (checks == null && modId == null) {
+        final String message = attributes.getValue(ATTRIBUTE_NAME_MESSAGE);
+        if (checks == null && modId == null && message == null) {
             // -@cs[IllegalInstantiation] SAXException is in the overridden method signature
-            throw new SAXException("missing checks and id attribute");
+            throw new SAXException("missing checks or id or message attribute");
         }
         final SuppressElement suppress;
         try {
             final String files = attributes.getValue(ATTRIBUTE_NAME_FILES);
             final String lines = attributes.getValue(ATTRIBUTE_NAME_LINES);
             final String columns = attributes.getValue(ATTRIBUTE_NAME_COLUMNS);
-            suppress = new SuppressElement(files, checks, modId, lines, columns);
+            suppress = new SuppressElement(files, checks, message, modId, lines, columns);
         }
         catch (final PatternSyntaxException ex) {
             // -@cs[IllegalInstantiation] SAXException is in the overridden method signature
-            throw new SAXException("invalid files or checks format", ex);
+            throw new SAXException("invalid files or checks or message format", ex);
         }
         return suppress;
     }
@@ -156,19 +171,21 @@ public final class SuppressionsLoader
     private static XpathFilter getXpathFilter(Attributes attributes) throws SAXException {
         final String checks = attributes.getValue(ATTRIBUTE_NAME_CHECKS);
         final String modId = attributes.getValue(ATTRIBUTE_NAME_ID);
-        if (checks == null && modId == null) {
+        final String message = attributes.getValue(ATTRIBUTE_NAME_MESSAGE);
+        if (checks == null && modId == null && message == null) {
             // -@cs[IllegalInstantiation] SAXException is in the overridden method signature
-            throw new SAXException("missing checks and id attribute for suppress-xpath");
+            throw new SAXException("missing checks or id or message attribute for suppress-xpath");
         }
         final XpathFilter filter;
         try {
             final String files = attributes.getValue(ATTRIBUTE_NAME_FILES);
             final String xpathQuery = attributes.getValue(ATTRIBUTE_NAME_QUERY);
-            filter = new XpathFilter(files, checks, modId, xpathQuery);
+            filter = new XpathFilter(files, checks, message, modId, xpathQuery);
         }
         catch (final PatternSyntaxException ex) {
             // -@cs[IllegalInstantiation] SAXException is in the overridden method signature
-            throw new SAXException("invalid files or checks format for suppress-xpath", ex);
+            throw new SAXException("invalid files or checks or message format for suppress-xpath",
+                    ex);
         }
         return filter;
     }
@@ -268,7 +285,9 @@ public final class SuppressionsLoader
         final Map<String, String> map = new HashMap<>();
         map.put(DTD_PUBLIC_ID_1_0, DTD_SUPPRESSIONS_NAME_1_0);
         map.put(DTD_PUBLIC_ID_1_1, DTD_SUPPRESSIONS_NAME_1_1);
+        map.put(DTD_PUBLIC_ID_1_2, DTD_SUPPRESSIONS_NAME_1_2);
         map.put(DTD_PUBLIC_ID_1_1_XPATH, DTD_SUPPRESSIONS_NAME_1_1_XPATH);
+        map.put(DTD_PUBLIC_ID_1_2_XPATH, DTD_SUPPRESSIONS_NAME_1_2_XPATH);
         return map;
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoader.java
@@ -51,19 +51,19 @@ public final class SuppressionsLoader
     private static final String DTD_PUBLIC_ID_1_0 =
         "-//Puppy Crawl//DTD Suppressions 1.0//EN";
     /** The resource for the configuration dtd. */
-    private static final String DTD_RESOURCE_NAME_1_0 =
+    private static final String DTD_SUPPRESSIONS_NAME_1_0 =
         "com/puppycrawl/tools/checkstyle/suppressions_1_0.dtd";
     /** The public ID for the configuration dtd. */
     private static final String DTD_PUBLIC_ID_1_1 =
         "-//Puppy Crawl//DTD Suppressions 1.1//EN";
     /** The resource for the configuration dtd. */
-    private static final String DTD_RESOURCE_NAME_1_1 =
+    private static final String DTD_SUPPRESSIONS_NAME_1_1 =
         "com/puppycrawl/tools/checkstyle/suppressions_1_1.dtd";
     /** The public ID for the configuration dtd. */
     private static final String DTD_PUBLIC_ID_1_1_XPATH =
             "-//Puppy Crawl//DTD Suppressions Xpath Experimental 1.1//EN";
     /** The resource for the configuration dtd. */
-    private static final String DTD_RESOURCE_NAME_1_1_XPATH =
+    private static final String DTD_SUPPRESSIONS_NAME_1_1_XPATH =
             "com/puppycrawl/tools/checkstyle/suppressions_1_1_xpath_experimental.dtd";
     /** File search error message. **/
     private static final String UNABLE_TO_FIND_ERROR_MESSAGE = "Unable to find: ";
@@ -266,9 +266,9 @@ public final class SuppressionsLoader
      */
     private static Map<String, String> createIdToResourceNameMap() {
         final Map<String, String> map = new HashMap<>();
-        map.put(DTD_PUBLIC_ID_1_0, DTD_RESOURCE_NAME_1_0);
-        map.put(DTD_PUBLIC_ID_1_1, DTD_RESOURCE_NAME_1_1);
-        map.put(DTD_PUBLIC_ID_1_1_XPATH, DTD_RESOURCE_NAME_1_1_XPATH);
+        map.put(DTD_PUBLIC_ID_1_0, DTD_SUPPRESSIONS_NAME_1_0);
+        map.put(DTD_PUBLIC_ID_1_1, DTD_SUPPRESSIONS_NAME_1_1);
+        map.put(DTD_PUBLIC_ID_1_1_XPATH, DTD_SUPPRESSIONS_NAME_1_1_XPATH);
         return map;
     }
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_2.dtd
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_2.dtd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Add the following to any file that is to be validated against this DTD:
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+-->
+
+<!ELEMENT suppressions (suppress*)>
+
+<!ELEMENT suppress EMPTY>
+<!ATTLIST suppress files CDATA #IMPLIED
+                   checks CDATA #IMPLIED
+                   message CDATA #IMPLIED
+                   id CDATA #IMPLIED
+                   lines CDATA #IMPLIED
+                   columns CDATA #IMPLIED>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_2_xpath_experimental.dtd
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_2_xpath_experimental.dtd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Add the following to any file that is to be validated against this DTD:
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions Xpath Experimental 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2_xpath_experimental.dtd">
+-->
+
+<!ELEMENT suppressions (suppress|suppress-xpath)*>
+
+<!ELEMENT suppress EMPTY>
+<!ATTLIST suppress files CDATA #IMPLIED
+                   checks CDATA #IMPLIED
+                   message CDATA #IMPLIED
+                   id CDATA #IMPLIED
+                   lines CDATA #IMPLIED
+                   columns CDATA #IMPLIED>
+
+<!ELEMENT suppress-xpath EMPTY>
+<!ATTLIST suppress-xpath files CDATA #IMPLIED
+                   checks CDATA #IMPLIED
+                   message CDATA #IMPLIED
+                   id CDATA #IMPLIED
+                   query CDATA #IMPLIED>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -150,7 +150,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * based on the given {@link Configuration} instance.
      * @param config {@link Configuration} instance.
      * @return {@link DefaultConfiguration} for the {@link TreeWalker}
-     * based on the given {@link Configuration} instance.
+     *     based on the given {@link Configuration} instance.
      */
     protected static DefaultConfiguration createTreeWalkerConfig(Configuration config) {
         final DefaultConfiguration dc =
@@ -257,8 +257,13 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
     }
 
     /**
-     *  We keep two verify methods with separate logic only for convenience of debugging
-     *  We have minimum amount of multi-file test cases
+     *  We keep two verify methods with separate logic only for convenience of debugging.
+     *  We have minimum amount of multi-file test cases.
+     *  @param checker {@link Checker} instance.
+     *  @param processedFiles list of files to verify.
+     *  @param messageFileName message file name.
+     *  @param expected an array of expected messages.
+     *  @throws Exception if exception occurs during verification process.
      */
     protected void verify(Checker checker,
                           File[] processedFiles,
@@ -383,6 +388,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      *
      * @param messageKey the key of message in 'messages.properties' file.
      * @param arguments  the arguments of message in 'messages.properties' file.
+     * @return The message of the check with the arguments applied.
      */
     protected final String getCheckMessage(String messageKey, Object... arguments) {
         return internalGetCheckMessage(getMessageBundle(), messageKey, arguments);
@@ -395,6 +401,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param clazz the related check class.
      * @param messageKey the key of message in 'messages.properties' file.
      * @param arguments the arguments of message in 'messages.properties' file.
+     * @return The message of the check with the arguments applied.
      */
     protected static String getCheckMessage(
             Class<?> clazz, String messageKey, Object... arguments) {
@@ -408,6 +415,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param messageBundle the bundle name.
      * @param messageKey the key of message in 'messages.properties' file.
      * @param arguments the arguments of message in 'messages.properties' file.
+     * @return The message of the check with the arguments applied.
      */
     private static String internalGetCheckMessage(
             String messageBundle, String messageKey, Object... arguments) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -619,7 +619,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
 
     /**
      * This SuppressWarning("unchecked") required to suppress
-     * "Unchecked generics array creation for varargs parameter" during mock
+     * "Unchecked generics array creation for varargs parameter" during mock.
      * @throws Exception could happen from PowerMokito calls and getAttribute
      */
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -245,7 +245,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
 
     /**
      * This SuppressWarning("unchecked") required to suppress
-     * "Unchecked generics array creation for varargs parameter" during mock
+     * "Unchecked generics array creation for varargs parameter" during mock.
      * @throws IOException when smth wrong with file creation or cache.load
      */
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -666,7 +666,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
             Whitebox.getInternalState(antTask, "classpath"));
     }
 
-    /** This test is created to satisfy pitest, it is hard to emulate Referece by Id */
+    /** This test is created to satisfy pitest, it is hard to emulate Referece by Id. */
     @Test
     public void testSetClasspathRef1() {
         final CheckstyleAntTask antTask = new CheckstyleAntTask();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
@@ -114,7 +114,7 @@ public class AbstractFileSetCheckTest {
     }
 
     /**
-     * This javadoc exists only to suppress Intellij Idea inspection
+     * This javadoc exists only to suppress Intellij Idea inspection.
      */
     @Test
     public void testSetExtentionThrowsExceptionWhenTheyAreNull() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
@@ -258,7 +258,7 @@ public class DetailASTTest extends AbstractModuleTestSupport {
     }
 
     /**
-     * There are asserts in checkNode, but idea does not see them
+     * There are asserts in checkNode, but idea does not see them.
      * @noinspection JUnitTestMethodWithNoAssertions
      */
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FilterSetTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FilterSetTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.filters.SeverityMatchFilter;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-/** Tests SuppressElementFilter. */
 public class FilterSetTest {
     @Test
     public void testEqualsAndHashCode() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -54,9 +54,6 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-/**
- * JUnit tests for Unique Properties check.
- */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Closeables.class)
 public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
@@ -28,11 +28,6 @@ import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
-/**
- *
- * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
- *
- */
 public class EmptyCatchBlockCheckTest extends AbstractModuleTestSupport {
     @Override
     protected String getPackageLocation() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheckTest.java
@@ -28,10 +28,6 @@ import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-/**
- * The unit-test for the {@code NestedForDepthCheck}-checkstyle enhancement.
- * @see NestedForDepthCheck
- */
 public class NestedForDepthCheckTest extends AbstractModuleTestSupport {
     @Override
     protected String getPackageLocation() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheckTest.java
@@ -27,9 +27,6 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
-/**
- * NoCloneCheck test.
- */
 public class NoCloneCheckTest
     extends AbstractModuleTestSupport {
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
@@ -31,12 +31,6 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-/**
-*
-* @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
-* @author <a href="mailto:andreyselkin@gmail.com">Andrei Selkin</a>
-*
-*/
 public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1869,10 +1869,10 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
      * {@link IndentationCheck#MSG_CHILD_ERROR}, {@link IndentationCheck#MSG_CHILD_ERROR_MULTI},
      * {@link IndentationCheck#MSG_CHILD_ERROR_MULTI} are in appropriate order.
      *
-     * In other tests, the argument 0 and text before it are chopped off and only the rest of
+     * <p>In other tests, the argument 0 and text before it are chopped off and only the rest of
      * messages are verified. Therefore, the argument 0 is required to be the first argument in
      * the messages above. If we update the messages in the future, it is required to keep the
-     * arguments in appropriate order to ensure other tests will work.
+     * arguments in appropriate order to ensure other tests will work.</p>
      *
      * @see IndentComment#getExpectedMessagePostfix(String)
      */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/ClassResolverTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/ClassResolverTest.java
@@ -158,7 +158,7 @@ public class ClassResolverTest {
     /**
      * This test exists to prevent any possible regression and let of
      * https://github.com/checkstyle/checkstyle/issues/1192 to be persistent
-     * event is not very obvious
+     * event is not very obvious.
      *
      * @throws Exception when smth is not expected
      */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -34,9 +34,6 @@ import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-/**
- * @author Oliver.Burn
- */
 public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Override
     protected String getPackageLocation() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/BlockTagUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/BlockTagUtilsTest.java
@@ -28,9 +28,6 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
-/**
- * Tests BlockTagUtils.
- */
 public class BlockTagUtilsTest {
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtilsTest.java
@@ -29,9 +29,6 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
-/**
- * Tests InlineTagUtils
- */
 public class InlineTagUtilsTest {
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
@@ -234,7 +234,7 @@ public class NoWhitespaceAfterCheckTest
     }
 
     /**
-     * Creates MOCK lexical token and returns AST node for this token
+     * Creates MOCK lexical token and returns AST node for this token.
      * @param tokenType type of token
      * @param tokenText text of token
      * @param tokenFileName file name of token

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-/** Tests CsvFilter. */
 public class CsvFilterTest {
     @Test
     public void testDecideSingle() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-/** Tests IntMatchFilter. */
 public class IntMatchFilterTest {
     @Test
     public void testDecide() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-/** Tests IntRangeFilter. */
 public class IntRangeFilterTest {
     @Test
     public void testDecide() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterTest.java
@@ -28,7 +28,6 @@ import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 
-/** Tests SeverityMatchFilter. */
 public class SeverityMatchFilterTest {
     private final SeverityMatchFilter filter = new SeverityMatchFilter();
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressElementTest.java
@@ -39,7 +39,7 @@ public class SuppressElementTest {
 
     @Before
     public void setUp() {
-        filter = new SuppressElement("Test", "Test", null, null, null);
+        filter = new SuppressElement("Test", "Test", null, null, null, null);
     }
 
     @Test
@@ -58,16 +58,29 @@ public class SuppressElementTest {
     }
 
     @Test
+    public void testDecideByMessage() {
+        final LocalizedMessage message =
+            new LocalizedMessage(0, 0, "", "", null, null, getClass(), "Test");
+        final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
+        final SuppressElement filter1 =
+                new SuppressElement(null, null, "Test", null, null, null);
+        final SuppressElement filter2 =
+                new SuppressElement(null, null, "Bad", null, null, null);
+        assertFalse("Message match", filter1.accept(ev));
+        assertTrue("Message not match", filter2.accept(ev));
+    }
+
+    @Test
     public void testDecideByLine() {
         final LocalizedMessage message =
             new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         final SuppressElement filter1 =
-                new SuppressElement("Test", "Test", null, "1-10", null);
+                new SuppressElement("Test", "Test", null, null, "1-10", null);
         final SuppressElement filter2 =
-                new SuppressElement("Test", "Test", null, "1-9, 11", null);
+                new SuppressElement("Test", "Test", null, null, "1-9, 11", null);
         final SuppressElement filter3 =
-                new SuppressElement("Test", "Test", null, null, null);
+                new SuppressElement("Test", "Test", null, null, null, null);
         //deny because there are matches on file name, check name, and line
         assertFalse("In range 1-10", filter1.accept(ev));
         assertTrue("Not in 1-9, 11", filter2.accept(ev));
@@ -80,9 +93,9 @@ public class SuppressElementTest {
             new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         final SuppressElement filter1 =
-                new SuppressElement("Test", "Test", null, null, "1-10");
+                new SuppressElement("Test", "Test", null, null, null, "1-10");
         final SuppressElement filter2 =
-                new SuppressElement("Test", "Test", null, null, "1-9, 11");
+                new SuppressElement("Test", "Test", null, null, null, "1-9, 11");
 
         //deny because there are matches on file name, check name, and column
         assertFalse("In range 1-10", filter1.accept(ev));
@@ -117,7 +130,7 @@ public class SuppressElementTest {
                 new LocalizedMessage(10, 10, "", "", null, "MyModule", getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         final SuppressElement myFilter =
-                new SuppressElement("Test", "Test", "MyModule", null, null);
+                new SuppressElement("Test", "Test", null, "MyModule", null, null);
 
         assertFalse("Filter should not accept invalid event", myFilter.accept(ev));
     }
@@ -128,7 +141,7 @@ public class SuppressElementTest {
                 new LocalizedMessage(10, 10, "", "", null, "TheirModule", getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         final SuppressElement myFilter =
-                new SuppressElement("Test", "Test", "MyModule", null, null);
+                new SuppressElement("Test", "Test", null, "MyModule", null, null);
 
         assertTrue("Filter should accept valid event", myFilter.accept(ev));
     }
@@ -147,7 +160,7 @@ public class SuppressElementTest {
                 new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "TestSUFFIX", message);
         final SuppressElement myFilter =
-                new SuppressElement("Test", null, null, null, null);
+                new SuppressElement("Test", null, null, null, null, null);
         assertFalse("Filter should not accept invalid event", myFilter.accept(ev));
     }
 
@@ -157,7 +170,7 @@ public class SuppressElementTest {
                 new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         final SuppressElement myFilter =
-                new SuppressElement("Test", "NON_EXISTING_CHECK", "MyModule", null, null);
+                new SuppressElement("Test", "NON_EXISTING_CHECK", null, "MyModule", null, null);
         assertTrue("Filter should accept valid event", myFilter.accept(ev));
     }
 
@@ -167,7 +180,7 @@ public class SuppressElementTest {
                 new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         final SuppressElement myFilter =
-                new SuppressElement("Test", getClass().getCanonicalName(), null, null, null);
+                new SuppressElement("Test", getClass().getCanonicalName(), null, null, null, null);
 
         assertFalse("Filter should not accept invalid event", myFilter.accept(ev));
     }
@@ -179,7 +192,7 @@ public class SuppressElementTest {
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         final SuppressElement myFilter =
                 new SuppressElement("Test", TreeWalkerTest.class.getCanonicalName(),
-                        null, null, null);
+                        null, null, null, null);
 
         assertTrue("Filter should not accept invalid event", myFilter.accept(ev));
     }
@@ -189,27 +202,27 @@ public class SuppressElementTest {
         // filterBased is used instead of filter field only to satisfy IntelliJ Idea Inspection
         // Inspection "Arguments to assertEquals() in wrong order "
         final SuppressElement filterBased =
-                new SuppressElement("Test", "Test", null, null, null);
+                new SuppressElement("Test", "Test", null, null, null, null);
 
         final SuppressElement filter2 =
-                new SuppressElement("Test", "Test", null, null, null);
+                new SuppressElement("Test", "Test", null, null, null, null);
         assertEquals("filter, filter2", filterBased, filter2);
         final SuppressElement filter3 =
-                new SuppressElement("Test", "Test3", null, null, null);
+                new SuppressElement("Test", "Test3", null, null, null, null);
         assertNotEquals("filter, filter3", filterBased, filter3);
         final SuppressElement filterBased1 =
-                new SuppressElement("Test", "Test", null, null, "1-10");
+                new SuppressElement("Test", "Test", null, null, null, "1-10");
 
         assertNotEquals("filter, filter2", filterBased1, filter2);
         final SuppressElement filter22 =
-                new SuppressElement("Test", "Test", null, null, "1-10");
+                new SuppressElement("Test", "Test", null, null, null, "1-10");
         assertEquals("filter, filter2", filterBased1, filter22);
         assertNotEquals("filter, filter2", filterBased1, filter2);
         final SuppressElement filterBased2 =
-                new SuppressElement("Test", "Test", null, "3,4", null);
+                new SuppressElement("Test", "Test", null, null, "3,4", null);
         assertNotEquals("filter, filter2", filterBased2, filter2);
         final SuppressElement filter23 =
-                new SuppressElement("Test", "Test", null, "3,4", null);
+                new SuppressElement("Test", "Test", null, null, "3,4", null);
         assertEquals("filter, filter2", filterBased2, filter23);
         assertNotEquals("filter, filter2", filterBased2, filter2);
         assertEquals("filter, filter2", filterBased2, filter23);
@@ -219,7 +232,8 @@ public class SuppressElementTest {
     public void testEqualsAndHashCode() {
         EqualsVerifier.forClass(SuppressElement.class)
                 .usingGetClass()
-                .withIgnoredFields("fileRegexp", "checkRegexp", "columnFilter", "lineFilter")
+                .withIgnoredFields("fileRegexp", "checkRegexp", "messageRegexp", "columnFilter",
+                        "lineFilter")
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressElementTest.java
@@ -33,7 +33,6 @@ import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 
-/** Tests SuppressElementFilter. */
 public class SuppressElementTest {
     private SuppressElement filter;
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
@@ -108,7 +108,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
         }
         catch (CheckstyleException ex) {
             assertEquals("Invalid error message",
-                "Unable to parse " + fileName + " - invalid files or checks format",
+                "Unable to parse " + fileName + " - invalid files or checks or message format",
                 ex.getMessage());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
@@ -108,9 +108,8 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid error message",
-                    "Unable to parse " + fileName + " - invalid files or checks format for "
-                            + "suppress-xpath",
+            assertEquals("Invalid error message", "Unable to parse " + fileName
+                    + " - invalid files or checks or message format for suppress-xpath",
                     ex.getMessage());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Rule;
@@ -122,17 +123,20 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final FilterSet fc2 = new FilterSet();
 
         final SuppressElement se0 =
-                new SuppressElement("file0", "check0", null, null, null);
+                new SuppressElement("file0", "check0", null, null, null, null);
         fc2.addFilter(se0);
         final SuppressElement se1 =
-                new SuppressElement("file1", "check1", null, "1,2-3", null);
+                new SuppressElement("file1", "check1", null, null, "1,2-3", null);
         fc2.addFilter(se1);
         final SuppressElement se2 =
-                new SuppressElement("file2", "check2", null, null, "1,2-3");
+                new SuppressElement("file2", "check2", null, null, null, "1,2-3");
         fc2.addFilter(se2);
         final SuppressElement se3 =
-                new SuppressElement("file3", "check3", null, "1,2-3", "1,2-3");
+                new SuppressElement("file3", "check3", null, null, "1,2-3", "1,2-3");
         fc2.addFilter(se3);
+        final SuppressElement se4 =
+                new SuppressElement(null, null, "message0", null, null, null);
+        fc2.addFilter(se4);
         assertEquals("Multiple suppressions were loaded incorrectly", fc2, fc);
     }
 
@@ -268,7 +272,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         }
         catch (CheckstyleException ex) {
             assertEquals("Invalid error message",
-                "Unable to parse " + fn + " - missing checks and id attribute",
+                "Unable to parse " + fn + " - missing checks or id or message attribute",
                 ex.getMessage());
         }
     }
@@ -290,7 +294,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         }
         catch (CheckstyleException ex) {
             assertEquals("Invalid error message",
-                "Unable to parse " + fn + " - invalid files or checks format",
+                "Unable to parse " + fn + " - invalid files or checks or message format",
                 ex.getMessage());
         }
     }
@@ -318,7 +322,15 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final String fn = getPath("InputSuppressionsLoaderXpathCorrect.xml");
         final Set<TreeWalkerFilter> filterSet = SuppressionsLoader.loadXpathSuppressions(fn);
 
-        assertEquals("Invalid number of filters", 1, filterSet.size());
+        final Set<TreeWalkerFilter> expectedFilterSet = new HashSet<>();
+        final XpathFilter xf0 =
+                new XpathFilter("file1", "test", null, "id1", "/CLASS_DEF");
+        expectedFilterSet.add(xf0);
+        final XpathFilter xf1 =
+                new XpathFilter(null, null, "message1", null, "/CLASS_DEF");
+        expectedFilterSet.add(xf1);
+        assertEquals("Multiple xpath suppressions were loaded incorrectly", expectedFilterSet,
+                filterSet);
     }
 
     @Test
@@ -330,7 +342,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         }
         catch (CheckstyleException ex) {
             assertEquals("Invalid error message",
-                    "Unable to parse " + fn + " - invalid files or checks format for "
+                    "Unable to parse " + fn + " - invalid files or checks or message format for "
                             + "suppress-xpath",
                     ex.getMessage());
         }
@@ -346,7 +358,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         }
         catch (CheckstyleException ex) {
             assertEquals("Invalid error message",
-                    "Unable to parse " + fn + " - missing checks and id attribute for "
+                    "Unable to parse " + fn + " - missing checks or id or message attribute for "
                             + "suppress-xpath",
                     ex.getMessage());
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterTest.java
@@ -61,7 +61,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
     public void testMatching() throws Exception {
         final String xpath = "/CLASS_DEF[@text='InputXpathFilterSuppressByXpath']";
         final XpathFilter filter =
-                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, xpath);
+                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, null, xpath);
         final TreeWalkerAuditEvent ev = getEvent(3, 0,
                 TokenTypes.CLASS_DEF);
         assertFalse("Event should be rejected", filter.accept(ev));
@@ -71,7 +71,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
     public void testNonMatchingTokenType() throws Exception {
         final String xpath = "//METHOD_DEF[@text='countTokens']";
         final XpathFilter filter =
-                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, xpath);
+                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, null, xpath);
         final TreeWalkerAuditEvent ev = getEvent(3, 0,
                 TokenTypes.CLASS_DEF);
         assertTrue("Event should be accepted", filter.accept(ev));
@@ -81,7 +81,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
     public void testNonMatchingLineNumber() throws Exception {
         final String xpath = "/CLASS_DEF[@text='InputXpathFilterSuppressByXpath']";
         final XpathFilter filter =
-                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, xpath);
+                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, null, xpath);
         final TreeWalkerAuditEvent ev = getEvent(100, 0,
                 TokenTypes.CLASS_DEF);
         assertTrue("Event should be accepted", filter.accept(ev));
@@ -91,7 +91,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
     public void testNonMatchingColumnNumber() throws Exception {
         final String xpath = "/CLASS_DEF[@text='InputXpathFilterSuppressByXpath']";
         final XpathFilter filter =
-                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, xpath);
+                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, null, xpath);
         final TreeWalkerAuditEvent ev = getEvent(3, 100,
                 TokenTypes.CLASS_DEF);
         assertTrue("Event should be accepted", filter.accept(ev));
@@ -103,7 +103,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
                 + "../..[@text='countTokens']] "
                 + "| //VARIABLE_DEF[@text='someVariable' and ../..[@text='sum']]";
         final XpathFilter filter =
-                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, xpath);
+                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, null, xpath);
         final TreeWalkerAuditEvent eventOne = getEvent(5, 8,
                 TokenTypes.VARIABLE_DEF);
         final TreeWalkerAuditEvent eventTwo = getEvent(10, 4,
@@ -120,7 +120,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
         final String xpath = "1@#";
         try {
             final Object test = new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null,
-                    xpath);
+                    null, xpath);
             fail("Exception was expected but got " + test);
         }
         catch (IllegalStateException ex) {
@@ -134,15 +134,15 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
         final TreeWalkerAuditEvent event = getEvent(15, 8,
                 TokenTypes.VARIABLE_DEF);
         final XpathFilter filter =
-                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, null);
-        assertFalse("Event should be rejected", filter.accept(event));
+                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, null, null);
+        assertFalse("Event should be accepted", filter.accept(event));
     }
 
     @Test
     public void testNullFileName() {
         final String xpath = "NON_MATCHING_QUERY";
         final XpathFilter filter =
-                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, xpath);
+                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, null, xpath);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(null,
                 null, null, null);
         assertTrue("Event should be accepted", filter.accept(ev));
@@ -152,7 +152,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
     public void testNonMatchingFileRegexp() throws Exception {
         final String xpath = "NON_MATCHING_QUERY";
         final XpathFilter filter =
-                new XpathFilter("NonMatchingRegexp", "Test", null, xpath);
+                new XpathFilter("NonMatchingRegexp", "Test", null, null, xpath);
         final TreeWalkerAuditEvent ev = getEvent(3, 0,
                 TokenTypes.CLASS_DEF);
         assertTrue("Event should be accepted", filter.accept(ev));
@@ -162,7 +162,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
     public void testNullLocalizedMessage() {
         final String xpath = "NON_MATCHING_QUERY";
         final XpathFilter filter =
-                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, xpath);
+                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, null, xpath);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(null,
                 file.getName(), null, null);
         assertTrue("Event should be accepted", filter.accept(ev));
@@ -172,7 +172,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
     public void testNonMatchingModuleId() throws Exception {
         final String xpath = "NON_MATCHING_QUERY";
         final XpathFilter filter =
-                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", "id19", xpath);
+                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, "id19", xpath);
         final LocalizedMessage message =
                 new LocalizedMessage(3, 0, TokenTypes.CLASS_DEF, "", "", null, null, "id20",
                         getClass(), null);
@@ -185,7 +185,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
     public void testMatchingModuleId() throws Exception {
         final String xpath = "/CLASS_DEF[@text='InputXpathFilterSuppressByXpath']";
         final XpathFilter filter =
-                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", "id19", xpath);
+                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, "id19", xpath);
         final LocalizedMessage message =
                 new LocalizedMessage(3, 0, TokenTypes.CLASS_DEF, "", "", null, null, "id19",
                         getClass(), null);
@@ -198,7 +198,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
     public void testNonMatchingChecks() throws Exception {
         final String xpath = "NON_MATCHING_QUERY";
         final XpathFilter filter = new XpathFilter("InputXpathFilterSuppressByXpath",
-                "NonMatchingRegexp", "id19", xpath);
+                "NonMatchingRegexp", null, "id19", xpath);
         final LocalizedMessage message =
                 new LocalizedMessage(3, 0, TokenTypes.CLASS_DEF, "", "", null, null, "id19",
                         getClass(), null);
@@ -211,7 +211,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
     public void testNonMatchingFileNameModuleIdAndCheck() throws Exception {
         final String xpath = "NON_MATCHING_QUERY";
         final XpathFilter filter =
-                new XpathFilter("InputXpathFilterSuppressByXpath", null, null, xpath);
+                new XpathFilter("InputXpathFilterSuppressByXpath", null, null, null, xpath);
         final TreeWalkerAuditEvent ev = getEvent(3, 0,
                 TokenTypes.CLASS_DEF);
         assertTrue("Event should be accepted", filter.accept(ev));
@@ -221,17 +221,29 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
     public void testNullModuleIdAndNonMatchingChecks() throws Exception {
         final String xpath = "NON_MATCHING_QUERY";
         final XpathFilter filter = new XpathFilter("InputXpathFilterSuppressByXpath",
-                "NonMatchingRegexp", null, xpath);
+                "NonMatchingRegexp", null, null, xpath);
         final TreeWalkerAuditEvent ev = getEvent(3, 0,
                 TokenTypes.CLASS_DEF);
         assertTrue("Event should be accepted", filter.accept(ev));
     }
 
     @Test
+    public void testDecideByMessage() throws Exception {
+        final LocalizedMessage message = new LocalizedMessage(0, 0, TokenTypes.CLASS_DEF, "", "",
+                null, null, null, getClass(), "Test");
+        final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents, file.getName(),
+                message, TestUtil.parseFile(file));
+        final XpathFilter filter1 = new XpathFilter(null, null, "Test", null, null);
+        final XpathFilter filter2 = new XpathFilter(null, null, "Bad", null, null);
+        assertFalse("Message match", filter1.accept(ev));
+        assertTrue("Message not match", filter2.accept(ev));
+    }
+
+    @Test
     public void testThrowException() {
         final String xpath = "/CLASS_DEF[@text='InputXpathFilterSuppressByXpath']";
         final XpathFilter filter =
-                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, xpath);
+                new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, null, xpath);
         final LocalizedMessage message =
                 new LocalizedMessage(3, 0, TokenTypes.CLASS_DEF, "", "", null, null, "id19",
                         getClass(), null);
@@ -254,7 +266,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
                 xpathEvaluator.createExpression("//METHOD_DEF"),
                 xpathEvaluator.createExpression("//VARIABLE_DEF"))
                 .usingGetClass()
-                .withIgnoredFields("fileRegexp", "checkRegexp", "xpathExpression")
+                .withIgnoredFields("fileRegexp", "checkRegexp", "messageRegexp", "xpathExpression")
                 .verify();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/GeneratedJavaTokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/GeneratedJavaTokenTypesTest.java
@@ -22,7 +22,10 @@ package com.puppycrawl.tools.checkstyle.grammars;
 import org.junit.Assert;
 import org.junit.Test;
 
-/** @noinspection ClassIndependentOfModule */
+/**
+ * GeneratedJavaTokenTypesTest.
+ * @noinspection ClassIndependentOfModule
+ */
 public class GeneratedJavaTokenTypesTest {
     /**
      * <p>
@@ -30,6 +33,7 @@ public class GeneratedJavaTokenTypesTest {
      * old tokens must remain and keep their current numbering. Old token
      * numberings are not allowed to change.
      * </p>
+     *
      * <p>
      * The reason behind this is Java inlines static final field values directly
      * into the compiled Java code. This loses all connections with the original
@@ -37,7 +41,9 @@ public class GeneratedJavaTokenTypesTest {
      * up in user-created checks and causes conflicts.
      * </p>
      *
+     * <p>
      * Issue: https://github.com/checkstyle/checkstyle/issues/505
+     * </p>
      */
     @Test
     public void testTokenNumbering() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/GeneratedJavadocTokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/GeneratedJavadocTokenTypesTest.java
@@ -23,7 +23,10 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-/** @noinspection ClassIndependentOfModule */
+/**
+ * GeneratedJavadocTokenTypesTest.
+ * @noinspection ClassIndependentOfModule
+ */
 public class GeneratedJavadocTokenTypesTest {
 
     private static final String MSG = "Ensure that token numbers generated for the elements"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParseTreeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParseTreeTest.java
@@ -26,7 +26,10 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractTreeTestSupport;
 
-/** @noinspection ClassOnlyUsedInOnePackage */
+/**
+ * JavadocParseTreeTest.
+ * @noinspection ClassOnlyUsedInOnePackage
+ */
 public class JavadocParseTreeTest extends AbstractTreeTestSupport {
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentationTest.java
@@ -56,7 +56,7 @@ public class CodeSelectorPresentationTest extends AbstractPathTestSupport {
     }
 
     /** Converts lineToPosition from multicharacter to one character line separator
-      * needs to support crossplatform line separators
+      * needs to support crossplatform line separators.
       * @param systemLinesToPosition lines to position mapping for current system
       * @return lines to position mapping with one character line separator
       */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
@@ -202,7 +202,8 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
     }
 
     /**
-     * The path to class name in InputJavadocAttributesAndMethods.java
+     * The path to class name in InputJavadocAttributesAndMethods.java.
+     * <pre>
      * CLASS_DEF
      *  - MODIFIERS
      *  - Comment node
@@ -210,6 +211,7 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
      *  - IDENT -> this is the node that holds the class name
      *  Line number 4 - first three lines are taken by javadoc
      *  Column 6 - first five columns taken by 'class '
+     *  </pre>
      */
     @Test
     public void testGetValueAt() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -548,6 +548,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
      * Checks that an array is a subset of other array.
      * @param array to check whether it is a subset.
      * @param arrayToCheckIn array to check in.
+     * @return {@code true} if all elements in {@code array} are in {@code arrayToCheckIn}.
      */
     private static boolean isSubset(int[] array, int... arrayToCheckIn) {
         Arrays.sort(arrayToCheckIn);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
@@ -32,7 +32,10 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 
-/** @noinspection ClassIndependentOfModule */
+/**
+ * AllTestsTest.
+ * @noinspection ClassIndependentOfModule
+ */
 public class AllTestsTest {
     @Test
     public void testAllInputsHaveTest() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
@@ -49,24 +49,24 @@ import org.junit.Test;
 /**
  * Validate commit message has proper structure.
  *
- * Commits to check are resolved from different places according
+ * <p>Commits to check are resolved from different places according
  * to type of commit in current HEAD. If current HEAD commit is
  * non-merge commit , previous commits are resolved due to current
  * HEAD commit. Otherwise if it is a merge commit, it will invoke
- * resolving previous commits due to commits which was merged.
+ * resolving previous commits due to commits which was merged.</p>
  *
- * After calculating commits to start with ts resolves previous
+ * <p>After calculating commits to start with ts resolves previous
  * commits according to COMMITS_RESOLUTION_MODE variable.
  * At default(BY_LAST_COMMIT_AUTHOR) it checks first commit author
  * and return all consecutive commits with same author. Second
  * mode(BY_COUNTER) makes returning first PREVIOUS_COMMITS_TO_CHECK_COUNT
- * commits after starter commit.
+ * commits after starter commit.</p>
  *
- * Resolved commits are filtered according to author. If commit author
+ * <p>Resolved commits are filtered according to author. If commit author
  * belong to list USERS_EXCLUDED_FROM_VALIDATION then this commit will
- * not be validated.
+ * not be validated.</p>
  *
- * Filtered commit list is checked if their messages has proper structure.
+ * <p>Filtered commit list is checked if their messages has proper structure.</p>
  *
  * @author <a href="mailto:piotr.listkiewicz@gmail.com">liscju</a>
  */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -292,7 +292,7 @@ public class XdocsPagesTest {
     }
 
     /**
-     * Test contains asserts in callstack, but idea does not see them
+     * Test contains asserts in callstack, but idea does not see them.
      * @noinspection JUnitTestMethodWithNoAssertions
      */
     @Test
@@ -646,7 +646,14 @@ public class XdocsPagesTest {
                         .replaceAll("\\s+", " ").trim());
     }
 
-    /** @noinspection IfStatementWithTooManyBranches */
+    /**
+     * Get's the name of the bean property's type for the class.
+     * @param clss The bean property's defined type.
+     * @param instance The class instance to work with.
+     * @param propertyName The property name to work with.
+     * @return String form of property's type.
+     * @noinspection IfStatementWithTooManyBranches
+     */
     private static String getModulePropertyExpectedTypeName(Class<?> clss, Object instance,
             String propertyName) {
         final String instanceName = instance.getClass().getSimpleName();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/TestFileSetCheck.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/TestFileSetCheck.java
@@ -26,6 +26,7 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 
 /**
+ * TestFileSetCheck.
  * @noinspection ClassOnlyUsedInOnePackage
  */
 public class TestFileSetCheck extends AbstractFileSetCheck {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/TestLoggingReporter.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/TestLoggingReporter.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.internal.testmodules;
 import com.puppycrawl.tools.checkstyle.api.AbstractViolationReporter;
 
 /**
+ * TestLoggingReporter.
  * @noinspection ClassOnlyUsedInOnePackage
  */
 public final class TestLoggingReporter extends AbstractViolationReporter {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
@@ -219,6 +219,7 @@ public final class CheckUtil {
      * Gets the check message 'as is' from appropriate 'messages.properties'
      * file.
      *
+     * @param module The package the message is located in.
      * @param locale the locale to get the message for.
      * @param messageKey the key of message in 'messages*.properties' file.
      * @param arguments the arguments of message in 'messages*.properties' file.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CloseAndFlushTestByteArrayOutputStream.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CloseAndFlushTestByteArrayOutputStream.java
@@ -22,7 +22,10 @@ package com.puppycrawl.tools.checkstyle.internal.utils;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-/** @noinspection ClassOnlyUsedInOnePackage */
+/**
+ * CloseAndFlushTestByteArrayOutputStream.
+ * @noinspection ClassOnlyUsedInOnePackage
+ */
 public final class CloseAndFlushTestByteArrayOutputStream extends ByteArrayOutputStream {
 
     private int closeCount;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
@@ -37,7 +37,10 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-/** @noinspection ClassOnlyUsedInOnePackage */
+/**
+ * XdocUtil.
+ * @noinspection ClassOnlyUsedInOnePackage
+ */
 public final class XdocUtil {
     public static final String DIRECTORY_PATH = "src/xdocs";
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XmlUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XmlUtil.java
@@ -34,7 +34,10 @@ import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-/** @noinspection ClassOnlyUsedInOnePackage */
+/**
+ * XmlUtil.
+ * @noinspection ClassOnlyUsedInOnePackage
+ */
 public final class XmlUtil {
     private XmlUtil() {
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XpathUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XpathUtil.java
@@ -29,6 +29,7 @@ import net.sf.saxon.sxpath.XPathExpression;
 import net.sf.saxon.trans.XPathException;
 
 /**
+ * XpathUtil.
  * @noinspection ClassOnlyUsedInOnePackage
  */
 public final class XpathUtil {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilsTest.java
@@ -147,7 +147,10 @@ public class ModuleReflectionUtilsTest {
         assertEquals("should use field", 1, test.getField());
     }
 
-    /** @noinspection SuperClassHasFrequentlyUsedInheritors */
+    /**
+     * ValidCheckstyleClass.
+     * @noinspection SuperClassHasFrequentlyUsedInheritors
+     */
     private static class ValidCheckstyleClass extends AutomaticBean {
         // empty, use default constructor
     }
@@ -156,7 +159,10 @@ public class ModuleReflectionUtilsTest {
         // empty, use default constructor
     }
 
-    /** @noinspection AbstractClassNeverImplemented */
+    /**
+     * AbstractInvalidClass.
+     * @noinspection AbstractClassNeverImplemented
+     */
     private abstract static class AbstractInvalidClass extends AutomaticBean {
         public abstract void method();
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsloader/InputSuppressionsLoaderMultiple.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsloader/InputSuppressionsLoaderMultiple.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.0//EN"
-    "http://checkstyle.sourceforge.net/dtds/suppressions_1_0.dtd">
+    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
 <suppressions>
   <suppress files="file0" checks="check0"/>
   <suppress files="file1" checks="check1" lines="1,2-3"/>
   <suppress files="file2" checks="check2" columns="1,2-3"/>
   <suppress files="file3" checks="check3" lines="1,2-3" columns="1,2-3"/>
+  <suppress message="message0"/>
 </suppressions>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsloader/InputSuppressionsLoaderXpathCorrect.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsloader/InputSuppressionsLoaderXpathCorrect.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions Xpath Experimental 1.1//EN"
-    "http://checkstyle.sourceforge.net/dtds/suppressions_1_1_xpath_experimental.dtd">
+    "-//Puppy Crawl//DTD Suppressions Xpath Experimental 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2_xpath_experimental.dtd">
 <suppressions>
   <suppress-xpath files="file1" id="id1" checks="test" query="/CLASS_DEF"/>
+  <suppress-xpath message="message1" query="/CLASS_DEF"/>
 </suppressions>

--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -917,8 +917,9 @@
 &lt;!ELEMENT suppressions (suppress*)&gt;
 
 &lt;!ELEMENT suppress EMPTY&gt;
-&lt;!ATTLIST suppress files CDATA #REQUIRED
+&lt;!ATTLIST suppress files CDATA #IMPLIED
                    checks CDATA #IMPLIED
+                   message CDATA #IMPLIED
                    id CDATA #IMPLIED
                    lines CDATA #IMPLIED
                    columns CDATA #IMPLIED&gt;

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -483,19 +483,25 @@ public class UserService {
                   <code>files</code> -
                   a <a href="property_types.html#regexp">Regular Expression</a>
                   matched against the file name associated with an audit
-                  event. It is mandatory.
+                  event. It is optional.
               </li>
               <li>
                   <code>checks</code> -
                   a <a href="property_types.html#regexp">Regular Expression</a>
                   matched against the name of the check associated with an audit
-                  event. Optional if <code>id</code> is specified.
+                  event. Optional as long as <code>id</code> or <code>message</code> is specified.
+              </li>
+              <li>
+                  <code>message</code> -
+                  a <a href="property_types.html#regexp">Regular Expression</a>
+                  matched against the message of the check associated with an audit
+                  event.  Optional as long as <code>checks</code> or <code>id</code> is specified.
               </li>
               <li>
                   <code>id</code> -
                   a <a href="property_types.html#string">string</a>
                   matched against the ID of the check associated with an audit
-                  event. Optional if <code>checks</code> is specified.
+                  event.  Optional as long as <code>checks</code> or <code>message</code> is specified.
               </li>
               <li>
                   <code>lines</code> - a comma-separated list of
@@ -527,7 +533,9 @@ public class UserService {
             lines 82 and 108 to 122 of
             file <code>AbstractComplexityCheck.java</code>,
             and <code>MagicNumberCheck</code> errors for line
-            221 of file <code>JavadocStyleCheck.java</code>:
+            221 of file <code>JavadocStyleCheck.java</code>,
+            and '<code>Missing a Javadoc comment</code>' errors
+            for all lines and files:
           </p>
           <source>
 &lt;?xml version=&quot;1.0&quot;?&gt;
@@ -544,6 +552,7 @@ public class UserService {
   files=&quot;JavadocStyleCheck.java&quot;
   lines=&quot;221&quot;/&gt;
 &lt;/suppressions&gt;
+&lt;suppress message=&quot;Missing a Javadoc comment&quot;/&gt;&lt;/suppressions&gt;
           </source>
           <p>
             As another example to suppress Check by module id:
@@ -614,6 +623,12 @@ public class UserService {
           </p>
           <source>
 &lt;suppress checks=&quot;FileLength&quot; files=&quot;com[\\/]mycompany[\\/]app[\\/].*IT.java&quot;/&gt;
+          </source>
+          <p>
+            Suppress naming errors on variable named 'log' in all files:
+          </p>
+          <source>
+&lt;suppress message=&quot;Name 'log' must match pattern&quot;/&gt;
           </source>
       </subsection>
       <subsection name="Example of Usage">


### PR DESCRIPTION
Issue #2804

Added support to suppress violations by message.

Some other small changes are you can suppression message by itself and don't need to specify message/check.

`CommonUtils.createPattern` was removed from `SuppressElement` to make all regular expressions follow the same pattern and produce the same exception.