### PR TITLE
Pull #5361: fixed RequireThisCheck and enum constants handling

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -367,6 +367,10 @@ public class RequireThisCheck extends AbstractCheck {
                 final DetailAST ctorFrameNameIdent = ast.findFirstToken(TokenTypes.IDENT);
                 frameStack.addFirst(new ConstructorFrame(frame, ctorFrameNameIdent));
                 break;
+            case TokenTypes.ENUM_CONSTANT_DEF :
+                final DetailAST ident = ast.findFirstToken(TokenTypes.IDENT);
+                ((ClassFrame) frame).addStaticMember(ident);
+                break;
             case TokenTypes.LITERAL_CATCH:
                 final AbstractFrame catchFrame = new CatchFrame(frame, ast);
                 catchFrame.addIdent(ast.findFirstToken(TokenTypes.PARAMETER_DEF).findFirstToken(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -308,6 +308,14 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testEnumConstant() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RequireThisCheck.class);
+        checkConfig.addAttribute("validateOnlyOverlapping", "false");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputRequireThisEnumConstant.java"), expected);
+    }
+
+    @Test
     public void test() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(RequireThisCheck.class);
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisEnumConstant.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisEnumConstant.java
@@ -1,0 +1,13 @@
+package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
+
+public class InputRequireThisEnumConstant {
+    private final String TEST = "";
+    
+    public enum TestEnum {
+        TEST;
+
+        public TestEnum method() {
+            return TEST;
+        }
+    }
+}


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/issues/5307#issuecomment-351240617

Enumerations don't see enumeration constants at all.

Easy printout of frame tree with this changes: https://github.com/rnveach/checkstyle/commit/b5840705bde5c53316717f265289d0b0af8aa045#diff-6b1f89f1bde0470d4bd42580d1aa8bfb
Regression: http://rveach.no-ip.org/checkstyle/regression/reports/143/

Regression was done in parallel with https://github.com/checkstyle/checkstyle/pull/5351 and it only showed regression for the other PR, so there is no regression with this PR.
Most likely it is because users don't write non-static variables in this casing.

The following shows the issue without the enum constants using the input file with the released CS version:
````
$ cat TestClass.java
package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;

public class InputRequireThisEnumConstant {
    private final String TEST = "";
    
    public enum TestEnum {
        TEST;

        public TestEnum method() {
            return TEST;
        }
    }
}


$ cat TestConfig.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>

    <module name="TreeWalker">
<module name="RequireThisCheck">
<property name="validateOnlyOverlapping" value="false" />
</module>
    </module>
</module>

$ java -jar checkstyle-8.5-all.jar -c TestConfig.xml TestClass.java
Starting audit...
[ERROR] TestClass.java:10:20: Reference to instance variable 'TEST' needs "InputRequireThisEnumConstant.this.". [RequireThis]
Audit done.
Checkstyle ends with 1 errors.
````

`TEST` can't be `this` because we are referencing the enum's constant and not the class' field.