### PR TITLE
minor: fix typos

### DIFF
--- a/.ci/idea_inspection.sh
+++ b/.ci/idea_inspection.sh
@@ -42,7 +42,7 @@ echo $IDEA_OUTPUT
 if [[ $IDEA_OUTPUT == "Already running" ]]; then
     echo "It might be that Intellij Idea is running, please close it."
     exit 1;
-else
+fi
 
 echo "Checking results ..."
 if [[ $(grep -R "<problems" $RESULTS_DIR/ | cat | wc -l ) > 0 ]]; then

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -223,7 +223,7 @@ public final class ConfigurationLoader {
      *            'ignore' should be omitted, {@code false} otherwise
      * @return the check configurations
      * @throws CheckstyleException if an error occurs
-     * @deprecated in order to fullfil demands of BooleanParameter IDEA check.
+     * @deprecated in order to fulfill demands of BooleanParameter IDEA check.
      * @noinspection BooleanParameter
      */
     @Deprecated
@@ -244,7 +244,7 @@ public final class ConfigurationLoader {
      * @param threadModeSettings the thread mode configuration
      * @return the check configurations
      * @throws CheckstyleException if an error occurs
-     * @deprecated in order to fullfil demands of BooleanParameter IDEA check.
+     * @deprecated in order to fulfill demands of BooleanParameter IDEA check.
      * @noinspection BooleanParameter, WeakerAccess
      */
     @Deprecated
@@ -296,7 +296,7 @@ public final class ConfigurationLoader {
      *            'ignore' should be omitted, {@code false} otherwise
      * @return the check configurations
      * @throws CheckstyleException if an error occurs
-     * @deprecated in order to fullfil demands of BooleanParameter IDEA check.
+     * @deprecated in order to fulfill demands of BooleanParameter IDEA check.
      * @noinspection BooleanParameter
      */
     @Deprecated
@@ -319,7 +319,7 @@ public final class ConfigurationLoader {
      * @param threadModeSettings the thread mode configuration
      * @return the check configurations
      * @throws CheckstyleException if an error occurs
-     * @deprecated in order to fullfil demands of BooleanParameter IDEA check.
+     * @deprecated in order to fulfill demands of BooleanParameter IDEA check.
      * @noinspection BooleanParameter, WeakerAccess
      */
     @Deprecated

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
@@ -78,7 +78,7 @@ public class DefaultLogger extends AutomaticBean implements AuditListener {
      * Creates a new {@code DefaultLogger} instance.
      * @param outputStream where to log infos and errors
      * @param closeStreamsAfterUse if oS should be closed in auditFinished()
-     * @deprecated in order to fullfil demands of BooleanParameter IDEA check.
+     * @deprecated in order to fulfill demands of BooleanParameter IDEA check.
      * @noinspection BooleanParameter
      */
     @Deprecated
@@ -93,7 +93,7 @@ public class DefaultLogger extends AutomaticBean implements AuditListener {
      * @param closeInfoAfterUse auditFinished should close infoStream.
      * @param errorStream the {@code OutputStream} for error messages.
      * @param closeErrorAfterUse auditFinished should close errorStream
-     * @deprecated in order to fullfil demands of BooleanParameter IDEA check.
+     * @deprecated in order to fulfill demands of BooleanParameter IDEA check.
      * @noinspection BooleanParameter
      */
     @Deprecated
@@ -113,7 +113,7 @@ public class DefaultLogger extends AutomaticBean implements AuditListener {
      * @param errorStream the {@code OutputStream} for error messages
      * @param closeErrorAfterUse auditFinished should close errorStream
      * @param messageFormatter formatter for the log message.
-     * @deprecated in order to fullfil demands of BooleanParameter IDEA check.
+     * @deprecated in order to fulfill demands of BooleanParameter IDEA check.
      * @noinspection BooleanParameter, WeakerAccess
      */
     @Deprecated

--- a/src/main/java/com/puppycrawl/tools/checkstyle/FileStatefulCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/FileStatefulCheck.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
  * Checker guarantees that each check instance processes only one file at the same time.
  * Checker guarantees that all check instances have equal (but not the same) configuration.
  * It means, that if a check holds a property of type "array of strings",
- * the property value will not be shared accross check instances.
+ * the property value will not be shared across check instances.
  * Instead, each check instance will hold its own array instance.
  * Checker does not guarantee that each file will have it's own thread -
  * there might be a list of files, which will be executed on the same thread.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/GlobalStatefulCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/GlobalStatefulCheck.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * The check methods and fields should be thread safe, because they may be accessed from others
  * threads at the same time.
  * Checker guarantees that there will be exactly one check instance
- * This is simular to multi-file validation, which checkstyle does not support fully yet.
+ * This is similar to multi-file validation, which checkstyle does not support fully yet.
  * Please refer to https://github.com/checkstyle/checkstyle/issues/3540 for details.
  * @author Andrew Kuchev
  * @noinspection AnnotationClass, ClassIndependentOfModule, unused

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -55,7 +55,7 @@ public class PackageObjectFactory implements ModuleFactory {
      */
     public enum ModuleLoadOption {
         /**
-         * Searching from registred checkstyle modules and from packages given in countructor.
+         * Searching from registered checkstyle modules and from packages given in constructor.
          **/
         SEARCH_REGISTERED_PACKAGES,
         /**
@@ -73,7 +73,7 @@ public class PackageObjectFactory implements ModuleFactory {
     public static final String UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE =
             "PackageObjectFactory.unableToInstantiateExceptionMessage";
 
-    /** Exception message when there is ambigugous module name in config file. */
+    /** Exception message when there is ambiguous module name in config file. */
     public static final String AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE =
             "PackageObjectFactory.ambiguousModuleNameExceptionMessage";
 
@@ -354,7 +354,7 @@ public class PackageObjectFactory implements ModuleFactory {
     }
 
     /**
-     * Searching to class with given name (or name concatinated with &quot;Check&quot;) in existing
+     * Searching to class with given name (or name concatenated with &quot;Check&quot;) in existing
      * packages. Returns instance if class found or, otherwise, null.
      * @param name the name of a class.
      * @return the {@code Object} created by loader.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -239,7 +239,7 @@ final class PropertyCacheFile {
 
     /**
      * Serializes object to output stream.
-     * @param object object to be erialized
+     * @param object object to be serialized
      * @param outputStream serialization stream
      * @throws IOException if an error occurs
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -82,7 +82,7 @@ public class XMLLogger
      * Sets the output to a defined stream.
      * @param outputStream the stream to write logs to.
      * @param closeStream close oS in auditFinished
-     * @deprecated in order to fullfil demands of BooleanParameter IDEA check.
+     * @deprecated in order to fulfill demands of BooleanParameter IDEA check.
      * @noinspection BooleanParameter
      */
     @Deprecated
@@ -200,7 +200,7 @@ public class XMLLogger
     }
 
     /**
-     * Outputs the given envet to the writer.
+     * Outputs the given event to the writer.
      * @param event An event to print.
      */
     private void writeFileError(AuditEvent event) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java
@@ -145,9 +145,9 @@ public class XmlLoader
         }
 
         /**
-         * Configures SAXParserFactory with features requered
-         * for exectution on very secured environments.
-         * @param factory factory to be configured with spectial features
+         * Configures SAXParserFactory with features required
+         * for execution on very secured environments.
+         * @param factory factory to be configured with special features
          * @throws SAXException if an error occurs
          * @throws ParserConfigurationException if an error occurs
          */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -132,19 +132,19 @@ public class TranslationCheck extends AbstractFileSetCheck {
     private static final String DEFAULT_TRANSLATION_REGEXP = "^.+\\..+$";
 
     /**
-     * Regexp pattern for bundles names wich end with language code, followed by country code and
+     * Regexp pattern for bundles names which end with language code, followed by country code and
      * variant suffix. For example, messages_es_ES_UNIX.properties.
      */
     private static final Pattern LANGUAGE_COUNTRY_VARIANT_PATTERN =
         CommonUtils.createPattern("^.+\\_[a-z]{2}\\_[A-Z]{2}\\_[A-Za-z]+\\..+$");
     /**
-     * Regexp pattern for bundles names wich end with language code, followed by country code
+     * Regexp pattern for bundles names which end with language code, followed by country code
      * suffix. For example, messages_es_ES.properties.
      */
     private static final Pattern LANGUAGE_COUNTRY_PATTERN =
         CommonUtils.createPattern("^.+\\_[a-z]{2}\\_[A-Z]{2}\\..+$");
     /**
-     * Regexp pattern for bundles names wich end with language code suffix.
+     * Regexp pattern for bundles names which end with language code suffix.
      * For example, messages_es.properties.
      */
     private static final Pattern LANGUAGE_PATTERN =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -113,7 +113,7 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
             }
             ++lineNumber;
         }
-        // -1 as check seeks for the first duplicate occurance in file,
+        // -1 as check seeks for the first duplicate occurrence in file,
         // so it cannot be the last line.
         if (lineNumber > fileText.size() - 1) {
             lineNumber = 0;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -483,7 +483,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
         // The minimal distance between objCalledOn and field (of type String) initialization
         // is calculated as follows:
         // String(6) + space(1) + variableName(1) + assign(1) +
-        // anotherStringVariableName(1) + semicolumn(1) = 11
+        // anotherStringVariableName(1) + semicolon(1) = 11
         // Example: length of "String s=d;" is 11 symbols.
         final int minimumSymbolsBetween = 11;
         if (field.getLineNo() < objCalledOn.getLineNo()

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -251,7 +251,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
             case TokenTypes.SLIST:
                 // -@cs[MoveVariableInsideIf] assignment value is modified later so it can't be
                 // moved
-                final Deque<DetailAST> prevScopeUnitializedVariableData =
+                final Deque<DetailAST> prevScopeUninitializedVariableData =
                     prevScopeUninitializedVariables.peek();
                 boolean containsBreak = false;
                 if (ast.getParent().getType() != TokenTypes.CASE_GROUP
@@ -263,7 +263,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
                 }
                 final DetailAST parent = ast.getParent();
                 if (containsBreak || shouldUpdateUninitializedVariables(parent)) {
-                    updateAllUninitializedVariables(prevScopeUnitializedVariableData);
+                    updateAllUninitializedVariables(prevScopeUninitializedVariableData);
                 }
                 updateCurrentScopeAssignedVariables();
                 break;
@@ -348,35 +348,35 @@ public class FinalLocalVariableCheck extends AbstractCheck {
      */
     private void storePrevScopeUninitializedVariableData() {
         final ScopeData scopeData = scopeStack.peek();
-        final Deque<DetailAST> prevScopeUnitializedVariableData =
+        final Deque<DetailAST> prevScopeUninitializedVariableData =
                 new ArrayDeque<>();
-        scopeData.uninitializedVariables.forEach(prevScopeUnitializedVariableData::push);
-        prevScopeUninitializedVariables.push(prevScopeUnitializedVariableData);
+        scopeData.uninitializedVariables.forEach(prevScopeUninitializedVariableData::push);
+        prevScopeUninitializedVariables.push(prevScopeUninitializedVariableData);
     }
 
     /**
      * Update current scope data uninitialized variable according to the whole scope data.
-     * @param prevScopeUnitializedVariableData variable for previous stack of uninitialized
+     * @param prevScopeUninitializedVariableData variable for previous stack of uninitialized
      *     variables
+     * @noinspection MethodParameterNamingConvention
      */
-    // -@cs[CyclomaticComplexity] Breaking apart will damage encapsulation.
     private void updateAllUninitializedVariables(
-            Deque<DetailAST> prevScopeUnitializedVariableData) {
+            Deque<DetailAST> prevScopeUninitializedVariableData) {
         // Check for only previous scope
-        updateUninitializedVariables(prevScopeUnitializedVariableData);
+        updateUninitializedVariables(prevScopeUninitializedVariableData);
         // Check for rest of the scope
         prevScopeUninitializedVariables.forEach(this::updateUninitializedVariables);
     }
 
     /**
      * Update current scope data uninitialized variable according to the specific scope data.
-     * @param scopeUnitializedVariableData variable for specific stack of uninitialized variables
+     * @param scopeUninitializedVariableData variable for specific stack of uninitialized variables
      */
-    private void updateUninitializedVariables(Deque<DetailAST> scopeUnitializedVariableData) {
+    private void updateUninitializedVariables(Deque<DetailAST> scopeUninitializedVariableData) {
         final Iterator<DetailAST> iterator = currentScopeAssignedVariables.peek().iterator();
         while (iterator.hasNext()) {
             final DetailAST assignedVariable = iterator.next();
-            for (DetailAST variable : scopeUnitializedVariableData) {
+            for (DetailAST variable : scopeUninitializedVariableData) {
                 for (ScopeData scopeData : scopeStack) {
                     final FinalVariableCandidate candidate =
                         scopeData.scope.get(variable.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -327,7 +327,7 @@ public class IllegalInstantiationCheck
      * @return true if type is standard
      */
     private boolean isStandardClass(String className, String illegal) {
-        boolean isStandardCalss = false;
+        boolean isStandardClass = false;
         // class from java.lang
         if (illegal.length() - JAVA_LANG.length() == className.length()
             && illegal.endsWith(className)
@@ -342,10 +342,10 @@ public class IllegalInstantiationCheck
             final boolean isSamePackage = isSamePackage(className);
 
             if (!isSameFile && !isSamePackage) {
-                isStandardCalss = true;
+                isStandardClass = true;
             }
         }
-        return isStandardCalss;
+        return isStandardClass;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler.java
@@ -129,9 +129,9 @@ public class TryHandler extends BlockParentHandler {
      */
     private void checkTryResources(final DetailAST resourcesSpecAst) {
         final DetailAST resourcesAst = resourcesSpecAst.findFirstToken(TokenTypes.RESOURCES);
-        final int indetation = getIndent().getFirstIndentLevel()
+        final int indentation = getIndent().getFirstIndentLevel()
             + getIndentCheck().getLineWrappingIndentation();
-        final IndentLevel expectedResourceIndent = new IndentLevel(indetation);
+        final IndentLevel expectedResourceIndent = new IndentLevel(indentation);
 
         final String subType = "resource";
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -140,7 +140,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
     }
 
     /**
-     * Sets user-excluded pakcages to ignore. All exlcuded packages should end with a period,
+     * Sets user-excluded packages to ignore. All excluded packages should end with a period,
      * so it also appends a dot to a package name.
      * @param excludedPackages the list of packages to ignore.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
@@ -337,7 +337,7 @@ public final class NPathComplexityCheck extends AbstractCheck {
     }
 
     /**
-     * Calculates number of conditional operators, including inline ternary operatior, for a token.
+     * Calculates number of conditional operators, including inline ternary operator, for a token.
      * @param ast inspected token.
      * @return number of conditional operators.
      * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.23">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java
@@ -62,15 +62,15 @@ public class RegexpSinglelineJavaCheck extends AbstractCheck {
 
     @Override
     public void beginTree(DetailAST rootAST) {
-        MatchSuppressor supressor = null;
+        MatchSuppressor suppressor = null;
         if (ignoreComments) {
-            supressor = new CommentSuppressor(getFileContents());
+            suppressor = new CommentSuppressor(getFileContents());
         }
 
         final DetectorOptions options = DetectorOptions.newBuilder()
             .reporter(this)
             .compileFlags(0)
-            .suppressor(supressor)
+            .suppressor(suppressor)
             .format(format)
             .message(message)
             .minimum(minimum)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
@@ -112,7 +112,7 @@ public final class MethodCountCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         if (ast.getType() == TokenTypes.METHOD_DEF) {
-            if (isInLastestScopeDefinition(ast)) {
+            if (isInLatestScopeDefinition(ast)) {
                 raiseCounter(ast);
             }
         }
@@ -134,11 +134,11 @@ public final class MethodCountCheck extends AbstractCheck {
      * Checks if there is a scope definition to check and that the method is found inside that scope
      * (class, enum, etc.).
      * @param methodDef
-     *        The method to analzye.
+     *        The method to analyze.
      * @return {@code true} if the method is part of the latest scope definition and should be
      *         counted.
      */
-    private boolean isInLastestScopeDefinition(DetailAST methodDef) {
+    private boolean isInLatestScopeDefinition(DetailAST methodDef) {
         boolean result = false;
 
         if (!counters.isEmpty()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
@@ -42,7 +42,7 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtils;
  */
 public class SuppressionFilter extends AutomaticBean implements Filter, ExternalResourceHolder {
 
-    /** Filename of supression file. */
+    /** Filename of suppression file. */
     private String file;
     /** Tells whether config file existence is optional. */
     private boolean optional;
@@ -50,7 +50,7 @@ public class SuppressionFilter extends AutomaticBean implements Filter, External
     private FilterSet filters = new FilterSet();
 
     /**
-     * Sets name of the supression file.
+     * Sets name of the suppression file.
      * @param fileName name of the suppressions file.
      */
     public void setFile(String fileName) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -41,7 +41,7 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtils;
 public class SuppressionXpathFilter extends AutomaticBean implements
         TreeWalkerFilter, ExternalResourceHolder {
 
-    /** Filename of supression file. */
+    /** Filename of suppression file. */
     private String file;
     /** Tells whether config file existence is optional. */
     private boolean optional;
@@ -49,7 +49,7 @@ public class SuppressionXpathFilter extends AutomaticBean implements
     private Set<TreeWalkerFilter> filters = new HashSet<>();
 
     /**
-     * Sets name of the supression file.
+     * Sets name of the suppression file.
      * @param fileName name of the suppressions file.
      */
     public void setFile(String fileName) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtils.java
@@ -129,7 +129,7 @@ public final class CommonUtils {
         commentContent.setText("*" + content);
         commentContent.setLineNo(0);
         // javadoc should starts at 0 column, so COMMENT_CONTENT node
-        // that contains javadoc identificator has -1 column
+        // that contains javadoc identifier has -1 column
         commentContent.setColumnNo(-1);
 
         final DetailAST blockCommentEnd = new DetailAST();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtils.java
@@ -177,8 +177,8 @@ public final class JavadocUtils {
         boolean result = false;
 
         if (!commentContent.isEmpty()) {
-            final char docCommentIdentificator = commentContent.charAt(0);
-            result = docCommentIdentificator == '*';
+            final char docCommentIdentifier = commentContent.charAt(0);
+            result = docCommentIdentifier == '*';
         }
 
         return result;


### PR DESCRIPTION
minor: fix typos

no changes in the code, except the names of local variables and private methods.