### PR TITLE
Issue #5419: prevented XMLLogger from sanitizing exception tags

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -240,14 +240,16 @@ public class XMLLogger
      * @param throwable The
      */
     private void writeException(Throwable throwable) {
+        writer.println("<exception>");
+        writer.println("<![CDATA[");
+
         final StringWriter stringWriter = new StringWriter();
         final PrintWriter printer = new PrintWriter(stringWriter);
-        printer.println("<exception>");
-        printer.println("<![CDATA[");
         throwable.printStackTrace(printer);
-        printer.println("]]>");
-        printer.println("</exception>");
         writer.println(encode(stringWriter.toString()));
+
+        writer.println("]]>");
+        writer.println("</exception>");
     }
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerException.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerException.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="">
-&lt;exception&gt;&#10;&lt;![CDATA[&#10;stackTrace&#10;example]]&gt;&#10;&lt;/exception&gt;&#10;
+<exception>
+<![CDATA[
+stackTrace&#10;example
+]]>
+</exception>
 </checkstyle>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerException2.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerException2.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="">
 <file name="Test.java">
-&lt;exception&gt;&#10;&lt;![CDATA[&#10;stackTrace&#10;example]]&gt;&#10;&lt;/exception&gt;&#10;
+<exception>
+<![CDATA[
+stackTrace&#10;example
+]]>
+</exception>
 </file>
 </checkstyle>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerException3.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerException3.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="">
-&lt;exception&gt;&#10;&lt;![CDATA[&#10;stackTrace&#10;example]]&gt;&#10;&lt;/exception&gt;&#10;
+<exception>
+<![CDATA[
+stackTrace&#10;example
+]]>
+</exception>
 <file name="Test.java">
 </file>
 </checkstyle>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerExceptionNullFileName.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xmllogger/ExpectedXMLLoggerExceptionNullFileName.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="">
-&lt;exception&gt;&#10;&lt;![CDATA[&#10;stackTrace&#10;example]]&gt;&#10;&lt;/exception&gt;&#10;
+<exception>
+<![CDATA[
+stackTrace&#10;example
+]]>
+</exception>
 </checkstyle>


### PR DESCRIPTION
Issue #5419

Regression isn't affected as we don't use `addException` method. See https://github.com/checkstyle/checkstyle/issues/4377 .
  