### PR TITLE
Pull #5321: fixed bug on matching xpath when no xpath given

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilter.java
@@ -121,8 +121,12 @@ public class XpathFilter implements TreeWalkerFilter {
      * @return true is matching
      */
     private boolean isXpathQueryMatching(TreeWalkerAuditEvent event) {
-        boolean isMatching = false;
-        if (xpathExpression != null) {
+        boolean isMatching;
+        if (xpathExpression == null) {
+            isMatching = true;
+        }
+        else {
+            isMatching = false;
             final List<Item> items = getItems(event);
             for (Item item : items) {
                 final AbstractNode abstractNode = (AbstractNode) item;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterTest.java
@@ -135,7 +135,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
                 TokenTypes.VARIABLE_DEF);
         final XpathFilter filter =
                 new XpathFilter("InputXpathFilterSuppressByXpath", "Test", null, null);
-        assertTrue("Event should be accepted", filter.accept(event));
+        assertFalse("Event should be rejected", filter.accept(event));
     }
 
     @Test


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/5236#issuecomment-349042760 ,

The constructor takes all the same fields as SuppressElement, but [it also takes an optional `xpathQuery`](https://github.com/checkstyle/checkstyle/blob/f994512712c08a16def4a3c5a0426b7ab1590cc9/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilter.java#L85-L88).
For other elements, [it is considered matching if the optional parameter is `null`](https://github.com/checkstyle/checkstyle/blob/f994512712c08a16def4a3c5a0426b7ab1590cc9/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilter.java#L114).

However as of right now, [`xpathQuery` it is considered not a match if is not given](https://github.com/checkstyle/checkstyle/blob/f994512712c08a16def4a3c5a0426b7ab1590cc9/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilter.java#L123-L125).
This seems wrong. An optional parameter should automatically be a match if it is not given. If anything is given without `xpathQuery` it should act the exact same as a `SuppressElement` as they are identical.