### PR TITLE
Issue #5228: property values must be acceptable types

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractPathTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractPathTestSupport.java
@@ -42,4 +42,8 @@ public abstract class AbstractPathTestSupport {
         return new File("src/test/resources/" + getPackageLocation() + "/" + filename)
                 .getCanonicalPath();
     }
+
+    protected final String getResourcePath(String filename) {
+        return "/" + getPackageLocation() + "/" + filename;
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -52,10 +52,6 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         return "com/puppycrawl/tools/checkstyle/checks/imports/importcontrol";
     }
 
-    private static String getResourcePath(String filename) {
-        return "/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/" + filename;
-    }
-
     @Test
     public void testGetRequiredTokens() {
         final ImportControlCheck checkObj = new ImportControlCheck();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -150,7 +150,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
             createModuleConfig(JavadocTypeCheck.class);
         checkConfig.addAttribute(
             "scope",
-            Scope.getInstance("package").getName());
+            Scope.PACKAGE.getName());
         final String[] expected = {
             "18: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "20: " + getCheckMessage(MSG_JAVADOC_MISSING),
@@ -165,7 +165,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
             createModuleConfig(JavadocTypeCheck.class);
         checkConfig.addAttribute(
             "scope",
-            Scope.getInstance("public").getName());
+            Scope.PUBLIC.getName());
         final String[] expected = {
             "18: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheckTest.java
@@ -26,9 +26,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
-import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
 
 public class TypeNameCheckTest
     extends AbstractModuleTestSupport {
@@ -70,7 +68,7 @@ public class TypeNameCheckTest
             throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(TypeNameCheck.class);
-        checkConfig.addAttribute("tokens", TokenUtils.getTokenName(TokenTypes.CLASS_DEF));
+        checkConfig.addAttribute("tokens", "CLASS_DEF");
         final String[] expected = {
             "3:7: " + getCheckMessage(MSG_INVALID_PATTERN,
                     "inputHeaderClass", DEFAULT_PATTERN),
@@ -83,7 +81,7 @@ public class TypeNameCheckTest
             throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(TypeNameCheck.class);
-        checkConfig.addAttribute("tokens", TokenUtils.getTokenName(TokenTypes.INTERFACE_DEF));
+        checkConfig.addAttribute("tokens", "INTERFACE_DEF");
         final String[] expected = {
             "5:22: " + getCheckMessage(MSG_INVALID_PATTERN,
                     "inputHeaderInterface", DEFAULT_PATTERN),
@@ -96,7 +94,7 @@ public class TypeNameCheckTest
             throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(TypeNameCheck.class);
-        checkConfig.addAttribute("tokens", TokenUtils.getTokenName(TokenTypes.ENUM_DEF));
+        checkConfig.addAttribute("tokens", "ENUM_DEF");
         final String[] expected = {
             "7:17: " + getCheckMessage(MSG_INVALID_PATTERN,
                     "inputHeaderEnum", DEFAULT_PATTERN),
@@ -109,7 +107,7 @@ public class TypeNameCheckTest
             throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(TypeNameCheck.class);
-        checkConfig.addAttribute("tokens", TokenUtils.getTokenName(TokenTypes.ANNOTATION_DEF));
+        checkConfig.addAttribute("tokens", "ANNOTATION_DEF");
         final String[] expected = {
             "9:23: " + getCheckMessage(MSG_INVALID_PATTERN,
                 "inputHeaderAnnotation", DEFAULT_PATTERN),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheckTest.java
@@ -40,7 +40,9 @@ public class FileTabCharacterCheckTest
 
     @Test
     public void testDefault() throws Exception {
-        final DefaultConfiguration checkConfig = createConfig(false);
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(FileTabCharacterCheck.class);
+        checkConfig.addAttribute("eachLine", "false");
         final String[] expected = {
             "19:25: " + getCheckMessage(MSG_FILE_CONTAINS_TAB),
         };
@@ -53,7 +55,9 @@ public class FileTabCharacterCheckTest
 
     @Test
     public void testVerbose() throws Exception {
-        final DefaultConfiguration checkConfig = createConfig(true);
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(FileTabCharacterCheck.class);
+        checkConfig.addAttribute("eachLine", "true");
         final String[] expected = {
             "19:25: " + getCheckMessage(MSG_CONTAINS_TAB),
             "145:35: " + getCheckMessage(MSG_CONTAINS_TAB),
@@ -73,7 +77,9 @@ public class FileTabCharacterCheckTest
 
     @Test
     public void testBadFile() throws Exception {
-        final DefaultConfiguration checkConfig = createConfig(false);
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(FileTabCharacterCheck.class);
+        checkConfig.addAttribute("eachLine", "false");
         final String path = getPath("Claira");
         final String exceptionMessage = " (No such file or directory)";
         final LocalizedMessage localizedMessage = new LocalizedMessage(0,
@@ -87,16 +93,5 @@ public class FileTabCharacterCheckTest
             new File(path),
         };
         verify(createChecker(checkConfig), files, path, expected);
-    }
-
-    /**
-     * Creates a configuration that is functionally close to that in the docs.
-     * @param verbose verbose mode
-     */
-    private static DefaultConfiguration createConfig(boolean verbose) {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(FileTabCharacterCheck.class);
-        checkConfig.addAttribute("eachLine", Boolean.toString(verbose));
-        return checkConfig;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheckTest.java
@@ -54,7 +54,7 @@ public class SingleSpaceSeparatorCheckTest extends AbstractModuleTestSupport {
     public void testSpaceErrors() throws Exception {
         final DefaultConfiguration checkConfig =
                 createModuleConfig(SingleSpaceSeparatorCheck.class);
-        checkConfig.addAttribute("validateComments", String.valueOf(true));
+        checkConfig.addAttribute("validateComments", "true");
         final String[] expected = {
             "1:9: " + getCheckMessage(MSG_KEY),
             "1:27: " + getCheckMessage(MSG_KEY),
@@ -97,7 +97,7 @@ public class SingleSpaceSeparatorCheckTest extends AbstractModuleTestSupport {
     public void testSpaceErrorsAroundComments() throws Exception {
         final DefaultConfiguration checkConfig =
                 createModuleConfig(SingleSpaceSeparatorCheck.class);
-        checkConfig.addAttribute("validateComments", String.valueOf(true));
+        checkConfig.addAttribute("validateComments", "true");
         final String[] expected = {
             "5:10: " + getCheckMessage(MSG_KEY),
             "5:42: " + getCheckMessage(MSG_KEY),


### PR DESCRIPTION
Issue #5228

We must only use acceptable types for property values so regression util can understand what that value is.
`getResourcePath` was added to abstract support as I feel this can be used elsewhere in the future and will be a recognizable method by the util.