### PR TITLE
minor: fix typos in tests

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -415,7 +415,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         assertEquals("Charset was different than expected",
                 System.getProperty("file.encoding", StandardCharsets.UTF_8.name()),
                 context.get("charset"));
-        assertEquals("Was used unsufficient classloader",
+        assertEquals("Was used insufficient classloader",
                 contextClassLoader, context.get("classLoader"));
         assertEquals("Severity is set to unexpected value",
                 "error", context.get("severity"));
@@ -1079,7 +1079,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         @Override
         public Set<String> getExternalResourceLocations() {
             final Set<String> externalResourceLocation = new HashSet<>(1);
-            externalResourceLocation.add("non_existing_external_resource.xml");
+            externalResourceLocation.add("non_existent_external_resource.xml");
             return externalResourceLocation;
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -511,16 +511,16 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public void testNonExistingPropertyName() throws Exception {
+    public void testNonExistentPropertyName() throws Exception {
         try {
-            loadConfiguration("InputConfigurationLoaderNonexistingProperty.xml");
+            loadConfiguration("InputConfigurationLoaderNonexistentProperty.xml");
             fail("exception in expected");
         }
         catch (CheckstyleException ex) {
             assertEquals("Invalid exception message",
                 "unable to parse configuration stream", ex.getMessage());
             assertEquals("Invalid exception cause message",
-                "Property ${nonexisting} has not been set",
+                "Property ${nonexistent} has not been set",
                     ex.getCause().getMessage());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultConfigurationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultConfigurationTest.java
@@ -32,18 +32,18 @@ public class DefaultConfigurationTest {
     public void testRemoveChild() {
         final DefaultConfiguration config = new DefaultConfiguration("MyConfig");
         final DefaultConfiguration configChild = new DefaultConfiguration("childConfig");
-        assertEquals("Invalid cildren count", 0, config.getChildren().length);
+        assertEquals("Invalid children count", 0, config.getChildren().length);
         config.addChild(configChild);
-        assertEquals("Invalid cildren count", 1, config.getChildren().length);
+        assertEquals("Invalid children count", 1, config.getChildren().length);
         config.removeChild(configChild);
-        assertEquals("Invalid cildren count", 0, config.getChildren().length);
+        assertEquals("Invalid children count", 0, config.getChildren().length);
     }
 
     @Test
-    public void testExceptionForNonExistingAttribute() {
+    public void testExceptionForNonExistentAttribute() {
         final String name = "MyConfig";
         final DefaultConfiguration config = new DefaultConfiguration(name);
-        final String attributeName = "NonExisting#$%";
+        final String attributeName = "NonExistent#$%";
         try {
             config.getAttribute(attributeName);
             fail("Exception is expected");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -77,7 +77,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
     }
 
     @Test
-    public void testNoUnnecessaryTextinJavadocAst() throws Exception {
+    public void testNoUnnecessaryTextInJavadocAst() throws Exception {
         verifyJavadocTree(
                 getPath("ExpectedDetailNodeTreeStringPrinterNoUnnecessaryTextInJavadocAst.txt"),
                 getPath("InputDetailNodeTreeStringPrinterNoUnnecessaryTextInJavadocAst.javadoc"));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -173,7 +173,7 @@ public class MainTest {
             throws Exception {
 
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log",
+            assertEquals("Unexpected output log",
                     "Checkstyle version: null" + System.lineSeparator(),
                     systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
@@ -188,7 +188,7 @@ public class MainTest {
         exit.checkAssertionAfterwards(() -> {
             final String usage = "Unrecognized option: -w" + EOL
                     + USAGE;
-            assertEquals("Unexpected ouput log", usage, systemOut.getLog());
+            assertEquals("Unexpected output log", usage, systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
         Main.main("-w");
@@ -199,7 +199,7 @@ public class MainTest {
             throws Exception {
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log",
+            assertEquals("Unexpected output log",
                     "Must specify a config XML file." + System.lineSeparator(),
                     systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
@@ -208,36 +208,36 @@ public class MainTest {
     }
 
     @Test
-    public void testNonExistingTargetFile()
+    public void testNonExistentTargetFile()
             throws Exception {
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "Files to process must be specified, found 0."
+            assertEquals("Unexpected output log", "Files to process must be specified, found 0."
                 + System.lineSeparator(), systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
-        Main.main("-c", "/google_checks.xml", "NonExistingFile.java");
+        Main.main("-c", "/google_checks.xml", "NonExistentFile.java");
     }
 
     @Test
-    public void testNonExistingConfigFile()
+    public void testNonExistentConfigFile()
             throws Exception {
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "Could not find config XML file "
-                        + "'src/main/resources/non_existing_config.xml'." + EOL,
+            assertEquals("Unexpected output log", "Could not find config XML file "
+                        + "'src/main/resources/non_existent_config.xml'." + EOL,
                     systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
-        Main.main("-c", "src/main/resources/non_existing_config.xml",
+        Main.main("-c", "src/main/resources/non_existent_config.xml",
                 getPath("InputMain.java"));
     }
 
     @Test
-    public void testNonExistingOutputFormat() throws Exception {
+    public void testNonExistentOutputFormat() throws Exception {
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "Invalid output format. "
+            assertEquals("Unexpected output log", "Invalid output format. "
                     + "Found 'xmlp' but expected 'plain' or 'xml'." + EOL, systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
@@ -246,19 +246,18 @@ public class MainTest {
     }
 
     @Test
-    public void testNonExistingClass() throws Exception {
+    public void testNonExistentClass() throws Exception {
         exit.expectSystemExitWithStatus(-2);
         exit.checkAssertionAfterwards(() -> {
-            final String expectedExceptionMessage = errorCounterOneMessage.getMessage()
-                    + EOL;
-            assertEquals("Unexpected ouput log", expectedExceptionMessage, systemOut.getLog());
+            final String expectedExceptionMessage = errorCounterOneMessage.getMessage() + EOL;
+            assertEquals("Unexpected output log", expectedExceptionMessage, systemOut.getLog());
 
             final String cause = "com.puppycrawl.tools.checkstyle.api.CheckstyleException:"
                     + " cannot initialize module TreeWalker - ";
             assertTrue("Unexpected system error log", systemErr.getLog().startsWith(cause));
         });
 
-        Main.main("-c", getPath("InputMainConfig-non-existing-classname.xml"),
+        Main.main("-c", getPath("InputMainConfig-non-existent-classname.xml"),
             getPath("InputMain.java"));
     }
 
@@ -266,7 +265,7 @@ public class MainTest {
     public void testExistingTargetFile() throws Exception {
 
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", auditStartMessage.getMessage() + EOL
+            assertEquals("Unexpected output log", auditStartMessage.getMessage() + EOL
                     + auditFinishMessage.getMessage() + EOL,
                     systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
@@ -284,7 +283,7 @@ public class MainTest {
                     ResourceBundle.getBundle("checkstylecompilation", Locale.ROOT);
             final String version = compilationProperties
                 .getString("checkstyle.compile.version");
-            assertEquals("Unexpected ouput log", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + EOL
+            assertEquals("Unexpected output log", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + EOL
                     + "<checkstyle version=\"" + version + "\">" + EOL
                     + "<file name=\"" + expectedPath + "\">" + EOL
                     + "</file>" + EOL
@@ -300,7 +299,7 @@ public class MainTest {
     public void testExistingTargetFilePlainOutput() throws Exception {
 
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", auditStartMessage.getMessage() + EOL
+            assertEquals("Unexpected output log", auditStartMessage.getMessage() + EOL
                     + auditFinishMessage.getMessage() + EOL, systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
@@ -321,7 +320,7 @@ public class MainTest {
                     "name.invalidPattern", new String[] {"InputMainInner", "^[a-z0-9]*$"},
                     null, getClass(), null);
             final String expectedPath = getFilePath("InputMain.java");
-            assertEquals("Unexpected ouput log", auditStartMessage.getMessage() + EOL
+            assertEquals("Unexpected output log", auditStartMessage.getMessage() + EOL
                             + "[WARN] " + expectedPath + ":3:14: "
                             + invalidPatternMessageMain.getMessage()
                             + " [TypeName]" + EOL
@@ -352,7 +351,7 @@ public class MainTest {
                     "name.invalidPattern", new String[] {"InputMainInner", "^[a-z0-9]*$"},
                     null, getClass(), null);
             final String expectedPath = getFilePath("InputMain.java");
-            assertEquals("Unexpected ouput log", auditStartMessage.getMessage() + EOL
+            assertEquals("Unexpected output log", auditStartMessage.getMessage() + EOL
                     + "[ERROR] " + expectedPath + ":3:14: "
                     + invalidPatternMessageMain.getMessage() + " [TypeName]" + EOL
                     + "[ERROR] " + expectedPath + ":5:7: "
@@ -367,11 +366,11 @@ public class MainTest {
     }
 
     @Test
-    public void testExistingTargetFilePlainOutputToNonExistingFile()
+    public void testExistentTargetFilePlainOutputToNonExistentFile()
             throws Exception {
 
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "", systemOut.getLog());
+            assertEquals("Unexpected output log", "", systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
         Main.main("-c", getPath("InputMainConfig-classname.xml"),
@@ -385,7 +384,7 @@ public class MainTest {
             throws Exception {
         final File file = temporaryFolder.newFile("file.output");
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "", systemOut.getLog());
+            assertEquals("Unexpected output log", "", systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
         Main.main("-c", getPath("InputMainConfig-classname.xml"),
@@ -395,8 +394,8 @@ public class MainTest {
     }
 
     @Test
-    public void testCreateNonExistingOutputFile() throws Exception {
-        final String outputFile = temporaryFolder.getRoot().getCanonicalPath() + "nonexisting.out";
+    public void testCreateNonExistentOutputFile() throws Exception {
+        final String outputFile = temporaryFolder.getRoot().getCanonicalPath() + "nonexistent.out";
         assertFalse("File must not exist", new File(outputFile).exists());
         Main.main("-c", getPath("InputMainConfig-classname.xml"),
                 "-f", "plain",
@@ -413,7 +412,7 @@ public class MainTest {
 
         //exit.expectSystemExitWithStatus(0);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", auditStartMessage.getMessage() + EOL
+            assertEquals("Unexpected output log", auditStartMessage.getMessage() + EOL
                     + auditFinishMessage.getMessage() + EOL, systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
@@ -426,16 +425,16 @@ public class MainTest {
     }
 
     @Test
-    public void testExistingTargetFilePlainOutputNonexistingProperties()
+    public void testExistingTargetFilePlainOutputNonexistentProperties()
             throws Exception {
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "Could not find file 'nonexisting.properties'."
+            assertEquals("Unexpected output log", "Could not find file 'nonexistent.properties'."
                     + System.lineSeparator(), systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
         Main.main("-c", getPath("InputMainConfig-classname-prop.xml"),
-                "-p", "nonexisting.properties",
+                "-p", "nonexistent.properties",
                 getPath("InputMain.java"));
     }
 
@@ -445,7 +444,7 @@ public class MainTest {
         exit.expectSystemExitWithStatus(-2);
         exit.checkAssertionAfterwards(() -> {
             final String output = errorCounterOneMessage.getMessage() + EOL;
-            assertEquals("Unexpected ouput log", output, systemOut.getLog());
+            assertEquals("Unexpected output log", output, systemOut.getLog());
             final String errorOutput = "com.puppycrawl.tools.checkstyle.api."
                 + "CheckstyleException: unable to parse configuration stream - ";
             assertTrue("Unexpected system error log", systemErr.getLog().startsWith(errorOutput));
@@ -460,7 +459,7 @@ public class MainTest {
         exit.expectSystemExitWithStatus(-2);
         exit.checkAssertionAfterwards(() -> {
             final String output = errorCounterOneMessage.getMessage() + EOL;
-            assertEquals("Unexpected ouput log", output, systemOut.getLog());
+            assertEquals("Unexpected output log", output, systemOut.getLog());
             final String errorOutput = "com.puppycrawl.tools.checkstyle.api."
                     + "CheckstyleException: cannot initialize module RegexpSingleline"
                     + " - RegexpSingleline is not allowed as a child in RegexpSingleline";
@@ -476,7 +475,7 @@ public class MainTest {
         exit.expectSystemExitWithStatus(-2);
         exit.checkAssertionAfterwards(() -> {
             final String output = errorCounterOneMessage.getMessage() + EOL;
-            assertEquals("Unexpected ouput log", output, systemOut.getLog());
+            assertEquals("Unexpected output log", output, systemOut.getLog());
             final String errorOutput = "com.puppycrawl.tools.checkstyle.api."
                     + "CheckstyleException: cannot initialize module TreeWalker"
                     + " - JavadocVariable is not allowed as a child in JavadocMethod";
@@ -521,12 +520,12 @@ public class MainTest {
             final boolean samePrefix = causeMessage.substring(0, causeMessage.indexOf(' '))
                     .equals(localizedMessage
                             .substring(0, localizedMessage.indexOf(' ')));
-            final boolean sameSufix =
+            final boolean sameSuffix =
                     causeMessage.substring(causeMessage.lastIndexOf(' '), causeMessage.length())
                     .equals(localizedMessage
                             .substring(localizedMessage.lastIndexOf(' '),
                                     localizedMessage.length()));
-            assertTrue("Invalid error message", samePrefix || sameSufix);
+            assertTrue("Invalid error message", samePrefix || sameSuffix);
             assertTrue("Invalid error message",
                     causeMessage.contains(":invalid"));
         }
@@ -614,7 +613,7 @@ public class MainTest {
             }
             sb.append(auditFinishMessage.getMessage())
                     .append(EOL);
-            assertEquals("Unexpected ouput log", sb.toString(), systemOut.getLog());
+            assertEquals("Unexpected output log", sb.toString(), systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
 
@@ -659,7 +658,7 @@ public class MainTest {
         exit.checkAssertionAfterwards(() -> {
             final String expectedExceptionMessage = auditStartMessage.getMessage() + EOL
                             + errorCounterOneMessage.getMessage() + EOL;
-            assertEquals("Unexpected ouput log", expectedExceptionMessage, systemOut.getLog());
+            assertEquals("Unexpected output log", expectedExceptionMessage, systemOut.getLog());
 
             final String exceptionFirstLine = "com.puppycrawl.tools.checkstyle.api."
                     + "CheckstyleException: Exception was thrown while processing "
@@ -669,7 +668,7 @@ public class MainTest {
                     systemErr.getLog().startsWith(exceptionFirstLine));
         });
 
-        // We put xml as source to cause parse excepion
+        // We put xml as source to cause parse exception
         Main.main("-c", getPath("InputMainConfig-classname.xml"),
                 getNonCompilablePath("InputMainIncorrectClass.java"));
     }
@@ -679,7 +678,7 @@ public class MainTest {
 
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "Printing AST is allowed for only one file."
+            assertEquals("Unexpected output log", "Printing AST is allowed for only one file."
                 + System.lineSeparator(), systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
@@ -718,7 +717,7 @@ public class MainTest {
             + "    `--RCURLY -> } [6:0]" + EOL;
 
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", expected, systemOut.getLog());
+            assertEquals("Unexpected output log", expected, systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
         Main.main("-t", getPath("InputMain.java"));
@@ -758,7 +757,7 @@ public class MainTest {
             + "    `--RCURLY -> } [6:0]" + EOL;
 
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", expected, systemOut.getLog());
+            assertEquals("Unexpected output log", expected, systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
         Main.main("-T", getPath("InputMain.java"));
@@ -771,7 +770,7 @@ public class MainTest {
             .replaceAll("\\\\r\\\\n", "\\\\n");
 
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log",
+            assertEquals("Unexpected output log",
                     expected, systemOut.getLog().replaceAll("\\\\r\\\\n", "\\\\n"));
             assertEquals("Unexpected system error log",
                     "", systemErr.getLog());
@@ -786,7 +785,7 @@ public class MainTest {
             StandardCharsets.UTF_8).replaceAll("\\\\r\\\\n", "\\\\n");
 
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log",
+            assertEquals("Unexpected output log",
                     expected, systemOut.getLog().replaceAll("\\\\r\\\\n", "\\\\n"));
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
@@ -798,7 +797,7 @@ public class MainTest {
 
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "Option '-t' cannot be used with other options."
+            assertEquals("Unexpected output log", "Option '-t' cannot be used with other options."
                 + System.lineSeparator(), systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
@@ -811,7 +810,7 @@ public class MainTest {
 
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "Option '-t' cannot be used with other options."
+            assertEquals("Unexpected output log", "Option '-t' cannot be used with other options."
                 + System.lineSeparator(), systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
@@ -824,7 +823,7 @@ public class MainTest {
 
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "Option '-t' cannot be used with other options."
+            assertEquals("Unexpected output log", "Option '-t' cannot be used with other options."
                 + System.lineSeparator(), systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
@@ -838,7 +837,7 @@ public class MainTest {
 
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "Option '-t' cannot be used with other options."
+            assertEquals("Unexpected output log", "Option '-t' cannot be used with other options."
                 + System.lineSeparator(), systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
@@ -857,7 +856,7 @@ public class MainTest {
     public void testExcludeOption() throws Exception {
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "Files to process must be specified, found 0."
+            assertEquals("Unexpected output log", "Files to process must be specified, found 0."
                 + System.lineSeparator(), systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
@@ -868,9 +867,9 @@ public class MainTest {
     public void testExcludeRegexpOption() throws Exception {
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "Files to process must be specified, found 0."
+            assertEquals("Unexpected output log", "Files to process must be specified, found 0."
                 + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected ouput log", "", systemErr.getLog());
+            assertEquals("Unexpected output log", "", systemErr.getLog());
         });
         Main.main("-c", "/google_checks.xml", getFilePath(""), "-x", ".");
     }
@@ -893,7 +892,7 @@ public class MainTest {
         TestRootModuleChecker.reset();
 
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "", systemOut.getLog());
+            assertEquals("Unexpected output log", "", systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
             assertTrue("Invalid Checker state", TestRootModuleChecker.isProcessed());
         });
@@ -916,7 +915,7 @@ public class MainTest {
                             + "TestRootModuleCheckerCheck, " + checkstylePackage
                             + "TestRootModuleCheckerCheck"},
                     null, getClass(), null);
-            assertEquals("Unexpected ouput log", errorCounterOneMessage.getMessage() + EOL,
+            assertEquals("Unexpected output log", errorCounterOneMessage.getMessage() + EOL,
                     systemOut.getLog());
             assertTrue("Unexpected system error log",
                     systemErr.getLog().startsWith(checkstylePackage + "api.CheckstyleException: "
@@ -932,14 +931,14 @@ public class MainTest {
         exit.expectSystemExitWithStatus(-2);
         exit.checkAssertionAfterwards(() -> {
             final String expectedExceptionMessage = errorCounterOneMessage.getMessage() + EOL;
-            assertEquals("Unexpected ouput log", expectedExceptionMessage, systemOut.getLog());
+            assertEquals("Unexpected output log", expectedExceptionMessage, systemOut.getLog());
 
             final String cause = "com.puppycrawl.tools.checkstyle.api.CheckstyleException:"
                     + " cannot initialize module TreeWalker - ";
             assertTrue("Unexpected system error log", systemErr.getLog().startsWith(cause));
         });
 
-        Main.main("-c", getPath("InputMainConfig-non-existing-classname-ignore.xml"),
+        Main.main("-c", getPath("InputMainConfig-non-existent-classname-ignore.xml"),
                 "-executeIgnoredModules",
                 getPath("InputMain.java"));
     }
@@ -948,7 +947,7 @@ public class MainTest {
     public void testInvalidCheckerThreadsNumber() throws Exception {
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "Invalid Checker threads number"
+            assertEquals("Unexpected output log", "Invalid Checker threads number"
                 + System.lineSeparator(), systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
@@ -959,7 +958,7 @@ public class MainTest {
     public void testInvalidTreeWalkerThreadsNumber() throws Exception {
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "Invalid TreeWalker threads number"
+            assertEquals("Unexpected output log", "Invalid TreeWalker threads number"
                 + System.lineSeparator(), systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
@@ -970,7 +969,7 @@ public class MainTest {
     public void testZeroCheckerThreadsNumber() throws Exception {
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "Checker threads number must be greater than zero"
+            assertEquals("Unexpected output log", "Checker threads number must be greater than zero"
                 + System.lineSeparator(), systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
         });
@@ -981,7 +980,7 @@ public class MainTest {
     public void testZeroTreeWalkerThreadsNumber() throws Exception {
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log",
+            assertEquals("Unexpected output log",
                     "TreeWalker threads number must be greater than zero"
                 + System.lineSeparator(), systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
@@ -994,7 +993,7 @@ public class MainTest {
         TestRootModuleChecker.reset();
 
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "", systemOut.getLog());
+            assertEquals("Unexpected output log", "", systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
             assertTrue("Invalid checker state", TestRootModuleChecker.isProcessed());
             final DefaultConfiguration config =
@@ -1014,7 +1013,7 @@ public class MainTest {
         TestRootModuleChecker.reset();
 
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "", systemOut.getLog());
+            assertEquals("Unexpected output log", "", systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
             assertTrue("Invalid checker state", TestRootModuleChecker.isProcessed());
             final DefaultConfiguration config =
@@ -1034,7 +1033,7 @@ public class MainTest {
         TestRootModuleChecker.reset();
 
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected ouput log", "", systemOut.getLog());
+            assertEquals("Unexpected output log", "", systemOut.getLog());
             assertEquals("Unexpected system error log", "", systemErr.getLog());
             assertTrue("Invalid checker state", TestRootModuleChecker.isProcessed());
             final DefaultConfiguration config =
@@ -1049,7 +1048,7 @@ public class MainTest {
                 .getChildren()[0];
             assertEquals("Invalid checker name", "Checker", checkerConfiguration.getName());
             final Configuration treeWalkerConfig = checkerConfiguration.getChildren()[0];
-            assertEquals("Invalid checker childs name", "TreeWalker", treeWalkerConfig.getName());
+            assertEquals("Invalid checker children name", "TreeWalker", treeWalkerConfig.getName());
         });
         Main.main("-C", "1", "-W", "1", "-c", getPath("InputMainConfig-multi-thread-mode.xml"),
             getPath("InputMain.java"));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -109,11 +109,11 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
         final String filePath = temporaryFolder.newFile().getPath();
         final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
         cache.put("myFile", 1);
-        assertTrue("Should return true wnen file is in cache",
+        assertTrue("Should return true when file is in cache",
                 cache.isInCache("myFile", 1));
-        assertFalse("Should return false wnen file is not in cache",
+        assertFalse("Should return false when file is not in cache",
                 cache.isInCache("myFile", 2));
-        assertFalse("Should return false wnen file is not in cache",
+        assertFalse("Should return false when file is not in cache",
                 cache.isInCache("myFile1", 1));
     }
 
@@ -216,7 +216,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public void testExternalResourseIsSavedInCache() throws Exception {
+    public void testExternalResourceIsSavedInCache() throws Exception {
         final Configuration config = new DefaultConfiguration("myName");
         final String filePath = temporaryFolder.newFile().getPath();
         final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
@@ -250,7 +250,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void testNonExistingResource() throws IOException {
+    public void testNonExistentResource() throws IOException {
         final Configuration config = new DefaultConfiguration("myName");
         final String filePath = temporaryFolder.newFile().getPath();
         final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
@@ -358,10 +358,10 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public void testPutNonExsistingExternalResourceSameExceptionBetweenRuns() throws Exception {
+    public void testPutNonExistentExternalResourceSameExceptionBetweenRuns() throws Exception {
         final File cacheFile = temporaryFolder.newFile();
 
-        // We mock getUriByFilename method of CommonUtils to garantee that it will
+        // We mock getUriByFilename method of CommonUtils to guarantee that it will
         // throw CheckstyleException with the specific content.
         mockStatic(CommonUtils.class);
         final CheckstyleException mockException =
@@ -370,7 +370,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
             .thenThrow(mockException);
 
         // We invoke 'putExternalResources' twice to invalidate cache
-        // and have two identical exceptions whith the equal content
+        // and have two identical exceptions which the equal content
         final int numberOfRuns = 2;
         final String[] configHashes = new String[numberOfRuns];
         final String[] externalResourceHashes = new String[numberOfRuns];
@@ -382,10 +382,10 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
             configHashes[i] = cache.get(PropertyCacheFile.CONFIG_HASH_KEY);
             assertNotNull("Config hash key should not be null", configHashes[i]);
 
-            final Set<String> nonExistingExternalResources = new HashSet<>();
-            final String externalResourceFileName = "non_existing_file.xml";
-            nonExistingExternalResources.add(externalResourceFileName);
-            cache.putExternalResources(nonExistingExternalResources);
+            final Set<String> nonExistentExternalResources = new HashSet<>();
+            final String externalResourceFileName = "non_existent_file.xml";
+            nonExistentExternalResources.add(externalResourceFileName);
+            cache.putExternalResources(nonExistentExternalResources);
 
             externalResourceHashes[i] = cache.get(PropertyCacheFile.EXTERNAL_RESOURCE_KEY_PREFIX
                     + externalResourceFileName);
@@ -412,7 +412,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
      * @noinspection InstanceMethodNamingConvention
      */
     @Test
-    public void testPutNonExsistingExternalResourceDifferentExceptionsBetweenRuns()
+    public void testPutNonExistentExternalResourceDifferentExceptionsBetweenRuns()
             throws Exception {
 
         final File cacheFile = temporaryFolder.newFile();
@@ -426,7 +426,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
             final Configuration config = new DefaultConfiguration("myConfig");
             final PropertyCacheFile cache = new PropertyCacheFile(config, cacheFile.getPath());
 
-            // We mock getUriByFilename method of CommonUtils to garantee that it will
+            // We mock getUriByFilename method of CommonUtils to guarantee that it will
             // throw CheckstyleException with the specific content.
             mockStatic(CommonUtils.class);
             final CheckstyleException mockException = new CheckstyleException("Exception #" + i);
@@ -438,10 +438,10 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
             configHashes[i] = cache.get(PropertyCacheFile.CONFIG_HASH_KEY);
             assertNotNull("Config hash key should not be null", configHashes[i]);
 
-            final Set<String> nonExistingExternalResources = new HashSet<>();
-            final String externalResourceFileName = "non_existing_file.xml";
-            nonExistingExternalResources.add(externalResourceFileName);
-            cache.putExternalResources(nonExistingExternalResources);
+            final Set<String> nonExistentExternalResources = new HashSet<>();
+            final String externalResourceFileName = "non_existent_file.xml";
+            nonExistentExternalResources.add(externalResourceFileName);
+            cache.putExternalResources(nonExistentExternalResources);
 
             externalResourceHashes[i] = cache.get(PropertyCacheFile.EXTERNAL_RESOURCE_KEY_PREFIX
                     + externalResourceFileName);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XmlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XmlLoaderTest.java
@@ -41,11 +41,11 @@ public class XmlLoaderTest {
             Constants.SAX_FEATURE_PREFIX + Constants.NAMESPACES_FEATURE;
 
     @Test
-    public void testParserConfiguratedSuccefully() throws Exception {
+    public void testParserConfiguredSuccessfully() throws Exception {
         final DummyLoader dummyLoader = new DummyLoader(new HashMap<>(1));
         final XMLReader parser = Whitebox.getInternalState(dummyLoader, "parser");
         assertTrue("Invalid feature state", parser.getFeature(NAMESPACES_FEATURE));
-        assertEquals("Invalid entity resoler", dummyLoader, parser.getEntityResolver());
+        assertEquals("Invalid entity resolver", dummyLoader, parser.getEntityResolver());
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -200,7 +200,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
                 filesToCheck.size(), is(9));
         assertThat("The path of file differs from expected",
                 filesToCheck.get(5).getAbsolutePath(), is(getPath(FLAWLESS_INPUT)));
-        assertEquals("Amount of logged messages in unxexpected",
+        assertEquals("Amount of logged messages in unexpected",
                 9, antTask.getLoggedMessages().size());
     }
 
@@ -250,7 +250,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public final void testNonExistingConfig() throws IOException {
+    public final void testNonExistentConfig() throws IOException {
         final CheckstyleAntTask antTask = new CheckstyleAntTask();
         antTask.setConfig(getPath(NOT_EXISTING_FILE));
         antTask.setProject(new Project());
@@ -491,7 +491,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public final void testSetPropertiesNonExistingFile() throws IOException {
+    public final void testSetPropertiesNonExistentFile() throws IOException {
         final CheckstyleAntTask antTask = getCheckstyleAntTask();
         antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
         antTask.setProperties(new File(getPath(NOT_EXISTING_FILE)));
@@ -666,7 +666,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
             Whitebox.getInternalState(antTask, "classpath"));
     }
 
-    /** This test is created to satisfy pitest, it is hard to emulate Referece by Id. */
+    /** This test is created to satisfy pitest, it is hard to emulate Reference by Id. */
     @Test
     public void testSetClasspathRef1() {
         final CheckstyleAntTask antTask = new CheckstyleAntTask();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
@@ -104,20 +104,20 @@ public class AbstractFileSetCheckTest {
     }
 
     @Test
-    public void testGetFileExtention() {
+    public void testGetFileExtension() {
         final DummyFileSetCheck check = new DummyFileSetCheck();
         check.setFileExtensions("tmp", ".java");
-        final String[] expectedExtentions = {".tmp", ".java"};
+        final String[] expectedExtensions = {".tmp", ".java"};
 
         Assert.assertArrayEquals("Invalid extensions",
-                expectedExtentions, check.getFileExtensions());
+                expectedExtensions, check.getFileExtensions());
     }
 
     /**
      * This javadoc exists only to suppress Intellij Idea inspection.
      */
     @Test
-    public void testSetExtentionThrowsExceptionWhenTheyAreNull() {
+    public void testSetExtensionThrowsExceptionWhenTheyAreNull() {
         final DummyFileSetCheck check = new DummyFileSetCheck();
         try {
             check.setFileExtensions((String[]) null);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -42,13 +42,13 @@ public class AutomaticBeanTest {
     public void testConfigureNoSuchAttribute() {
         final TestBean testBean = new TestBean();
         final DefaultConfiguration conf = new DefaultConfiguration("testConf");
-        conf.addAttribute("NonExisting", "doesn't matter");
+        conf.addAttribute("NonExistent", "doesn't matter");
         try {
             testBean.configure(conf);
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            final String expected = "Property 'NonExisting' in module ";
+            final String expected = "Property 'NonExistent' in module ";
             assertNull("Exceptions cause should be null", ex.getCause());
             assertTrue("Invalid exception message, should start with: " + expected,
                     ex.getMessage().startsWith(expected));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -80,7 +80,7 @@ public class NewlineAtEndOfFileCheckTest
 
     /**
      * Pitest requires all closes of streams and readers to be verified. Using PowerMock
-     * is almost only posibility to check it without rewriting production code.
+     * is almost only possibility to check it without rewriting production code.
      *
      * @throws Exception when code tested throws some exception
      */
@@ -230,7 +230,7 @@ public class NewlineAtEndOfFileCheckTest
         final File impossibleFile = new File("");
         final FileText fileText = new FileText(impossibleFile, lines);
         final Set<LocalizedMessage> messages = check.process(impossibleFile, fileText);
-        assertEquals("Ammount of messages is unexpected",
+        assertEquals("Amount of messages is unexpected",
                 1, messages.size());
         final Iterator<LocalizedMessage> iterator = messages.iterator();
         assertEquals("Violation message differs from expected",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -85,9 +85,9 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
 
     @Test
     public void testGetDefaultAlias() {
-        assertEquals("Diffault alias differs from expected",
+        assertEquals("Default alias differs from expected",
                 "somename", SuppressWarningsHolder.getDefaultAlias("SomeName"));
-        assertEquals("Diffault alias differs from expected",
+        assertEquals("Default alias differs from expected",
                 "somename", SuppressWarningsHolder.getDefaultAlias("SomeNameCheck"));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -369,7 +369,7 @@ public class TranslationCheckTest extends AbstractModuleTestSupport {
 
     /**
      * Pitest requires all closes of streams and readers to be verified. Using PowerMock
-     * is almost only posibility to check it without rewriting production code.
+     * is almost only possibility to check it without rewriting production code.
      *
      * @throws Exception when code tested throws some exception
      */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -92,7 +92,7 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
 
     /**
      * Pitest requires all closes of streams and readers to be verified. Using PowerMock
-     * is almost only posibility to check it without rewriting production code.
+     * is almost only possibility to check it without rewriting production code.
      *
      * @throws Exception when code tested throws some exception
      */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheckTest.java
@@ -72,7 +72,7 @@ public class ExplicitInitializationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testonlyObjectReferences() throws Exception {
+    public void testOnlyObjectReferences() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(ExplicitInitializationCheck.class);
         checkConfig.addAttribute("onlyObjectReferences", "true");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -264,7 +264,7 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "15:9: " + getCheckMessage(MSG_VARIABLE, "tags", ""),
         };
-        verify(checkConfig, getPath("InputRequireThisMetodReferences.java"), expected);
+        verify(checkConfig, getPath("InputRequireThisMethodReferences.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
@@ -114,6 +114,6 @@ public class ThrowsCountCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "18:26: " + getCheckMessage(MSG_KEY, 5, 4),
         };
-        verify(checkConfig, getPath("InputThrowsCountMwthodWithAnnotation.java"), expected);
+        verify(checkConfig, getPath("InputThrowsCountMethodWithAnnotation.java"), expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -450,7 +450,7 @@ public class VisibilityModifierCheckTest
      * class with name "", but in this case internal collection will have short names
      * as "" that will not make problems, but will be weird in debug.
      *
-     * @throws Exception when exception occured during execution.
+     * @throws Exception when exception occurred during execution.
      */
     @Test
     public void testIsStarImportNullAst() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -88,9 +88,9 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNonExistingHeaderFile() throws Exception {
+    public void testNonExistentHeaderFile() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
-        checkConfig.addAttribute("headerFile", getPath("nonExisting.file"));
+        checkConfig.addAttribute("headerFile", getPath("nonExistent.file"));
         try {
             createChecker(checkConfig);
             fail("CheckstyleException is expected");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AccessResultTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AccessResultTest.java
@@ -48,6 +48,6 @@ public class AccessResultTest {
             AccessResult.DISALLOWED,
             AccessResult.UNKNOWN,
         };
-        assertArrayEquals("Invalid aaccess result values", expected, actual);
+        assertArrayEquals("Invalid access result values", expected, actual);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
@@ -112,7 +112,7 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testIllegalClassessRegularExpression()
+    public void testIllegalClassesRegularExpression()
             throws Exception {
         final DefaultConfiguration checkConfig =
                 createModuleConfig(IllegalImportCheck.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -349,7 +349,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         // One more time to use cache.
         verify(checkerConfig, filePath, expected);
 
-        assertTrue("External resourse is not present in cache",
+        assertTrue("External resource is not present in cache",
                 new String(Files.readAllBytes(cacheFile.toPath()),
                         StandardCharsets.UTF_8).contains("InputImportControlOneRegExp.xml"));
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlTest.java
@@ -68,92 +68,92 @@ public class ImportControlTest {
 
     @Test
     public void testLocateFinest() {
-        assertEquals("Unxpected response", icRoot, icRoot
+        assertEquals("Unexpected response", icRoot, icRoot
                 .locateFinest("com.kazgroup.courtlink.domain"));
-        assertEquals("Unxpected response", icCommon, icRoot
+        assertEquals("Unexpected response", icCommon, icRoot
                 .locateFinest("com.kazgroup.courtlink.common.api"));
-        assertNull("Unxpected response", icRoot.locateFinest("com"));
+        assertNull("Unexpected response", icRoot.locateFinest("com"));
     }
 
     @Test
     public void testEnsureTrailingDot() {
-        assertNull("Unxpected response", icRoot.locateFinest("com.kazgroup.courtlinkkk"));
-        assertNull("Unxpected response",
+        assertNull("Unexpected response", icRoot.locateFinest("com.kazgroup.courtlinkkk"));
+        assertNull("Unexpected response",
                 icRoot.locateFinest("com.kazgroup.courtlink/common.api"));
     }
 
     @Test
     public void testCheckAccess() {
-        assertEquals("Unxpected access result", AccessResult.DISALLOWED, icCommon.checkAccess(
+        assertEquals("Unexpected access result", AccessResult.DISALLOWED, icCommon.checkAccess(
                 "com.kazgroup.courtlink.common",
                 "org.springframework.something"));
-        assertEquals("Unxpected access result", AccessResult.ALLOWED, icCommon
+        assertEquals("Unexpected access result", AccessResult.ALLOWED, icCommon
                 .checkAccess("com.kazgroup.courtlink.common",
                         "org.apache.commons.something"));
-        assertEquals("Unxpected access result", AccessResult.DISALLOWED, icCommon.checkAccess(
+        assertEquals("Unexpected access result", AccessResult.DISALLOWED, icCommon.checkAccess(
                 "com.kazgroup.courtlink.common", "org.apache.commons"));
-        assertEquals("Unxpected access result", AccessResult.ALLOWED, icCommon.checkAccess(
+        assertEquals("Unexpected access result", AccessResult.ALLOWED, icCommon.checkAccess(
                 "com.kazgroup.courtlink.common", "org.hibernate.something"));
-        assertEquals("Unxpected access result", AccessResult.DISALLOWED, icCommon.checkAccess(
+        assertEquals("Unexpected access result", AccessResult.DISALLOWED, icCommon.checkAccess(
                 "com.kazgroup.courtlink.common", "com.badpackage.something"));
-        assertEquals("Unxpected access result", AccessResult.DISALLOWED, icRoot.checkAccess(
+        assertEquals("Unexpected access result", AccessResult.DISALLOWED, icRoot.checkAccess(
                 "com.kazgroup.courtlink", "org.hibernate.something"));
     }
 
     @Test
     public void testUnknownPkg() {
-        assertNull("Unxpected response", icRoot.locateFinest("net.another"));
+        assertNull("Unexpected response", icRoot.locateFinest("net.another"));
     }
 
     @Test
     public void testRegExpChildLocateFinest() {
-        assertEquals("Unxpected response", icRootRegexpChild, icRootRegexpChild
+        assertEquals("Unexpected response", icRootRegexpChild, icRootRegexpChild
                 .locateFinest("com.kazgroup.courtlink.domain"));
-        assertEquals("Unxpected response", icCommonRegexpChild, icRootRegexpChild
+        assertEquals("Unexpected response", icCommonRegexpChild, icRootRegexpChild
                 .locateFinest("com.kazgroup.courtlink.common.api"));
-        assertNull("Unxpected response", icRootRegexpChild.locateFinest("com"));
+        assertNull("Unexpected response", icRootRegexpChild.locateFinest("com"));
     }
 
     @Test
     public void testRegExpChildCheckAccess() {
-        assertEquals("Unxpected access result", AccessResult.DISALLOWED,
+        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common",
                         "org.springframework.something"));
-        assertEquals("Unxpected access result", AccessResult.DISALLOWED,
+        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common",
                         "org.luiframework.something"));
-        assertEquals("Unxpected access result", AccessResult.DISALLOWED,
+        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common",
                         "de.springframework.something"));
-        assertEquals("Unxpected access result", AccessResult.DISALLOWED,
+        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common",
                 "de.luiframework.something"));
-        assertEquals("Unxpected access result", AccessResult.ALLOWED,
+        assertEquals("Unexpected access result", AccessResult.ALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common",
                         "org.apache.commons.something"));
-        assertEquals("Unxpected access result", AccessResult.ALLOWED,
+        assertEquals("Unexpected access result", AccessResult.ALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common",
                         "org.lui.commons.something"));
-        assertEquals("Unxpected access result", AccessResult.DISALLOWED,
+        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common",
                         "org.apache.commons"));
-        assertEquals("Unxpected access result", AccessResult.DISALLOWED,
+        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common",
                         "org.lui.commons"));
-        assertEquals("Unxpected access result", AccessResult.ALLOWED,
+        assertEquals("Unexpected access result", AccessResult.ALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common",
                         "org.hibernate.something"));
-        assertEquals("Unxpected access result", AccessResult.DISALLOWED,
+        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common",
                         "com.badpackage.something"));
-        assertEquals("Unxpected access result", AccessResult.DISALLOWED,
+        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
                 icRootRegexpChild.checkAccess("com.kazgroup.courtlink",
                         "org.hibernate.something"));
     }
 
     @Test
     public void testRegExpChildUnknownPkg() {
-        assertNull("Unxpected response", icRootRegexpChild.locateFinest("net.another"));
+        assertNull("Unexpected response", icRootRegexpChild.locateFinest("net.another"));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -133,7 +133,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             "7: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.junit.Assert.assertEquals"),
         };
 
-        verify(checkConfig, getPath("InputImportOrderStaticGroupSeperated.java"), expected);
+        verify(checkConfig, getPath("InputImportOrderStaticGroupSeparated.java"), expected);
     }
 
     @Test
@@ -430,7 +430,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "6: " + getCheckMessage(MSG_ORDERING, "java.awt.event.ActionEvent"),
         };
-        verify(checkConfig, getPath("InputImportOrderRepetiton.java"), expected);
+        verify(checkConfig, getPath("InputImportOrderRepetition.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
@@ -215,7 +215,7 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
         }
         catch (IllegalArgumentException ex) {
             final String msg = ex.getMessage();
-            Assert.assertEquals("Invalid excpeton message",
+            Assert.assertEquals("Invalid exception message",
                     "Unexpected token type: methodStub", msg);
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -224,7 +224,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
         Assert.assertNotNull("Default tokens should not be null", check.getDefaultTokens());
         Assert.assertArrayEquals("Acceptable tokens should be equal to default",
                 check.getDefaultTokens(), check.getAcceptableTokens());
-        Assert.assertArrayEquals("REquired tokens should be equal to default",
+        Assert.assertArrayEquals("Required tokens should be equal to default",
                 check.getDefaultTokens(), check.getRequiredTokens());
         Assert.assertArrayEquals("Invalid default javadoc tokens",
                 defaultJavadocTokens, check.getDefaultJavadocTokens());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/ClassResolverTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/ClassResolverTest.java
@@ -150,7 +150,7 @@ public class ClassResolverTest {
             final String expected = "expected exception";
             assertTrue("Invalid exception cause, should be: ClassNotFoundException",
                     ex.getCause() instanceof ClassNotFoundException);
-            assertTrue("Invalid excpetion message, should end with: " + expected,
+            assertTrue("Invalid exception message, should end with: " + expected,
                     ex.getMessage().endsWith(expected));
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
@@ -86,7 +86,7 @@ public class JavadocTagInfoTest {
         }
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.AUTHOR.isValidOn(ast));
     }
 
@@ -129,11 +129,11 @@ public class JavadocTagInfoTest {
 
             astParent.setType(TokenTypes.SLIST);
             ast.setType(TokenTypes.VARIABLE_DEF);
-            assertFalse("Should return false when ast type is invalid for currrent tag",
+            assertFalse("Should return false when ast type is invalid for current tag",
                     tagInfo.isValidOn(ast));
 
             ast.setType(TokenTypes.PARAMETER_DEF);
-            assertFalse("Should return false when ast type is invalid for currrent tag",
+            assertFalse("Should return false when ast type is invalid for current tag",
                     tagInfo.isValidOn(ast));
         }
     }
@@ -166,11 +166,11 @@ public class JavadocTagInfoTest {
 
         astParent.setType(TokenTypes.SLIST);
         ast.setType(TokenTypes.VARIABLE_DEF);
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.DEPRECATED.isValidOn(ast));
 
         ast.setType(TokenTypes.PARAMETER_DEF);
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.DEPRECATED.isValidOn(ast));
     }
 
@@ -194,11 +194,11 @@ public class JavadocTagInfoTest {
 
         astParent.setType(TokenTypes.SLIST);
         ast.setType(TokenTypes.VARIABLE_DEF);
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.SERIAL.isValidOn(ast));
 
         ast.setType(TokenTypes.PARAMETER_DEF);
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.SERIAL.isValidOn(ast));
     }
 
@@ -217,7 +217,7 @@ public class JavadocTagInfoTest {
         }
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.EXCEPTION.isValidOn(ast));
     }
 
@@ -236,7 +236,7 @@ public class JavadocTagInfoTest {
         }
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.THROWS.isValidOn(ast));
     }
 
@@ -258,7 +258,7 @@ public class JavadocTagInfoTest {
         }
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.VERSION.isValidOn(ast));
     }
 
@@ -279,7 +279,7 @@ public class JavadocTagInfoTest {
         }
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.PARAM.isValidOn(ast));
     }
 
@@ -303,11 +303,11 @@ public class JavadocTagInfoTest {
         }
 
         astChild2.setType(TokenTypes.LITERAL_VOID);
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.RETURN.isValidOn(ast));
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.RETURN.isValidOn(ast));
     }
 
@@ -332,15 +332,15 @@ public class JavadocTagInfoTest {
         }
 
         astChild2.setText("1111");
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.SERIAL_FIELD.isValidOn(ast));
 
         astChild2.setType(TokenTypes.LITERAL_VOID);
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.SERIAL_FIELD.isValidOn(ast));
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.SERIAL_FIELD.isValidOn(ast));
     }
 
@@ -368,11 +368,11 @@ public class JavadocTagInfoTest {
         }
 
         astChild.setText("1111");
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.SERIAL_DATA.isValidOn(ast));
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for currrent tag",
+        assertFalse("Should return false when ast type is invalid for current tag",
                 JavadocTagInfo.SERIAL_DATA.isValidOn(ast));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
@@ -71,7 +71,7 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
     }
 
     @Test
-    public void testExludedPackageDirectPackages() throws Exception {
+    public void testExcludedPackageDirectPackages() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(ClassDataAbstractionCouplingCheck.class);
 
@@ -91,7 +91,7 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
     }
 
     @Test
-    public void testExludedPackageCommonPackages() throws Exception {
+    public void testExcludedPackageCommonPackages() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(ClassDataAbstractionCouplingCheck.class);
 
@@ -110,7 +110,7 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
     }
 
     @Test
-    public void testExludedPackageWithEndingDot() throws Exception {
+    public void testExcludedPackageWithEndingDot() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(ClassDataAbstractionCouplingCheck.class);
 
@@ -136,7 +136,7 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
     }
 
     @Test
-    public void testExludedPackageCommonPackagesAllIgnored() throws Exception {
+    public void testExcludedPackageCommonPackagesAllIgnored() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(ClassDataAbstractionCouplingCheck.class);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckTest.java
@@ -130,7 +130,7 @@ public class AbstractClassNameCheckTest extends AbstractModuleTestSupport {
         final int[] expected = {
             TokenTypes.CLASS_DEF,
         };
-        Assert.assertArrayEquals("Invalid accaptable tokens", expected, actual);
+        Assert.assertArrayEquals("Invalid acceptable tokens", expected, actual);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
@@ -81,8 +81,8 @@ public class MethodNameCheckTest
                     "InputMethodNameEqualClassName", pattern),
             "47:9: " + getCheckMessage(MSG_KEY, "SweetInterface"),
             "47:9: " + getCheckMessage(MSG_INVALID_PATTERN, "SweetInterface", pattern),
-            "53:17: " + getCheckMessage(MSG_KEY, "Outter"),
-            "53:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outter", pattern),
+            "53:17: " + getCheckMessage(MSG_KEY, "Outer"),
+            "53:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),
         };
 
         verify(checkConfig, getPath("InputMethodNameEqualClassName.java"), expected);
@@ -109,7 +109,7 @@ public class MethodNameCheckTest
             "37:24: " + getCheckMessage(MSG_INVALID_PATTERN,
                     "InputMethodNameEqualClassName", pattern),
             "47:9: " + getCheckMessage(MSG_INVALID_PATTERN, "SweetInterface", pattern),
-            "53:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outter", pattern),
+            "53:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),
         };
 
         verify(checkConfig, getPath("InputMethodNameEqualClassName.java"), expected);
@@ -137,7 +137,7 @@ public class MethodNameCheckTest
             "37:24: " + getCheckMessage(MSG_INVALID_PATTERN,
                     "InputMethodNameEqualClassName", pattern),
             "47:9: " + getCheckMessage(MSG_INVALID_PATTERN, "SweetInterface", pattern),
-            "53:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outter", pattern),
+            "53:17: " + getCheckMessage(MSG_INVALID_PATTERN, "Outer", pattern),
         };
 
         verify(checkConfig, getPath("InputMethodNameEqualClassName.java"), expected);
@@ -165,7 +165,7 @@ public class MethodNameCheckTest
             "20:20: " + getCheckMessage(MSG_INVALID_PATTERN, "PROTECTEDfoo", pattern),
         };
 
-        verify(checkConfig, getPath("InputMethodNameOverridenMethods.java"), expected);
+        verify(checkConfig, getPath("InputMethodNameOverriddenMethods.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
@@ -108,7 +108,7 @@ public class NoWhitespaceAfterCheckTest
             "39:11: " + getCheckMessage(MSG_KEY, "ar"),
             "39:24: " + getCheckMessage(MSG_KEY, "int"),
             "40:16: " + getCheckMessage(MSG_KEY, "int"),
-            "43:63: " + getCheckMessage(MSG_KEY, "getLongMultArray"),
+            "43:64: " + getCheckMessage(MSG_KEY, "getLongMultiArray"),
             "47:26: " + getCheckMessage(MSG_KEY, "}"),
             "49:22: " + getCheckMessage(MSG_KEY, "int"),
             "50:24: " + getCheckMessage(MSG_KEY, "]"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
@@ -476,7 +476,7 @@ public class ParenPadCheckTest
         final Method method = Whitebox.getMethod(ParenPadCheck.class,
             "isAcceptableToken", DetailAST.class);
         final DetailAST ast = new DetailAST();
-        final String message = "Expected that all accaptable tokens will pass isAccaptableToken "
+        final String message = "Expected that all acceptable tokens will pass isAcceptableToken "
             + "method, but some token don't: ";
 
         for (int token : check.getAcceptableTokens()) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressElementTest.java
@@ -169,7 +169,7 @@ public class SuppressElementTest {
                 new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         final SuppressElement myFilter =
-                new SuppressElement("Test", "NON_EXISTING_CHECK", null, "MyModule", null, null);
+                new SuppressElement("Test", "NON_EXISTENT_CHECK", null, "MyModule", null, null);
         assertTrue("Filter should accept valid event", myFilter.accept(ev));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -401,7 +401,7 @@ public class SuppressionCommentFilterTest
         final TreeWalkerAuditEvent dummyEvent = new TreeWalkerAuditEvent(contents, "filename",
                 new LocalizedMessage(1, null, null, null, null, Object.class, null), null);
         final boolean result = suppressionCommentFilter.accept(dummyEvent);
-        assertFalse("Fileter should not accept event", result);
+        assertFalse("Filter should not accept event", result);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
@@ -85,8 +85,8 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNonExistingSuppressionFileWithFalseOptional() {
-        final String fileName = "non_existing_suppression_file.xml";
+    public void testNonExistentSuppressionFileWithFalseOptional() {
+        final String fileName = "non_existent_suppression_file.xml";
         try {
             final boolean optional = false;
             createSuppressionFilter(fileName, optional);
@@ -126,8 +126,8 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNonExistingSuppressionFileWithTrueOptional() throws Exception {
-        final String fileName = "non_existing_suppression_file.xml";
+    public void testNonExistentSuppressionFileWithTrueOptional() throws Exception {
+        final String fileName = "non_existent_suppression_file.xml";
         final boolean optional = true;
         final SuppressionFilter filter = createSuppressionFilter(fileName, optional);
 
@@ -138,9 +138,9 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNonExistingSuppressionUrlWithTrueOptional() throws Exception {
+    public void testNonExistentSuppressionUrlWithTrueOptional() throws Exception {
         final String fileName =
-                "http://checkstyle.sourceforge.net/non_existing_suppression.xml";
+                "http://checkstyle.sourceforge.net/non_existent_suppression.xml";
         final boolean optional = true;
         final SuppressionFilter filter = createSuppressionFilter(fileName, optional);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
@@ -86,8 +86,8 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNonExistingSuppressionFileWithFalseOptional() throws Exception {
-        final String fileName = getPath("non_existing_suppression_file.xml");
+    public void testNonExistentSuppressionFileWithFalseOptional() throws Exception {
+        final String fileName = getPath("non_existent_suppression_file.xml");
         try {
             final boolean optional = false;
             createSuppressionXpathFilter(fileName, optional);
@@ -128,9 +128,9 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNonExistingSuppressionFileWithTrueOptional() throws Exception {
+    public void testNonExistentSuppressionFileWithTrueOptional() throws Exception {
         final String fileName = "src/test/resources/com/puppycrawl/tools/checkstyle/filters/"
-                + "non_existing_suppression_file.xml";
+                + "non_existent_suppression_file.xml";
         final boolean optional = true;
         final SuppressionXpathFilter filter = createSuppressionXpathFilter(fileName, optional);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -105,7 +105,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public void testLoadFromNonExistingUrl() {
+    public void testLoadFromNonExistentUrl() {
         try {
             SuppressionsLoader.loadSuppressions("http://^%$^* %&% %^&");
             fail("exception expected");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/GeneratedJavadocTokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/GeneratedJavadocTokenTypesTest.java
@@ -36,7 +36,7 @@ public class GeneratedJavadocTokenTypesTest {
      * This method checks that the numbers generated for tokens in <tt>JavadocLexer.g4</tt> don't
      * change with the lexer grammar itself.
      * <br>ANTLR maps all the lexer elements to compile time constants used internally by ANTLR.
-     * Compatability damange is incurred <i>(with respect to the previous checkstyle versions)
+     * Compatibility damage is incurred <i>(with respect to the previous checkstyle versions)
      * </i> if these compile time constants keep changing with the grammar.
      *
      * @see "https://github.com/checkstyle/checkstyle/issues/5139"
@@ -146,7 +146,7 @@ public class GeneratedJavadocTokenTypesTest {
      * This method checks that the numbers generated for rules in <tt>JavadocParser.g4</tt> don't
      * change with the Parser grammar itself.
      * <br>ANTLR maps all the parser rules to compile time constants used internally by ANTLR.
-     * Compatability damange is incurred <i>(with respect to the previous checkstyle versions)
+     * Compatibility damage is incurred <i>(with respect to the previous checkstyle versions)
      * </i> if these compile time constants keep changing with the grammar.
      *
      * @see "https://github.com/checkstyle/checkstyle/issues/5139"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
@@ -191,13 +191,13 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
         final ParseTreeTablePresentation parseTree = new ParseTreeTablePresentation(null);
         int index = 0;
         while (ithChild != null) {
-            Assert.assertEquals("Invalud child index",
+            Assert.assertEquals("Invalid child index",
                     index, parseTree.getIndexOfChild(tree, ithChild));
             ithChild = ithChild.getNextSibling();
             index++;
         }
 
-        Assert.assertEquals("Invalud child index",
+        Assert.assertEquals("Invalid child index",
                 -1, parseTree.getIndexOfChild(tree, new DetailAST()));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilsTest.java
@@ -186,23 +186,23 @@ public class CheckUtilsTest extends AbstractPathTestSupport {
 
     @Test
     public void testGetTypeParameterNames() throws Exception {
-        final DetailAST parameterisedClassNode = getNodeFromFile(TokenTypes.CLASS_DEF);
+        final DetailAST parameterizedClassNode = getNodeFromFile(TokenTypes.CLASS_DEF);
         final List<String> expected = Arrays.asList("V", "C");
 
         assertEquals("Invalid type parameters",
-                expected, CheckUtils.getTypeParameterNames(parameterisedClassNode));
+                expected, CheckUtils.getTypeParameterNames(parameterizedClassNode));
     }
 
     @Test
     public void testGetTypeParameters() throws Exception {
-        final DetailAST parameterisedClassNode = getNodeFromFile(TokenTypes.CLASS_DEF);
+        final DetailAST parameterizedClassNode = getNodeFromFile(TokenTypes.CLASS_DEF);
         final DetailAST firstTypeParameter =
-                getNode(parameterisedClassNode, TokenTypes.TYPE_PARAMETER);
+                getNode(parameterizedClassNode, TokenTypes.TYPE_PARAMETER);
         final List<DetailAST> expected = Arrays.asList(firstTypeParameter,
                 firstTypeParameter.getNextSibling().getNextSibling());
 
         assertEquals("Invalid type parameters", expected,
-                CheckUtils.getTypeParameters(parameterisedClassNode));
+                CheckUtils.getTypeParameters(parameterizedClassNode));
     }
 
     @Test
@@ -235,7 +235,7 @@ public class CheckUtilsTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public void testIsNonViodMethod() throws Exception {
+    public void testIsNonVoidMethod() throws Exception {
         final DetailAST nonVoidMethod = getNodeFromFile(TokenTypes.METHOD_DEF);
         final DetailAST voidMethod = nonVoidMethod.getNextSibling();
 
@@ -276,13 +276,13 @@ public class CheckUtilsTest extends AbstractPathTestSupport {
         final DetailAST publicVariable = protectedVariable.getNextSibling();
         final DetailAST packageVariable = publicVariable.getNextSibling();
 
-        assertEquals("Invalid access modofier", AccessModifier.PRIVATE,
+        assertEquals("Invalid access modifier", AccessModifier.PRIVATE,
                 CheckUtils.getAccessModifierFromModifiersToken(privateVariable.getFirstChild()));
-        assertEquals("Invalid access modofier", AccessModifier.PROTECTED,
+        assertEquals("Invalid access modifier", AccessModifier.PROTECTED,
                 CheckUtils.getAccessModifierFromModifiersToken(protectedVariable.getFirstChild()));
-        assertEquals("Invalid access modofier", AccessModifier.PUBLIC,
+        assertEquals("Invalid access modifier", AccessModifier.PUBLIC,
                 CheckUtils.getAccessModifierFromModifiersToken(publicVariable.getFirstChild()));
-        assertEquals("Invalid access modofier", AccessModifier.PACKAGE,
+        assertEquals("Invalid access modifier", AccessModifier.PACKAGE,
                 CheckUtils.getAccessModifierFromModifiersToken(packageVariable.getFirstChild()));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
@@ -132,14 +132,14 @@ public class CommonUtilsTest {
         assertEquals("Invalid line number", 0, testCommentBlock.getLineNo());
 
         final DetailAST contentCommentBlock = testCommentBlock.getFirstChild();
-        assertEquals("Invalid tiken type",
+        assertEquals("Invalid token type",
                 TokenTypes.COMMENT_CONTENT, contentCommentBlock.getType());
         assertEquals("Invalid text", "*test_comment", contentCommentBlock.getText());
         assertEquals("Invalid line number", 0, contentCommentBlock.getLineNo());
         assertEquals("Invalid column number", -1, contentCommentBlock.getColumnNo());
 
         final DetailAST endCommentBlock = contentCommentBlock.getNextSibling();
-        assertEquals("Invalid tiken type", TokenTypes.BLOCK_COMMENT_END, endCommentBlock.getType());
+        assertEquals("Invalid token type", TokenTypes.BLOCK_COMMENT_END, endCommentBlock.getType());
         assertEquals("Invalid text", "*/", endCommentBlock.getText());
     }
 
@@ -229,7 +229,7 @@ public class CommonUtilsTest {
     }
 
     @Test
-    public void testGetNonExistingConstructor() {
+    public void testGetNonExistentConstructor() {
         try {
             CommonUtils.getConstructor(Math.class);
             fail("IllegalStateException is expected");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/FilterUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/FilterUtilsTest.java
@@ -58,9 +58,9 @@ public class FilterUtilsTest {
     }
 
     @Test
-    public void testNonExistingFile() {
+    public void testNonExistentFile() {
         assertFalse("Suppression file does not exist",
-                FilterUtils.isFileExists("non-existing.xml"));
+                FilterUtils.isFileExists("non-existent.xml"));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilsTest.java
@@ -187,7 +187,7 @@ public class JavadocUtilsTest {
     @Test
     public void testEmptyJavadocComment() {
         final String emptyJavadocComment = "*";
-        assertTrue("Should return true when empty jabadoc comment is passed",
+        assertTrue("Should return true when empty javadoc comment is passed",
                 JavadocUtils.isJavadocComment(emptyJavadocComment));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilsTest.java
@@ -145,7 +145,7 @@ public class TokenUtilsTest {
 
     @Test
     public void testTokenIdIncorrect() {
-        final String id = "NON_EXISTING_VALUE";
+        final String id = "NON_EXISTENT_VALUE";
         try {
             TokenUtils.getTokenId(id);
             fail("IllegalArgumentException is expected");
@@ -158,7 +158,7 @@ public class TokenUtilsTest {
 
     @Test
     public void testShortDescriptionIncorrect() {
-        final String id = "NON_EXISTING_VALUE";
+        final String id = "NON_EXISTENT_VALUE";
         try {
             TokenUtils.getShortDescription(id);
             fail("IllegalArgumentException is expected");
@@ -184,7 +184,7 @@ public class TokenUtilsTest {
     }
 
     @Test
-    public void tetsGetTokenTypesTotalNumber() {
+    public void testGetTokenTypesTotalNumber() {
         final int tokenTypesTotalNumber = TokenUtils.getTokenTypesTotalNumber();
 
         assertEquals("Invalid token total number", 169, tokenTypesTotalNumber);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
@@ -111,7 +111,7 @@ public class XpathMapperTest extends AbstractPathTestSupport {
 
     @Test
     public void testAttributeOr() throws Exception {
-        final String xpath = "//METHOD_DEF[@text='getSomeMethod' or @text='nonExistingMethod']";
+        final String xpath = "//METHOD_DEF[@text='getSomeMethod' or @text='nonExistentMethod']";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final DetailAST[] actual = convertToArray(getXpathItems(xpath, rootNode));
         final DetailAST expectedClassDefNode = getSiblingByType(rootNode.getUnderlyingNode(),
@@ -413,7 +413,7 @@ public class XpathMapperTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public void testQueryNonExistingAttribute() throws Exception {
+    public void testQueryNonExistentAttribute() throws Exception {
         final String xpath = "/CLASS_DEF[@text='InputXpathMapperAst']";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<Item> nodes = getXpathItems(xpath, rootNode);
@@ -450,7 +450,7 @@ public class XpathMapperTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public void testQueryNonExistingAnnotation() throws Exception {
+    public void testQueryNonExistentAnnotation() throws Exception {
         final String xpath = "//ANNOTATION[@text='SpringBootApplication']";
         final RootNode rootNode = getRootNode("InputXpathMapperAnnotation.java");
         final List<Item> nodes = getXpathItems(xpath, rootNode);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisMethodReferences.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisMethodReferences.java
@@ -6,16 +6,16 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-public class InputRequireThisMetodReferences {
+public class InputRequireThisMethodReferences {
     private Set<String> tags = Collections.unmodifiableSortedSet(
         Arrays.stream(new String[] {"br", "li", "dt", "dd", "hr", "img", "p", "td", "tr", "th",})
             .collect(Collectors.toCollection(TreeSet::new)));
 
-    public InputRequireThisMetodReferences(Set<String> tags) {
+    public InputRequireThisMethodReferences(Set<String> tags) {
         tags = tags; // violation
     }
 
-    public InputRequireThisMetodReferences() {
+    public InputRequireThisMethodReferences() {
         this.tags = Arrays.stream(
             new String[] {"br", "li", "dt", "dd", "hr", "img", "p", "td", "tr", "th",})
             .collect(Collectors.toCollection(TreeSet::new));

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/throwscount/InputThrowsCountMethodWithAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/throwscount/InputThrowsCountMethodWithAnnotation.java
@@ -6,7 +6,7 @@ import java.io.FileNotFoundException;
 import java.nio.file.FileAlreadyExistsException;
 import java.sql.SQLException;
 
-public class InputThrowsCountMwthodWithAnnotation extends ParentClass {
+public class InputThrowsCountMethodWithAnnotation extends ParentClass {
     @Override
     public void method() throws AWTException, SQLException, FileNotFoundException,
             EOFException, FileAlreadyExistsException {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderRepetition.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderRepetition.java
@@ -8,5 +8,5 @@ import java.awt.event.ActionEvent;    //Repetitive import
 import javax.swing.JComponent;
 import javax.swing.JTable;
 
-public class InputImportOrderRepetiton {
+public class InputImportOrderRepetition {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderStaticGroupSeparated.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderStaticGroupSeparated.java
@@ -7,7 +7,7 @@ import static java.lang.Math.cos;;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-public class InputImportOrderStaticGroupSeperated {
+public class InputImportOrderStaticGroupSeparated {
     void method() {
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameEqualClassName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameEqualClassName.java
@@ -47,10 +47,10 @@ interface SweetInterface {
     int SweetInterface();
 }
 
-class Outter {
+class Outer {
 	
 	//illegal name
-    public void Outter() {
+    public void Outer() {
 		
 	}
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameOverriddenMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameOverriddenMethods.java
@@ -1,6 +1,6 @@
 package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 
-public class InputMethodNameOverridenMethods extends SomeClass 
+public class InputMethodNameOverriddenMethods extends SomeClass
 {
     @Override
     public void PUBLICfoo() { //Ignored due to impossibility of change by developer

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterArrayDeclarations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterArrayDeclarations.java
@@ -37,10 +37,10 @@ public class InputNoWhitespaceAfterArrayDeclarations
         };
     }
     int ar [] = new int [] {1, 2}; //Incorrect (2 warnings)
-    private int [][][] getMultArray() { //Incorrect
+    private int [][][] getMultiArray() { //Incorrect
         return null;
     }
-    private long getLongMultArray(int someParam, String value) [][][] { //Incorrect
+    private long getLongMultiArray(int someParam, String value) [][][] { //Incorrect
         return null;
     }
     int aa = new int[]{1}[0];//Correct

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderNonexistentProperty.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderNonexistentProperty.xml
@@ -5,5 +5,5 @@
     "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
-    <property name="tabWidth" value="${nonexisting}" />
+    <property name="tabWidth" value="${nonexistent}" />
 </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainConfig-non-existent-classname-ignore.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainConfig-non-existent-classname-ignore.xml
@@ -6,7 +6,7 @@
 
 <module name="Checker">
     <module name="TreeWalker">
-        <module name="NonExistingClass">
+        <module name="NonExistentClass">
             <property name="severity" value="ignore"/>
         </module>
     </module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainConfig-non-existent-classname.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainConfig-non-existent-classname.xml
@@ -6,7 +6,7 @@
 
 <module name="Checker">
     <module name="TreeWalker">
-        <module name="NonExistingClass">
+        <module name="NonExistentClass">
             <property name="severity" value="warning"/>
         </module>
     </module>


### PR DESCRIPTION
minor: fix typos in tests

Mistypes in the test sources. Mostly in the comments and assertion messages.
Six _input_ classes  have been renamed.