### PR TITLE
Pull #5351: fixed RequireThisCheck and catch variable handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1110,8 +1110,7 @@
           <!-- generated classes, unfortunately use problematic api -->
           <exclude>**/GeneratedJavaLexer.class</exclude>
           <exclude>**/JavadocParser.class</exclude>
-          <!-- excluded till https://github.com/policeman-tools/forbidden-apis/issues/108-->
-          <exclude>**/checks/annotation/annotationlocation/InputAnnotationLocationDeprecatedAndCustom*</exclude>
+          <exclude>**/Input*</exclude>
         </excludes>
       </configuration>
       <executions>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import static com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck.MSG_METHOD;
 import static com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck.MSG_VARIABLE;
 
+import java.lang.reflect.Constructor;
 import java.util.SortedSet;
 
 import org.junit.Assert;
@@ -33,6 +34,7 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class RequireThisCheckTest extends AbstractModuleTestSupport {
@@ -296,6 +298,16 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testCatchVariables() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RequireThisCheck.class);
+        checkConfig.addAttribute("validateOnlyOverlapping", "false");
+        final String[] expected = {
+            "29:21: " + getCheckMessage(MSG_VARIABLE, "ex", ""),
+        };
+        verify(checkConfig, getPath("InputRequireThisCatchVariables.java"), expected);
+    }
+
+    @Test
     public void test() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(RequireThisCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
@@ -308,5 +320,19 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("validateOnlyOverlapping", "false");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputRequireThisExtendedMethod.java"), expected);
+    }
+
+    @Test
+    public void testUnusedMethod() throws Exception {
+        final DetailAST ident = new DetailAST();
+        ident.setText("testName");
+
+        final Class<?> cls = Class.forName(RequireThisCheck.class.getName() + "$CatchFrame");
+        final Constructor<?> constructor = cls.getDeclaredConstructors()[0];
+        constructor.setAccessible(true);
+        final Object o = constructor.newInstance(null, ident);
+
+        Assert.assertEquals("expected ident token", ident,
+                TestUtil.getClassDeclaredMethod(cls, "getFrameNameIdent").invoke(o));
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisCatchVariables.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisCatchVariables.java
@@ -1,0 +1,40 @@
+package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
+
+public class InputRequireThisCatchVariables extends Thread {
+    private Throwable ex;
+
+    public InputRequireThisCatchVariables(Throwable ex) {
+        this.ex = ex;
+    }
+
+    @Override
+    public void run() {
+        if (this.ex != null) {
+            try {
+                exceptional(this.ex);
+            }
+            catch (RuntimeException ex) {
+                if (ex == this.ex) {
+                    debug("Expected exception thrown", ex);
+                }
+                else {
+                    ex.printStackTrace();
+                }
+            }
+            catch (Error err) {
+                if (err == this.ex) {
+                    debug("Expected exception thrown", err);
+                }
+                else {
+                    ex.printStackTrace();
+                }
+            }
+            catch (Throwable ex) {
+                ex.printStackTrace();
+            }
+        }
+    }
+
+    private static void exceptional(Throwable ex) {}
+    private static void debug(String message, Throwable err) {}
+}


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/issues/5307#issuecomment-351240617

Catch variables are seen in the scope of the try block instead of the catch block.

Easy printout of frame tree with this changes: https://github.com/rnveach/checkstyle/commit/aad8b0382813c6abadf951b603b2e884bb4a0478#diff-6b1f89f1bde0470d4bd42580d1aa8bfb
Regression: http://rveach.no-ip.org/checkstyle/regression/reports/143/
http://rveach.no-ip.org/checkstyle/regression/reports/143/spring-framework/index.html#A1