### PR TITLE
Removed maxLineLength property from javadoc, the property itself had been removed earlier

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -44,9 +44,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *
  * <p>
  * The policy to verify is specified using the {@link LeftCurlyOption} class and
- * defaults to {@link LeftCurlyOption#EOL}. Policies {@link LeftCurlyOption#EOL}
- * and {@link LeftCurlyOption#NLOW} take into account property maxLineLength.
- * The default value for maxLineLength is 80.
+ * defaults to {@link LeftCurlyOption#EOL}.
  * </p>
  * <p>
  * An example of how to configure the check is:
@@ -56,13 +54,12 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * </pre>
  * <p>
  * An example of how to configure the check with policy
- * {@link LeftCurlyOption#NLOW} and maxLineLength 120 is:
+ * {@link LeftCurlyOption#NLOW} is:
  * </p>
  * <pre>
  * &lt;module name="LeftCurly"&gt;
- *      &lt;property name="option"
- * value="nlow"/&gt;     &lt;property name="maxLineLength" value="120"/&gt; &lt;
- * /module&gt;
+ *      &lt;property name="option" value="nlow"/&gt;
+ * &lt;/module&gt;
  * </pre>
  * <p>
  * An example of how to configure the check to validate enum definitions:


### PR DESCRIPTION
…been removed earlier
