### PR TITLE
Issue #5210: added junit failures if exception is not thrown

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle;
 import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_MISSED_HTML_CLOSE;
 import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_PARSE_RULE_ERROR;
 import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_WRONG_SINGLETON_TAG;
-import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseErrorMessage;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -34,6 +33,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
+import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseErrorMessage;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 
 public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
@@ -141,6 +141,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             DetailNodeTreeStringPrinter.printFileAst(new File(
                     getPath("InputDetailNodeTreeStringPrinter"
                             + "UnescapedJavaCodeWithGenericsInJavadoc.javadoc")));
+            Assert.fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
             final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
@@ -155,6 +156,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
         try {
             DetailNodeTreeStringPrinter.printFileAst(new File(getPath(
                     "InputDetailNodeTreeStringPrinterNoViableAltException.javadoc")));
+            Assert.fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
             final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
@@ -171,6 +173,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             DetailNodeTreeStringPrinter.printFileAst(new File(getPath(
                     "InputDetailNodeTreeStringPrinterHtmlTagCloseBeforeTagOpen.javadoc"
             )));
+            Assert.fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
             final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
@@ -187,6 +190,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             DetailNodeTreeStringPrinter.printFileAst(new File(getPath(
                     "InputDetailNodeTreeStringPrinterWrongHtmlTagOrder.javadoc"
             )));
+            Assert.fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
             final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
@@ -202,6 +206,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             DetailNodeTreeStringPrinter.printFileAst(new File(getPath(
                     "InputDetailNodeTreeStringPrinterOmittedStartTagForHtmlElement.javadoc"
             )));
+            Assert.fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
             final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ThreadModeSettingsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ThreadModeSettingsTest.java
@@ -67,6 +67,7 @@ public class ThreadModeSettingsTest {
 
         try {
             configuration.resolveName(ThreadModeSettings.TREE_WALKER_MODULE_NAME);
+            fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
             assertEquals("Invalid exception message",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -200,6 +200,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         try {
             final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
             verify(checkConfig, pathToEmptyFile, expected);
+            fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
             assertTrue("Error message is unexpected",
@@ -270,6 +271,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final FileText fileText = new FileText(file, lines);
         try {
             treeWalker.processFiltered(file, fileText);
+            fail("Exception is expected");
         }
         catch (CheckstyleException exception) {
             assertTrue("Error message is unexpected",
@@ -292,6 +294,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final FileText fileText = new FileText(file, lines);
         try {
             treeWalker.processFiltered(file, fileText);
+            fail("Exception is expected");
         }
         catch (CheckstyleException exception) {
             assertTrue("Error message is unexpected",
@@ -326,14 +329,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             createModuleConfig(RequiredTokenIsEmptyIntArray.class);
         final String pathToEmptyFile = temporaryFolder.newFile("file.java").getPath();
 
-        try {
-            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
-            verify(checkConfig, pathToEmptyFile, expected);
-        }
-        catch (CheckstyleException ignored) {
-            // unexpected
-            fail("CheckstyleException is NOT expected");
-        }
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, pathToEmptyFile, expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -45,6 +45,7 @@ public class AutomaticBeanTest {
         conf.addAttribute("NonExisting", "doesn't matter");
         try {
             testBean.configure(conf);
+            fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
             final String expected = "Property 'NonExisting' in module ";
@@ -61,6 +62,7 @@ public class AutomaticBeanTest {
         conf.addAttribute("privateField", "doesn't matter");
         try {
             testBean.configure(conf);
+            fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
             final String expected = "Property 'privateField' in module ";

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -250,6 +250,7 @@ public class NewlineAtEndOfFileCheckTest
         when(file.length()).thenReturn(2_000_000L);
         try {
             method.invoke(new NewlineAtEndOfFileCheck(), file);
+            fail("Exception is expected");
         }
         catch (InvocationTargetException ex) {
             assertTrue("Error type is unexpected",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -71,30 +71,20 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testNoHeader() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
-        try {
-            createChecker(checkConfig);
-            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
-            verify(checkConfig, getPath("InputHeaderRegexp.java"), expected);
-        }
-        catch (CheckstyleException ex) {
-            // Exception is not expected
-            fail("Exception is not expected");
-        }
+
+        createChecker(checkConfig);
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputHeaderRegexp.java"), expected);
     }
 
     @Test
     public void testWhitespaceHeader() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
         checkConfig.addAttribute("header", "\n    \n");
-        try {
-            createChecker(checkConfig);
-            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
-            verify(checkConfig, getPath("InputHeaderRegexp.java"), expected);
-        }
-        catch (CheckstyleException ex) {
-            // Exception is not expected
-            fail("Exception is not expected");
-        }
+
+        createChecker(checkConfig);
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputHeaderRegexp.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import org.junit.Test;
@@ -366,19 +365,12 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
     @Test
     // UT uses Reflection to avoid removing null-validation from static method,
     // which is a candidate for utility method in the future
-    public void testGetFullImportIdent() {
-        Object actual;
-        try {
-            final Class<?> clazz = CustomImportOrderCheck.class;
-            final Object t = clazz.getConstructor().newInstance();
-            final Method method = clazz.getDeclaredMethod("getFullImportIdent", DetailAST.class);
-            method.setAccessible(true);
-            actual = method.invoke(t, (DetailAST) null);
-        }
-        catch (NoSuchMethodException | InstantiationException
-                  | IllegalAccessException | InvocationTargetException ignored) {
-            actual = null;
-        }
+    public void testGetFullImportIdent() throws Exception {
+        final Class<?> clazz = CustomImportOrderCheck.class;
+        final Object t = clazz.getConstructor().newInstance();
+        final Method method = clazz.getDeclaredMethod("getFullImportIdent", DetailAST.class);
+        method.setAccessible(true);
+        final Object actual = method.invoke(t, (DetailAST) null);
 
         final String expected = "";
         assertEquals("Invalid getFullImportIdent result", expected, actual);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractTypeAwareCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractTypeAwareCheckTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -78,6 +79,7 @@ public class AbstractTypeAwareCheckTest extends AbstractModuleTestSupport {
 
         try {
             regularClassConstructor.newInstance(null, "", new JavadocMethodCheck());
+            fail("Exception is expected");
         }
         catch (InvocationTargetException ex) {
             assertTrue("Invalid exception class, expected: IllegalArgumentException.class",
@@ -159,6 +161,7 @@ public class AbstractTypeAwareCheckTest extends AbstractModuleTestSupport {
         };
         try {
             verify(config, getPath("InputAbstractTypeAwareLoadErrors.java"), expected);
+            fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
             final IllegalStateException cause = (IllegalStateException) ex.getCause();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/ClassResolverTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/ClassResolverTest.java
@@ -122,6 +122,7 @@ public class ClassResolverTest {
 
         try {
             classResolver.resolve("Entry", "Map");
+            fail("Exception is expected");
         }
         catch (ClassNotFoundException ex) {
             assertEquals("Invalid exception message", "Entry", ex.getMessage());
@@ -172,15 +173,7 @@ public class ClassResolverTest {
         PowerMockito.doThrow(new NoClassDefFoundError("expected exception"))
                 .when(classResolver, "safeLoad", anyObject());
 
-        try {
-            final boolean result = classResolver.isLoadable("someClass");
-            assertFalse("result should be false", result);
-        }
-        catch (NoClassDefFoundError ex) {
-            fail("NoClassDefFoundError is not expected");
-            final String expected = "expected exception";
-            assertTrue("Invalid exception message, should end with: " + expected,
-                    ex.getMessage().endsWith(expected));
-        }
+        final boolean result = classResolver.isLoadable("someClass");
+        assertFalse("result should be false", result);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -246,6 +247,7 @@ public class SuppressWithNearbyCommentFilterTest
         try {
             final String[] suppressed = CommonUtils.EMPTY_STRING_ARRAY;
             verifySuppressed(filterConfig, suppressed);
+            fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
             final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
@@ -282,6 +284,7 @@ public class SuppressWithNearbyCommentFilterTest
         try {
             final String[] suppressed = CommonUtils.EMPTY_STRING_ARRAY;
             verifySuppressed(filterConfig, suppressed);
+            fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
             final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -264,6 +265,7 @@ public class SuppressionCommentFilterTest
         try {
             final String[] suppressed = CommonUtils.EMPTY_STRING_ARRAY;
             verifySuppressed(filterConfig, suppressed);
+            fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
             final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
@@ -281,6 +283,7 @@ public class SuppressionCommentFilterTest
         try {
             final String[] suppressed = CommonUtils.EMPTY_STRING_ARRAY;
             verifySuppressed(filterConfig, suppressed);
+            fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
             final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -141,6 +141,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final String fn = getPath("InputSuppressionsLoaderNoFile.xml");
         try {
             SuppressionsLoader.loadSuppressions(fn);
+            fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
             final String messageStart = "Unable to parse " + fn;
@@ -158,6 +159,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final String fn = getPath("InputSuppressionsLoaderNoCheck.xml");
         try {
             SuppressionsLoader.loadSuppressions(fn);
+            fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
             final String messageStart = "Unable to parse " + fn;
@@ -175,6 +177,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final String fn = getPath("InputSuppressionsLoaderBadInt.xml");
         try {
             SuppressionsLoader.loadSuppressions(fn);
+            fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
             assertTrue(
@@ -261,6 +264,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final String fn = getPath("InputSuppressionsLoaderNoCheckAndId.xml");
         try {
             SuppressionsLoader.loadSuppressions(fn);
+            fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
             assertEquals("Invalid error message",
@@ -282,6 +286,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final String fn = getPath("InputSuppressionsLoaderInvalidFile.xml");
         try {
             SuppressionsLoader.loadSuppressions(fn);
+            fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
             assertEquals("Invalid error message",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterTest.java
@@ -239,6 +239,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
                 file.getName(), message, null);
         try {
             filter.accept(ev);
+            fail("Exception is expected");
         }
         catch (IllegalStateException ex) {
             assertTrue("Exception message does not match expected one",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilityTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilityTest.java
@@ -37,6 +37,7 @@ public class AnnotationUtilityTest {
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         try {
             isUtilsClassHasPrivateConstructor(AnnotationUtility.class, true);
+            Assert.fail("Exception is expected");
         }
         catch (InvocationTargetException ex) {
             assertEquals("Invalid exception message",


### PR DESCRIPTION
Issue #5210 

Some try/catches were invalid as they were catching exceptions that weren't expected. These try/catch blocks were removed.
`ClassResolverTest` had an interesting case where it had a fail but more code after it which shouldn't be possible to execute.