### PR TITLE
minor: fixed missing coverage in SeverityMatchFilter

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterTest.java
@@ -20,11 +20,14 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 
@@ -85,5 +88,11 @@ public class SeverityMatchFilterTest {
             null, getClass(), null);
         final AuditEvent ev3 = new AuditEvent(this, "ATest.java", infoMessage);
         assertFalse("level:" + infoLevel, filter.accept(ev3));
+    }
+
+    @Test
+    public void testConfigure() throws CheckstyleException {
+        filter.configure(new DefaultConfiguration("test"));
+        assertNotNull("object exists", filter);
     }
 }


### PR DESCRIPTION
Fix for missing coverage in master that pitest caught.

35c607f167d79343258926919799dab9bce9d33b added a new method to the class and no new tests were added.
a3ea8636e224f854ce56450c65139a805a9fab6f forced violations if pitest had uncovered lines.
The 2 in the end conflicted with one another.