### PR TITLE
Issue #5409: fixed intellij 2017.3 violations part 2

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java
@@ -54,7 +54,7 @@ import com.google.common.collect.ImmutableList;
  * @author Lars Kühne
  * @noinspection ThisEscapedInObjectConstruction
  */
-public class TreeTable extends JTable {
+public final class TreeTable extends JTable {
 
     private static final long serialVersionUID = -8493693409423365387L;
     /** A subclass of JTree. */
@@ -207,7 +207,7 @@ public class TreeTable extends JTable {
      * Overridden to pass the new rowHeight to the tree.
      */
     @Override
-    public final void setRowHeight(int newRowHeight) {
+    public void setRowHeight(int newRowHeight) {
         super.setRowHeight(newRowHeight);
         if (tree != null && tree.getRowHeight() != newRowHeight) {
             tree.setRowHeight(getRowHeight());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
@@ -156,11 +156,9 @@ public class JavadocPackageCheckTest
     /**
      * Using direct call to check here because there is no other way
      * to reproduce exception with invalid canonical path.
-     *
-     * @throws Exception if error occurs
      */
     @Test
-    public void testCheckstyleExceptionIfFailedToGetCanonicalPathToFile() throws Exception {
+    public void testCheckstyleExceptionIfFailedToGetCanonicalPathToFile() {
         final JavadocPackageCheck check = new JavadocPackageCheck();
         final File fileWithInvalidPath = new File("\u0000\u0000\u0000");
         final FileText mockFileText = new FileText(fileWithInvalidPath, Collections.emptyList());


### PR DESCRIPTION
Issue #5409

http://rveach.no-ip.org/checkstyle/regression/reports/issue5409.html
~Fixes all `Unsafe lazy initialization of 'static' field inspection   2 errors`.~
Fixes all `Overridable method called during object construction inspection   8 errors`
Fixes one instance of `Redundant throws clause inspection   25 errors`.
  