### PR TITLE
Issue #4675: increased pitest coverage for misc package

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
@@ -80,6 +80,27 @@ public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testFormat() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(TrailingCommentCheck.class);
+        checkConfig.addAttribute("format", "NOT MATCH");
+        final String[] expected = {
+            "4: " + getCheckMessage(MSG_KEY),
+            "5: " + getCheckMessage(MSG_KEY),
+            "6: " + getCheckMessage(MSG_KEY),
+            "7: " + getCheckMessage(MSG_KEY),
+            "8: " + getCheckMessage(MSG_KEY),
+            "13: " + getCheckMessage(MSG_KEY),
+            "14: " + getCheckMessage(MSG_KEY),
+            "15: " + getCheckMessage(MSG_KEY),
+            "18: " + getCheckMessage(MSG_KEY),
+            "19: " + getCheckMessage(MSG_KEY),
+            "26: " + getCheckMessage(MSG_KEY),
+            "29: " + getCheckMessage(MSG_KEY),
+        };
+        verify(checkConfig, getPath("InputTrailingComment.java"), expected);
+    }
+
+    @Test
     public void testCallVisitToken() {
         final TrailingCommentCheck check = new TrailingCommentCheck();
         try {


### PR DESCRIPTION
Issue #4675

@romani This is missing line coverage, not mutation coverage.
Shippable isn't picking this up because it uses a different class name.
You are searching for `survived` when this had a class of `uncovered`. Shippable needs to be updated. Please make the update since you are better with shell scripts.
https://github.com/checkstyle/checkstyle/blob/master/shippable.yml#L55