### PR TITLE
Issue #5405: SuppressWithPlainTextComment should ignore directories

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -117,8 +117,10 @@ public class SuppressWithPlainTextCommentFilter extends AutomaticBean implements
         boolean accepted = true;
         if (event.getLocalizedMessage() != null) {
             final FileText fileText = getFileText(event.getFileName());
-            final List<Suppression> suppressions = getSuppressions(fileText);
-            accepted = getNearestSuppression(suppressions, event) == null;
+            if (fileText != null) {
+                final List<Suppression> suppressions = getSuppressions(fileText);
+                accepted = getNearestSuppression(suppressions, event) == null;
+            }
         }
         return accepted;
     }
@@ -134,12 +136,20 @@ public class SuppressWithPlainTextCommentFilter extends AutomaticBean implements
      * @return {@link FileText} instance.
      */
     private static FileText getFileText(String fileName) {
-        try {
-            return new FileText(new File(fileName), StandardCharsets.UTF_8.name());
+        final File file = new File(fileName);
+        FileText result = null;
+
+        // some violations can be on a directory, instead of a file
+        if (!file.isDirectory()) {
+            try {
+                result = new FileText(file, StandardCharsets.UTF_8.name());
+            }
+            catch (IOException ex) {
+                throw new IllegalStateException("Cannot read source file: " + fileName, ex);
+            }
         }
-        catch (IOException ex) {
-            throw new IllegalStateException("Cannot read source file: " + fileName, ex);
-        }
+
+        return result;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -454,6 +455,16 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
             removeSuppressed(violationMessages, suppressed),
             filterCfg, fileTabCheckCfg, regexpCheckCfg
         );
+    }
+
+    @Test
+    public void testFilterWithDirectory() throws IOException {
+        final SuppressWithPlainTextCommentFilter filter = new SuppressWithPlainTextCommentFilter();
+        final AuditEvent event = new AuditEvent(this, getPath(""), new LocalizedMessage(1, 1,
+                "bundle", "key", null, SeverityLevel.ERROR, "moduleId", getClass(),
+                "customMessage"));
+
+        assertTrue("filter should accept directory", filter.accept(event));
     }
 
     private void verifySuppressed(String fileNameWithExtension, String[] violationMessages,


### PR DESCRIPTION
Issue #5405

Violations are not always on files. Sometimes they are on directories.
`SuppressWithPlainTextComment` was changed to ignore these violations and not to try to read them as a file.