### PR TITLE
minor: sevntu must use appropriate checkstyle version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
     <saxon.version>9.8.0-7</saxon.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
     <maven.sevntu.checkstyle.plugin.version>1.26.0</maven.sevntu.checkstyle.plugin.version>
-    <maven.sevntu-checkstyle-check.checkstyle.version>8.7</maven.sevntu-checkstyle-check.checkstyle.version>
+    <maven.sevntu-checkstyle-check.checkstyle.version>8.5</maven.sevntu-checkstyle-check.checkstyle.version>
     <maven.versions.plugin.version>2.5</maven.versions.plugin.version>
     <java.version>1.8</java.version>
     <tools.jar.version>${java.version}.0</tools.jar.version>


### PR DESCRIPTION
See discussions at https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/628 .