### PR TITLE
Issue #5124: removed usage of branchContains for simple cases

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
@@ -143,7 +143,8 @@ public class FinalParametersCheck extends AbstractCheck {
             method.findFirstToken(TokenTypes.MODIFIERS);
         // exit on fast lane if there is nothing to check here
 
-        if (method.branchContains(TokenTypes.PARAMETER_DEF)
+        if (method.findFirstToken(TokenTypes.PARAMETERS)
+                .findFirstToken(TokenTypes.PARAMETER_DEF) != null
                 // ignore abstract and native methods
                 && modifiers.findFirstToken(TokenTypes.ABSTRACT) == null
                 && modifiers.findFirstToken(TokenTypes.LITERAL_NATIVE) == null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
@@ -160,8 +160,8 @@ public final class MissingOverrideCheck extends AbstractCheck {
             if (javaFiveCompatibility) {
                 final DetailAST defOrNew = ast.getParent().getParent();
 
-                if (defOrNew.branchContains(TokenTypes.EXTENDS_CLAUSE)
-                    || defOrNew.branchContains(TokenTypes.IMPLEMENTS_CLAUSE)
+                if (defOrNew.findFirstToken(TokenTypes.EXTENDS_CLAUSE) != null
+                    || defOrNew.findFirstToken(TokenTypes.IMPLEMENTS_CLAUSE) != null
                     || defOrNew.getType() == TokenTypes.LITERAL_NEW) {
                     check = false;
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -162,7 +162,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
                 && astType != TokenTypes.SLIST
                 && astType != TokenTypes.LITERAL_NEW
                 || astType == TokenTypes.LITERAL_NEW
-                    && ast.branchContains(TokenTypes.LCURLY)) {
+                    && ast.findFirstToken(TokenTypes.OBJBLOCK) != null) {
             currentFrame = currentFrame.getParent();
         }
         else if (astType == TokenTypes.SLIST) {
@@ -243,7 +243,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
      * @param ast LITERAL_NEW ast.
      */
     private void processLiteralNew(DetailAST ast) {
-        if (ast.branchContains(TokenTypes.LCURLY)) {
+        if (ast.findFirstToken(TokenTypes.OBJBLOCK) != null) {
             final FieldFrame frame = new FieldFrame(currentFrame);
             currentFrame.addChild(frame);
             currentFrame = frame;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
@@ -120,7 +120,7 @@ public class EqualsHashCodeCheck
         return CheckUtils.isEqualsMethod(ast)
                 && modifiers.findFirstToken(TokenTypes.LITERAL_PUBLIC) != null
                 && isObjectParam(parameters.getFirstChild())
-                && (ast.branchContains(TokenTypes.SLIST)
+                && (ast.findFirstToken(TokenTypes.SLIST) != null
                         || modifiers.findFirstToken(TokenTypes.LITERAL_NATIVE) != null);
     }
 
@@ -141,7 +141,7 @@ public class EqualsHashCodeCheck
                 && modifiers.findFirstToken(TokenTypes.LITERAL_PUBLIC) != null
                 && modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) == null
                 && parameters.getFirstChild() == null
-                && (ast.branchContains(TokenTypes.SLIST)
+                && (ast.findFirstToken(TokenTypes.SLIST) != null
                         || modifiers.findFirstToken(TokenTypes.LITERAL_NATIVE) != null);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -203,7 +203,8 @@ public class FinalLocalVariableCheck extends AbstractCheck {
                 break;
             case TokenTypes.PARAMETER_DEF:
                 if (!isInLambda(ast)
-                        && !ast.branchContains(TokenTypes.FINAL)
+                        && ast.findFirstToken(TokenTypes.MODIFIERS)
+                            .findFirstToken(TokenTypes.FINAL) == null
                         && !isInAbstractOrNativeMethod(ast)
                         && !ScopeUtils.isInInterfaceBlock(ast)
                         && !isMultipleTypeCatch(ast)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -607,7 +607,8 @@ public class RequireThisCheck extends AbstractCheck {
             else {
                 final DetailAST frameNameIdent = variableDeclarationFrame.getFrameNameIdent();
                 final DetailAST definitionToken = frameNameIdent.getParent();
-                staticContext = definitionToken.branchContains(TokenTypes.LITERAL_STATIC);
+                staticContext = definitionToken.findFirstToken(TokenTypes.MODIFIERS)
+                        .findFirstToken(TokenTypes.LITERAL_STATIC) != null;
             }
         }
         return !staticContext;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
@@ -138,7 +138,8 @@ public enum JavadocTagInfo {
             final int astType = ast.getType();
 
             return astType == TokenTypes.METHOD_DEF
-                && !ast.branchContains(TokenTypes.LITERAL_STATIC)
+                && ast.findFirstToken(TokenTypes.MODIFIERS)
+                    .findFirstToken(TokenTypes.LITERAL_STATIC) == null
                 && ScopeUtils.getScopeFromMods(ast
                     .findFirstToken(TokenTypes.MODIFIERS)) != Scope.PRIVATE;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
@@ -309,7 +309,7 @@ public class RedundantModifierCheck
             checkForRedundantModifier(ast, TokenTypes.FINAL);
         }
 
-        if (!ast.branchContains(TokenTypes.SLIST)) {
+        if (ast.findFirstToken(TokenTypes.SLIST) == null) {
             processAbstractMethodParameters(ast);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtility.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtility.java
@@ -84,7 +84,7 @@ public final class AnnotationUtility {
             throw new IllegalArgumentException(THE_AST_IS_NULL);
         }
         final DetailAST holder = getAnnotationHolder(ast);
-        return holder != null && holder.branchContains(TokenTypes.ANNOTATION);
+        return holder != null && holder.findFirstToken(TokenTypes.ANNOTATION) != null;
     }
 
     /**


### PR DESCRIPTION
Issue #5124

This removes 13 out of the 27 uses of `branchContains` left.
This removes all cases where the item being looked for was in a standard location.