### PR TITLE
Issue #5409: fixed intellij 2017.3 violations part 1

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/AbstractModuleTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/AbstractModuleTestSupport.java
@@ -285,21 +285,15 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param messageKey the key of message in 'messages.properties' file.
      * @param arguments  the arguments of message in 'messages.properties' file.
      * @return The message of the check with the arguments applied.
+     * @throws IOException if there is a problem loading the property file.
      */
     protected static String getCheckMessage(Class<? extends AbstractViolationReporter> aClass,
-            String messageKey, Object... arguments) {
-        String checkMessage;
-        try {
-            final Properties pr = new Properties();
-            pr.load(aClass.getResourceAsStream("messages.properties"));
-            final MessageFormat formatter = new MessageFormat(pr.getProperty(messageKey),
-                    Locale.ROOT);
-            checkMessage = formatter.format(arguments);
-        }
-        catch (IOException ex) {
-            checkMessage = null;
-        }
-        return checkMessage;
+            String messageKey, Object... arguments) throws IOException {
+        final Properties pr = new Properties();
+        pr.load(aClass.getResourceAsStream("messages.properties"));
+        final MessageFormat formatter = new MessageFormat(pr.getProperty(messageKey),
+                Locale.ROOT);
+        return formatter.format(arguments);
     }
 
     /**

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/GenericWhitespaceTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/GenericWhitespaceTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import com.google.checkstyle.test.base.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class GenericWhitespaceTest extends AbstractModuleTestSupport {
 
@@ -109,8 +110,7 @@ public class GenericWhitespaceTest extends AbstractModuleTestSupport {
     @Test
     public void genericEndsTheLine() throws Exception {
         final Configuration checkConfig = getModuleConfig("GenericWhitespace");
-        final String[] expected = {
-        };
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputGenericWhitespaceEndsTheLine.java"),
                 expected);
     }

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
@@ -19,6 +19,8 @@
 
 package com.google.checkstyle.test.chapter5naming.rule53camelcase;
 
+import java.io.IOException;
+
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.AbstractModuleTestSupport;
@@ -59,7 +61,8 @@ public class AbbreviationAsWordInNameTest extends AbstractModuleTestSupport {
         verify(checkConfig, filePath, expected, warnList);
     }
 
-    private String getWarningMessage(String typeName, int expectedCapitalCount) {
+    private String getWarningMessage(String typeName, int expectedCapitalCount)
+            throws IOException {
         return getCheckMessage(clazz, MSG_KEY, typeName, expectedCapitalCount);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -127,40 +127,40 @@ public class AvoidEscapedUnicodeCharactersCheck
      * @see <a href="https://en.wiktionary.org/wiki/Appendix:Control_characters">
      *     Appendix:Control characters</a>
      */
-    private static final Pattern UNICODE_CONTROL = Pattern.compile("\\\\(u|U)"
-            + "(00[0-1][0-9A-Fa-f]|00[8-9][0-9A-Fa-f]|00(a|A)(d|D)|034(f|F)|070(f|F)"
-            + "|180(e|E)|200[b-fB-F]|202[a-eA-E]|206[0-4a-fA-F]"
+    private static final Pattern UNICODE_CONTROL = Pattern.compile("\\\\[uU]"
+            + "(00[0-1][0-9A-Fa-f]|00[8-9][0-9A-Fa-f]|00[aA][dD]|034[fF]|070[fF]"
+            + "|180[eE]|200[b-fB-F]|202[a-eA-E]|206[0-4a-fA-F]"
             + "|[fF]{3}[9a-bA-B]|[fF][eE][fF]{2})");
 
     /** Regular expression for all escaped chars. */
     private static final Pattern ALL_ESCAPED_CHARS =
             Pattern.compile("^((\\\\u)[a-fA-F0-9]{4}"
-                    + "||\\\\b|\\\\t|\\\\n|\\\\f|\\\\r|\\\\|\"|\')+$");
+                    + "|\\\\b|\\\\t|\\\\n|\\\\f|\\\\r|\\\\|\"|\')+$");
 
     /** Regular expression for escaped backslash. */
     private static final Pattern ESCAPED_BACKSLASH = Pattern.compile("\\\\\\\\");
 
     /** Regular expression for non-printable unicode chars. */
     private static final Pattern NON_PRINTABLE_CHARS = Pattern.compile("\\\\u1680|\\\\u2028"
-            + "|\\\\u2029|\\\\u205(f|F)|\\\\u3000|\\\\u2007|\\\\u2000|\\\\u200(a|A)"
-            + "|\\\\u007(F|f)|\\\\u009(f|F)|\\\\u(f|F){4}|\\\\u007(F|f)|\\\\u00(a|A)(d|D)"
-            + "|\\\\u0600|\\\\u061(c|C)|\\\\u06(d|D){2}|\\\\u070(f|F)|\\\\u1680|\\\\u180(e|E)"
-            + "|\\\\u2000|\\\\u2028|\\\\u205(f|F)|\\\\u2066|\\\\u2067|\\\\u2068|\\\\u2069"
-            + "|\\\\u206(a|A)|\\\\u(d|D)800|\\\\u(f|F)(e|E)(f|F){2}|\\\\u(f|F){3}9"
-            + "|\\\\u(f|F){3}(a|A)|\\\\u0020|\\\\u00(a|A)0|\\\\u00(a|A)(d|D)|\\\\u0604"
-            + "|\\\\u061(c|C)|\\\\u06(d|D){2}|\\\\u070(f|F)|\\\\u1680|\\\\u180(e|E)|\\\\u200(f|F)"
-            + "|\\\\u202(f|F)|\\\\u2064|\\\\u2066|\\\\u2067|\\\\u2068|\\\\u2069|\\\\u206(f|F)"
-            + "|\\\\u(f|F)8(f|F){2}|\\\\u(f|F)(e|E)(f|F){2}|\\\\u(f|F){3}9|\\\\u(f|F){3}(b|B)"
-            + "|\\\\u05(d|D)0|\\\\u05(f|F)3|\\\\u0600|\\\\u0750|\\\\u0(e|E)00|\\\\u1(e|E)00"
-            + "|\\\\u2100|\\\\u(f|F)(b|B)50|\\\\u(f|F)(e|E)70|\\\\u(F|f){2}61|\\\\u04(f|F)9"
-            + "|\\\\u05(b|B)(e|E)|\\\\u05(e|E)(a|A)|\\\\u05(f|F)4|\\\\u06(f|F){2}"
-            + "|\\\\u077(f|F)|\\\\u0(e|E)7(f|F)|\\\\u20(a|A)(f|F)|\\\\u213(a|A)|\\\\u0000"
-            + "|\\\\u(f|F)(d|D)(f|F){2}|\\\\u(f|F)(e|E)(f|F){2}|\\\\u(f|F){2}(d|D)(c|C)"
-            + "|\\\\u2002|\\\\u0085|\\\\u200(a|A)|\\\\u2005|\\\\u2000|\\\\u2029|\\\\u000(B|b)"
-            + "|\\\\u2008|\\\\u2003|\\\\u205(f|F)|\\\\u1680|\\\\u0009|\\\\u0020|\\\\u2006"
-            + "|\\\\u2001|\\\\u202(f|F)|\\\\u00(a|A)0|\\\\u000(c|C)|\\\\u2009|\\\\u2004|\\\\u2028"
-            + "|\\\\u2028|\\\\u2007|\\\\u2004|\\\\u2028|\\\\u2007|\\\\u2025"
-            + "|\\\\u(f|F){2}0(e|E)|\\\\u(f|F){2}61");
+            + "|\\\\u2029|\\\\u205[fF]|\\\\u3000|\\\\u2007|\\\\u2000|\\\\u200[aA]"
+            + "|\\\\u007[fF]|\\\\u009[fF]|\\\\u[fF]{4}|\\\\u00[aA][dD]"
+            + "|\\\\u0600|\\\\u061[cC]|\\\\u06[dD]{2}|\\\\u070[fF]|\\\\u180[eE]"
+            + "|\\\\u2066|\\\\u2067|\\\\u2068|\\\\u2069"
+            + "|\\\\u206[aA]|\\\\u[dD]800|\\\\u[fF][eE][fF]{2}|\\\\u[fF]{3}9"
+            + "|\\\\u[fF]{3}[aA]|\\\\u0020|\\\\u00[aA]0|\\\\u0604"
+            + "|\\\\u200[fF]"
+            + "|\\\\u202[fF]|\\\\u2064|\\\\u206[fF]"
+            + "|\\\\u[fF]8[fF]{2}|\\\\u[fF]{3}[bB]"
+            + "|\\\\u05[dD]0|\\\\u05[fF]3|\\\\u0750|\\\\u0[eE]00|\\\\u1[eE]00"
+            + "|\\\\u2100|\\\\u[fF][bB]50|\\\\u[fF][eE]70|\\\\u[fF]{2}61|\\\\u04[fF]9"
+            + "|\\\\u05[bB][eE]|\\\\u05[eE][aA]|\\\\u05[fF]4|\\\\u06[fF]{2}"
+            + "|\\\\u077[fF]|\\\\u0[eE]7[fF]|\\\\u20[aA][fF]|\\\\u213[aA]|\\\\u0000"
+            + "|\\\\u[fF][dD][fF]{2}|\\\\u[fF]{2}[dD][cC]"
+            + "|\\\\u2002|\\\\u0085|\\\\u2005|\\\\u000[bB]"
+            + "|\\\\u2008|\\\\u2003|\\\\u0009|\\\\u2006"
+            + "|\\\\u2001|\\\\u000[cC]|\\\\u2009|\\\\u2004"
+            + "|\\\\u2025"
+            + "|\\\\u[fF]{2}0[eE]");
 
     /** Cpp style comments. */
     private Map<Integer, TextBlock> singlelineComments;


### PR DESCRIPTION
Issue #5409 

I will generate regression on the changes in the Check.

The sheer amount of duplication in `AvoidEscapedUnicodeCharactersCheck` is very sad.
I will create another issue once this PR is merged to sort the unicodes and split them apart better so they are easier to read.
