### PR TITLE
Issue #5102: Fix Java9 build

### DIFF
--- a/config/ant-phase-compile.xml
+++ b/config/ant-phase-compile.xml
@@ -7,20 +7,5 @@
       <entry key="checkstyle.compile.version" value="${mvn.project.version}"/>
       <entry key="checkstyle.compile.timestamp" type="date" value="now" pattern="E MMMM dd yyyy, HH:mm z"/>
     </propertyfile>
-    <javadoc sourcefiles="src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java"
-             encoding="UTF-8"
-             source="${java.version}"
-             failonerror="yes">
-      <classpath>
-        <pathelement location="${mvn.project.build.outputDirectory}"/>
-        <pathelement path="${mvn.compile_classpath}"/>
-      </classpath>
-      <doclet name="com.puppycrawl.tools.checkstyle.doclets.TokenTypesDoclet"
-              path="${mvn.project.build.outputDirectory}">
-        <param name="-destfile"
-               value="${mvn.project.build.outputDirectory}/com/puppycrawl/tools/checkstyle/api/tokentypes.properties"
-               />
-      </doclet>
-    </javadoc>
   </target>
 </project>

--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -430,7 +430,7 @@
     </module>
     <module name="TrailingComment"/>
     <module name="UncommentedMain">
-      <property name="excludedClasses" value="\.Main$"/>
+      <property name="excludedClasses" value="\.(Main|TokenTypesDoclet)$"/>
     </module>
     <module name="UpperEll"/>
 

--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -93,7 +93,7 @@
     <Match>
         <!-- false-positive. Bugs reported even though casting is done only after verification using instanceof -->
         <Class name="com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser"/>
-        <Method name="parseJavadocAsDetailNode"/>
+        <Method name="parseJavadoc"/>
         <Bug pattern="BC_UNCONFIRMED_CAST_OF_RETURN_VALUE"/>
     </Match>
     <Match>

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -167,7 +167,7 @@
     <allow pkg="java.util" exact-match="true"/>
     <allow pkg="com.puppycrawl.tools.checkstyle.api" local-only="true"/>
     <allow pkg="com.puppycrawl.tools.checkstyle.utils" local-only="true"/>
-    <allow class="com.puppycrawl.tools.checkstyle.TreeWalker" local-only="true"/>
+    <allow class="com.puppycrawl.tools.checkstyle.Parser" local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.gui.MainFrameModel.ParseMode"
            local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser" local-only="true"/>

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -141,10 +141,14 @@
   </subpackage>
 
   <subpackage name="doclets" strategyOnMismatch="disallowed">
-    <allow class="java.nio.charset.StandardCharsets"/>
-    <allow pkg="com.sun.javadoc"/>
-    <allow pkg="java.io"/>
-    <allow pkg="java.util"/>
+    <allow pkg="com.puppycrawl.tools.checkstyle.api" local-only="true"/>
+    <allow class="com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser" local-only="true"/>
+    <allow class="com.puppycrawl.tools.checkstyle.Parser" local-only="true"/>
+    <allow class="com.puppycrawl.tools.checkstyle.utils.JavadocUtils" local-only="true"/>
+    <allow pkg="java.io" local-only="true"/>
+    <allow class="java.nio.charset.StandardCharsets" local-only="true"/>
+    <allow pkg="java.util.regex" local-only="true"/>
+    <allow pkg="org.apache.commons.cli" local-only="true"/>
   </subpackage>
 
   <subpackage name="filters">

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -22,7 +22,7 @@
       <property name="showClassesComplexity" value="false"/>
       <property name="reportLevel" value="11"/>
       <!-- DeclarationOrder - 'visitToken' has just big SWITCH block which contains IF blocks.
-           If we split the block to several methods it will demage readibility.
+           If we split the block to several methods it will damage readability.
            validateCli is not reasonable to split as encapsulation of logic will be damaged
            getDetails - huge Switch, it has to be monolithic
            JavadocMethodCheck, JavadocStyleCheck, JavadocUtils.getJavadocTags() - deprecated
@@ -222,20 +222,20 @@
   <rule ref="rulesets/java/logging-java.xml/SystemPrintln">
     <properties>
       <!-- it is ok to use println in CLI class -->
-      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='Main']"/>
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='Main' or @Image='TokenTypesDoclet']"/>
     </properties>
   </rule>
   <rule ref="rulesets/java/logging-java.xml/AvoidPrintStackTrace">
     <properties>
       <!-- it is ok to use print stack trace in CLI class -->
-      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='Main']"/>
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='Main' or @Image='TokenTypesDoclet']"/>
     </properties>
   </rule>
 
   <rule ref="rulesets/java/migrating.xml"/>
 
   <rule ref="rulesets/java/naming.xml">
-    <!-- we use CheckstyleCustomShortVariable, to control lenght (will be fixed in PMD 5.4) and skip Override methods -->
+    <!-- we use CheckstyleCustomShortVariable, to control length (will be fixed in PMD 5.4) and skip Override methods -->
     <exclude name="ShortVariable"/>
   </rule>
 <rule name="CheckstyleCustomShortVariable"

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -133,9 +133,9 @@
   </rule>
   <rule ref="rulesets/java/coupling.xml/ExcessiveImports">
     <properties>
-      <!-- TreeWalker integrates Checkstyle and antlr and CheckstyleAntTask integrates Checkstyle
+      <!-- JavadocDetailNodeParser integrates Checkstyle and antlr and CheckstyleAntTask integrates Checkstyle
        with Ant. Checker collects external resource locations and setup configuration. -->
-      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='TreeWalker' or @Image='CheckstyleAntTask' or @Image='Checker' or @Image='Main']"/>
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='JavadocDetailNodeParser' or @Image='CheckstyleAntTask' or @Image='Checker' or @Image='Main']"/>
     </properties>
   </rule>
   <rule ref="rulesets/java/coupling.xml/CouplingBetweenObjects">

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -75,6 +75,7 @@
     <suppress checks="ClassDataAbstractionCoupling" files="(CheckerTest|TreeWalkerTest|AbstractModuleTestSupport|XdocsPagesTest|CheckstyleAntTaskTest)\.java"/>
     <suppress checks="ClassDataAbstractionCoupling" files="PropertyCacheFile\.java"/>
     <suppress checks="ClassDataAbstractionCoupling" files="PropertyCacheFileTest\.java"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="TokenTypesDoclet\.java"/>
     <suppress checks="ClassFanOutComplexity" files="[\\/]Main\.java"/>
     <suppress checks="ClassFanOutComplexity" files="CheckstyleAntTask\.java"/>
     <suppress checks="ClassFanOutComplexity" files="CheckerTest\.java"/>

--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,11 @@
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>1.6.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
           <artifactId>sonar-maven-plugin</artifactId>
           <version>3.4.0.905</version>
         </plugin>
@@ -707,6 +712,28 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
         <version>2.5.2</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <classpathScope>compile</classpathScope>
+              <mainClass>com.puppycrawl.tools.checkstyle.doclets.TokenTypesDoclet</mainClass>
+              <arguments>
+                <argument>${project.build.sourceDirectory}/com/puppycrawl/tools/checkstyle/api/TokenTypes.java</argument>
+                <argument>--destfile</argument>
+                <argument>${project.build.outputDirectory}/com/puppycrawl/tools/checkstyle/api/tokentypes.properties</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
@@ -1128,6 +1155,7 @@
         <excludes>
           <!-- system-out is ok there, that is CLI -->
           <exclude>**/Main.class</exclude>
+          <exclude>**/TokenTypesDoclet.class</exclude>
           <!-- generated classes, unfortunately use problematic api -->
           <exclude>**/GeneratedJavaLexer.class</exclude>
           <exclude>**/JavadocParser.class</exclude>
@@ -2413,7 +2441,6 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>1.6.0</version>
             <configuration>
               <executable>.ci/eclipse-compiler-javac.sh</executable>
               <classpathScope>test</classpathScope>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java
@@ -21,16 +21,11 @@ package com.puppycrawl.tools.checkstyle;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Locale;
 import java.util.regex.Pattern;
 
-import antlr.RecognitionException;
-import antlr.TokenStreamException;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtils;
@@ -41,22 +36,6 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
  * @author Vladislav Lisetskii
  */
 public final class AstTreeStringPrinter {
-
-    /**
-     * Enum to be used for test if comments should be printed.
-     */
-    public enum PrintOptions {
-
-        /**
-         * Comments has to be printed.
-         */
-        WITH_COMMENTS,
-        /**
-         * Comments has NOT to be printed.
-         */
-        WITHOUT_COMMENTS
-
-    }
 
     /** Newline pattern. */
     private static final Pattern NEWLINE = Pattern.compile("\n");
@@ -76,14 +55,14 @@ public final class AstTreeStringPrinter {
     /**
      * Parse a file and print the parse tree.
      * @param file the file to print.
-     * @param withComments true to include comments to AST
+     * @param withComments {@link Parser.Options#WITH_COMMENTS} to include comment nodes to the tree
      * @return the AST of the file in String form.
      * @throws IOException if the file could not be read.
      * @throws CheckstyleException if the file is not a Java source.
      */
-    public static String printFileAst(File file, PrintOptions withComments)
+    public static String printFileAst(File file, Parser.Options withComments)
             throws IOException, CheckstyleException {
-        return printTree(parseFile(file, withComments));
+        return printTree(Parser.parseFile(file, withComments));
     }
 
     /**
@@ -95,7 +74,7 @@ public final class AstTreeStringPrinter {
      */
     public static String printJavaAndJavadocTree(File file)
             throws IOException, CheckstyleException {
-        final DetailAST tree = parseFile(file, PrintOptions.WITH_COMMENTS);
+        final DetailAST tree = Parser.parseFileWithComments(file);
         return printJavaAndJavadocTree(tree);
     }
 
@@ -143,13 +122,13 @@ public final class AstTreeStringPrinter {
     /**
      * Parse a file and print the parse tree.
      * @param text the text to parse.
-     * @param withComments true to include comments to AST
+     * @param withComments {@link Parser.Options#WITH_COMMENTS} to include comment nodes to the tree
      * @return the AST of the file in String form.
      * @throws CheckstyleException if the file is not a Java source.
      */
     public static String printAst(FileText text,
-                                  PrintOptions withComments) throws CheckstyleException {
-        return printTree(parseFileText(text, withComments));
+                                  Parser.Options withComments) throws CheckstyleException {
+        return printTree(Parser.parseFileText(text, withComments));
     }
 
     /**
@@ -224,50 +203,6 @@ public final class AstTreeStringPrinter {
         final String textWithoutNewlines = NEWLINE.matcher(text).replaceAll("\\\\n");
         final String textWithoutReturns = RETURN.matcher(textWithoutNewlines).replaceAll("\\\\r");
         return TAB.matcher(textWithoutReturns).replaceAll("\\\\t");
-    }
-
-    /**
-     * Parse a file and return the parse tree.
-     * @param file the file to parse.
-     * @param withComments true to include comment nodes to the tree
-     * @return the root node of the parse tree.
-     * @throws IOException if the file could not be read.
-     * @throws CheckstyleException if the file is not a Java source.
-     */
-    private static DetailAST parseFile(File file, PrintOptions withComments)
-            throws IOException, CheckstyleException {
-        final FileText text = new FileText(file.getAbsoluteFile(),
-            System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
-        return parseFileText(text, withComments);
-    }
-
-    /**
-     * Parse a text and return the parse tree.
-     * @param text the text to parse.
-     * @param withComments true to include comment nodes to the tree
-     * @return the root node of the parse tree.
-     * @throws CheckstyleException if the file is not a Java source.
-     */
-    private static DetailAST parseFileText(FileText text, PrintOptions withComments)
-            throws CheckstyleException {
-        final FileContents contents = new FileContents(text);
-        final DetailAST result;
-        try {
-            if (withComments == PrintOptions.WITH_COMMENTS) {
-                result = TreeWalker.parseWithComments(contents);
-            }
-            else {
-                result = TreeWalker.parse(contents);
-            }
-        }
-        catch (RecognitionException | TokenStreamException ex) {
-            final String exceptionMsg = String.format(Locale.ROOT,
-                "%s occurred during the analysis of file %s.",
-                ex.getClass().getSimpleName(), text.getFile().getPath());
-            throw new CheckstyleException(exceptionMsg, ex);
-        }
-
-        return result;
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
@@ -23,13 +23,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseErrorMessage;
-import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseStatus;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
-import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtils;
 
@@ -64,11 +61,7 @@ public final class DetailNodeTreeStringPrinter {
      */
     public static DetailNode parseJavadocAsDetailNode(DetailAST blockComment) {
         final JavadocDetailNodeParser parser = new JavadocDetailNodeParser();
-        final ParseStatus status = parser.parseJavadocAsDetailNode(blockComment);
-        if (status.getParseErrorMessage() != null) {
-            throw new IllegalArgumentException(getParseErrorMessage(status.getParseErrorMessage()));
-        }
-        return status.getTree();
+        return parser.parseJavadocAsDetailNode(blockComment);
     }
 
     /**
@@ -79,23 +72,6 @@ public final class DetailNodeTreeStringPrinter {
     private static DetailNode parseJavadocAsDetailNode(String javadocComment) {
         final DetailAST blockComment = CommonUtils.createBlockCommentNode(javadocComment);
         return parseJavadocAsDetailNode(blockComment);
-    }
-
-    /**
-     * Builds error message base on ParseErrorMessage's message key, its arguments, etc.
-     * @param parseErrorMessage ParseErrorMessage
-     * @return error message
-     */
-    private static String getParseErrorMessage(ParseErrorMessage parseErrorMessage) {
-        final LocalizedMessage lmessage = new LocalizedMessage(
-                parseErrorMessage.getLineNumber(),
-                "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
-                parseErrorMessage.getMessageKey(),
-                parseErrorMessage.getMessageArguments(),
-                "",
-                DetailNodeTreeStringPrinter.class,
-                null);
-        return "[ERROR:" + parseErrorMessage.getLineNumber() + "] " + lmessage.getMessage();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -393,13 +393,13 @@ public final class Main {
             // print AST
             final File file = config.files.get(0);
             final String stringAst = AstTreeStringPrinter.printFileAst(file,
-                    AstTreeStringPrinter.PrintOptions.WITHOUT_COMMENTS);
+                    Parser.Options.WITHOUT_COMMENTS);
             System.out.print(stringAst);
         }
         else if (commandLine.hasOption(OPTION_CAPITAL_T_NAME)) {
             final File file = config.files.get(0);
             final String stringAst = AstTreeStringPrinter.printFileAst(file,
-                    AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                    Parser.Options.WITH_COMMENTS);
             System.out.print(stringAst);
         }
         else if (commandLine.hasOption(OPTION_J_NAME)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -295,7 +295,7 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
             }
             else {
                 result = context.get().parser
-                        .parseJavadocAsDetailNode(blockCommentNode);
+                        .parseJavadoc(blockCommentNode);
                 TREE_CACHE.get().put(treeCacheKey, result);
             }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDoclet.java
@@ -19,149 +19,270 @@
 
 package com.puppycrawl.tools.checkstyle.doclets;
 
-import java.io.FileNotFoundException;
+import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import com.sun.javadoc.ClassDoc;
-import com.sun.javadoc.DocErrorReporter;
-import com.sun.javadoc.FieldDoc;
-import com.sun.javadoc.RootDoc;
-import com.sun.javadoc.Tag;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser;
+import com.puppycrawl.tools.checkstyle.Parser;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.DetailNode;
+import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.JavadocUtils;
 
 /**
- * Doclet which is used to write property file with short descriptions
- * (first sentences) of TokenTypes' constants.
+ * This class is used internally in the build process to write a property file
+ * with short descriptions (the first sentences) of TokenTypes constants.
  * Request: 724871
- * For ide plugins (like the eclipse plugin) it would be useful to have
- * programmatic access to the first sentence of the TokenType constants,
+ * For IDE plugins (like the eclipse plugin) it would be useful to have
+ * a programmatic access to the first sentence of the TokenType constants,
  * so they can use them in their configuration gui.
- * @author o_sukhodolsky
+ * @author Pavel Bludov
  */
 public final class TokenTypesDoclet {
 
-    /** Command line option to specify file to write output of the doclet. */
-    private static final String DEST_FILE_OPT = "-destfile";
+    /**
+     * The command line option to specify the output file.
+     */
+    private static final String OPTION_DEST_FILE = "destfile";
 
-    /** Stop instances being created. */
+    /**
+     * The width of the CLI help option.
+     */
+    private static final int HELP_WIDTH = 100;
+
+    /**
+     * This regexp is used to extract the first sentence from the text.
+     */
+    private static final Pattern FIRST_SENTENCE_PATTERN = Pattern.compile("(.*?\\.)(\\s|$)");
+
+    /**
+     * Parses content of Javadoc comment as DetailNode tree.
+     */
+    private static final JavadocDetailNodeParser JAVADOC_PARSER = new JavadocDetailNodeParser();
+
+    /**
+     * Don't create instance of this class, use the {@link #main(String[])} method instead.
+     */
     private TokenTypesDoclet() {
     }
 
     /**
-     * The doclet's starter method.
-     * @param root {@code RootDoc} given to the doclet
-     * @return true if the given {@code RootDoc} is processed.
-     * @exception FileNotFoundException will be thrown if the doclet
-     *            will be unable to write to the specified file.
+     * TokenTypes.properties generator entry point.
+     * @param args the command line arguments.
+     * @throws CheckstyleException if parser or lexer failed or if there is an IO problem
+     * @throws ParseException if the command line can not be passed
+     **/
+    public static void main(String... args)
+            throws CheckstyleException, ParseException {
+        final CommandLine commandLine = parseCli(args);
+        if (commandLine.getArgList().size() == 1) {
+            try {
+                writePropertiesFile(commandLine.getArgList().get(0),
+                    commandLine.getOptionValue(OPTION_DEST_FILE));
+            }
+            catch (IOException ex) {
+                throw new CheckstyleException("Failed to write properties file", ex);
+            }
+        }
+        else {
+            printUsage();
+        }
+    }
+
+    /**
+     * Creates the .properties file from a .java file.
+     * @param inputFile .java file.
+     * @param outputFile .properties file.
+     * @throws CheckstyleException if a javadoc comment can not be parsed
+     * @throws IOException if there is a problem with files access
      */
-    public static boolean start(RootDoc root)
-            throws FileNotFoundException {
-        final String fileName = getDestFileName(root.options());
-        final FileOutputStream fos = new FileOutputStream(fileName);
+    private static void writePropertiesFile(String inputFile, String outputFile)
+            throws CheckstyleException, IOException {
+        final FileOutputStream fos = new FileOutputStream(outputFile);
         final Writer osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
         final PrintWriter writer = new PrintWriter(osw, false);
 
         try {
-            final ClassDoc[] classes = root.classes();
-            final FieldDoc[] fields = classes[0].fields();
-            for (final FieldDoc field : fields) {
-                if (field.isStatic() && field.isPublic() && field.isFinal()
-                        && "int".equals(field.type().qualifiedTypeName())) {
-                    final String firstSentence;
-
-                    if (field.firstSentenceTags().length == 1) {
-                        firstSentence = field.firstSentenceTags()[0].text();
+            for (DetailAST top = Parser.parseFileWithComments(new File(inputFile));
+                 top != null; top = top.getNextSibling()) {
+                if (top.getType() != TokenTypes.CLASS_DEF) {
+                    continue;
+                }
+                final DetailAST objBlock = top.getLastChild();
+                for (DetailAST ast = objBlock.getFirstChild(); ast != null;
+                        ast = ast.getNextSibling()) {
+                    if (isPublicStaticFinalIntField(ast)) {
+                        final String firstJavadocSentence = getFirstJavadocSentence(ast);
+                        if (firstJavadocSentence != null) {
+                            writer.println(getName(ast) + "=" + firstJavadocSentence.trim());
+                        }
                     }
-                    else if (Arrays.stream(field.firstSentenceTags())
-                            .filter(tag -> !"Text".equals(tag.name())).count() == 1) {
-                        // We have to filter "Text" tags because of jdk parsing bug
-                        // till JDK-8186270
-                        firstSentence = field.firstSentenceTags()[0].text()
-                                + "<code>"
-                                + field.firstSentenceTags()[1].text()
-                                + "</code>"
-                                + field.firstSentenceTags()[2].text();
-                    }
-                    else {
-                        final List<Tag> tags = Arrays.asList(field.firstSentenceTags());
-                        final String joinedTags = tags
-                            .stream()
-                            .map(Tag::toString)
-                            .collect(Collectors.joining("\", \"", "[\"", "\"]"));
-                        final String message = String.format(Locale.ROOT,
-                                "Should be only one tag for %s. Tags %s.",
-                                field.toString(), joinedTags);
-                        throw new IllegalArgumentException(message);
-                    }
-                    writer.println(field.name() + "=" + firstSentence);
                 }
             }
         }
         finally {
             writer.close();
         }
-
-        return true;
     }
 
     /**
-     * Returns option length (how many parts are in option).
-     * @param option option name to process
-     * @return option length (how many parts are in option).
+     * Checks that the DetailAST is a {@code public} {@code static} {@code final} {@code int} field.
+     * @param ast to process
+     * @return {@code true} if matches, {@code false} otherwise.
      */
-    public static int optionLength(String option) {
-        int length = 0;
-        if (DEST_FILE_OPT.equals(option)) {
-            length = 2;
+    private static boolean isPublicStaticFinalIntField(DetailAST ast) {
+        boolean result = ast.getType() == TokenTypes.VARIABLE_DEF;
+        if (result) {
+            final DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
+            result = type.findFirstToken(TokenTypes.LITERAL_INT) != null;
+            if (result) {
+                final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
+                result = modifiers.findFirstToken(TokenTypes.LITERAL_PUBLIC) != null
+                    && modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null
+                    && modifiers.findFirstToken(TokenTypes.FINAL) != null;
+            }
         }
-        return length;
+        return result;
     }
 
     /**
-     * Checks that only valid options was specified.
-     * @param options all parsed options
-     * @param reporter the reporter to report errors.
-     * @return true if only valid options was specified
+     * Extracts the name of an ast.
+     * @param ast to extract the name
+     * @return the text content of the inner {@code TokenTypes.IDENT} node
      */
-    public static boolean checkOptions(String[][] options, DocErrorReporter reporter) {
-        boolean foundDestFileOption = false;
-        boolean onlyOneDestFileOption = true;
-        for (final String[] opt : options) {
-            if (DEST_FILE_OPT.equals(opt[0])) {
-                if (foundDestFileOption) {
-                    reporter.printError("Only one -destfile option allowed.");
-                    onlyOneDestFileOption = false;
-                    break;
+    private static String getName(DetailAST ast) {
+        return ast.findFirstToken(TokenTypes.IDENT).getText();
+    }
+
+    /**
+     * Extracts the first sentence of an ast javadoc comment.
+     * @param ast to extract the first sentence
+     * @return the first sentence of the inner {@code TokenTypes.BLOCK_COMMENT_BEGIN} node
+     *     or {@code null} if the first sentence is absent or malformed (does not end with period)
+     * @throws CheckstyleException if a javadoc comment can not be parsed
+     */
+    private static String getFirstJavadocSentence(DetailAST ast) throws CheckstyleException {
+        String firstSentence = null;
+        final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
+        for (DetailAST comment = modifiers.getFirstChild(); comment != null;
+                comment = comment.getNextSibling()) {
+            if (comment.getType() == TokenTypes.BLOCK_COMMENT_BEGIN
+                    && JavadocUtils.isJavadocComment(comment)) {
+                final DetailNode root = JAVADOC_PARSER.parseJavadocAsDetailNode(comment);
+                final StringBuilder builder = new StringBuilder(128);
+                for (DetailNode node : root.getChildren()) {
+                    if (node.getType() == JavadocTokenTypes.TEXT) {
+                        final Matcher matcher = FIRST_SENTENCE_PATTERN.matcher(node.getText());
+                        if (matcher.find()) {
+                            firstSentence = builder.append(matcher.group(1)).toString();
+                            break;
+                        }
+                        else {
+                            builder.append(node.getText());
+                        }
+                    }
+                    else if (node.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG) {
+                        formatInlineCodeTag(builder, node);
+                    }
+                    else if (node.getType() == JavadocTokenTypes.HTML_ELEMENT) {
+                        formatHtmlElement(builder, node);
+                    }
                 }
-                foundDestFileOption = true;
             }
         }
-        if (!foundDestFileOption) {
-            reporter.printError("Usage: javadoc -destfile file -doclet TokenTypesDoclet ...");
-        }
-        return onlyOneDestFileOption && foundDestFileOption;
+        return firstSentence;
     }
 
     /**
-     * Reads destination file name.
-     * @param options all specified options.
-     * @return destination file name
+     * Converts inline code tag into HTML form.
+     * @param builder to append
+     * @param inlineTag to format
+     * @throws CheckstyleException if the inline javadoc tag is not a code tag
      */
-    private static String getDestFileName(String[]... options) {
-        String fileName = null;
-        for (final String[] opt : options) {
-            if (DEST_FILE_OPT.equals(opt[0])) {
-                fileName = opt[1];
+    private static void formatInlineCodeTag(StringBuilder builder, DetailNode inlineTag)
+            throws CheckstyleException {
+        if (JavadocUtils.findFirstToken(inlineTag, JavadocTokenTypes.CODE_LITERAL) == null) {
+            throw new CheckstyleException("Expected inline @code tag");
+        }
+        builder.append("<code>");
+        for (DetailNode node : inlineTag.getChildren()) {
+            if (node.getType() == JavadocTokenTypes.TEXT) {
+                builder.append(node.getText());
             }
         }
-        return fileName;
+        builder.append("</code>");
+    }
+
+    /**
+     * Rebuilds HTML text from the AST of a HTML_ELEMENT.
+     * @param builder to append
+     * @param node to format
+     */
+    private static void formatHtmlElement(StringBuilder builder, DetailNode node) {
+        switch (node.getType()) {
+            case JavadocTokenTypes.START:
+            case JavadocTokenTypes.HTML_TAG_NAME:
+            case JavadocTokenTypes.END:
+            case JavadocTokenTypes.TEXT:
+            case JavadocTokenTypes.SLASH:
+                builder.append(node.getText());
+                break;
+            default:
+                for (DetailNode child : node.getChildren()) {
+                    formatHtmlElement(builder, child);
+                }
+                break;
+        }
+    }
+
+    /**
+     *  Prints the usage information.
+     */
+    private static void printUsage() {
+        final HelpFormatter formatter = new HelpFormatter();
+        formatter.setWidth(HELP_WIDTH);
+        formatter.printHelp(String.format("java %s [options] <input file>.",
+            TokenTypesDoclet.class.getName()), buildOptions());
+    }
+
+    /**
+     * Parses doclet command line based on passed arguments.
+     * @param args
+     *        command line arguments
+     * @return parsed information about passed arguments
+     * @throws ParseException
+     *         when passed arguments are not valid
+     */
+    private static CommandLine parseCli(String... args)
+            throws ParseException {
+        final CommandLineParser clp = new DefaultParser();
+        return clp.parse(buildOptions(), args);
+    }
+
+    /**
+     * Builds and returns the list of parameters supported by doclet cli.
+     * @return available options
+     */
+    private static Options buildOptions() {
+        final Options options = new Options();
+        options.addRequiredOption(null, OPTION_DEST_FILE, true, "The output file.");
+        return options;
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java
@@ -26,12 +26,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import antlr.ANTLRException;
 import com.google.common.collect.ImmutableList;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 
 /**
@@ -199,11 +197,11 @@ public class MainFrameModel {
 
                 switch (parseMode) {
                     case PLAIN_JAVA:
-                        parseTree = parseFile(file);
+                        parseTree = Parser.parseFile(file);
                         break;
                     case JAVA_WITH_COMMENTS:
                     case JAVA_WITH_JAVADOC_AND_COMMENTS:
-                        parseTree = parseFileWithComments(file);
+                        parseTree = Parser.parseFileWithComments(file);
                         break;
                     default:
                         throw new IllegalArgumentException("Unknown mode: " + parseMode);
@@ -226,39 +224,13 @@ public class MainFrameModel {
                 linesToPosition = ImmutableList.copyOf(linesToPositionTemp);
                 text = sb.toString();
             }
-            catch (IOException | ANTLRException ex) {
+            catch (IOException ex) {
                 final String exceptionMsg = String.format(Locale.ROOT,
                     "%s occurred while opening file %s.",
                     ex.getClass().getSimpleName(), file.getPath());
                 throw new CheckstyleException(exceptionMsg, ex);
             }
         }
-    }
-
-    /**
-     * Parse a file and return the parse tree.
-     * @param file the file to parse.
-     * @return the root node of the parse tree.
-     * @throws IOException if the file could not be read.
-     * @throws ANTLRException if the file is not a Java source.
-     */
-    private static DetailAST parseFile(File file) throws IOException, ANTLRException {
-        final FileText fileText = getFileText(file);
-        final FileContents contents = new FileContents(fileText);
-        return TreeWalker.parse(contents);
-    }
-
-    /**
-     * Parse a file and return the parse tree with comment nodes.
-     * @param file the file to parse.
-     * @return the root node of the parse tree.
-     * @throws IOException if the file could not be read.
-     * @throws ANTLRException if the file is not a Java source.
-     */
-    private static DetailAST parseFileWithComments(File file) throws IOException, ANTLRException {
-        final FileText fileText = getFileText(file);
-        final FileContents contents = new FileContents(fileText);
-        return TreeWalker.parseWithComments(contents);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentation.java
@@ -360,8 +360,7 @@ public class ParseTreeTablePresentation {
     private DetailNode getJavadocTree(DetailAST blockComment) {
         DetailNode javadocTree = blockCommentToJavadocTree.get(blockComment);
         if (javadocTree == null) {
-            javadocTree = new JavadocDetailNodeParser().parseJavadocAsDetailNode(blockComment)
-                    .getTree();
+            javadocTree = new JavadocDetailNodeParser().parseJavadocAsDetailNode(blockComment);
             blockCommentToJavadocTree.put(blockComment, javadocTree);
         }
         return javadocTree;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractTreeTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractTreeTestSupport.java
@@ -48,7 +48,7 @@ public abstract class AbstractTreeTestSupport extends AbstractPathTestSupport {
      * @throws Exception if exception occurs during verification.
      */
     protected static void verifyAst(String expectedTextPrintFileName, String actualJavaFileName,
-                                    AstTreeStringPrinter.PrintOptions withComments)
+                                    Parser.Options withComments)
             throws Exception {
         final String expectedContents = readFile(expectedTextPrintFileName);
 
@@ -62,7 +62,7 @@ public abstract class AbstractTreeTestSupport extends AbstractPathTestSupport {
     /**
      * Performs verification of the given text ast tree representation.
      * This implementation uses
-     * {@link AbstractTreeTestSupport#verifyAst(String, String, AstTreeStringPrinter.PrintOptions)}
+     * {@link AbstractTreeTestSupport#verifyAst(String, String, Parser.Options)}
      * method inside.
      * @param expectedTextPrintFileName expected text ast tree representation.
      * @param actualJavaFileName actual text ast tree representation.
@@ -71,7 +71,7 @@ public abstract class AbstractTreeTestSupport extends AbstractPathTestSupport {
     protected static void verifyAst(String expectedTextPrintFileName, String actualJavaFileName)
             throws Exception {
         verifyAst(expectedTextPrintFileName, actualJavaFileName,
-                AstTreeStringPrinter.PrintOptions.WITHOUT_COMMENTS);
+                Parser.Options.WITHOUT_COMMENTS);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
@@ -51,8 +51,7 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
     public void testParseFileThrowable() throws Exception {
         final File input = new File(getNonCompilablePath("InputAstTreeStringPrinter.java"));
         try {
-            AstTreeStringPrinter.printFileAst(input,
-                    AstTreeStringPrinter.PrintOptions.WITHOUT_COMMENTS);
+            AstTreeStringPrinter.printFileAst(input, Parser.Options.WITHOUT_COMMENTS);
             Assert.fail("exception expected");
         }
         catch (CheckstyleException ex) {
@@ -67,8 +66,7 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
     @Test
     public void testParseFile() throws Exception {
         verifyAst(getPath("ExpectedAstTreeStringPrinter.txt"),
-                getPath("InputAstTreeStringPrinterComments.java"),
-                AstTreeStringPrinter.PrintOptions.WITHOUT_COMMENTS);
+                getPath("InputAstTreeStringPrinterComments.java"), Parser.Options.WITHOUT_COMMENTS);
     }
 
     @Test
@@ -76,8 +74,7 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
         final FileText text = new FileText(
                 new File(getPath("InputAstTreeStringPrinterComments.java")).getAbsoluteFile(),
                 System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
-        final String actual = AstTreeStringPrinter.printAst(text,
-                AstTreeStringPrinter.PrintOptions.WITHOUT_COMMENTS);
+        final String actual = AstTreeStringPrinter.printAst(text, Parser.Options.WITHOUT_COMMENTS);
         final String expected = new String(Files.readAllBytes(Paths.get(
                 getPath("ExpectedAstTreeStringPrinter.txt"))), StandardCharsets.UTF_8);
 
@@ -88,7 +85,7 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
     public void testParseFileWithComments() throws Exception {
         verifyAst(getPath("ExpectedAstTreeStringPrinterComments.txt"),
                 getPath("InputAstTreeStringPrinterComments.java"),
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
     @Test
@@ -121,21 +118,21 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
     public void testAstTreeBlockComments() throws Exception {
         verifyAst(getPath("ExpectedAstTreeStringPrinterFullOfBlockComments.txt"),
                 getPath("InputAstTreeStringPrinterFullOfBlockComments.java"),
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
     @Test
     public void testAstTreeBlockCommentsCarriageReturn() throws Exception {
         verifyAst(getPath("ExpectedAstTreeStringPrinterFullOfBlockCommentsCR.txt"),
                 getPath("InputAstTreeStringPrinterFullOfBlockCommentsCR.java"),
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
     @Test
     public void testAstTreeSingleLineComments() throws Exception {
         verifyAst(getPath("ExpectedAstTreeStringPrinterFullOfSinglelineComments.txt"),
                 getPath("InputAstTreeStringPrinterFullOfSinglelineComments.java"),
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -42,7 +42,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
     // DetailNodeTreeStringPrinter#getParseErrorMessage is used for creating error messages
     // for validating those obtained in UTs against the ones created.
     private static final Method GET_PARSE_ERROR_MESSAGE = Whitebox.getMethod(
-            DetailNodeTreeStringPrinter.class, "getParseErrorMessage", ParseErrorMessage.class);
+            JavadocDetailNodeParser.class, "getParseErrorMessage", ParseErrorMessage.class);
 
     @Override
     protected String getPackageLocation() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Paths;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.DetailNode;
 
 public class JavadocDetailNodeParserTest extends AbstractModuleTestSupport {
 
@@ -46,8 +47,8 @@ public class JavadocDetailNodeParserTest extends AbstractModuleTestSupport {
                 .parseFileWithComments(new File(getPath("InputJavadocDetailNodeParser.java")))
                 .getNextSibling().getFirstChild().getFirstChild();
         final JavadocDetailNodeParser parser = new JavadocDetailNodeParser();
-        final JavadocDetailNodeParser.ParseStatus status = parser.parseJavadocAsDetailNode(ast);
-        final String actual = DetailNodeTreeStringPrinter.printTree(status.getTree(), "", "");
+        final DetailNode node = parser.parseJavadocAsDetailNode(ast);
+        final String actual = DetailNodeTreeStringPrinter.printTree(node, "", "");
         final String expected;
 
         // line separators in the input file while running this test on Windows are different,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
@@ -30,7 +30,6 @@ import java.nio.file.Paths;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class JavadocDetailNodeParserTest extends AbstractModuleTestSupport {
 
@@ -43,9 +42,9 @@ public class JavadocDetailNodeParserTest extends AbstractModuleTestSupport {
 
     @Test
     public void testParseJavadocAsDetailNode() throws Exception {
-        final DetailAST ast = TestUtil
-                .parseFile(new File(getPath("InputJavadocDetailNodeParser.java"))).getNextSibling()
-                .getFirstChild().getFirstChild();
+        final DetailAST ast = Parser
+                .parseFileWithComments(new File(getPath("InputJavadocDetailNodeParser.java")))
+                .getNextSibling().getFirstChild().getFirstChild();
         final JavadocDetailNodeParser parser = new JavadocDetailNodeParser();
         final JavadocDetailNodeParser.ParseStatus status = parser.parseJavadocAsDetailNode(ast);
         final String actual = DetailNodeTreeStringPrinter.printTree(status.getTree(), "", "");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ParserTest.java
@@ -1,0 +1,118 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2018 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
+
+public class ParserTest extends AbstractModuleTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/parser";
+    }
+
+    @Test
+    public void testIsProperUtilsClass() throws ReflectiveOperationException {
+        assertTrue("Constructor is not private", TestUtil.isUtilsClassHasPrivateConstructor(
+            Parser.class, false));
+    }
+
+    @Test
+    public void testAppendHiddenBlockCommentNodes() throws Exception {
+        final DetailAST root = Parser.parseFileWithComments(
+            new File(getPath("InputParserHiddenComments.java")));
+
+        final Optional<DetailAST> blockComment = TestUtil.findTokenInAstByPredicate(root,
+            ast -> ast.getType() == TokenTypes.BLOCK_COMMENT_BEGIN);
+
+        assertTrue("Block comment should be present", blockComment.isPresent());
+
+        final DetailAST commentContent = blockComment.get().getFirstChild();
+        final DetailAST commentEnd = blockComment.get().getLastChild();
+
+        assertEquals("Unexpected line number", 3, commentContent.getLineNo());
+        assertEquals("Unexpected column number", 2, commentContent.getColumnNo());
+        assertEquals("Unexpected line number", 9, commentEnd.getLineNo());
+        assertEquals("Unexpected column number", 1, commentEnd.getColumnNo());
+    }
+
+    @Test
+    public void testAppendHiddenSingleLineCommentNodes() throws Exception {
+        final DetailAST root = Parser.parseFileWithComments(
+            new File(getPath("InputParserHiddenComments.java")));
+
+        final Optional<DetailAST> singleLineComment = TestUtil.findTokenInAstByPredicate(root,
+            ast -> ast.getType() == TokenTypes.SINGLE_LINE_COMMENT);
+        assertTrue("Single line comment should be present", singleLineComment.isPresent());
+
+        final DetailAST commentContent = singleLineComment.get().getFirstChild();
+
+        assertEquals("Unexpected token type", TokenTypes.COMMENT_CONTENT, commentContent.getType());
+        assertEquals("Unexpected line number", 13, commentContent.getLineNo());
+        assertEquals("Unexpected column number", 2, commentContent.getColumnNo());
+        assertTrue("Unexpected comment content",
+            commentContent.getText().startsWith(" inline comment"));
+    }
+
+    /**
+     * Could not find proper test case to test pitest mutations functionally.
+     * Should be rewritten during grammar update.
+     *
+     * @throws Exception when code tested throws exception
+     */
+    @Test
+    public void testIsPositionGreater() throws Exception {
+        final DetailAST ast1 = createAst(1, 3);
+        final DetailAST ast2 = createAst(1, 2);
+        final DetailAST ast3 = createAst(2, 2);
+
+        final TreeWalker treeWalker = new TreeWalker();
+        final Method isPositionGreater = Whitebox.getMethod(Parser.class,
+                "isPositionGreater", DetailAST.class, DetailAST.class);
+
+        assertTrue("Should return true when lines are equal and column is greater",
+                (boolean) isPositionGreater.invoke(treeWalker, ast1, ast2));
+        assertFalse("Should return false when lines are equal columns are equal",
+                (boolean) isPositionGreater.invoke(treeWalker, ast1, ast1));
+        assertTrue("Should return true when line is greater",
+                (boolean) isPositionGreater.invoke(treeWalker, ast3, ast1));
+    }
+
+    private static DetailAST createAst(int line, int column) {
+        final DetailAST ast = new DetailAST();
+        ast.setLineNo(line);
+        ast.setColumnNo(column);
+        return ast;
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle;
 
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -30,7 +29,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -38,7 +36,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -52,7 +49,6 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.Context;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck;
@@ -64,7 +60,6 @@ import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck;
 import com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter;
 import com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class TreeWalkerTest extends AbstractModuleTestSupport {
@@ -453,43 +448,6 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testAppendHiddenBlockCommentNodes() throws Exception {
-        final DetailAST root =
-            TestUtil.parseFile(new File(getPath("InputTreeWalkerHiddenComments.java")));
-
-        final Optional<DetailAST> blockComment = TestUtil.findTokenInAstByPredicate(root,
-            ast -> ast.getType() == TokenTypes.BLOCK_COMMENT_BEGIN);
-
-        assertTrue("Block comment should be present", blockComment.isPresent());
-
-        final DetailAST commentContent = blockComment.get().getFirstChild();
-        final DetailAST commentEnd = blockComment.get().getLastChild();
-
-        assertEquals("Unexpected line number", 3, commentContent.getLineNo());
-        assertEquals("Unexpected column number", 2, commentContent.getColumnNo());
-        assertEquals("Unexpected line number", 9, commentEnd.getLineNo());
-        assertEquals("Unexpected column number", 1, commentEnd.getColumnNo());
-    }
-
-    @Test
-    public void testAppendHiddenSingleLineCommentNodes() throws Exception {
-        final DetailAST root =
-            TestUtil.parseFile(new File(getPath("InputTreeWalkerHiddenComments.java")));
-
-        final Optional<DetailAST> singleLineComment = TestUtil.findTokenInAstByPredicate(root,
-            ast -> ast.getType() == TokenTypes.SINGLE_LINE_COMMENT);
-        assertTrue("Single line comment should be present", singleLineComment.isPresent());
-
-        final DetailAST commentContent = singleLineComment.get().getFirstChild();
-
-        assertEquals("Unexpected token type", TokenTypes.COMMENT_CONTENT, commentContent.getType());
-        assertEquals("Unexpected line number", 13, commentContent.getLineNo());
-        assertEquals("Unexpected column number", 2, commentContent.getColumnNo());
-        assertTrue("Unexpected comment content",
-            commentContent.getText().startsWith(" inline comment"));
-    }
-
-    @Test
     public void testFinishLocalSetupFullyInitialized() {
         final TreeWalker treeWalker = new TreeWalker();
         final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
@@ -561,37 +519,6 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
                 new String(Files.readAllBytes(cacheFile.toPath()),
                         StandardCharsets.UTF_8).contains(
                                 "InputTreeWalkerSuppressionXpathFilter.xml"));
-    }
-
-    /**
-     * Could not find proper test case to test pitest mutations functionally.
-     * Should be rewritten during grammar update.
-     *
-     * @throws Exception when code tested throws exception
-     */
-    @Test
-    public void testIsPositionGreater() throws Exception {
-        final DetailAST ast1 = createAst(1, 3);
-        final DetailAST ast2 = createAst(1, 2);
-        final DetailAST ast3 = createAst(2, 2);
-
-        final TreeWalker treeWalker = new TreeWalker();
-        final Method isPositionGreater = Whitebox.getMethod(TreeWalker.class,
-                "isPositionGreater", DetailAST.class, DetailAST.class);
-
-        assertTrue("Should return true when lines are equal and column is greater",
-                (boolean) isPositionGreater.invoke(treeWalker, ast1, ast2));
-        assertFalse("Should return false when lines are equal columns are equal",
-                (boolean) isPositionGreater.invoke(treeWalker, ast1, ast1));
-        assertTrue("Should return true when line is greater",
-                (boolean) isPositionGreater.invoke(treeWalker, ast3, ast1));
-    }
-
-    private static DetailAST createAst(int line, int column) {
-        final DetailAST ast = new DetailAST();
-        ast.setLineNo(line);
-        ast.setColumnNo(column);
-        return ast;
     }
 
     private static class BadJavaDocCheck extends AbstractCheck {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
@@ -45,7 +45,7 @@ import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
@@ -293,10 +293,7 @@ public class DetailASTTest extends AbstractModuleTestSupport {
     }
 
     private static void checkFile(String filename) throws Exception {
-        final FileText text = new FileText(new File(filename),
-                           System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
-        final FileContents contents = new FileContents(text);
-        final DetailAST rootAST = TreeWalker.parse(contents);
+        final DetailAST rootAST = Parser.parseFile(new File(filename));
         if (rootAST != null) {
             checkTree(filename, rootAST);
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/TokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/TokenTypesTest.java
@@ -23,11 +23,37 @@ import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsCla
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.ResourceBundle;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
 
 public class TokenTypesTest {
+
+    @Test
+    public void testAllTokenTypesHasDescription() {
+        final String tokenTypes = "com.puppycrawl.tools.checkstyle.api.tokentypes";
+        final ResourceBundle bundle = ResourceBundle.getBundle(tokenTypes, Locale.ROOT);
+
+        final Set<String> expected = Arrays.stream(TokenUtils.getAllTokenIds())
+            .mapToObj(TokenUtils::getTokenName).collect(Collectors.toSet());
+        final Set<String> actual = bundle.keySet();
+        assertEquals("TokenTypes without description", expected, actual);
+    }
+
+    @Test
+    public void testAllDescriptionsEndsWithPeriod() {
+        final Set<String> badDescriptions = Arrays.stream(TokenUtils.getAllTokenIds())
+            .mapToObj(TokenUtils::getTokenName).map(TokenUtils::getShortDescription)
+            .filter(desc -> desc.charAt(desc.length() - 1) != '.').collect(Collectors.toSet());
+        assertEquals("Malformed TokenType descriptions", Collections.emptySet(), badDescriptions);
+    }
 
     @Test
     public void testGetShortDescription() {
@@ -44,7 +70,7 @@ public class TokenTypesTest {
                 TokenUtils.getShortDescription("LCURLY"));
 
         assertEquals("short description for SR_ASSIGN",
-                "The <code>>>=</code> (signed right shift assignment)",
+                "The <code>>>=</code> (signed right shift assignment) operator.",
                 TokenUtils.getShortDescription("SR_ASSIGN"));
 
         assertEquals("short description for SL",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -143,8 +144,8 @@ public class ModifiedControlVariableCheckTest
     public void testClearState() throws Exception {
         final ModifiedControlVariableCheck check = new ModifiedControlVariableCheck();
         final Optional<DetailAST> methodDef = TestUtil.findTokenInAstByPredicate(
-            TestUtil.parseFile(new File(
-                getPath("InputModifiedControlVariableEnhancedForLoopVariable.java"))),
+            Parser.parseFile(
+                new File(getPath("InputModifiedControlVariableEnhancedForLoopVariable.java"))),
             ast -> ast.getType() == TokenTypes.OBJBLOCK);
 
         assertTrue("Ast should contain METHOD_DEF", methodDef.isPresent());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -110,7 +111,7 @@ public class ParameterAssignmentCheckTest extends AbstractModuleTestSupport {
     public void testClearState() throws Exception {
         final ParameterAssignmentCheck check = new ParameterAssignmentCheck();
         final Optional<DetailAST> methodDef = TestUtil.findTokenInAstByPredicate(
-            TestUtil.parseFile(new File(getPath("InputParameterAssignmentReceiver.java"))),
+            Parser.parseFile(new File(getPath("InputParameterAssignmentReceiver.java"))),
             ast -> ast.getType() == TokenTypes.METHOD_DEF);
 
         assertTrue("Ast should contain METHOD_DEF", methodDef.isPresent());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -169,7 +170,7 @@ public class ReturnCountCheckTest extends AbstractModuleTestSupport {
     public void testClearState() throws Exception {
         final ReturnCountCheck check = new ReturnCountCheck();
         final Optional<DetailAST> methodDef = TestUtil.findTokenInAstByPredicate(
-            TestUtil.parseFile(new File(getPath("InputReturnCountVoid.java"))),
+            Parser.parseFile(new File(getPath("InputReturnCountVoid.java"))),
             ast -> ast.getType() == TokenTypes.METHOD_DEF);
 
         assertTrue("Ast should contain METHOD_DEF", methodDef.isPresent());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -86,7 +87,7 @@ public class SuperCloneCheckTest
     public void testClearState() throws Exception {
         final AbstractSuperCheck check = new SuperCloneCheck();
         final Optional<DetailAST> methodDef = TestUtil.findTokenInAstByPredicate(
-            TestUtil.parseFile(new File(getPath("InputSuperCloneWithoutWarnings.java"))),
+            Parser.parseFile(new File(getPath("InputSuperCloneWithoutWarnings.java"))),
             ast -> ast.getType() == TokenTypes.METHOD_DEF);
 
         assertTrue("Ast should contain METHOD_DEF", methodDef.isPresent());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -34,9 +34,9 @@ import org.powermock.reflect.Whitebox;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class VisibilityModifierCheckTest
@@ -455,8 +455,8 @@ public class VisibilityModifierCheckTest
      */
     @Test
     public void testIsStarImportNullAst() throws Exception {
-        final DetailAST importAst = TestUtil.parseFile(new File(getPath(
-            "InputVisibilityModifierIsStarImport.java"))).getNextSibling();
+        final DetailAST importAst = Parser.parseFile(
+            new File(getPath("InputVisibilityModifierIsStarImport.java"))).getNextSibling();
         final VisibilityModifierCheck check = new VisibilityModifierCheck();
         final Method isStarImport = Whitebox.getMethod(VisibilityModifierCheck.class,
             "isStarImport", DetailAST.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.Context;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
@@ -148,7 +149,7 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
     public void testStatefulFieldsClearedOnBeginTree3() throws Exception {
         final NPathComplexityCheck check = new NPathComplexityCheck();
         final Optional<DetailAST> question = TestUtil.findTokenInAstByPredicate(
-            TestUtil.parseFile(new File(getPath("InputNPathComplexity.java"))),
+            Parser.parseFile(new File(getPath("InputNPathComplexity.java"))),
             ast -> ast.getType() == TokenTypes.QUESTION);
 
         Assert.assertTrue("Ast should contain QUESTION", question.isPresent());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDocletTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/doclets/TokenTypesDocletTest.java
@@ -19,222 +19,239 @@
 
 package com.puppycrawl.tools.checkstyle.doclets;
 
-import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.lang.reflect.Method;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Locale;
 
-import javax.tools.JavaFileObject;
-
+import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 
+import antlr.ANTLRException;
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
-import com.sun.javadoc.RootDoc;
-import com.sun.tools.javac.util.Context;
-import com.sun.tools.javac.util.ListBuffer;
-import com.sun.tools.javadoc.JavadocTool;
-import com.sun.tools.javadoc.Messager;
-import com.sun.tools.javadoc.ModifierFilter;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class TokenTypesDocletTest extends AbstractPathTestSupport {
+
+    private static final String EOL = System.lineSeparator();
+    private static final String USAGE = String.format(Locale.ROOT,
+          "usage: java com.puppycrawl.tools.checkstyle.doclets.TokenTypesDoclet [options]"
+              + " <input file>.%n"
+              + "    --destfile <arg>   The output file.%n");
+    private static final File DESTFILE = new File("target/tokentypes.properties");
+
+    @Rule
+    public final SystemErrRule systemErr = new SystemErrRule().enableLog().mute();
+    @Rule
+    public final SystemOutRule systemOut = new SystemOutRule().enableLog().mute();
 
     @Override
     protected String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/doclets/tokentypesdoclet";
     }
 
+    /**
+     * Returns canonical path for the file with the given file name.
+     * The path is formed base on the non-compilable resources location.
+     * This implementation uses 'src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/'
+     * as a non-compilable resource location.
+     * @param filename file name.
+     * @return canonical path for the file with the given file name.
+     * @throws IOException if I/O exception occurs while forming the path.
+     */
+    protected final String getNonCompilablePath(String filename) throws IOException {
+        return new File("src/test/resources-noncompilable/" + getPackageLocation() + "/"
+                + filename).getCanonicalPath();
+    }
+
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
-        assertTrue("Constructor is not private",
-                isUtilsClassHasPrivateConstructor(TokenTypesDoclet.class, true));
+        assertTrue("Constructor is not private", TestUtil.isUtilsClassHasPrivateConstructor(
+            TokenTypesDoclet.class, false));
     }
 
     @Test
-    public void testOptionLength() {
-        // optionLength returns 2 for option "-destfile"
-        assertEquals("Invalid option length", 2, TokenTypesDoclet.optionLength("-destfile"));
-
-        // optionLength returns 0 for options different from "-destfile"
-        assertEquals("Invalid option length", 0, TokenTypesDoclet.optionLength("-anyOtherOption"));
-    }
-
-    @Test
-    public void testCheckOptions() {
-        final Context context = new Context();
-        final TestMessager testMessager = new TestMessager(context);
-
-        final String[][] options = new String[3][1];
-        assertFalse("Should return false when options are empty",
-                TokenTypesDoclet.checkOptions(options, testMessager));
-
-        options[0][0] = "-destfile";
-        assertTrue("Should return true when options are valid",
-                TokenTypesDoclet.checkOptions(options, testMessager));
-
-        //pass invalid options - array with more than one "-destfile" option
-        options[1][0] = "-destfile";
-        assertFalse("Should return false when more then one '-destfile' option passed",
-                TokenTypesDoclet.checkOptions(options, testMessager));
-
-        final String[] expected = {
-            "Usage: javadoc -destfile file -doclet TokenTypesDoclet ...",
-            "Only one -destfile option allowed.",
-        };
-
-        Assert.assertArrayEquals("Invalid message", expected, testMessager.messages.toArray());
-    }
-
-    @Test
-    public void testNotConstants() throws Exception {
-        // Token types must be public int constants, which means that they must have
-        // modifiers public, static, final and type int, because they are referenced statically in
-        // a lot of different places, must not be changed and an int value is used to encrypt
-        // a token type.
-        final ListBuffer<String[]> options = new ListBuffer<>();
-        options.add(new String[] {"-doclet", "TokenTypesDoclet"});
-        options.add(new String[] {"-destfile", "target/tokentypes.properties"});
-
-        final ListBuffer<String> names = new ListBuffer<>();
-        names.add(getPath("InputTokenTypesDocletNotConstants.java"));
-
-        final Context context = new Context();
-        final TestMessager test = new TestMessager(context);
-        assertNotNull("should be able to create TestMessager without issue", test);
-        final JavadocTool javadocTool = JavadocTool.make0(context);
-        final RootDoc rootDoc = getRootDoc(javadocTool, options, names);
-
-        assertTrue("Should process valid root doc", TokenTypesDoclet.start(rootDoc));
-    }
-
-    @Test
-    public void testEmptyJavadoc() throws Exception {
-        final ListBuffer<String[]> options = new ListBuffer<>();
-        options.add(new String[] {"-destfile", "target/tokentypes.properties"});
-
-        final ListBuffer<String> names = new ListBuffer<>();
-        names.add(getPath("InputTokenTypesDocletEmptyJavadoc.java"));
-
-        final Context context = new Context();
-        final TestMessager test = new TestMessager(context);
-        assertNotNull("should be able to create TestMessager without issue", test);
-        final JavadocTool javadocTool = JavadocTool.make0(context);
-        final RootDoc rootDoc = getRootDoc(javadocTool, options, names);
+    public void testNonExistentArgument() throws Exception {
+        final String expectedErr = "";
+        final String expectedOut = "";
 
         try {
-            TokenTypesDoclet.start(rootDoc);
-            fail("IllegalArgumentException is expected");
+            TokenTypesDoclet.main("--nonexistent-argument");
+            fail("Exception was expected");
         }
-        catch (IllegalArgumentException expected) {
-            // Token types must have first sentence of Javadoc summary
-            // so that a brief description could be provided. Otherwise,
-            // an IllegalArgumentException is thrown.
+        catch (ParseException ex) {
+            assertTrue("Invalid error message", ex.getMessage().contains("--nonexistent-argument"));
         }
+        assertEquals("Unexpected error log", expectedErr, systemErr.getLog());
+        assertEquals("Unexpected output log", expectedOut, systemOut.getLog());
+    }
+
+    @Test
+    public void testNoDestfileSpecified() throws Exception {
+        final String expectedErr = "";
+        final String expectedOut = "";
+
+        try {
+            TokenTypesDoclet.main(getPath("InputMain.java"));
+            fail("Exception was expected");
+        }
+        catch (ParseException ex) {
+            assertTrue("Invalid error message",
+                ex.getMessage().contains("Missing required option: destfile"));
+        }
+        assertEquals("Unexpected error log", expectedErr, systemErr.getLog());
+        assertEquals("Unexpected output log", expectedOut, systemOut.getLog());
+    }
+
+    @Test
+    public void testNoInputSpecified() throws Exception {
+        final String expectedErr = "";
+
+        TokenTypesDoclet.main("--destfile", DESTFILE.getAbsolutePath());
+        assertEquals("Unexpected error log", expectedErr, systemErr.getLog());
+        assertEquals("Unexpected output log", USAGE, systemOut.getLog());
+    }
+
+    @Test
+    public void testNotExistentInputSpecified() throws Exception {
+        final String expectedErr = "";
+        final String expectedOut = "";
+
+        try {
+            TokenTypesDoclet.main("--destfile", DESTFILE.getAbsolutePath(), "NotExistent.java");
+            fail("Exception was expected");
+        }
+        catch (CheckstyleException ex) {
+            assertEquals("Invalid error message", "Failed to write properties file",
+                ex.getMessage());
+
+            final Throwable cause = ex.getCause();
+            assertTrue("Invalid error message", cause instanceof FileNotFoundException);
+            assertTrue("Invalid error message", cause.getMessage().contains("NotExistent.java"));
+        }
+        assertEquals("Unexpected error log", expectedErr, systemErr.getLog());
+        assertEquals("Unexpected output log", expectedOut, systemOut.getLog());
+    }
+
+    @Test
+    public void testInvalidDestinationSpecified() throws Exception {
+        final String expectedErr = "";
+        final String expectedOut = "";
+
+        try {
+            // Passing a folder name will cause the FileNotFoundException.
+            TokenTypesDoclet.main("--destfile", "..", getPath("InputMainCorrect.java"));
+            fail("Exception was expected");
+        }
+        catch (CheckstyleException ex) {
+            final String expectedError = "Failed to write properties file";
+            assertEquals("Invalid error message", expectedError, ex.getMessage());
+
+            final Throwable cause = ex.getCause();
+            assertTrue("Invalid error message", cause instanceof FileNotFoundException);
+            assertTrue("Invalid error message", cause.getMessage().contains(".."));
+        }
+        assertEquals("Unexpected error log", expectedErr, systemErr.getLog());
+        assertEquals("Unexpected output log", expectedOut, systemOut.getLog());
     }
 
     @Test
     public void testCorrect() throws Exception {
-        final ListBuffer<String[]> options = new ListBuffer<>();
-        options.add(new String[] {"-destfile", "target/tokentypes.properties"});
+        final String expectedErr = "";
+        final String expectedOut = "";
+        final String expectedContent = "EOF1=The end of file token." + EOL
+            + "EOF2=The end of file token." + EOL
+            + "TYPE_EXTENSION_AND='&amp;' symbol when used in a generic upper or lower bounds"
+            + " constrain e.g&#46;"
+            + " <code>Comparable<T extends Serializable & CharSequence></code>." + EOL
+            + "LCURLY=A left curly brace (<code>{</code>)." + EOL;
 
-        final ListBuffer<String> names = new ListBuffer<>();
-        names.add(getPath("InputTokenTypesDocletCorrect.java"));
-
-        final Context context = new Context();
-        final TestMessager test = new TestMessager(context);
-        assertNotNull("should be able to create TestMessager without issue", test);
-        final JavadocTool javadocTool = JavadocTool.make0(context);
-        final RootDoc rootDoc = getRootDoc(javadocTool, options, names);
-
-        assertTrue("Should process valid root doc", TokenTypesDoclet.start(rootDoc));
-        final String fileContent =
-                FileUtils.readFileToString(new File("target/tokentypes.properties"),
-                        StandardCharsets.UTF_8);
-        assertTrue("File content is not expected",
-                fileContent.startsWith("EOF=The end of file token."));
+        TokenTypesDoclet.main(getPath("InputTokenTypesDocletCorrect.java"), "--destfile",
+            DESTFILE.getAbsolutePath());
+        assertEquals("Unexpected error log", expectedErr, systemErr.getLog());
+        assertEquals("Unexpected output log", expectedOut, systemOut.getLog());
+        final String fileContent = FileUtils.readFileToString(DESTFILE, StandardCharsets.UTF_8);
+        assertEquals("File content is not expected", expectedContent, fileContent);
     }
 
     @Test
-    public void testJavadocTagPassValidation() throws Exception {
-        final ListBuffer<String[]> options = new ListBuffer<>();
-        options.add(new String[] {"-destfile", "target/tokentypes.properties"});
+    public void testEmptyJavadoc() throws Exception {
+        final String expectedErr = "";
+        final String expectedOut = "";
 
-        final ListBuffer<String> names = new ListBuffer<>();
-        names.add(getPath("InputTokenTypesDocletJavadocParseError.java"));
-
-        final Context context = new Context();
-        final TestMessager test = new TestMessager(context);
-        assertNotNull("should be able to create TestMessager without issue", test);
-        final JavadocTool javadocTool = JavadocTool.make0(context);
-        final RootDoc rootDoc = getRootDoc(javadocTool, options, names);
-
-        assertTrue("Should process valid root doc", TokenTypesDoclet.start(rootDoc));
+        TokenTypesDoclet.main(getPath("InputTokenTypesDocletEmptyJavadoc.java"), "--destfile",
+            DESTFILE.getAbsolutePath());
+        assertEquals("Unexpected error log", expectedErr, systemErr.getLog());
+        assertEquals("Unexpected output log", expectedOut, systemOut.getLog());
+        assertEquals("File '" + DESTFILE + "' must be empty", 0, FileUtils.sizeOf(DESTFILE));
     }
 
-    private static RootDoc getRootDoc(JavadocTool javadocTool, ListBuffer<String[]> options,
-            ListBuffer<String> names) throws Exception {
-        final Method getRootDocImpl = getMethodGetRootDocImplByReflection();
-        final RootDoc rootDoc;
-        if (System.getProperty("java.version").startsWith("1.7.")) {
-            rootDoc = (RootDoc) getRootDocImpl.invoke(javadocTool, "",
-                    StandardCharsets.UTF_8.name(),
-                    new ModifierFilter(ModifierFilter.ALL_ACCESS),
-                    names.toList(),
-                    options.toList(),
-                    false,
-                    new ListBuffer<String>().toList(),
-                    new ListBuffer<String>().toList(),
-                    false, false, false);
-        }
-        else {
-            rootDoc = (RootDoc) getRootDocImpl.invoke(javadocTool, "",
-                    StandardCharsets.UTF_8.name(),
-                    new ModifierFilter(ModifierFilter.ALL_ACCESS),
-                    names.toList(),
-                    options.toList(),
-                    new ListBuffer<JavaFileObject>().toList(),
-                    false,
-                    new ListBuffer<String>().toList(),
-                    new ListBuffer<String>().toList(),
-                    false, false, false);
-        }
-        return rootDoc;
+    @Test
+    public void testNotConstants() throws Exception {
+        final String expectedErr = "";
+        final String expectedOut = "";
+
+        TokenTypesDoclet.main(getPath("InputTokenTypesDocletNotConstants.java"), "--destfile",
+            DESTFILE.getAbsolutePath());
+        assertEquals("Unexpected error log", expectedErr, systemErr.getLog());
+        assertEquals("Unexpected output log", expectedOut, systemOut.getLog());
+        assertEquals("File '" + DESTFILE + "' must be empty", 0, FileUtils.sizeOf(DESTFILE));
     }
 
-    private static Method getMethodGetRootDocImplByReflection() throws ClassNotFoundException {
-        Method result = null;
-        final Class<?> javadocToolClass = Class.forName("com.sun.tools.javadoc.JavadocTool");
-        final Method[] methods = javadocToolClass.getMethods();
-        for (Method method: methods) {
-            if ("getRootDocImpl".equals(method.getName())) {
-                result = method;
-            }
+    @Test
+    public void testJavadocParseError() throws Exception {
+        try {
+            TokenTypesDoclet.main(getPath("InputTokenTypesDocletJavadocParseError.java"),
+                "--destfile", DESTFILE.getAbsolutePath());
+            fail("Exception was expected");
         }
-        return result;
+        catch (IllegalArgumentException ex) {
+            assertTrue("Invalid error message", ex.getMessage().contains(
+                "mismatched input '<EOF>' expecting JAVADOC_INLINE_TAG_END"));
+        }
+        assertEquals("File '" + DESTFILE + "' must be empty", 0, FileUtils.sizeOf(DESTFILE));
     }
 
-    private static class TestMessager extends Messager {
-
-        private final List<String> messages = new ArrayList<>();
-
-        TestMessager(Context context) {
-            super(context, "");
+    @Test
+    public void testNotCodeTag() throws Exception {
+        try {
+            TokenTypesDoclet.main(getPath("InputTokenTypesDocletNotCodeTag.java"),
+                "--destfile", DESTFILE.getAbsolutePath());
+            fail("Exception was expected");
         }
-
-        @Override
-        public void printError(String message) {
-            messages.add(message);
+        catch (CheckstyleException ex) {
+            assertEquals("Invalid error message", "Expected inline @code tag", ex.getMessage());
         }
+        assertEquals("File '" + DESTFILE + "' must be empty", 0, FileUtils.sizeOf(DESTFILE));
+    }
 
+    @Test
+    public void testParseError() throws Exception {
+        try {
+            TokenTypesDoclet.main(getNonCompilablePath("InputTokenTypesDocletParseError.java"),
+                "--destfile", DESTFILE.getAbsolutePath());
+            fail("Exception was expected");
+        }
+        catch (CheckstyleException ex) {
+            assertTrue("Invalid error message",
+                ex.getMessage().contains("InputTokenTypesDocletParseError.java"));
+
+            final Throwable cause = ex.getCause();
+            assertTrue("Invalid error message", cause instanceof ANTLRException);
+            assertTrue("Invalid error message",
+                cause.getMessage().contains("Unexpected character 0x23 in identifier"));
+        }
+        assertEquals("File '" + DESTFILE + "' must be empty", 0, FileUtils.sizeOf(DESTFILE));
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
@@ -32,11 +32,11 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 
@@ -149,7 +149,7 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
         final LocalizedMessage message = new LocalizedMessage(3, 0, TokenTypes.CLASS_DEF, "", "",
                 null, null, "777", getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(null, "file1.java",
-                message, TestUtil.parseFile(file));
+                message, Parser.parseFile(file));
 
         assertFalse("TreeWalker audit event should be rejected",
                 filter.accept(ev));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterTest.java
@@ -30,12 +30,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import net.sf.saxon.sxpath.XPathEvaluator;
 import net.sf.saxon.sxpath.XPathExpression;
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -177,7 +177,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
                 new LocalizedMessage(3, 0, TokenTypes.CLASS_DEF, "", "", null, null, "id20",
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents,
-                file.getName(), message, TestUtil.parseFile(file));
+                file.getName(), message, Parser.parseFile(file));
         assertTrue("Event should be accepted", filter.accept(ev));
     }
 
@@ -190,7 +190,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
                 new LocalizedMessage(3, 0, TokenTypes.CLASS_DEF, "", "", null, null, "id19",
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents,
-                file.getName(), message, TestUtil.parseFile(file));
+                file.getName(), message, Parser.parseFile(file));
         assertFalse("Event should be rejected", filter.accept(ev));
     }
 
@@ -203,7 +203,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
                 new LocalizedMessage(3, 0, TokenTypes.CLASS_DEF, "", "", null, null, "id19",
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents,
-                file.getName(), message, TestUtil.parseFile(file));
+                file.getName(), message, Parser.parseFile(file));
         assertTrue("Event should be accepted", filter.accept(ev));
     }
 
@@ -232,7 +232,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
         final LocalizedMessage message = new LocalizedMessage(0, 0, TokenTypes.CLASS_DEF, "", "",
                 null, null, null, getClass(), "Test");
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents, file.getName(),
-                message, TestUtil.parseFile(file));
+                message, Parser.parseFile(file));
         final XpathFilter filter1 = new XpathFilter(null, null, "Test", null, null);
         final XpathFilter filter2 = new XpathFilter(null, null, "Bad", null, null);
         assertFalse("Message match", filter1.accept(ev));
@@ -276,7 +276,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
                 new LocalizedMessage(line, column, tokenType, "", "", null, null, null,
                         getClass(), null);
         return new TreeWalkerAuditEvent(fileContents, file.getName(), message,
-                TestUtil.parseFile(file));
+            Parser.parseFile(file));
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/AstRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/AstRegressionTest.java
@@ -40,6 +40,7 @@ import antlr.SemanticException;
 import antlr.TokenBuffer;
 import com.puppycrawl.tools.checkstyle.AbstractTreeTestSupport;
 import com.puppycrawl.tools.checkstyle.AstTreeStringPrinter;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 
 public class AstRegressionTest extends AbstractTreeTestSupport {
@@ -139,25 +140,23 @@ public class AstRegressionTest extends AbstractTreeTestSupport {
         verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "\r\r");
         verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "\r");
         verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "\u000c\f");
-        verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "// \n",
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
-        verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "// \r",
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+        verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "// \n", Parser.Options.WITH_COMMENTS);
+        verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "// \r", Parser.Options.WITH_COMMENTS);
         verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "// \r\n",
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
         verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "/* \n */",
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
         verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "/* \r\n */",
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
         verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "/* \r" + "\u0000\u0000" + " */",
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
     @Test
     public void testNewlineCr() throws Exception {
         verifyAst(getPath("InputNewlineCrAtEndOfFileAst.txt"),
                 getPath("InputAstRegressionNewlineCrAtEndOfFile.java"),
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
     @Test
@@ -211,12 +210,11 @@ public class AstRegressionTest extends AbstractTreeTestSupport {
 
     private static void verifyAstRaw(String expectedTextPrintFileName, String actualJava)
             throws Exception {
-        verifyAstRaw(expectedTextPrintFileName, actualJava,
-                AstTreeStringPrinter.PrintOptions.WITHOUT_COMMENTS);
+        verifyAstRaw(expectedTextPrintFileName, actualJava, Parser.Options.WITHOUT_COMMENTS);
     }
 
     private static void verifyAstRaw(String expectedTextPrintFileName, String actualJava,
-            AstTreeStringPrinter.PrintOptions withComments) throws Exception {
+            Parser.Options withComments) throws Exception {
         final File expectedFile = new File(expectedTextPrintFileName);
         final String expectedContents = new FileText(expectedFile, System.getProperty(
                 "file.encoding", StandardCharsets.UTF_8.name()))

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
@@ -23,7 +23,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractTreeTestSupport;
-import com.puppycrawl.tools.checkstyle.AstTreeStringPrinter;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.Comment;
 
 public class CommentsTest extends AbstractTreeTestSupport {
@@ -36,13 +36,13 @@ public class CommentsTest extends AbstractTreeTestSupport {
     @Test
     public void testCompareExpectedTreeWithInput1() throws Exception {
         verifyAst(getPath("InputComments1Ast.txt"), getPath("InputComments1.java"),
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
     @Test
     public void testCompareExpectedTreeWithInput2() throws Exception {
         verifyAst(getPath("InputComments2Ast.txt"), getPath("InputComments2.java"),
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModelTest.java
@@ -197,7 +197,7 @@ public class MainFrameModelTest extends AbstractModuleTestSupport {
         }
         catch (CheckstyleException ex) {
             final String expectedMsg = String.format(Locale.ROOT,
-                    "NoViableAltException occurred while opening file %s.",
+                    "NoViableAltException occurred during the analysis of file %s.",
                     nonCompilableFile.getPath());
 
             assertEquals("Invalid exception message", expectedMsg, ex.getMessage());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.gui;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -28,11 +27,9 @@ import org.junit.Test;
 
 import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
-import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.gui.MainFrameModel.ParseMode;
@@ -47,18 +44,10 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
         return "com/puppycrawl/tools/checkstyle/gui/parsetreetablepresentation";
     }
 
-    private static DetailAST parseFile(File file) throws Exception {
-        final FileContents contents = new FileContents(
-                new FileText(file.getAbsoluteFile(),
-                        System.getProperty("file.encoding",
-                        StandardCharsets.UTF_8.name())));
-        return TreeWalker.parseWithComments(contents);
-    }
-
     @Before
     public void loadTree() throws Exception {
-        tree = parseFile(
-                new File(getPath("InputParseTreeTablePresentation.java")));
+        tree = Parser.parseFileWithComments(
+            new File(getPath("InputParseTreeTablePresentation.java")));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
@@ -19,28 +19,20 @@
 
 package com.puppycrawl.tools.checkstyle.internal.utils;
 
-import static com.puppycrawl.tools.checkstyle.TreeWalker.parseWithComments;
-
-import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
-import antlr.ANTLRException;
 import com.puppycrawl.tools.checkstyle.PackageNamesLoader;
 import com.puppycrawl.tools.checkstyle.PackageObjectFactory;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
-import com.puppycrawl.tools.checkstyle.api.FileText;
 
 public final class TestUtil {
 
@@ -179,20 +171,6 @@ public final class TestUtil {
             curNode = toVisit;
         }
         return Optional.ofNullable(curNode);
-    }
-
-    /**
-     * Parses Java source file. Results in AST which contains comment nodes.
-     * @param file file to parse
-     * @return DetailAST tree
-     * @throws NullPointerException if the text is null
-     * @throws IOException          if the file could not be read
-     * @throws ANTLRException       if parser or lexer failed
-     */
-    public static DetailAST parseFile(File file) throws IOException, ANTLRException {
-        final FileText text = new FileText(file.getAbsoluteFile(), StandardCharsets.UTF_8.name());
-        final FileContents contents = new FileContents(text);
-        return parseWithComments(contents);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -67,9 +68,8 @@ public class BlockCommentPositionTest extends AbstractPathTestSupport {
         );
 
         for (BlockCommentPositionTestMetadata metadata : metadataList) {
-            final DetailAST ast = TestUtil.parseFile(
-                    new File(getPath(metadata.getFileName()))
-            );
+            final DetailAST ast = Parser.parseFileWithComments(
+                new File(getPath(metadata.getFileName())));
             final int matches = getJavadocsCount(ast, metadata.getAssertion());
             assertEquals("Invalid javadoc count", metadata.getMatchesNum(), matches);
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilsTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.findTokenInAstByPredicate;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
-import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.parseFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -37,6 +36,7 @@ import java.util.Set;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifier;
@@ -370,7 +370,8 @@ public class CheckUtilsTest extends AbstractPathTestSupport {
     }
 
     private DetailAST getNodeFromFile(int type) throws Exception {
-        return getNode(parseFile(new File(getPath("InputCheckUtilsTest.java"))), type);
+        return getNode(Parser.parseFileWithComments(
+            new File(getPath("InputCheckUtilsTest.java"))), type);
     }
 
     private static DetailAST getNode(DetailAST root, int type) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/ElementNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/ElementNodeTest.java
@@ -30,9 +30,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import net.sf.saxon.om.Item;
 import net.sf.saxon.om.NodeInfo;
 
@@ -48,7 +48,7 @@ public class ElementNodeTest extends AbstractPathTestSupport {
     @Before
     public void init() throws Exception {
         final File file = new File(getPath("InputXpathMapperAst.java"));
-        final DetailAST rootAst = TestUtil.parseFile(file);
+        final DetailAST rootAst = Parser.parseFile(file);
         rootNode = new RootNode(rootAst);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
@@ -32,9 +32,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import net.sf.saxon.om.AxisInfo;
 import net.sf.saxon.om.Item;
 import net.sf.saxon.om.NamespaceBinding;
@@ -52,7 +52,7 @@ public class RootNodeTest extends AbstractPathTestSupport {
     @Before
     public void init() throws Exception {
         final File file = new File(getPath("InputXpathMapperAst.java"));
-        final DetailAST rootAst = TestUtil.parseFile(file);
+        final DetailAST rootAst = Parser.parseFile(file);
         rootNode = new RootNode(rootAst);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
@@ -32,9 +32,9 @@ import java.util.List;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import net.sf.saxon.om.AxisInfo;
 import net.sf.saxon.om.Item;
 import net.sf.saxon.trans.XPathException;
@@ -527,7 +527,7 @@ public class XpathMapperTest extends AbstractPathTestSupport {
 
     private RootNode getRootNode(String fileName) throws Exception {
         final File file = new File(getPath(fileName));
-        final DetailAST rootAst = TestUtil.parseFile(file);
+        final DetailAST rootAst = Parser.parseFile(file);
         return new RootNode(rootAst);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java
@@ -32,9 +32,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileText;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
 
@@ -54,7 +54,7 @@ public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
         final File file = new File(getPath("InputXpathQueryGenerator.java"));
         fileText = new FileText(file,
                 StandardCharsets.UTF_8.name());
-        rootAst = TestUtil.parseFile(file);
+        rootAst = Parser.parseFileWithComments(file);
     }
 
     @Test
@@ -322,7 +322,7 @@ public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
         final File testFile = new File(getPath("InputXpathQueryGeneratorTabWidth.java"));
         final FileText testFileText = new FileText(testFile,
                 StandardCharsets.UTF_8.name());
-        final DetailAST detailAst = TestUtil.parseFile(testFile);
+        final DetailAST detailAst = Parser.parseFile(testFile);
         final int lineNumber = 4;
         final int columnNumber = 13;
         final int tabWidth = 4;
@@ -344,7 +344,7 @@ public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
         final File testFile = new File(getPath("InputXpathQueryGeneratorTabWidth.java"));
         final FileText testFileText = new FileText(testFile,
                 StandardCharsets.UTF_8.name());
-        final DetailAST detailAst = TestUtil.parseFile(testFile);
+        final DetailAST detailAst = Parser.parseFile(testFile);
         final int lineNumber = 8;
         final int columnNumber = 41;
         final int tabWidth = 8;
@@ -364,7 +364,7 @@ public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
         final File testFile = new File(getPath("InputXpathQueryGeneratorTabWidth.java"));
         final FileText testFileText = new FileText(testFile,
                 StandardCharsets.UTF_8.name());
-        final DetailAST detailAst = TestUtil.parseFile(testFile);
+        final DetailAST detailAst = Parser.parseFile(testFile);
         final int lineNumber = 12;
         final int columnNumber = 57;
         final int tabWidth = 8;
@@ -382,7 +382,7 @@ public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
         final File testFile = new File(getPath("InputXpathQueryGeneratorTabWidth.java"));
         final FileText testFileText = new FileText(testFile,
                 StandardCharsets.UTF_8.name());
-        final DetailAST detailAst = TestUtil.parseFile(testFile);
+        final DetailAST detailAst = Parser.parseFile(testFile);
         final int lineNumber = 16;
         final int columnNumber = 58;
         final int tabWidth = 8;

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/doclets/tokentypesdoclet/InputTokenTypesDocletParseError.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/doclets/tokentypesdoclet/InputTokenTypesDocletParseError.java
@@ -1,0 +1,8 @@
+package com.puppycrawl.tools.checkstyle.doclets.tokentypesdoclet;
+
+public final class InputTokenTypesDocletParseError {
+
+    private InputTokenTypesDocletParseError() {
+    }
+
+!@#$^$^&%5

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/doclets/tokentypesdoclet/InputTokenTypesDocletCorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/doclets/tokentypesdoclet/InputTokenTypesDocletCorrect.java
@@ -4,11 +4,24 @@ import com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaTokenTypes;
 
 public class InputTokenTypesDocletCorrect {
 
-        /**
-         * The end of file token.  This is the root node for the source
-         * file.  It's children are an optional package definition, zero
-         * or more import statements, and one or more class or interface
-         * definitions.
-         **/
-        public static final int EOF = GeneratedJavaTokenTypes.EOF;
+    /**
+     * The end of file token.  This is the root node for the source
+     * file.  It's children are an optional package definition, zero
+     * or more import statements, and one or more class or interface
+     * definitions.
+     **/
+    public static final int EOF1 = 1, EOF2 = 2;
+
+    /**
+     * '&amp;' symbol when used in a generic upper or lower bounds constrain
+     * e.g&#46; {@code Comparable<T extends Serializable & CharSequence>}.
+     */
+    public static final int TYPE_EXTENSION_AND = GeneratedJavaTokenTypes.TYPE_EXTENSION_AND;
+
+    /**
+     * A left curly brace (<code>{</code>).
+     *
+     * @noinspection HtmlTagCanBeJavadocTag
+     **/
+    public static final int LCURLY = GeneratedJavaTokenTypes.LCURLY;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/doclets/tokentypesdoclet/InputTokenTypesDocletEmptyJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/doclets/tokentypesdoclet/InputTokenTypesDocletEmptyJavadoc.java
@@ -4,6 +4,12 @@ import com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaTokenTypes;
 
 public class InputTokenTypesDocletEmptyJavadoc {
 
+    // Singleline comment
+
+    /**
+     * Not a javadoc comment.
+     */
+
     /**
      *
      */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/doclets/tokentypesdoclet/InputTokenTypesDocletJavadocParseError.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/doclets/tokentypesdoclet/InputTokenTypesDocletJavadocParseError.java
@@ -6,17 +6,8 @@ public final class InputTokenTypesDocletJavadocParseError {
     }
 
     /**
-     * The <code>+</code> (unary plus) operator.
-     **/
-    public static final int CONSTANT1 = 1;
-
-    /**
-     * The {@code ++} (postfix increment) operator.
+     * Incomplete {@code tag
      */
-    public static final int CONSTANT2 = 2;
+    public static final int CONSTANT = 0;
 
-    /**
-     * Here you can see sentence without html or javadoc tags.
-     **/
-    public static final int CONSTANT3 = 3;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/doclets/tokentypesdoclet/InputTokenTypesDocletNotCodeTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/doclets/tokentypesdoclet/InputTokenTypesDocletNotCodeTag.java
@@ -1,0 +1,13 @@
+package com.puppycrawl.tools.checkstyle.doclets.tokentypesdoclet;
+
+public final class InputTokenTypesDocletNotCodeTag {
+
+    private InputTokenTypesDocletNotCodeTag() {
+    }
+
+    /**
+     * {@link InputTokenTypesDocletNotCodeTag}
+     */
+    public static final int CONSTANT = 0;
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/doclets/tokentypesdoclet/InputTokenTypesDocletNotConstants.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/doclets/tokentypesdoclet/InputTokenTypesDocletNotConstants.java
@@ -22,4 +22,11 @@ public final class InputTokenTypesDocletNotConstants {
      * A list of statements.
      **/
     public static final double SLIST = GeneratedJavaTokenTypes.SLIST; // must be int
+
+    /**
+     * Not a field.
+     **/
+    public final int method() {
+        return 0;
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/parser/InputParserHiddenComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/parser/InputParserHiddenComments.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.treewalker;
+package com.puppycrawl.tools.checkstyle.parser;
 
 /**
  * Some Javadoc.
@@ -7,7 +7,7 @@ package com.puppycrawl.tools.checkstyle.treewalker;
  *
  * @since 8.0
  */
-public class InputTreeWalkerHiddenComments {
+public class InputParserHiddenComments {
 
 }
 // inline comment


### PR DESCRIPTION
Issue #5102 

* All references to internal sun.* classes have been removed.
* The doclet is replaced with an internal class with the same functionality but based on the internal parser.

To build Checkstyle with JDK9, all tests and cobertura reports must be disabled.