### PR TITLE
minor: removed temporary issues that are closed

### DIFF
--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -91,13 +91,6 @@
         <Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE" />
     </Match>
     <Match>
-        <!-- Temporary disabled. Have to deal with Javadoc nodes as well
-         See https://github.com/checkstyle/checkstyle/issues/3432-->
-        <Class name="com.puppycrawl.tools.checkstyle.gui.TreeTable" />
-        <Method name="makeCodeSelection"/>
-        <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
-    </Match>
-    <Match>
         <!-- false-positive. Bugs reported even though casting is done only after verification using instanceof -->
         <Class name="com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser"/>
         <Method name="parseJavadocAsDetailNode"/>

--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -2091,8 +2091,6 @@ isolated classes and we cannot put them to separate package as it will affect us
                      See https://github.com/checkstyle/checkstyle/issues/2285-->
                 <option value="ProhibitedExceptionThrown" />
                 <option value="MismatchedQueryAndUpdateOfCollection" />
-                <!-- Till https://github.com/checkstyle/checkstyle/issues/3066 -->
-                <option value="ProhibitedExceptionCaught" />
                 <!-- No way to split apart huge if/else branches in test. -->
                 <option value="IfStatementWithTooManyBranches" />
                 <!-- we have to catch Exception in Checker and rethrow it -->

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
@@ -143,7 +143,6 @@ public class AllTestsTest {
 
             // until https://github.com/checkstyle/checkstyle/issues/5105
             if (!path.contains(File.separatorChar + "grammars" + File.separatorChar)
-                    // until https://github.com/checkstyle/checkstyle/issues/5104
                     && !path.contains(File.separatorChar + "foo" + File.separatorChar)
                     && !path.contains(File.separatorChar + "bar" + File.separatorChar)) {
                 String fileName = file.getName();


### PR DESCRIPTION
I did a search on all issues in our source and looked for ones that were closed and waiting for some fix.
The command I used was: `grep -ohr  "https://github.com/checkstyle/checkstyle/issues/[0-9]*" ~/opensource/checkstyle --exclude="releasenotes.xml" --exclude="releasenotes_old.xml" | sort -u -f`
Inputs could also be skipped in the search.
