### PR TITLE
minor: locked down abstract test classes from overriding

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/AbstractModuleTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/AbstractModuleTestSupport.java
@@ -87,7 +87,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * Returns test logger.
      * @return logger test logger
      */
-    public BriefUtLogger getBriefUtLogger() {
+    public final BriefUtLogger getBriefUtLogger() {
         return new BriefUtLogger(stream);
     }
 
@@ -122,7 +122,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @return {@link Checker} instance based on the given {@link Configuration} instance.
      * @throws Exception if an exception occurs during checker configuration.
      */
-    public Checker createChecker(Configuration moduleConfig)
+    public final Checker createChecker(Configuration moduleConfig)
             throws Exception {
         if (checkstyleModules == null) {
             checkstyleModules = CheckUtil.getCheckstyleModules();
@@ -153,7 +153,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @return {@link Checker} instance.
      * @throws CheckstyleException if an exception occurs during checker configuration.
      */
-    protected Checker createChecker(Configuration moduleConfig,
+    protected final Checker createChecker(Configuration moduleConfig,
                                     ModuleCreationOption moduleCreationOption)
             throws Exception {
         final DefaultConfiguration dc;
@@ -183,7 +183,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param config {@link Configuration} instance.
      * @return {@link DefaultConfiguration} for the {@link Checker}.
      */
-    protected DefaultConfiguration createTreeWalkerConfig(Configuration config) {
+    protected static DefaultConfiguration createTreeWalkerConfig(Configuration config) {
         final DefaultConfiguration dc =
                 new DefaultConfiguration("configuration");
         final DefaultConfiguration twConf = createModuleConfig(TreeWalker.class);
@@ -199,7 +199,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param config {@link Configuration} instance.
      * @return {@link DefaultConfiguration} for the given {@link Configuration} instance.
      */
-    protected DefaultConfiguration createRootConfig(Configuration config) {
+    protected static DefaultConfiguration createRootConfig(Configuration config) {
         final DefaultConfiguration dc = new DefaultConfiguration("root");
         dc.addChild(config);
         return dc;
@@ -218,7 +218,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param warnsExpected an array of expected warning numbers.
      * @throws Exception if exception occurs during verification process.
      */
-    protected void verify(Configuration config, String fileName, String[] expected,
+    protected final void verify(Configuration config, String fileName, String[] expected,
             Integer... warnsExpected) throws Exception {
         verify(createChecker(config),
                 new File[] {new File(fileName)},
@@ -234,7 +234,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param warnsExpected an array of expected warning line numbers.
      * @throws Exception if exception occurs during verification process.
      */
-    protected void verify(Checker checker,
+    protected final void verify(Checker checker,
             File[] processedFiles,
             String messageFileName,
             String[] expected,
@@ -284,7 +284,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param messageKey the key of message in 'messages.properties' file.
      * @param arguments  the arguments of message in 'messages.properties' file.
      */
-    protected String getCheckMessage(Class<? extends AbstractViolationReporter> aClass,
+    protected static String getCheckMessage(Class<? extends AbstractViolationReporter> aClass,
             String messageKey, Object... arguments) {
         String checkMessage;
         try {
@@ -305,7 +305,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param messageKey the key of message in 'messages.properties' file.
      * @param arguments the arguments of message in 'messages.properties' file.
      */
-    protected String getCheckMessage(Map<String, String> messages, String messageKey,
+    protected static String getCheckMessage(Map<String, String> messages, String messageKey,
             Object... arguments) {
         String checkMessage = null;
         for (Map.Entry<String, String> entry : messages.entrySet()) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -81,7 +81,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * Returns test logger.
      * @return logger for tests
      */
-    public BriefUtLogger getBriefUtLogger() {
+    public final BriefUtLogger getBriefUtLogger() {
         return new BriefUtLogger(stream);
     }
 
@@ -95,7 +95,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @return {@link Checker} instance based on the given {@link Configuration} instance.
      * @throws Exception if an exception occurs during checker configuration.
      */
-    public Checker createChecker(Configuration moduleConfig)
+    public final Checker createChecker(Configuration moduleConfig)
             throws Exception {
         ModuleCreationOption moduleCreationOption = ModuleCreationOption.IN_CHECKER;
 
@@ -124,7 +124,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @return {@link Checker} instance based on the given {@link Configuration} instance.
      * @throws Exception if an exception occurs during checker configuration.
      */
-    public Checker createChecker(Configuration moduleConfig,
+    public final Checker createChecker(Configuration moduleConfig,
                                  ModuleCreationOption moduleCreationOption)
             throws Exception {
         final Checker checker = new Checker();
@@ -152,7 +152,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @return {@link DefaultConfiguration} for the {@link TreeWalker}
      * based on the given {@link Configuration} instance.
      */
-    protected DefaultConfiguration createTreeWalkerConfig(Configuration config) {
+    protected static DefaultConfiguration createTreeWalkerConfig(Configuration config) {
         final DefaultConfiguration dc =
                 new DefaultConfiguration("configuration");
         final DefaultConfiguration twConf = createModuleConfig(TreeWalker.class);
@@ -168,7 +168,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param config {@link Configuration} instance.
      * @return {@link DefaultConfiguration} for the given {@link Configuration} instance.
      */
-    protected DefaultConfiguration createRootConfig(Configuration config) {
+    protected static DefaultConfiguration createRootConfig(Configuration config) {
         final DefaultConfiguration dc = new DefaultConfiguration(ROOT_MODULE_NAME);
         if (config != null) {
             dc.addChild(config);
@@ -198,7 +198,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param filename file name.
      * @return URI-representation of the path for the file with the given file name.
      */
-    protected String getUriString(String filename) {
+    protected final String getUriString(String filename) {
         return new File("src/test/resources/" + getPackageLocation() + "/" + filename).toURI()
                 .toString();
     }
@@ -213,7 +213,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param expected an array of expected messages.
      * @throws Exception if exception occurs during verification process.
      */
-    protected void verify(Configuration aConfig, String fileName, String... expected)
+    protected final void verify(Configuration aConfig, String fileName, String... expected)
             throws Exception {
         verify(createChecker(aConfig), fileName, fileName, expected);
     }
@@ -246,7 +246,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param expected an array of expected messages.
      * @throws Exception if exception occurs during verification process.
      */
-    protected void verify(Checker checker,
+    protected final void verify(Checker checker,
                           String processedFilename,
                           String messageFileName,
                           String... expected)
@@ -299,7 +299,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param expectedViolations a map of expected violations per files.
      * @throws Exception if exception occurs during verification process.
      */
-    protected void verify(Checker checker,
+    protected final void verify(Checker checker,
                           File[] processedFiles,
                           Map<String, List<String>> expectedViolations)
             throws Exception {
@@ -384,7 +384,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param messageKey the key of message in 'messages.properties' file.
      * @param arguments  the arguments of message in 'messages.properties' file.
      */
-    protected String getCheckMessage(String messageKey, Object... arguments) {
+    protected final String getCheckMessage(String messageKey, Object... arguments) {
         return internalGetCheckMessage(getMessageBundle(), messageKey, arguments);
     }
 


### PR DESCRIPTION
This change is to lock down our main abstract test classes from overriding to make it clear it isn't allowed anymore. We should be using what we built, instead of re-inventing things. If something is wrong with these classes, then they should be fixed.
See conversation at https://github.com/checkstyle/checkstyle/pull/5213#discussion_r155634192 .

I am unable to lockdown 2 methods, one in test and the other in IT.

https://github.com/checkstyle/checkstyle/blob/acb8b7f8da7336eebb9eac6c25680cc83c65be5d/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java#L208
This can't be swapped because `WriteTagCheck` prints violations as `info` and it messes up the audit count because we only count errors. I will continue looking into how to remedy this.

https://github.com/checkstyle/checkstyle/blob/6d290adcd7efb8e9f07d2730e9960c6dc3e713ba/src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java#L58
This could easily be swapped with the called method in the class that uses it, but I think we might want to consider removing `AbstractIndentationTestSupport` completely since only 1 class uses it and in `test` we have no problem with all indentation being in 1 class.

Just from observation, I am not sure why we have some of these methods as `public` which seems slightly weird.