### PR TITLE
Pull #5392: fixed RequireThisCheck and for loop variable handling

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -61,8 +61,10 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
             "122:13: " + getCheckMessage(MSG_VARIABLE, "i", "Issue2240."),
             "134:9: " + getCheckMessage(MSG_METHOD, "foo", ""),
             "142:9: " + getCheckMessage(MSG_VARIABLE, "s", ""),
-            "167:16: " + getCheckMessage(MSG_VARIABLE, "a", ""),
-            "167:20: " + getCheckMessage(MSG_VARIABLE, "a", ""),
+            "168:16: " + getCheckMessage(MSG_VARIABLE, "a", ""),
+            "168:20: " + getCheckMessage(MSG_VARIABLE, "a", ""),
+            "174:16: " + getCheckMessage(MSG_VARIABLE, "b", ""),
+            "174:20: " + getCheckMessage(MSG_VARIABLE, "b", ""),
         };
         verify(checkConfig,
                getPath("InputRequireThisEnumInnerClassesAndBugs.java"),
@@ -101,8 +103,10 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
             "114:9: " + getCheckMessage(MSG_VARIABLE, "i", ""),
             "122:13: " + getCheckMessage(MSG_VARIABLE, "i", "Issue2240."),
             "142:9: " + getCheckMessage(MSG_VARIABLE, "s", ""),
-            "167:16: " + getCheckMessage(MSG_VARIABLE, "a", ""),
-            "167:20: " + getCheckMessage(MSG_VARIABLE, "a", ""),
+            "168:16: " + getCheckMessage(MSG_VARIABLE, "a", ""),
+            "168:20: " + getCheckMessage(MSG_VARIABLE, "a", ""),
+            "174:16: " + getCheckMessage(MSG_VARIABLE, "b", ""),
+            "174:20: " + getCheckMessage(MSG_VARIABLE, "b", ""),
         };
         verify(checkConfig,
                getPath("InputRequireThisEnumInnerClassesAndBugs.java"),
@@ -325,6 +329,17 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("validateOnlyOverlapping", "false");
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputRequireThisAnnotationInterface.java"), expected);
+    }
+
+    @Test
+    public void testFor() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RequireThisCheck.class);
+        checkConfig.addAttribute("validateOnlyOverlapping", "false");
+        final String[] expected = {
+            "13:13: " + getCheckMessage(MSG_VARIABLE, "bottom", ""),
+            "21:34: " + getCheckMessage(MSG_VARIABLE, "name", ""),
+        };
+        verify(checkConfig, getPath("InputRequireThisFor.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisEnumInnerClassesAndBugs.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisEnumInnerClassesAndBugs.java
@@ -152,6 +152,7 @@ class NestedRechange {
 }
 class NestedFrames {
     int a = 0;
+    int b = 0;
 
     public int oneReturnInMethod2() {
         for (int i = 0; i < 10; i++) {
@@ -165,5 +166,11 @@ class NestedFrames {
             }
         }
         return a + a * a;
+    }
+
+    public int oneReturnInMethod3() {
+        for (int b = 0; b < 10; b++) {
+        }
+        return b + b * b;
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisFor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisFor.java
@@ -1,0 +1,23 @@
+package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class InputRequireThisFor {
+    private String name;
+    int bottom;
+
+    public void method1() {
+        for (int i = 0; i < 10; i++) {
+            int bottom = i - 4;
+            bottom = bottom > 0 ? bottom - 1 : bottom;
+        }
+    }
+
+    public void method2() {
+        for (String name : new String[]{}) {
+        }
+
+        Path jarfile = Paths.get(name + ".jar");
+    }
+}


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/issues/5307#issuecomment-352784756 
For loop variables are seen in the wrong scope. They are thought to be in the base method definition when they are actually scoped inside the loop itself.

You can clearly see the scope change at https://github.com/rnveach/checkstyle/commit/85c10036687b19156b06110d02c6408eac028864#diff-6b1f89f1bde0470d4bd42580d1aa8bfb .

````
$ cat TestClass.java
public class TestClass {
    int b = 0;

    void method() {
        for (int b = 0; b < 10; b++) {
        }
        return b + b * b;
    }
}

$ cat TestConfig.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>

    <module name="TreeWalker">
<module name="RequireThisCheck">
<property name="validateOnlyOverlapping" value="false" />
</module>
    </module>
</module>

$ java -jar checkstyle-8.5-all.jar -c TestConfig.xml TestClass.java
Starting audit...
Audit done.
````

No violation even though variable `b` is the field variable.

First regression: http://rveach.no-ip.org/checkstyle/regression/reports/148/
Showed a new NPE which I fixed.

I will provide newer regression.