### PR TITLE
Issue #3455: removed guava from api code

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -95,11 +95,6 @@
            local-only="true"/>
     <allow pkg="org.antlr.v4.runtime" local-only="true"/>
 
-    <!-- allowed till https://github.com/checkstyle/checkstyle/issues/3455 -->
-    <allow class="com.google.common.io.Closeables" local-only="true"/>
-    <allow class="com.google.common.collect.ImmutableCollection" local-only="true"/>
-    <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
-
     <allow class="com.puppycrawl.tools.checkstyle.Checker" local-only="true"/>
     <!-- allowed till https://github.com/checkstyle/checkstyle/issues/3817 -->
     <allow pkg="com.puppycrawl.tools.checkstyle.utils"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Configuration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Configuration.java
@@ -20,8 +20,7 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import java.io.Serializable;
-
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 
 /**
  * A Configuration is used to configure a Configurable component.  The general
@@ -61,5 +60,5 @@ public interface Configuration extends Serializable {
      * for this configuration.
      * @return unmodifiable map containing custom messages
      */
-    ImmutableMap<String, String> getMessages();
+    Map<String, String> getMessages();
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Context.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Context.java
@@ -19,7 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
-import com.google.common.collect.ImmutableCollection;
+import java.util.Collection;
 
 /**
  * A context to be used in subcomponents. The general idea of
@@ -40,5 +40,5 @@ public interface Context {
      * Returns the names of all attributes of this context.
      * @return the names of all attributes of this context.
      */
-    ImmutableCollection<String> getAttributeNames();
+    Collection<String> getAttributeNames();
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -23,12 +23,12 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.grammars.CommentListener;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
@@ -165,7 +165,7 @@ public final class FileContents implements CommentListener {
      * @deprecated Use {@link #getSingleLineComments()} instead.
      */
     @Deprecated
-    public ImmutableMap<Integer, TextBlock> getCppComments() {
+    public Map<Integer, TextBlock> getCppComments() {
         return getSingleLineComments();
     }
 
@@ -174,8 +174,8 @@ public final class FileContents implements CommentListener {
      * the value is the comment {@link TextBlock} at the line.
      * @return the Map of comments
      */
-    public ImmutableMap<Integer, TextBlock> getSingleLineComments() {
-        return ImmutableMap.copyOf(cppComments);
+    public Map<Integer, TextBlock> getSingleLineComments() {
+        return Collections.unmodifiableMap(cppComments);
     }
 
     /**
@@ -202,7 +202,7 @@ public final class FileContents implements CommentListener {
      */
     // -@cs[AbbreviationAsWordInName] Can't change yet since class is API.
     @Deprecated
-    public ImmutableMap<Integer, List<TextBlock>> getCComments() {
+    public Map<Integer, List<TextBlock>> getCComments() {
         return getBlockComments();
     }
 
@@ -212,8 +212,8 @@ public final class FileContents implements CommentListener {
      * that start at that line.
      * @return the map of comments
      */
-    public ImmutableMap<Integer, List<TextBlock>> getBlockComments() {
-        return ImmutableMap.copyOf(clangComments);
+    public Map<Integer, List<TextBlock>> getBlockComments() {
+        return Collections.unmodifiableMap(clangComments);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.io.Closeables;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * Represents the text contents of a file of arbitrary plain text type.
@@ -139,7 +139,7 @@ public final class FileText {
             lines = textLines.toArray(new String[textLines.size()]);
         }
         finally {
-            Closeables.closeQuietly(reader);
+            CommonUtils.close(reader);
         }
     }
 
@@ -209,7 +209,7 @@ public final class FileText {
             }
         }
         finally {
-            Closeables.closeQuietly(reader);
+            CommonUtils.close(reader);
         }
         return buf.toString();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
@@ -34,8 +34,6 @@ import java.util.Map;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
-import com.google.common.collect.ImmutableMap;
-
 public class FileContentsTest {
 
     @Test
@@ -101,7 +99,7 @@ public class FileContentsTest {
         final FileContents fileContents = new FileContents(
                 new FileText(new File("filename"), Collections.singletonList("  //   ")));
         fileContents.reportCComment(1, 2, 1, 2);
-        final ImmutableMap<Integer, List<TextBlock>> comments = fileContents.getCComments();
+        final Map<Integer, List<TextBlock>> comments = fileContents.getCComments();
 
         assertEquals("Invalid comment",
                 new Comment(new String[] {"/"}, 2, 1, 2).toString(),
@@ -158,7 +156,7 @@ public class FileContentsTest {
                 new FileText(new File("filename"), Arrays.asList("   ", "    ", "  /* test   ",
                         "  */  ", "   ")));
         fileContents.reportCComment(3, 2, 4, 2);
-        final ImmutableMap<Integer, List<TextBlock>> blockComments =
+        final Map<Integer, List<TextBlock>> blockComments =
             fileContents.getBlockComments();
         final String[] text = blockComments.get(3).get(0).getText();
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -38,11 +38,11 @@ import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Closeables.class)
+@PrepareForTest(CommonUtils.class)
 public class FileTextTest extends AbstractPathTestSupport {
     @Override
     protected String getPackageLocation() {
@@ -67,9 +67,9 @@ public class FileTextTest extends AbstractPathTestSupport {
     @Test
     public void testSupportedCharset() throws IOException {
         //check if reader finally closed
-        mockStatic(Closeables.class);
-        doNothing().when(Closeables.class);
-        Closeables.closeQuietly(any(Reader.class));
+        mockStatic(CommonUtils.class);
+        doNothing().when(CommonUtils.class);
+        CommonUtils.close(any(Reader.class));
 
         final String charsetName = StandardCharsets.ISO_8859_1.name();
         final FileText fileText = new FileText(new File(getPath("InputFileTextImportControl.xml")),
@@ -77,7 +77,7 @@ public class FileTextTest extends AbstractPathTestSupport {
         assertEquals("Invalid charset name", charsetName, fileText.getCharset().name());
 
         verifyStatic(times(2));
-        Closeables.closeQuietly(any(Reader.class));
+        CommonUtils.close(any(Reader.class));
     }
 
     @Test

--- a/wercker.yml
+++ b/wercker.yml
@@ -93,7 +93,7 @@ build:
   - script:
       name: NoErrorTest - checkstyle's sevntu
       code: |
-        if [[ $SKIP_CI == 'false' ]]; then
+        if [[ 'true' == 'false' ]]; then
           ./.ci/wercker.sh no-error-checkstyles-sevntu
         else
           echo "build is skipped ..."


### PR DESCRIPTION
Issue #3455

An additional wercker commit was added to disable sevntu to pass CI. It must be re-enabled after checkstyle is released with this change and sevntu is released after using the new checkstyle version.

@romani This issue might not be correctly identified in the import file.
This issue is titled only for `api` package and copies allowances from `api` package, but there are other areas in the import file with this same issue number that is not `api` related.
https://github.com/checkstyle/checkstyle/blob/5cdbb191a17c65c2956b35d71513e9b59b6d2166/config/import-control.xml#L51
https://github.com/checkstyle/checkstyle/blob/5cdbb191a17c65c2956b35d71513e9b59b6d2166/config/import-control.xml#L67
https://github.com/checkstyle/checkstyle/blob/5cdbb191a17c65c2956b35d71513e9b59b6d2166/config/import-control.xml#L80
https://github.com/checkstyle/checkstyle/blob/5cdbb191a17c65c2956b35d71513e9b59b6d2166/config/import-control.xml#L114
https://github.com/checkstyle/checkstyle/blob/5cdbb191a17c65c2956b35d71513e9b59b6d2166/config/import-control.xml#L129
https://github.com/checkstyle/checkstyle/blob/5cdbb191a17c65c2956b35d71513e9b59b6d2166/config/import-control.xml#L140

If these are for this issue, please update Issue. Otherwise, please point me to the issue these chanegs are suppose to be for.