### PR TITLE
Pull #5364: changed RequireThis kept track of the frame being examined

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -145,11 +145,11 @@ public class RequireThisCheck extends AbstractCheck {
             TokenTypes.BXOR_ASSIGN,
         }).collect(Collectors.toSet()));
 
+    /** Frame for the currently processed AST. */
+    private final Deque<AbstractFrame> current = new ArrayDeque<>();
+
     /** Tree of all the parsed frames. */
     private Map<DetailAST, AbstractFrame> frames;
-
-    /** Frame for the currently processed AST. */
-    private AbstractFrame current;
 
     /** Whether we should check fields usage. */
     private boolean checkFields = true;
@@ -208,7 +208,7 @@ public class RequireThisCheck extends AbstractCheck {
     @Override
     public void beginTree(DetailAST rootAST) {
         frames = new HashMap<>();
-        current = null;
+        current.clear();
 
         final Deque<AbstractFrame> frameStack = new LinkedList<>();
         DetailAST curNode = rootAST;
@@ -239,7 +239,24 @@ public class RequireThisCheck extends AbstractCheck {
             case TokenTypes.SLIST :
             case TokenTypes.METHOD_DEF :
             case TokenTypes.CTOR_DEF :
-                current = frames.get(ast);
+                current.push(frames.get(ast));
+                break;
+            default :
+                // do nothing
+        }
+    }
+
+    @Override
+    public void leaveToken(DetailAST ast) {
+        switch (ast.getType()) {
+            case TokenTypes.CLASS_DEF :
+            case TokenTypes.INTERFACE_DEF :
+            case TokenTypes.ENUM_DEF :
+            case TokenTypes.ANNOTATION_DEF :
+            case TokenTypes.SLIST :
+            case TokenTypes.METHOD_DEF :
+            case TokenTypes.CTOR_DEF :
+                current.pop();
                 break;
             default :
                 // do nothing
@@ -836,7 +853,7 @@ public class RequireThisCheck extends AbstractCheck {
      * @return AbstractFrame containing declaration or null.
      */
     private AbstractFrame findClassFrame(DetailAST name, boolean lookForMethod) {
-        AbstractFrame frame = current;
+        AbstractFrame frame = current.peek();
 
         while (true) {
             frame = findFrame(frame, name, lookForMethod);
@@ -858,7 +875,7 @@ public class RequireThisCheck extends AbstractCheck {
      * @return AbstractFrame containing declaration or null.
      */
     private AbstractFrame findFrame(DetailAST name, boolean lookForMethod) {
-        return findFrame(current, name, lookForMethod);
+        return findFrame(current.peek(), name, lookForMethod);
     }
 
     /**
@@ -912,7 +929,7 @@ public class RequireThisCheck extends AbstractCheck {
      * @return the name of the nearest parent ClassFrame.
      */
     private String getNearestClassFrameName() {
-        AbstractFrame frame = current;
+        AbstractFrame frame = current.peek();
         while (frame.getType() != FrameType.CLASS_FRAME) {
             frame = frame.getParent();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -61,6 +61,8 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
             "122:13: " + getCheckMessage(MSG_VARIABLE, "i", "Issue2240."),
             "134:9: " + getCheckMessage(MSG_METHOD, "foo", ""),
             "142:9: " + getCheckMessage(MSG_VARIABLE, "s", ""),
+            "167:16: " + getCheckMessage(MSG_VARIABLE, "a", ""),
+            "167:20: " + getCheckMessage(MSG_VARIABLE, "a", ""),
         };
         verify(checkConfig,
                getPath("InputRequireThisEnumInnerClassesAndBugs.java"),
@@ -99,6 +101,8 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
             "114:9: " + getCheckMessage(MSG_VARIABLE, "i", ""),
             "122:13: " + getCheckMessage(MSG_VARIABLE, "i", "Issue2240."),
             "142:9: " + getCheckMessage(MSG_VARIABLE, "s", ""),
+            "167:16: " + getCheckMessage(MSG_VARIABLE, "a", ""),
+            "167:20: " + getCheckMessage(MSG_VARIABLE, "a", ""),
         };
         verify(checkConfig,
                getPath("InputRequireThisEnumInnerClassesAndBugs.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisEnumInnerClassesAndBugs.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisEnumInnerClassesAndBugs.java
@@ -150,3 +150,20 @@ class NestedRechange {
         }
     }
 }
+class NestedFrames {
+    int a = 0;
+
+    public int oneReturnInMethod2() {
+        for (int i = 0; i < 10; i++) {
+            int a = 1;
+            if (a != 2 && true) {
+                if (true | false) {
+                    if (a - a != 0) {
+                        a += 1;
+                    }
+                }
+            }
+        }
+        return a + a * a;
+    }
+}


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/issues/5307#issuecomment-352307935 .
We assign current on a visit, but we don't reset it when we leave a token. So check thinks we are still in the previous frame, when we are back in the parent.

Here is proof:
````
$ cat TestClass.java
class NestedFrames {
    int a = 0;

    public int oneReturnInMethod2() {
        for (int i = 0; i < 10; i++) {
            int a = 1;
            if (a != 2 && true) {
                if (true | false) {
                    if (a - a != 0) {
                        a += 1;
                    }
                }
            }
        }
        return a + a * a;
    }
}

$ cat TestConfig.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>

    <module name="TreeWalker">
    <module name="RequireThisCheck">
      <property name="validateOnlyOverlapping" value="false" />
     </module>
    </module>
</module>

$ java -jar checkstyle-8.5-all.jar -c TestConfig.xml TestClass.java
Starting audit...
Audit done.
````
Expecting a violation for `return a + a * a` as `a` is not the local variable `a`, but the class field and thus should be a violation for `this`.

--------------------------

Regression: http://rveach.no-ip.org/checkstyle/regression/reports/147/

We are seeing alot of differences.
http://rveach.no-ip.org/checkstyle/regression/reports/147/sevntu-checkstyle/index.html#A7
These are new violations, added in the test.
http://rveach.no-ip.org/checkstyle/regression/reports/147/guava-mvnstyle/index.html#A259
These violations are removed as list is a local variable, not the anonymous class' same variable name.

All other differences are changes in violation messages from `InnerClass.this` to just `this`.