### PR TITLE
Issue #5157: removed custom create configuration methods

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -19,6 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_JAVADOC_MISSING;
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -33,6 +36,7 @@ import com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder;
 import com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck;
 import com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck;
@@ -41,28 +45,45 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 public class SuppressWarningsFilterTest
     extends AbstractModuleTestSupport {
     private static final String[] ALL_MESSAGES = {
-        "16: Missing a Javadoc comment.",
-        "17: Missing a Javadoc comment.",
-        "19: Missing a Javadoc comment.",
-        "22:45: Name 'I' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "24:17: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "25:17: Name 'K' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "29:17: Name 'L' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "29:32: Name 'X' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "33:30: Name 'm' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-        "34:30: Name 'n' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-        "39:17: More than 7 parameters (found 8).",
-        "45:9: Catching 'Exception' is not allowed.",
-        "56:9: Catching 'Exception' is not allowed.",
-        "61: Missing a Javadoc comment.",
-        "71: Uncommented main method found.",
-        "76: Missing a Javadoc comment.",
-        "77: Uncommented main method found.",
-        "83: Missing a Javadoc comment.",
-        "84: Uncommented main method found.",
-        "90: Missing a Javadoc comment.",
-        "91: Uncommented main method found.",
-        "97: Missing a Javadoc comment.",
+        "16: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "17: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "19: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "22:45: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "I", "^[a-z][a-zA-Z0-9]*$"),
+        "24:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "J", "^[a-z][a-zA-Z0-9]*$"),
+        "25:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "K", "^[a-z][a-zA-Z0-9]*$"),
+        "29:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "L", "^[a-z][a-zA-Z0-9]*$"),
+        "29:32: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "X", "^[a-z][a-zA-Z0-9]*$"),
+        "33:30: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "m", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+        "34:30: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "n", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+        "39:17: "
+            + getCheckMessage(ParameterNumberCheck.class, ParameterNumberCheck.MSG_KEY, 7, 8),
+        "45:9: "
+            + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
+        "56:9: "
+            + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
+        "61: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "71: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+        "76: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "77: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+        "83: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "84: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+        "90: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "91: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+        "97: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
     };
 
     @Override
@@ -82,16 +103,24 @@ public class SuppressWarningsFilterTest
         final DefaultConfiguration filterConfig =
             createModuleConfig(SuppressWarningsFilter.class);
         final String[] suppressed = {
-            "24:17: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "29:17: Name 'L' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "33:30: Name 'm' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "39:17: More than 7 parameters (found 8).",
-            "56:9: Catching 'Exception' is not allowed.",
-            "71: Uncommented main method found.",
-            "77: Uncommented main method found.",
-            "84: Uncommented main method found.",
-            "91: Uncommented main method found.",
-            "97: Missing a Javadoc comment.",
+            "24:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "J", "^[a-z][a-zA-Z0-9]*$"),
+            "29:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "L", "^[a-z][a-zA-Z0-9]*$"),
+            "33:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "m", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+            "39:17: "
+                + getCheckMessage(ParameterNumberCheck.class, ParameterNumberCheck.MSG_KEY, 7, 8),
+            "56:9: "
+                + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
+            "71: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+            "77: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+            "84: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+            "91: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
+            "97: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -155,13 +184,19 @@ public class SuppressWarningsFilterTest
         final DefaultConfiguration filterConfig =
             createModuleConfig(SuppressWarningsFilter.class);
         final String[] suppressedViolationMessages = {
-            "6:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "8: Uncommented main method found.",
+            "6:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "8: "
+                + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
         };
         final String[] expectedViolationMessages = {
-            "3: Missing a Javadoc comment.",
-            "6:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "8: Uncommented main method found.",
+            "3: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "6:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "8: "
+                + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
         };
 
         verifySuppressed(filterConfig, getPath("InputSuppressWarningsFilterById.java"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -40,6 +41,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -48,32 +50,81 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 public class SuppressWithNearbyCommentFilterTest
     extends AbstractModuleTestSupport {
     private static final String[] ALL_MESSAGES = {
-        "14:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "15:17: Name 'A2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "16:59: Name 'A3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "18:17: Name 'B1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "19:17: Name 'B2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "20:59: Name 'B3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "22:17: Name 'C1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "24:17: Name 'C2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "25:17: Name 'C3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "27:17: Name 'D1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "28:17: Name 'D2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "30:17: Name 'D3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "32:30: Name 'e1' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-        "33:17: Name 'E2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "34:17: Name 'E3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "35:30: Name 'e4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-        "36:17: Name 'E5' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "37:30: Name 'e6' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-        "38:17: Name 'E7' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "39:17: Name 'E8' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "40:30: Name 'e9' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-        "64:23: Catching 'Exception' is not allowed.",
-        "66:23: Catching 'Throwable' is not allowed.",
-        "73:11: Catching 'Exception' is not allowed.",
-        "80:59: Name 'A2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "81:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "14:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+        "15:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "A2", "^[a-z][a-zA-Z0-9]*$"),
+        "16:59: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "A3", "^[a-z][a-zA-Z0-9]*$"),
+        "18:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "B1", "^[a-z][a-zA-Z0-9]*$"),
+        "19:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "B2", "^[a-z][a-zA-Z0-9]*$"),
+        "20:59: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "B3", "^[a-z][a-zA-Z0-9]*$"),
+        "22:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "C1", "^[a-z][a-zA-Z0-9]*$"),
+        "24:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "C2", "^[a-z][a-zA-Z0-9]*$"),
+        "25:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "C3", "^[a-z][a-zA-Z0-9]*$"),
+        "27:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "D1", "^[a-z][a-zA-Z0-9]*$"),
+        "28:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "D2", "^[a-z][a-zA-Z0-9]*$"),
+        "30:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "D3", "^[a-z][a-zA-Z0-9]*$"),
+        "32:30: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "e1", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+        "33:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "E2", "^[a-z][a-zA-Z0-9]*$"),
+        "34:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "E3", "^[a-z][a-zA-Z0-9]*$"),
+        "35:30: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "e4", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+        "36:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "E5", "^[a-z][a-zA-Z0-9]*$"),
+        "37:30: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "e6", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+        "38:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "E7", "^[a-z][a-zA-Z0-9]*$"),
+        "39:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "E8", "^[a-z][a-zA-Z0-9]*$"),
+        "40:30: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "e9", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+        "64:23: "
+            + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
+        "66:23: "
+            + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Throwable"),
+        "73:11: "
+            + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
+        "80:59: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "A2", "^[a-z][a-zA-Z0-9]*$"),
+        "81:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
     };
 
     @Override
@@ -93,13 +144,27 @@ public class SuppressWithNearbyCommentFilterTest
         final DefaultConfiguration filterConfig =
             createModuleConfig(SuppressWithNearbyCommentFilter.class);
         final String[] suppressed = {
-            "14:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "15:17: Name 'A2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "16:59: Name 'A3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "18:17: Name 'B1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "19:17: Name 'B2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "20:59: Name 'B3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "80:59: Name 'A2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "14:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "15:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A2", "^[a-z][a-zA-Z0-9]*$"),
+            "16:59: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A3", "^[a-z][a-zA-Z0-9]*$"),
+            "18:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "B1", "^[a-z][a-zA-Z0-9]*$"),
+            "19:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "B2", "^[a-z][a-zA-Z0-9]*$"),
+            "20:59: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "B3", "^[a-z][a-zA-Z0-9]*$"),
+            "80:59: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A2", "^[a-z][a-zA-Z0-9]*$"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -110,8 +175,12 @@ public class SuppressWithNearbyCommentFilterTest
             createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("checkC", "false");
         final String[] suppressed = {
-            "14:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "18:17: Name 'B1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "14:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "18:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "B1", "^[a-z][a-zA-Z0-9]*$"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -122,11 +191,21 @@ public class SuppressWithNearbyCommentFilterTest
             createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("checkCPP", "false");
         final String[] suppressed = {
-            "15:17: Name 'A2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "16:59: Name 'A3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "19:17: Name 'B2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "20:59: Name 'B3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "80:59: Name 'A2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "15:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A2", "^[a-z][a-zA-Z0-9]*$"),
+            "16:59: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A3", "^[a-z][a-zA-Z0-9]*$"),
+            "19:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "B2", "^[a-z][a-zA-Z0-9]*$"),
+            "20:59: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "B3", "^[a-z][a-zA-Z0-9]*$"),
+            "80:59: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A2", "^[a-z][a-zA-Z0-9]*$"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -140,8 +219,12 @@ public class SuppressWithNearbyCommentFilterTest
         filterConfig.addAttribute("messageFormat", "$1");
         filterConfig.addAttribute("influenceFormat", "-1");
         final String[] suppressed = {
-            "66:23: Catching 'Throwable' is not allowed.",
-            "73:11: Catching 'Exception' is not allowed.",
+            "66:23: "
+                + getCheckMessage(IllegalCatchCheck.class,
+                    IllegalCatchCheck.MSG_KEY, "Throwable"),
+            "73:11: "
+                + getCheckMessage(IllegalCatchCheck.class,
+                    IllegalCatchCheck.MSG_KEY, "Exception"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -154,7 +237,9 @@ public class SuppressWithNearbyCommentFilterTest
         filterConfig.addAttribute("checkFormat", "$1");
         filterConfig.addAttribute("influenceFormat", "1");
         final String[] suppressed = {
-            "24:17: Name 'C2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "24:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "C2", "^[a-z][a-zA-Z0-9]*$"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -167,7 +252,9 @@ public class SuppressWithNearbyCommentFilterTest
         filterConfig.addAttribute("checkFormat", "$1");
         filterConfig.addAttribute("influenceFormat", "-1");
         final String[] suppressed = {
-            "28:17: Name 'D2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "28:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "D2", "^[a-z][a-zA-Z0-9]*$"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -180,10 +267,18 @@ public class SuppressWithNearbyCommentFilterTest
         filterConfig.addAttribute("checkFormat", "$1");
         filterConfig.addAttribute("influenceFormat", "$2");
         final String[] suppressed = {
-            "35:30: Name 'e4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "36:17: Name 'E5' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "38:17: Name 'E7' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "39:17: Name 'E8' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "35:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "e4", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+            "36:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "E5", "^[a-z][a-zA-Z0-9]*$"),
+            "38:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "E7", "^[a-z][a-zA-Z0-9]*$"),
+            "39:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "E8", "^[a-z][a-zA-Z0-9]*$"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -257,14 +352,30 @@ public class SuppressWithNearbyCommentFilterTest
         filterConfig.addAttribute("influenceFormat", "1");
 
         final String[] suppressed = {
-            "14:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "15:17: Name 'A2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "16:59: Name 'A3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "18:17: Name 'B1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "19:17: Name 'B2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "20:59: Name 'B3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "80:59: Name 'A2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "81:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "14:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "15:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A2", "^[a-z][a-zA-Z0-9]*$"),
+            "16:59: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A3", "^[a-z][a-zA-Z0-9]*$"),
+            "18:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "B1", "^[a-z][a-zA-Z0-9]*$"),
+            "19:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "B2", "^[a-z][a-zA-Z0-9]*$"),
+            "20:59: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "B3", "^[a-z][a-zA-Z0-9]*$"),
+            "80:59: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A2", "^[a-z][a-zA-Z0-9]*$"),
+            "81:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -323,14 +434,26 @@ public class SuppressWithNearbyCommentFilterTest
         filterConfig.addAttribute("checkFormat", "$1");
         filterConfig.addAttribute("influenceFormat", "0");
         final String[] suppressedViolationMessages = {
-            "5:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "9:9: Name 'line_length' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "5:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "9:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
         };
         final String[] expectedViolationMessages = {
-            "5:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "7:30: Name 'abc' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "9:9: Name 'line_length' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "11:18: Name 'ID' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "5:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "7:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "abc", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+            "9:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
+            "11:18: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "ID", "^[a-z][a-zA-Z0-9]*$"),
         };
 
         verifySuppressed(filterConfig,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
@@ -41,6 +42,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
@@ -49,23 +51,53 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 public class SuppressionCommentFilterTest
     extends AbstractModuleTestSupport {
     private static final String[] ALL_MESSAGES = {
-        "13:17: Name 'I' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "16:17: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "19:17: Name 'K' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "22:17: Name 'L' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "23:30: Name 'm' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-        "27:17: Name 'M2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "28:30: Name 'n' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-        "32:17: Name 'P' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "35:17: Name 'Q' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "38:17: Name 'R' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "39:30: Name 's' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-        "43:17: Name 'T' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-        "64:23: Catching 'Exception' is not allowed.",
-        "71:11: Catching 'Exception' is not allowed.",
-        "77:11: Catching 'RuntimeException' is not allowed.",
-        "78:11: Catching 'Exception' is not allowed.",
-        "86:31: Catching 'Exception' is not allowed.",
+        "13:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "I", "^[a-z][a-zA-Z0-9]*$"),
+        "16:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "J", "^[a-z][a-zA-Z0-9]*$"),
+        "19:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "K", "^[a-z][a-zA-Z0-9]*$"),
+        "22:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "L", "^[a-z][a-zA-Z0-9]*$"),
+        "23:30: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "m", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+        "27:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "M2", "^[a-z][a-zA-Z0-9]*$"),
+        "28:30: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "n", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+        "32:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "P", "^[a-z][a-zA-Z0-9]*$"),
+        "35:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "Q", "^[a-z][a-zA-Z0-9]*$"),
+        "38:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "R", "^[a-z][a-zA-Z0-9]*$"),
+        "39:30: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "s", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+        "43:17: "
+            + getCheckMessage(AbstractNameCheck.class,
+                MSG_INVALID_PATTERN, "T", "^[a-z][a-zA-Z0-9]*$"),
+        "64:23: "
+            + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
+        "71:11: "
+            + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
+        "77:11: "
+            + getCheckMessage(IllegalCatchCheck.class,
+                IllegalCatchCheck.MSG_KEY, "RuntimeException"),
+        "78:11: "
+            + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
+        "86:31: "
+            + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
     };
 
     @Override
@@ -86,11 +118,18 @@ public class SuppressionCommentFilterTest
         final DefaultConfiguration filterConfig =
             createModuleConfig(SuppressionCommentFilter.class);
         final String[] suppressed = {
-            "16:17: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "43:17: Name 'T' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "64:23: Catching 'Exception' is not allowed.",
-            "71:11: Catching 'Exception' is not allowed.",
-            "86:31: Catching 'Exception' is not allowed.",
+            "16:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "J", "^[a-z][a-zA-Z0-9]*$"),
+            "43:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "T", "^[a-z][a-zA-Z0-9]*$"),
+            "64:23: "
+                + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
+            "71:11: "
+                + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
+            "86:31: "
+                + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -101,9 +140,13 @@ public class SuppressionCommentFilterTest
             createModuleConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("checkC", "false");
         final String[] suppressed = {
-            "43:17: Name 'T' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "64:23: Catching 'Exception' is not allowed.",
-            "71:11: Catching 'Exception' is not allowed.",
+            "43:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "T", "^[a-z][a-zA-Z0-9]*$"),
+            "64:23: "
+                + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
+            "71:11: "
+                + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -114,8 +157,11 @@ public class SuppressionCommentFilterTest
             createModuleConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("checkCPP", "false");
         final String[] suppressed = {
-            "16:17: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "86:31: Catching 'Exception' is not allowed.",
+            "16:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "J", "^[a-z][a-zA-Z0-9]*$"),
+            "86:31: "
+                + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -128,10 +174,18 @@ public class SuppressionCommentFilterTest
         filterConfig.addAttribute("offCommentFormat", "CS_OFF");
         filterConfig.addAttribute("onCommentFormat", "CS_ON");
         final String[] suppressed = {
-            "32:17: Name 'P' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "38:17: Name 'R' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "39:30: Name 's' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "42:17: Name 'T' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "32:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "P", "^[a-z][a-zA-Z0-9]*$"),
+            "38:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "R", "^[a-z][a-zA-Z0-9]*$"),
+            "39:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "s", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+            "42:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "T", "^[a-z][a-zA-Z0-9]*$"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -146,7 +200,9 @@ public class SuppressionCommentFilterTest
         filterConfig.addAttribute("onCommentFormat", "CS_ON");
         filterConfig.addAttribute("checkFormat", "ConstantNameCheck");
         final String[] suppressed = {
-            "39:30: Name 's' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "39:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "s", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -158,9 +214,12 @@ public class SuppressionCommentFilterTest
         filterConfig.addAttribute("offCommentFormat", "IllegalCatchCheck OFF\\: (\\w+)");
         filterConfig.addAttribute("onCommentFormat", "IllegalCatchCheck ON\\: (\\w+)");
         filterConfig.addAttribute("checkFormat", "IllegalCatchCheck");
-        filterConfig.addAttribute("messageFormat", "^Catching '$1' is not allowed.*$");
+        filterConfig.addAttribute("messageFormat",
+                "^" + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "$1")
+                        + "*$");
         final String[] suppressed = {
-            "78:11: Catching 'Exception' is not allowed.",
+            "78:11: "
+                + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -173,9 +232,15 @@ public class SuppressionCommentFilterTest
         filterConfig.addAttribute("onCommentFormat", "CSON\\: ([\\w\\|]+)");
         filterConfig.addAttribute("checkFormat", "$1");
         final String[] suppressed = {
-            "22:17: Name 'L' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "23:30: Name 'm' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "28:30: Name 'n' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "22:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "L", "^[a-z][a-zA-Z0-9]*$"),
+            "23:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "m", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+            "28:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "n", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -188,9 +253,7 @@ public class SuppressionCommentFilterTest
         filterConfig.addAttribute("offCommentFormat", "UNUSED OFF\\: (\\w+)");
         filterConfig.addAttribute("checkFormat", "Unused");
         filterConfig.addAttribute("messageFormat", "^Unused \\w+ '$1'.$");
-        final String[] suppressed = {
-            "47:34: Unused parameter 'aInt'.",
-        };
+        final String[] suppressed = CommonUtils.EMPTY_STRING_ARRAY;
         verifySuppressed(filterConfig, suppressed);
     }
 
@@ -302,14 +365,26 @@ public class SuppressionCommentFilterTest
         filterConfig.addAttribute("onCommentFormat", "CSON (\\w+)");
         filterConfig.addAttribute("checkFormat", "$1");
         final String[] suppressedViolationMessages = {
-            "6:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "12:9: Name 'line_length' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "6:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "12:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
             };
         final String[] expectedViolationMessages = {
-            "6:17: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "9:30: Name 'abc' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "12:9: Name 'line_length' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "15:18: Name 'ID' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "6:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "9:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "abc", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+            "12:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
+            "15:18: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "ID", "^[a-z][a-zA-Z0-9]*$"),
             };
 
         verifySuppressed(filterConfig, getPath("InputSuppressionCommentFilterSuppressById.java"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.fail;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
@@ -34,7 +33,6 @@ import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
@@ -196,41 +194,36 @@ public class SuppressionCommentFilterTest
         verifySuppressed(filterConfig, suppressed);
     }
 
-    private void verifySuppressed(Configuration aFilterConfig,
+    private void verifySuppressed(Configuration moduleConfig,
             String... aSuppressed)
             throws Exception {
-        verify(createChecker(aFilterConfig),
-               getPath("InputSuppressionCommentFilter.java"),
-               removeSuppressed(ALL_MESSAGES, aSuppressed));
+        verifySuppressed(moduleConfig, getPath("InputSuppressionCommentFilter.java"),
+               ALL_MESSAGES, aSuppressed);
     }
 
-    @Override
-    public Checker createChecker(Configuration moduleConfig)
-            throws CheckstyleException {
-        final DefaultConfiguration checkerConfig =
-            new DefaultConfiguration("configuration");
-        final DefaultConfiguration checksConfig = createModuleConfig(TreeWalker.class);
+    private void verifySuppressed(Configuration moduleConfig, String fileName,
+            String[] expectedViolations, String... suppressedViolations) throws Exception {
         final DefaultConfiguration memberNameCheckConfig =
                 createModuleConfig(MemberNameCheck.class);
         memberNameCheckConfig.addAttribute("id", "ignore");
-        checksConfig.addChild(memberNameCheckConfig);
+
         final DefaultConfiguration constantNameCheckConfig =
             createModuleConfig(ConstantNameCheck.class);
         constantNameCheckConfig.addAttribute("id", null);
-        checksConfig.addChild(constantNameCheckConfig);
-        checksConfig.addChild(createModuleConfig(IllegalCatchCheck.class));
-        checkerConfig.addChild(checksConfig);
+
+        final DefaultConfiguration treewalkerConfig = createModuleConfig(TreeWalker.class);
+        treewalkerConfig.addChild(memberNameCheckConfig);
+        treewalkerConfig.addChild(constantNameCheckConfig);
+        treewalkerConfig.addChild(createModuleConfig(IllegalCatchCheck.class));
+
         if (moduleConfig != null) {
-            checksConfig.addChild(moduleConfig);
+            treewalkerConfig.addChild(moduleConfig);
         }
-        final Checker checker = new Checker();
-        final Locale locale = Locale.ROOT;
-        checker.setLocaleCountry(locale.getCountry());
-        checker.setLocaleLanguage(locale.getLanguage());
-        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
-        checker.configure(checkerConfig);
-        checker.addListener(getBriefUtLogger());
-        return checker;
+
+        final DefaultConfiguration checkerConfig = createRootConfig(treewalkerConfig);
+
+        verify(checkerConfig, fileName,
+                removeSuppressed(expectedViolations, suppressedViolations));
     }
 
     private static String[] removeSuppressed(String[] from, String... remove) {
@@ -319,9 +312,8 @@ public class SuppressionCommentFilterTest
             "15:18: Name 'ID' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             };
 
-        verify(createChecker(filterConfig),
-            getPath("InputSuppressionCommentFilterSuppressById.java"),
-            removeSuppressed(expectedViolationMessages, suppressedViolationMessages));
+        verifySuppressed(filterConfig, getPath("InputSuppressionCommentFilterSuppressById.java"),
+                expectedViolationMessages, suppressedViolationMessages);
     }
 
     @Test


### PR DESCRIPTION
Issue #5157

Custom `verify` methods will be supported, however they shouldn't be creating configurations of the module being tested as we may not examine them for their properties.
Custom `create` methods will not be supported just like very custom property settings as there is too much variable in how they can be defined.

This fixes all cases.