### PR TITLE
Issue #5423: Javadoc fixes

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -225,7 +225,7 @@ public final class JavadocTokenTypes {
     public static final int SEE_LITERAL = JavadocParser.SEE_LITERAL;
 
     /**
-     * '@see' literal in @see Javadoc tag.
+     * '@serial' literal in @serial Javadoc tag.
      *
      * <p>Such Javadoc tag can have one argument - {@link #REFERENCE} or {@link #LITERAL_EXCLUDE}
      * or {@link #LITERAL_INCLUDE}</p>
@@ -376,16 +376,18 @@ public final class JavadocTokenTypes {
      * First child of {@link #JAVADOC_INLINE_TAG} that represents left curly brace '{'.
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code {&#64;code Comparable&lt;E&gt;}}</pre>
+     * <pre><code>{&#64;code Comparable&lt;E&gt;}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
+     * <code> |--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
      *         |--JAVADOC_INLINE_TAG_START[3x0] : [{]
      *         |--CODE_LITERAL[3x1] : [@code]
      *         |--WS[3x6] : [ ]
      *         |--TEXT[3x7] : [Comparable&lt;E&gt;]
      *         |--JAVADOC_INLINE_TAG_END[3x21] : [}]
-     * }</pre>
+     * </code>
+     * </pre>
+     * @noinspection HtmlTagCanBeJavadocTag
      */
     public static final int JAVADOC_INLINE_TAG_START = JavadocParser.JAVADOC_INLINE_TAG_START;
 
@@ -393,17 +395,18 @@ public final class JavadocTokenTypes {
      * Last child of {@link #JAVADOC_INLINE_TAG} that represents right curly brace '}'.
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code {&#64;code Comparable&lt;E&gt;}}</pre>
+     * <pre><code>{&#64;code Comparable&lt;E&gt;}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
+     * <code> |--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
      *         |--JAVADOC_INLINE_TAG_START[3x0] : [{]
      *         |--CODE_LITERAL[3x1] : [@code]
      *         |--WS[3x6] : [ ]
      *         |--TEXT[3x7] : [Comparable&lt;E&gt;]
      *         |--JAVADOC_INLINE_TAG_END[3x21] : [}]
-     * }
+     * </code>
      * </pre>
+     * @noinspection HtmlTagCanBeJavadocTag
      */
     public static final int JAVADOC_INLINE_TAG_END = JavadocParser.JAVADOC_INLINE_TAG_END;
 
@@ -418,22 +421,23 @@ public final class JavadocTokenTypes {
      * </ul>
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code {&#64;code Comparable&lt;E&gt;}}</pre>
+     * <pre><code>{&#64;code Comparable&lt;E&gt;}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
+     * <code> |--JAVADOC_INLINE_TAG[3x0] : [{&#64;code Comparable&lt;E&gt;}]
      *         |--JAVADOC_INLINE_TAG_START[3x0] : [{]
      *         |--CODE_LITERAL[3x1] : [@code]
      *         |--WS[3x6] : [ ]
      *         |--TEXT[3x7] : [Comparable&lt;E&gt;]
      *         |--JAVADOC_INLINE_TAG_END[3x21] : [}]
-     * }
+     * </code>
      * </pre>
      *
      * @see
      * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDFHHBB">
      * Oracle Docs</a>
      * @see #JAVADOC_INLINE_TAG
+     * @noinspection HtmlTagCanBeJavadocTag
      */
     public static final int CODE_LITERAL = JavadocParser.CODE_LITERAL;
 
@@ -447,34 +451,35 @@ public final class JavadocTokenTypes {
      * </ul>
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code {&#64;docRoot}}</pre>
+     * <pre><code>{&#64;docRoot}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code  |--JAVADOC_INLINE_TAG[1x0] : [{&#64;docRoot \n}]
+     * <code>  |--JAVADOC_INLINE_TAG[1x0] : [{&#64;docRoot}]
      *            |--JAVADOC_INLINE_TAG_START[1x0] : [{]
      *            |--DOC_ROOT_LITERAL[1x1] : [@docRoot]
      *            |--JAVADOC_INLINE_TAG_END[2x0] : [}]
-     * }
+     * </code>
      * </pre>
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code {&#64;docRoot
-     *}}</pre>
+     * <pre><code>{&#64;docRoot
+     *}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code  |--JAVADOC_INLINE_TAG[1x0] : [{&#64;docRoot \n}]
+     * <code>  |--JAVADOC_INLINE_TAG[1x0] : [{&#64;docRoot \n}]
      *            |--JAVADOC_INLINE_TAG_START[1x0] : [{]
      *            |--DOC_ROOT_LITERAL[1x1] : [@docRoot]
      *            |--WS[1x9] : [ ]
      *            |--NEWLINE[1x10] : [\n]
      *            |--JAVADOC_INLINE_TAG_END[2x0] : [}]
-     * }
+     * </code>
      * </pre>
      *
      * @see
      * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDBACBF">
      * Oracle Docs</a>
      * @see #JAVADOC_INLINE_TAG
+     * @noinspection HtmlTagCanBeJavadocTag
      */
     public static final int DOC_ROOT_LITERAL = JavadocParser.DOC_ROOT_LITERAL;
 
@@ -482,10 +487,10 @@ public final class JavadocTokenTypes {
      * '@link' literal in {&#64;link} Javadoc inline tag.
      * <p>Such Javadoc inline tag can have one argument - {@link #REFERENCE}</p>
      * <p><b>Example:</b></p>
-     * <pre>{@code {&#64;link org.apache.utils.Lists.Comparator#compare(Object)}}</pre>
+     * <pre><code>{&#64;link org.apache.utils.Lists.Comparator#compare(Object)}</code></pre>
      * <p><b>Tree:</b></p>
      * <pre>
-     * {@code |--JAVADOC_INLINE_TAG[1x0] :
+     * <code> |--JAVADOC_INLINE_TAG[1x0] :
      *               [{&#64;link org.apache.utils.Lists.Comparator#compare(Object)}]
      *        |--JAVADOC_INLINE_TAG_START[1x0] : [{]
      *        |--LINK_LITERAL[1x1] : [@link]
@@ -503,13 +508,14 @@ public final class JavadocTokenTypes {
      *                |--ARGUMENT[1x49] : [Object]
      *                |--RIGHT_BRACE[1x55] : [)]
      *        |--JAVADOC_INLINE_TAG_END[1x56] : [}]
-     * }
+     * </code>
      * </pre>
      *
      * @see
      * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDDIECH">
      * Oracle Docs</a>
      * @see #JAVADOC_INLINE_TAG
+     * @noinspection HtmlTagCanBeJavadocTag
      */
     public static final int LINK_LITERAL = JavadocParser.LINK_LITERAL;
 
@@ -523,20 +529,21 @@ public final class JavadocTokenTypes {
      * </ul>
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code {&#64;inheritDoc}}</pre>
+     * <pre><code>{&#64;inheritDoc}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code  |--JAVADOC_INLINE_TAG[1x0] : [{&#64;inheritDoc}]
+     * <code>  |--JAVADOC_INLINE_TAG[1x0] : [{&#64;inheritDoc}]
      *            |--JAVADOC_INLINE_TAG_START[1x0] : [{]
      *            |--INHERIT_DOC_LITERAL[1x1] : [@inheritDoc]
      *            |--JAVADOC_INLINE_TAG_END[1x12] : [}]
-     * }
+     * </code>
      * </pre>
      *
      * @see
      * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDGJCHC">
      * Oracle Docs</a>
      * @see #JAVADOC_INLINE_TAG
+     * @noinspection HtmlTagCanBeJavadocTag
      */
     public static final int INHERIT_DOC_LITERAL = JavadocParser.INHERIT_DOC_LITERAL;
 
@@ -546,10 +553,11 @@ public final class JavadocTokenTypes {
      * <p>Such Javadoc inline tag can have one argument - {@link #REFERENCE}</p>
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code {&#64;linkplain org.apache.utils.Lists.Comparator#compare(Object) compare}}</pre>
+     * <pre><code>{&#64;linkplain org.apache.utils.Lists.Comparator#compare(Object) compare}</code>
+     * </pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_INLINE_TAG[1x0] :
+     * <code> |--JAVADOC_INLINE_TAG[1x0] :
      *               [{&#64;linkplain org.apache.utils.Lists.Comparator#compare(Object) compare}]
      *        |--JAVADOC_INLINE_TAG_START[1x0] : [{]
      *        |--LINKPLAIN_LITERAL[1x1] : [@linkplain]
@@ -569,13 +577,14 @@ public final class JavadocTokenTypes {
      *        |--DESCRIPTION[1x61] : [ compare]
      *            |--TEXT[1x61] : [ compare]
      *        |--JAVADOC_INLINE_TAG_END[1x69] : [}]
-     * }
+     * </code>
      * </pre>
      *
      * @see
      * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDGBICD">
      * Oracle Docs</a>
      * @see #JAVADOC_INLINE_TAG
+     * @noinspection HtmlTagCanBeJavadocTag
      */
     public static final int LINKPLAIN_LITERAL = JavadocParser.LINKPLAIN_LITERAL;
 
@@ -590,22 +599,23 @@ public final class JavadocTokenTypes {
      * </ul>
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code {&#64;literal #compare(Object)}}</pre>
+     * <pre><code>{&#64;literal #compare(Object)}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_INLINE_TAG[1x0] : [{&#64;literal #compare(Object)}]
+     * <code> |--JAVADOC_INLINE_TAG[1x0] : [{&#64;literal #compare(Object)}]
      *        |--JAVADOC_INLINE_TAG_START[1x0] : [{]
      *        |--LITERAL_LITERAL[1x1] : [@literal]
      *        |--WS[1x9] : [ ]
      *        |--TEXT[1x10] : [#compare(Object)]
      *        |--JAVADOC_INLINE_TAG_END[1x27] : [}]
-     * }
+     * </code>
      * </pre>
      *
      * @see
      * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDCFJDG">
      * Oracle Docs</a>
      * @see #JAVADOC_INLINE_TAG
+     * @noinspection HtmlTagCanBeJavadocTag
      */
     public static final int LITERAL_LITERAL = JavadocParser.LITERAL_LITERAL;
 
@@ -620,10 +630,10 @@ public final class JavadocTokenTypes {
      * </ul>
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code {&#64;value Integer#MAX_VALUE}}</pre>
+     * <pre><code>{&#64;value Integer#MAX_VALUE}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_INLINE_TAG[1x0] : [{&#64;value Integer#MAX_VALUE}]
+     * <code> |--JAVADOC_INLINE_TAG[1x0] : [&#64;value Integer#MAX_VALUE}]
      *        |--JAVADOC_INLINE_TAG_START[1x0] : [{]
      *        |--VALUE_LITERAL[1x1] : [@value]
      *        |--WS[1x7] : [ ]
@@ -632,13 +642,14 @@ public final class JavadocTokenTypes {
      *            |--HASH[1x15] : [#]
      *            |--MEMBER[1x16] : [MAX_VALUE]
      *        |--JAVADOC_INLINE_TAG_END[1x25] : [}]
-     * }
+     * </code>
      * </pre>
      *
      * @see
      * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDDCDHH">
      * Oracle Docs</a>
      * @see #JAVADOC_INLINE_TAG
+     * @noinspection HtmlTagCanBeJavadocTag
      */
     public static final int VALUE_LITERAL = JavadocParser.VALUE_LITERAL;
 
@@ -1142,7 +1153,7 @@ public final class JavadocTokenTypes {
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
-     * HTML comment start symbol '&lt;!--'.
+     * HTML comment start symbol '&lt;&#33;--'.
      */
     public static final int HTML_COMMENT_START = JavadocParser.HTML_COMMENT_START;
 
@@ -1152,7 +1163,7 @@ public final class JavadocTokenTypes {
     public static final int HTML_COMMENT_END = JavadocParser.HTML_COMMENT_END;
 
     /**
-     * &lt;![CDATA[...]]&gt; block.
+     * &lt;&#33;[CDATA[&#46;&#46;&#46;]]&gt; block.
      */
     public static final int CDATA = JavadocParser.CDATA;
 
@@ -1280,18 +1291,19 @@ public final class JavadocTokenTypes {
      * </ul>
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code {&#64;link String}}</pre>
+     * <pre><code>{&#64;link String}</code></pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_INLINE_TAG[4x3] : [{&#64;link String}]
+     * <code> |--JAVADOC_INLINE_TAG[4x3] : [&#64;link String}]
      *        |--JAVADOC_INLINE_TAG_START[4x3] : [{]
      *        |--LINK_LITERAL[4x4] : [@link]
      *        |--WS[4x9] : [ ]
      *        |--REFERENCE[4x10] : [String]
      *            |--CLASS[4x10] : [String]
      *        |--JAVADOC_INLINE_TAG_END[4x16] : [}]
-     * }
+     * </code>
      * </pre>
+     * @noinspection HtmlTagCanBeJavadocTag
      */
     public static final int JAVADOC_INLINE_TAG = JavadocParser.RULE_javadocInlineTag
             + RULE_TYPES_OFFSET;
@@ -1348,29 +1360,28 @@ public final class JavadocTokenTypes {
      * <p>It is argument for many Javadoc tags and inline tags.</p>
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code @throws IOException if &lt;b&gt;connection&lt;/b&gt; problems occur}</pre>
+     * <pre>{@code @throws IOException if <b>connection</b> problems occur}</pre>
      * <b>Tree:</b>
      * <pre>
-     * {@code |--JAVADOC_TAG[1x0] :
-     *               [@throws IOException if &lt;b&gt;connection&lt;/b&gt; problems occur]
+     * {@code |--JAVADOC_TAG[1x0] : [@throws IOException if <b>connection</b> problems occur]
      *        |--THROWS_LITERAL[1x0] : [@throws]
      *        |--WS[1x7] : [ ]
      *        |--CLASS_NAME[1x8] : [IOException]
      *        |--WS[1x19] : [ ]
-     *        |--DESCRIPTION[1x20] : [if &lt;b&gt;connection&lt;/b&gt; problems occur]
+     *        |--DESCRIPTION[1x20] : [if <b>connection</b> problems occur]
      *            |--TEXT[1x20] : [if ]
-     *            |--HTML_ELEMENT[1x23] : [&lt;b&gt;connection&lt;/b&gt;]
-     *                |--HTML_TAG[1x23] : [&lt;b&gt;connection&lt;/b&gt;]
-     *                    |--HTML_ELEMENT_START[1x23] : [&lt;b&gt;]
-     *                        |--START[1x23] : [&lt;]
+     *            |--HTML_ELEMENT[1x23] : [<b>connection</b>]
+     *                |--HTML_TAG[1x23] : [<b>connection</b>]
+     *                    |--HTML_ELEMENT_START[1x23] : [<b>]
+     *                        |--START[1x23] : [<]
      *                        |--HTML_TAG_NAME[1x24] : [b]
-     *                        |--END[1x25] : [&gt;]
+     *                        |--END[1x25] : [>]
      *                    |--TEXT[1x26] : [connection]
-     *                    |--HTML_ELEMENT_END[1x36] : [&lt;/b&gt;]
-     *                        |--START[1x36] : [&lt;]
+     *                    |--HTML_ELEMENT_END[1x36] : [</b>]
+     *                        |--START[1x36] : [<]
      *                        |--SLASH[1x37] : [/]
      *                        |--HTML_TAG_NAME[1x38] : [b]
-     *                        |--END[1x39] : [&gt;]
+     *                        |--END[1x39] : [>]
      *            |--TEXT[1x40] : [ problems occur]
      * }
      * </pre>
@@ -1591,7 +1602,9 @@ public final class JavadocTokenTypes {
     /**
      * HTML void element {@code <source>}.
      * @see #SINGLETON_ELEMENT
-     * @see "https://www.w3.org/TR/html51/semantics-embedded-content.html#elementdef-media-source"
+     * @see <a href=
+     *     "https://www.w3.org/TR/html51/semantics-embedded-content.html#elementdef-media-source">
+     *     W3 docs</a>
      */
     public static final int SOURCE_TAG = JavadocParser.RULE_sourceTag + RULE_TYPES_OFFSET;
 
@@ -1614,7 +1627,9 @@ public final class JavadocTokenTypes {
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
-    /** Html comment: {@code <!-- -->}. */
+    /** Html comment: <code>&lt;&#33;-- --&gt;</code>.
+     * @noinspection HtmlTagCanBeJavadocTag
+     */
     public static final int HTML_COMMENT = JavadocParser.RULE_htmlComment
             + RULE_TYPES_OFFSET;
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -34,12 +34,6 @@ import com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaTokenTypes;
  */
 public final class TokenTypes {
 
-    // The following three types are never part of an AST,
-    // left here as a reminder so nobody will read them accidentally
-
-    // These are the types that can actually occur in an AST
-    // it makes sense to register Checks for these types
-
     /**
      * The end of file token.  This is the root node for the source
      * file.  It's children are an optional package definition, zero
@@ -1203,9 +1197,10 @@ public final class TokenTypes {
      **/
     public static final int IDENT = GeneratedJavaTokenTypes.IDENT;
     /**
-     * The {@code &#46;} (dot) operator.
+     * The <code>&#46;</code> (dot) operator.
      *
      * @see FullIdent
+     * @noinspection HtmlTagCanBeJavadocTag
      **/
     public static final int DOT = GeneratedJavaTokenTypes.DOT;
     /**
@@ -1361,19 +1356,21 @@ public final class TokenTypes {
         GeneratedJavaTokenTypes.LITERAL_interface;
 
     /**
-     * A left (curly) brace ({@code &#123;}).
+     * A left curly brace (<code>{</code>).
      *
      * @see #OBJBLOCK
      * @see #ARRAY_INIT
      * @see #SLIST
+     * @noinspection HtmlTagCanBeJavadocTag
      **/
     public static final int LCURLY = GeneratedJavaTokenTypes.LCURLY;
     /**
-     * A right (curly) brace ({@code &#125;}).
+     * A right curly brace (<code>}</code>).
      *
      * @see #OBJBLOCK
      * @see #ARRAY_INIT
      * @see #SLIST
+     * @noinspection HtmlTagCanBeJavadocTag
      **/
     public static final int RCURLY = GeneratedJavaTokenTypes.RCURLY;
     /**
@@ -1897,7 +1894,7 @@ public final class TokenTypes {
 
     /**
      * The {@code case} keyword.  The first child is a constant
-     * expression that evaluates to a integer.
+     * expression that evaluates to an integer.
      *
      * @see #CASE_GROUP
      * @see #EXPR
@@ -2209,7 +2206,7 @@ public final class TokenTypes {
      **/
     public static final int MOD_ASSIGN = GeneratedJavaTokenTypes.MOD_ASSIGN;
     /**
-     * The {@code &gt;&gt;=} (signed right shift assignment)
+     * The {@code >>=} (signed right shift assignment)
      * operator.
      *
      * @see <a
@@ -2219,7 +2216,7 @@ public final class TokenTypes {
      **/
     public static final int SR_ASSIGN = GeneratedJavaTokenTypes.SR_ASSIGN;
     /**
-     * The {@code &gt;&gt;&gt;=} (unsigned right shift assignment)
+     * The {@code >>>=} (unsigned right shift assignment)
      * operator.
      *
      * @see <a
@@ -2229,7 +2226,7 @@ public final class TokenTypes {
      **/
     public static final int BSR_ASSIGN = GeneratedJavaTokenTypes.BSR_ASSIGN;
     /**
-     * The {@code &lt;&lt;=} (left shift assignment) operator.
+     * The {@code <<=} (left shift assignment) operator.
      *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
@@ -2238,7 +2235,7 @@ public final class TokenTypes {
      **/
     public static final int SL_ASSIGN = GeneratedJavaTokenTypes.SL_ASSIGN;
     /**
-     * The {@code &amp;=} (bitwise AND assignment) operator.
+     * The {@code &=} (bitwise AND assignment) operator.
      *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.2">Java
@@ -2265,7 +2262,7 @@ public final class TokenTypes {
      **/
     public static final int BOR_ASSIGN = GeneratedJavaTokenTypes.BOR_ASSIGN;
     /**
-     * The {@code &#63;} (conditional) operator.  Technically,
+     * The <code>&#63;</code> (conditional) operator.  Technically,
      * the colon is also part of this operator, but it appears as a
      * separate token.
      *
@@ -2295,6 +2292,7 @@ public final class TokenTypes {
      * Language Specification, &sect;15.25</a>
      * @see #EXPR
      * @see #COLON
+     * @noinspection HtmlTagCanBeJavadocTag
      **/
     public static final int QUESTION = GeneratedJavaTokenTypes.QUESTION;
     /**
@@ -2307,7 +2305,7 @@ public final class TokenTypes {
      **/
     public static final int LOR = GeneratedJavaTokenTypes.LOR;
     /**
-     * The {@code &amp;&amp;} (conditional AND) operator.
+     * The {@code &&} (conditional AND) operator.
      *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.23">Java
@@ -2334,7 +2332,7 @@ public final class TokenTypes {
      **/
     public static final int BXOR = GeneratedJavaTokenTypes.BXOR;
     /**
-     * The {@code &amp;} (bitwise AND) operator.
+     * The {@code &} (bitwise AND) operator.
      *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.22.1">Java
@@ -2343,9 +2341,10 @@ public final class TokenTypes {
      **/
     public static final int BAND = GeneratedJavaTokenTypes.BAND;
     /**
-     * The {@code &#33;=} (not equal) operator.
+     * The <code>&#33;=</code> (not equal) operator.
      *
      * @see #EXPR
+     * @noinspection HtmlTagCanBeJavadocTag
      **/
     public static final int NOT_EQUAL = GeneratedJavaTokenTypes.NOT_EQUAL;
     /**
@@ -2355,25 +2354,25 @@ public final class TokenTypes {
      **/
     public static final int EQUAL = GeneratedJavaTokenTypes.EQUAL;
     /**
-     * The {@code &lt;} (less than) operator.
+     * The {@code <} (less than) operator.
      *
      * @see #EXPR
      **/
     public static final int LT = GeneratedJavaTokenTypes.LT;
     /**
-     * The {@code &gt;} (greater than) operator.
+     * The {@code >} (greater than) operator.
      *
      * @see #EXPR
      **/
     public static final int GT = GeneratedJavaTokenTypes.GT;
     /**
-     * The {@code &lt;=} (less than or equal) operator.
+     * The {@code <=} (less than or equal) operator.
      *
      * @see #EXPR
      **/
     public static final int LE = GeneratedJavaTokenTypes.LE;
     /**
-     * The {@code &gt;=} (greater than or equal) operator.
+     * The {@code >=} (greater than or equal) operator.
      *
      * @see #EXPR
      **/
@@ -2397,7 +2396,7 @@ public final class TokenTypes {
         GeneratedJavaTokenTypes.LITERAL_instanceof;
 
     /**
-     * The {@code &lt;&lt;} (shift left) operator.
+     * The {@code <<} (shift left) operator.
      *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.19">Java
@@ -2406,7 +2405,7 @@ public final class TokenTypes {
      **/
     public static final int SL = GeneratedJavaTokenTypes.SL;
     /**
-     * The {@code &gt;&gt;} (signed shift right) operator.
+     * The {@code >>} (signed shift right) operator.
      *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.19">Java
@@ -2415,7 +2414,7 @@ public final class TokenTypes {
      **/
     public static final int SR = GeneratedJavaTokenTypes.SR;
     /**
-     * The {@code &gt;&gt;&gt;} (unsigned shift right) operator.
+     * The {@code >>>} (unsigned shift right) operator.
      *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.19">Java
@@ -2489,12 +2488,13 @@ public final class TokenTypes {
      **/
     public static final int BNOT = GeneratedJavaTokenTypes.BNOT;
     /**
-     * The {@code &#33;} (logical complement) operator.
+     * The <code>&#33;</code> (logical complement) operator.
      *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.6">Java
      * Language Specification, &sect;15.15.6</a>
      * @see #EXPR
+     * @noinspection HtmlTagCanBeJavadocTag
      **/
     public static final int LNOT = GeneratedJavaTokenTypes.LNOT;
     /**
@@ -3160,7 +3160,7 @@ public final class TokenTypes {
         GeneratedJavaTokenTypes.ANNOTATION;
 
     /**
-     * An initialisation of an annotation member with a value.
+     * An initialization of an annotation member with a value.
      * Its children are the name of the member, the assignment literal
      * and the (compile-time constant conditional expression) value.
      *
@@ -3173,9 +3173,9 @@ public final class TokenTypes {
         GeneratedJavaTokenTypes.ANNOTATION_MEMBER_VALUE_PAIR;
 
     /**
-     * An annotation array member initialisation.
+     * An annotation array member initialization.
      * Initializers can not be nested.
-     * Am initializer may be present as a default to a annotation
+     * An initializer may be present as a default to an annotation
      * member, as the single default value to an annotation
      * (e.g. @Annotation({1,2})) or as the value of an annotation
      * member value pair.
@@ -3403,7 +3403,7 @@ public final class TokenTypes {
         GeneratedJavaTokenTypes.TYPE_LOWER_BOUNDS;
 
     /**
-     * An 'at' symbol - signifying an annotation instance or the prefix
+     * An {@code @} symbol - signifying an annotation instance or the prefix
      * to the interface literal signifying the definition of an annotation
      * declaration.
      *
@@ -3422,26 +3422,26 @@ public final class TokenTypes {
     public static final int ELLIPSIS = GeneratedJavaTokenTypes.ELLIPSIS;
 
     /**
-     * '&amp;' symbol when used in a generic upper or lower bounds constrain
-     * e.g. {@code Comparable&lt;<? extends Serializable, CharSequence>}.
+     * The {@code &} symbol when used in a generic upper or lower bounds constrain
+     * e.g&#46; <code>Comparable&lt;T extends Serializable &amp; CharSequence&gt;</code>.
+     * @noinspection HtmlTagCanBeJavadocTag
      */
     public static final int TYPE_EXTENSION_AND =
         GeneratedJavaTokenTypes.TYPE_EXTENSION_AND;
 
     /**
-     * '&lt;' symbol signifying the start of type arguments or type
-     * parameters.
+     * A {@code <} symbol signifying the start of type arguments or type parameters.
      */
     public static final int GENERIC_START =
         GeneratedJavaTokenTypes.GENERIC_START;
 
     /**
-     * '&gt;' symbol signifying the end of type arguments or type parameters.
+     * A {@code >} symbol signifying the end of type arguments or type parameters.
      */
     public static final int GENERIC_END = GeneratedJavaTokenTypes.GENERIC_END;
 
     /**
-     * Special lambda symbol '-&gt;'.
+     * Special lambda symbol {@code ->}.
      */
     public static final int LAMBDA = GeneratedJavaTokenTypes.LAMBDA;
 
@@ -3471,7 +3471,7 @@ public final class TokenTypes {
             GeneratedJavaTokenTypes.BLOCK_COMMENT_BEGIN;
 
     /**
-     * End of block comment: '* /'.
+     * End of block comment: '&#42;/'.
      *
      * <pre>
      * +--BLOCK_COMMENT_BEGIN

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -35,7 +35,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * <p>
  * Restrict using <a href =
  * "https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.3">
- * Unicode escapes</a> (such as {@code &#92;u221e}).
+ * Unicode escapes</a> (such as <code>&#92;u221e</code>).
  * It is possible to allow using escapes for
  * <a href="https://en.wiktionary.org/wiki/Appendix:Control_characters">
  * non-printable(control) characters</a>.
@@ -107,7 +107,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * </pre>
  *
  * @author maxvetrenko
- *
+ * @noinspection HtmlTagCanBeJavadocTag
  */
 @FileStatefulCheck
 public class AvoidEscapedUnicodeCharactersCheck

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -34,12 +34,13 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 /**
  * <p>
  * The check to ensure that comments are the only thing on a line.
- * For the case of // comments that means that the only thing that should
+ * For the case of {@code //} comments that means that the only thing that should
  * precede it is whitespace.
  * It doesn't check comments if they do not end line, i.e. it accept
  * the following:
- * {@code Thread.sleep( 10 &lt;some comment here&gt; );}
- * Format property is intended to deal with the "} // while" example.
+ * </p>
+ * <pre><code>Thread.sleep( 10 /*some comment here&#42;/ );</code></pre>
+ * <p>Format property is intended to deal with the <code>} // while</code> example.
  * </p>
  *
  * <p>Rationale: Steve McConnell in &quot;Code Complete&quot; suggests that endline
@@ -97,6 +98,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * </pre>
  *
  * @author o_sukhodolsky
+ * @noinspection HtmlTagCanBeJavadocTag
  */
 @StatelessCheck
 public class TrailingCommentCheck extends AbstractCheck {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyOption.java
@@ -20,9 +20,10 @@
 package com.puppycrawl.tools.checkstyle.checks.blocks;
 
 /**
- * Represents the options for placing the left curly brace {@code '&#123;'}.
+ * Represents the options for placing the left curly brace <code>'{'</code>.
  *
  * @author Oliver Burn
+ * @noinspection HtmlTagCanBeJavadocTag
  */
 public enum LeftCurlyOption {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java
@@ -20,9 +20,10 @@
 package com.puppycrawl.tools.checkstyle.checks.blocks;
 
 /**
- * Represents the options for placing the right curly brace {@code '}'}.
+ * Represents the options for placing the right curly brace <code>'}'</code>.
  *
  * @author Oliver Burn
+ * @noinspection HtmlTagCanBeJavadocTag
  */
 public enum RightCurlyOption {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -27,15 +27,16 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * <p>Checks that string literals are not used with
- * {@code ==} or {@code &#33;=}.
+ * {@code ==} or <code>&#33;=</code>.
  * </p>
  * <p>
  * Rationale: Novice Java programmers often use code like
- * {@code if (x == &quot;something&quot;)} when they mean
- * {@code if (&quot;something&quot;.equals(x))}.
+ * {@code if (x == "something")} when they mean
+ * {@code if ("something".equals(x))}.
  * </p>
  *
  * @author Lars K&uuml;hne
+ * @noinspection HtmlTagCanBeJavadocTag
  */
 @StatelessCheck
 public class StringLiteralEqualityCheck extends AbstractCheck {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -31,6 +31,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
+ * Checks the ordering/grouping of imports. Features are:
  * <ul>
  * <li>groups imports: ensures that groups of imports come in a specific order
  * (e.g., java. comes first, javax. comes second, then everything else)</li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/TokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/TokenTypesTest.java
@@ -36,23 +36,23 @@ public class TokenTypesTest {
                 TokenUtils.getShortDescription("EQUAL"));
 
         assertEquals("short description for LAND",
-                "The <code>&amp;&amp;</code> (conditional AND) operator.",
+                "The <code>&&</code> (conditional AND) operator.",
                 TokenUtils.getShortDescription("LAND"));
 
         assertEquals("short description for LCURLY",
-                "A left (curly) brace (<code>&#123;</code>).",
+                "A left curly brace (<code>{</code>).",
                 TokenUtils.getShortDescription("LCURLY"));
 
         assertEquals("short description for SR_ASSIGN",
-                "The <code>&gt;&gt;=</code> (signed right shift assignment)",
+                "The <code>>>=</code> (signed right shift assignment)",
                 TokenUtils.getShortDescription("SR_ASSIGN"));
 
         assertEquals("short description for SL",
-                "The <code>&lt;&lt;</code> (shift left) operator.",
+                "The <code><<</code> (shift left) operator.",
                 TokenUtils.getShortDescription("SL"));
 
         assertEquals("short description for BSR",
-                "The <code>&gt;&gt;&gt;</code> (unsigned shift right) operator.",
+                "The <code>>>></code> (unsigned shift right) operator.",
                 TokenUtils.getShortDescription("BSR"));
     }
 


### PR DESCRIPTION
Issue #5423

The {@code } inline tag has some limitations:

- it may not contains encoded html entities such a &amp;lt; - they will be displayed 'as is'
- it may not contains symbols "!?." since they are treated as the end-of-sentence marker by the javadoc tool
- it may not contains symbols "{}" for obvious reason

To mark such fragments as code, the {@code } inline tag must be replaced with the HTML &lt;code&gt; tag.

In addition, several typos have been fixed.
  