### PR TITLE
Issue #5291: fixed long xdoc lines of 130 characters or more

### DIFF
--- a/src/xdocs/anttask.xml.vm
+++ b/src/xdocs/anttask.xml.vm
@@ -436,7 +436,8 @@
     &lt;fileset dir=&quot;src&quot; includes=&quot;**/*.java&quot;/&gt;
   &lt;/checkstyle&gt;
 
-  &lt;style in=&quot;checkstyle_report.xml&quot; out=&quot;checkstyle_report.html&quot; style=&quot;checkstyle.xsl&quot;/&gt;
+  &lt;style in=&quot;checkstyle_report.xml&quot; out=&quot;checkstyle_report.html&quot;
+      style=&quot;checkstyle.xsl&quot;/&gt;
 
 &lt;/target&gt;
 

--- a/src/xdocs/cmdline.xml.vm
+++ b/src/xdocs/cmdline.xml.vm
@@ -78,18 +78,21 @@ java -D&lt;property&gt;=&lt;value&gt;  \
           cannot be used other options and requires exactly one file to run on to be specified.
         </li>
         <li>
-          <code>-T, --treeWithComments</code> - print Abstract Syntax Tree(AST) with comment nodes of the checked file. The option
-          cannot be used other options and requires exactly one file to run on to be specified.
+          <code>-T, --treeWithComments</code> - print Abstract Syntax Tree(AST) with comment nodes
+          of the checked file. The option cannot be used other options and requires exactly one
+          file to run on to be specified.
         </li>
         <li>
-          <code>-J, --treeWithJavadoc</code> - print Abstract Syntax Tree(AST) with Javadoc nodes and comment nodes
-          of the checked file. Attention that line number and columns will not be the same as it is a file due to the fact
-          that each javadoc comment is parsed separately from java file. The option cannot be used other options and requires
-          exactly one file to run on to be specified.
+          <code>-J, --treeWithJavadoc</code> - print Abstract Syntax Tree(AST) with Javadoc nodes
+          and comment nodes of the checked file. Attention that line number and columns will not be
+          the same as it is a file due to the fact that each javadoc comment is parsed separately
+          from java file. The option cannot be used other options and requires exactly one file to
+          run on to be specified.
         </li>
         <li>
           <code>-j, --javadocTree</code> - print Parse Tree of the Javadoc comment.
-          The file have to contain <b>only Javadoc comment content</b> without including '/**' and '*/' at the beginning and at the end respectively.
+          The file have to contain <b>only Javadoc comment content</b> without including '/**' and
+          '*/' at the beginning and at the end respectively.
           For example:
           MyTestFile.javadoc
           <source>

--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -118,8 +118,8 @@
 
       <ol>
         <li>
-          Load a class directly according to a package-qualified <code>name</code>, such as loading class <code>com.puppycrawl.tools.checkstyle.TreeWalker</code>
-          for element:
+          Load a class directly according to a package-qualified <code>name</code>, such as loading
+          class <code>com.puppycrawl.tools.checkstyle.TreeWalker</code> for element:
 
           <source>
 &lt;module name=&quot;com.puppycrawl.tools.checkstyle.TreeWalker&quot;/&gt;
@@ -165,7 +165,8 @@
         Each module property has a default value, and you are not
         required to define a property in the configuration document if
         the default value is satisfactory.  To assign a non-default
-        value to a module's property, define a child <code>property</code> element of the <code>module</code> element in the configuration XML
+        value to a module's property, define a child <code>property</code> element
+        of the <code>module</code> element in the configuration XML
         document. Also provide appropriate <code>name</code> and <code>value</code>
         attributes for the <code>property</code> element.
         For example, property <code>max</code> of module
@@ -457,8 +458,8 @@
           </tr>
           <tr>
             <td>tabWidth</td>
-            <td>number of expanded spaces for a tab character (<code>'\t'</code>); used in messages and Checks that
-            require a tab width, such as <a
+            <td>number of expanded spaces for a tab character (<code>'\t'</code>); used in
+            messages and Checks that require a tab width, such as <a
             href="config_sizes.html#LineLength"><code>LineLength</code></a></td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td><code>8</code></td>
@@ -573,14 +574,15 @@
       <p>
         The default token set for <code>MethodLength</code>
         is <code>{METHOD_DEF, CTOR_DEF}</code>, method
-        definition and constructor definition tokens, so <code>TreeWalker</code> invokes <code>MethodLength</code> whenever it visits a node with
-        a <code>METHOD_DEF</code> or a <code>CTOR_DEF</code> token.
+        definition and constructor definition tokens, so <code>TreeWalker</code> invokes
+        <code>MethodLength</code> whenever it visits a node with a <code>METHOD_DEF</code>
+        or a <code>CTOR_DEF</code> token.
       </p>
 
       <p>
-        You specify the trigger tokens for a Check with property <code>tokens</code>.  The value of <code>tokens</code> is a list that denotes a subset of
-        the Check's tokens, as in the following element that configures
-        Check <code>MethodLength</code> to check the number
+        You specify the trigger tokens for a Check with property <code>tokens</code>.  The value
+        of <code>tokens</code> is a list that denotes a subset of the Check's tokens, as in the
+        following element that configures Check <code>MethodLength</code> to check the number
         of lines of methods only:
       </p>
 
@@ -667,8 +669,8 @@
       </source>
 
       <p>
-        Each check configuration element can have zero or more <code>message</code> elements. Every check uses one or
-        more distinct message keys to log violations. If you want to
+        Each check configuration element can have zero or more <code>message</code> elements.
+        Every check uses one or more distinct message keys to log violations. If you want to
         customize a certain message you need to specify the message key
         in the <code>key</code> attribute of the <code>message</code> element.
       </p>
@@ -751,7 +753,8 @@
         for a loadable class.  By default, Checkstyle applies packages
         <code> com.puppycrawl.tools.checkstyle</code>,
         <code>
-        com.puppycrawl.tools.checkstyle.filters</code>, and <code> com.puppycrawl.tools.checkstyle.checks</code> as
+        com.puppycrawl.tools.checkstyle.filters</code>, and
+        <code>com.puppycrawl.tools.checkstyle.checks</code> as
         well as any sub-packages of <code>com.puppycrawl.tools.checkstyle.checks</code> that
         are distributed with Checkstyle. However standard checkstyle modules are loaded
         with the help of inner map of their names to fully qualified names.
@@ -812,9 +815,9 @@
       </source>
 
       <p>
-        Now you can configure a module of package <code>com.mycompany.checks</code>, say <code>com.mycompany.checks.MethodLimitCheck</code>, with
-        a shortened <code>module</code> element in the
-        configuration document:
+        Now you can configure a module of package <code>com.mycompany.checks</code>, say
+        <code>com.mycompany.checks.MethodLimitCheck</code>, with a shortened <code>module</code>
+        element in the configuration document:
       </p>
 
       <source>

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -26,12 +26,14 @@
         <p>Since Checkstyle 6.0</p>
         <p>
           Check location of annotation on language elements.
-          By default, Check enforce to locate annotations immediately
-          after documentation block and before target element, annotation should be located on separate line from target element.
+          By default, Check enforce to locate annotations immediately after documentation block
+          and before target element, annotation should be located on separate line from target
+          element.
         </p>
         <p>
           Attention: Annotations among modifiers are ignored (looks like false-negative)
-          as there might be a problem with annotations for return types <source>public @Nullable Long getStartTimeOrNull() { ... }</source>
+          as there might be a problem with annotations for return types
+          <source>public @Nullable Long getStartTimeOrNull() { ... }</source>
           Such annotations are better to keep close to type.
           Due to limitations Checkstyle can not examine target of annotation.
         </p>
@@ -70,7 +72,8 @@ public String getNameIfPresent() { ... }
           </tr>
           <tr>
             <td>allowSamelineParameterizedAnnotation</td>
-            <td>To allow one and only parameterized annotation to be located on the same line as target element.</td>
+            <td>To allow one and only parameterized annotation to be located on the same line as
+                target element.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
             <td>6.4</td>
@@ -890,9 +893,12 @@ public static final int COUNTER = 10; // violation as javadoc exists
           </source>
         </p>
 
-        <p>The general rule is that the argument of the <code>@SuppressWarnings</code> will be matched against class name of the checker in lower case
-          and without <code>Check</code> suffix if present</p>
-          <p>If <code>aliasList</code> property was provided you can use your own names e.g below code will work if there was provided a <code>ParameterNumberCheck=paramnum</code> in the <code>aliasList</code>
+        <p>The general rule is that the argument of the <code>@SuppressWarnings</code> will be
+          matched against class name of the checker in lower case and without <code>Check</code>
+          suffix if present</p>
+          <p>If <code>aliasList</code> property was provided you can use your own names e.g below
+             code will work if there was provided a <code>ParameterNumberCheck=paramnum</code> in
+             the <code>aliasList</code>
           <source>
             @SuppressWarnings("paramnum")
             public void needsLotsOfParameters(@SuppressWarnings("unused") int a,

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -1512,7 +1512,8 @@ class SomeClass
             <td>illegalClassNames</td>
             <td>exception class names to reject</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>java.lang.Throwable, RuntimeException, Error, Throwable, java.lang.Error, java.lang.RuntimeException, Exception, java.lang.Exception</code></td>
+            <td><code>java.lang.Throwable, RuntimeException, Error, Throwable, java.lang.Error,
+                java.lang.RuntimeException, Exception, java.lang.Exception</code></td>
             <td>3.2</td>
           </tr>
         </table>
@@ -1706,7 +1707,8 @@ class SomeClass
             <td>throw class names to reject</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td>
-              <code>java.lang.Throwable, RuntimeException, Error, Throwable, java.lang.Error, java.lang.RuntimeException</code>
+              <code>java.lang.Throwable, RuntimeException, Error, Throwable, java.lang.Error,
+              java.lang.RuntimeException</code>
             </td>
             <td>4.0</td>
           </tr>
@@ -3835,14 +3837,15 @@ class C {
         </p>
 
         <p>
-          <b>max</b> property will only check returns in methods and lambdas that return a specific value (Ex: 'return 1;').
+          <b>max</b> property will only check returns in methods and lambdas that return a specific
+          value (Ex: 'return 1;').
         </p>
 
         <p>
-          <b>maxForVoid</b> property will only check returns in methods, constructors, and lambdas that have no return type (IE
-          'return;').
-          It will only count visible return statements. Return statements not normally written, but implied, at
-          the end of the method/constructor definition will not be taken into account.
+          <b>maxForVoid</b> property will only check returns in methods, constructors, and lambdas
+          that have no return type (IE 'return;').
+          It will only count visible return statements. Return statements not normally written, but
+          implied, at the end of the method/constructor definition will not be taken into account.
           To disallow "return;" in void return type methods, use a value of 0.
         </p>
 
@@ -4492,7 +4495,8 @@ if (&quot;something&quot;.equals(x))
 
           <tr>
             <td>allowedDistance</td>
-            <td>A distance between declaration of variable and its first usage. Values should be greater than 0.</td>
+            <td>A distance between declaration of variable and its first usage.
+                Values should be greater than 0.</td>
             <td><a href="property_types.html#integer">Integer</a></td>
             <td>3</td>
             <td>5.8</td>
@@ -4508,7 +4512,8 @@ if (&quot;something&quot;.equals(x))
 
           <tr>
             <td>validateBetweenScopes</td>
-            <td>Allows to calculate the distance between declaration of variable and its first usage in the different scopes.</td>
+            <td>Allows to calculate the distance between declaration of variable and its
+                first usage in the different scopes.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
             <td>5.8</td>

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -52,7 +52,8 @@
          overridden in its subclass.
         </p>
          <p>
-          Problem is described at "Effective Java, 2nd Edition by Josh Bloch" book, chapter "Item 17: Design and document for inheritance or else prohibit it".
+          Problem is described at "Effective Java, 2nd Edition by Josh Bloch" book, chapter
+          "Item 17: Design and document for inheritance or else prohibit it".
         </p>
         <p>
           Some quotes from book:
@@ -662,7 +663,8 @@ public class StringUtils // not final to allow subclassing
 &lt;module name="OneTopLevelClass"/&gt;
         </source>
         <p>
-          <b>ATTENTION:</b> This Check does not support customization of validated tokens, so do not use the "tokens" property.
+          <b>ATTENTION:</b> This Check does not support customization of validated tokens, so do
+          not use the "tokens" property.
         </p>
         <p>
           An example of code with violations:
@@ -864,9 +866,9 @@ public class Foo{
         </p>
         <p>Note that
           Checkstyle 2 used to include <code>"^f[A-Z][a-zA-Z0-9]*$"</code> in the default
-          pattern to allow names used in container-managed persistence for Enterprise JavaBeans (EJB) 1.1 with the default settings.
-          With EJB 2.0 it is no longer necessary to have public access
-          for persistent fields, so the default has been changed.
+          pattern to allow names used in container-managed persistence for Enterprise JavaBeans
+          (EJB) 1.1 with the default settings. With EJB 2.0 it is no longer necessary to have
+          public access for persistent fields, so the default has been changed.
         </p>
 
         <p>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -294,7 +294,8 @@ private int array1 []; // CHECKSTYLE_ON: ALMOST_ALL
   &lt;property name=&quot;offCommentFormat&quot; value=&quot;stop&quot;/&gt;
   &lt;property name=&quot;onCommentFormat&quot; value=&quot;resume&quot;/&gt;
   &lt;property name=&quot;checkFormat&quot; value=&quot;IllegalTypeCheck&quot;/&gt;
-  &lt;property name=&quot;messageFormat&quot; value=&quot;^Declaring variables, return values or parameters of type 'GregorianCalendar' is not allowed.$&quot;/&gt;
+  &lt;property name=&quot;messageFormat&quot;
+      value=&quot;^Declaring variables, return values or parameters of type 'GregorianCalendar' is not allowed.$&quot;/&gt;
 &lt;/module&gt;
           </source>
           <p>
@@ -1096,9 +1097,9 @@ catch (Throwable th) { ... }
 . . .
             </source>
             <p>
-                To configure a filter so that <code>CHECKSTYLE IGNORE <i>check</i> FOR NEXT <i>var</i> LINES</code>
-                avoids triggering any audits for the given check for the current line and the next <i>var</i> lines
-                (for a total of <i>var</i>+1 lines):
+                To configure a filter so that <code>CHECKSTYLE IGNORE <i>check</i> FOR NEXT
+                <i>var</i> LINES</code> avoids triggering any audits for the given check for
+                the current line and the next <i>var</i> lines (for a total of <i>var</i>+1 lines):
             </p>
             <source>
 &lt;module name=&quot;SuppressWithNearbyCommentFilter&quot;&gt;
@@ -1423,7 +1424,8 @@ private int array1 [];
     &lt;property name=&quot;offCommentFormat&quot; value=&quot;stop&quot;/&gt;
     &lt;property name=&quot;onCommentFormat&quot; value=&quot;resume&quot;/&gt;
     &lt;property name=&quot;checkFormat&quot; value=&quot;FileTabCharacterCheck&quot;/&gt;
-    &lt;property name=&quot;messageFormat&quot; value=&quot;^File contains tab characters (this is the first instance)\.$&quot;/&gt;
+    &lt;property name=&quot;messageFormat&quot;
+        value=&quot;^File contains tab characters (this is the first instance)\.$&quot;/&gt;
   &lt;/module&gt;
 &lt;/module>
               </source>

--- a/src/xdocs/config_header.xml
+++ b/src/xdocs/config_header.xml
@@ -107,7 +107,8 @@ line 5: ////////////////////////////////////////////////////////////////////
 
       <subsection name="Examples">
           <p>
-              In default configuration the check does not rise any violations. Default values of properties are used.
+              In default configuration the check does not rise any violations.
+              Default values of properties are used.
           </p>
 
           <source>
@@ -115,7 +116,9 @@ line 5: ////////////////////////////////////////////////////////////////////
           </source>
 
         <p>
-          To configure the check to use header file <code>&quot;config/java.header&quot;</code> and ignore lines <code>2</code>, <code>3</code>, and <code> 4</code> and only process Java files:
+          To configure the check to use header file <code>&quot;config/java.header&quot;</code> and
+          ignore lines <code>2</code>, <code>3</code>, and <code> 4</code> and only process Java
+          files:
         </p>
 
         <source>
@@ -315,14 +318,16 @@ line 6: ^\W*$
 
       <subsection name="Examples">
           <p>
-              In default configuration the check does not rise any violations. Default values of properties are used.
+              In default configuration the check does not rise any violations.
+              Default values of properties are used.
           </p>
           <source>
 &lt;module name=&quot;RegexpHeader&quot;/&gt;
           </source>
 
         <p>
-          To configure the check to use header file <code>&quot;config/java.header&quot;</code> and <code>10</code> and <code>13</code> multi-lines:
+          To configure the check to use header file <code>&quot;config/java.header&quot;</code> and
+          <code>10</code> and <code>13</code> multi-lines:
         </p>
         <source>
 &lt;module name=&quot;RegexpHeader&quot;&gt;

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -251,7 +251,8 @@
         </p>
         <p>
           2) SAME_PACKAGE(n) group. This group sets the ordering of the same package imports.
-          Imports are considered on SAME_PACKAGE group if <b>n</b> first domains in package name and import name are identical. For example:
+          Imports are considered on SAME_PACKAGE group if <b>n</b> first domains in package
+          name and import name are identical. For example:
         </p>
         <source>
 package java.util.concurrent.locks;
@@ -266,7 +267,12 @@ import java.util.regex.Pattern; //#7
 import java.util.regex.Matcher; //#8
         </source>
         <p>
-          If we have SAME_PACKAGE(3) on configuration file, imports #4-6 will be considered as a SAME_PACKAGE group (java.util.concurrent.*, java.util.concurrent.AbstractExecutorService, java.util.concurrent.locks.LockSupport). SAME_PACKAGE(2) will include #1-8. SAME_PACKAGE(4) will include only #6. SAME_PACKAGE(5) will result in no imports assigned to SAME_PACKAGE group because actual package java.util.concurrent.locks has only 4 domains.
+          If we have SAME_PACKAGE(3) on configuration file, imports #4-6 will be considered as a
+          SAME_PACKAGE group (java.util.concurrent.*, java.util.concurrent.AbstractExecutorService,
+          java.util.concurrent.locks.LockSupport). SAME_PACKAGE(2) will include #1-8.
+          SAME_PACKAGE(4) will include only #6. SAME_PACKAGE(5) will result in no imports assigned
+          to SAME_PACKAGE group because actual package java.util.concurrent.locks has only 4
+          domains.
         </p>
         <p>
           3) THIRD_PARTY_PACKAGE group. This group sets ordering of third party imports.
@@ -605,8 +611,9 @@ import android.*;
           Checks for imports from a set of illegal packages. By default, the
           check rejects all <code>sun.*</code> packages since
           programs that contain direct calls to the <code>sun.*</code> packages are <a
-          href="http://www.oracle.com/technetwork/java/faq-sun-packages-142232.html">"not guaranteed
-          to work on all Java-compatible platforms"</a>. To reject other packages, set property <code> illegalPkgs</code> to a list of the illegal packages.
+          href="http://www.oracle.com/technetwork/java/faq-sun-packages-142232.html">"not
+          guaranteed to work on all Java-compatible platforms"</a>. To reject other packages,
+          set property <code> illegalPkgs</code> to a list of the illegal packages.
         </p>
       </subsection>
 
@@ -621,23 +628,28 @@ import android.*;
           </tr>
           <tr>
             <td>illegalPkgs</td>
-            <td>Packages to reject, if <b>regexp</b> variable is not set, checks if import is the part of package. If <b>regexp</b> variable is set, then list of packages will be
-                interpreted as regular expressions. Note, all properties for match will be used.</td>
+            <td>Packages to reject, if <b>regexp</b> variable is not set, checks if import is the
+                part of package. If <b>regexp</b> variable is set, then list of packages will be
+                interpreted as regular expressions. Note, all properties for match will be
+                used.</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>sun</code></td>
             <td>3.0</td>
           </tr>
           <tr>
             <td>illegalClasses</td>
-            <td>Class names to reject, if <b>regexp</b> variable is not set, checks if import equals class name. If <b>regexp</b> variable is set, then list of class name will be
-                interpreted as regular expressions. Note, all properties for match will be used.</td>
+            <td>Class names to reject, if <b>regexp</b> variable is not set, checks if import
+                equals class name. If <b>regexp</b> variable is set, then list of class name will
+                be interpreted as regular expressions. Note, all properties for match will be
+                used.</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
             <td><code>{}</code></td>
             <td>7.8</td>
           </tr>
           <tr>
             <td>regexp</td>
-            <td>Whether the <b>illegalPkgs</b> and <b>illegalClasses</b> should be interpreted as regular expressions</td>
+            <td>Whether the <b>illegalPkgs</b> and <b>illegalClasses</b> should be interpreted as
+                regular expressions</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
             <td>7.8</td>
@@ -694,11 +706,13 @@ public class InputIllegalImport { }
         </source>
 
         <p>
-          To configure the check so that it rejects classes <code>java.util.Date</code> and <code>java.sql.Connection</code>:
+          To configure the check so that it rejects classes <code>java.util.Date</code> and
+          <code>java.sql.Connection</code>:
         </p>
         <source>
 &lt;module name=&quot;IllegalImport&quot;&gt;
-    &lt;property name=&quot;illegalClasses&quot; value=&quot;java.util.Date, java.sql.Connection&quot;/&gt;
+    &lt;property name=&quot;illegalClasses&quot;
+        value=&quot;java.util.Date, java.sql.Connection&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
@@ -778,7 +792,9 @@ public class InputIllegalImport { }
         </source>
 
         <p>
-          To configure the check so that it rejects class names not satisfying to regular expression <code>^java\.util\.(List|Arrays)</code> and <code>^java\.sql\.Connection</code>:
+          To configure the check so that it rejects class names not satisfying to regular
+          expression <code>^java\.util\.(List|Arrays)</code> and
+          <code>^java\.sql\.Connection</code>:
         </p>
         <source>
 &lt;module name=&quot;IllegalImport&quot;&gt;
@@ -871,10 +887,15 @@ public class InputIllegalImport { }
         <p>
           Short description of the behaviour:
           <ul>
-              <li>Check starts checking from the longest matching subpackage (later 'current subpackage') described inside import control file to package defined in class file.</li>
-              <li>If there is matching allow/disallow rule inside the current subpackage then the Check returns "allowed" or "disallowed" message.</li>
-              <li>If there is no matching allow/disallow rule inside the current subpackage then it continues checking in the parent subpackage.</li>
-              <li>If there is no matching allow/disallow rule in any of the subpackages, including the root level (import-control), then the import is disallowed by default.</li>
+              <li>Check starts checking from the longest matching subpackage (later 'current
+                  subpackage') described inside import control file to package defined in class
+                  file.</li>
+              <li>If there is matching allow/disallow rule inside the current subpackage then the
+                  Check returns "allowed" or "disallowed" message.</li>
+              <li>If there is no matching allow/disallow rule inside the current subpackage then it
+                  continues checking in the parent subpackage.</li>
+              <li>If there is no matching allow/disallow rule in any of the subpackages, including
+                  the root level (import-control), then the import is disallowed by default.</li>
           </ul>
         </p>
 
@@ -1014,22 +1035,32 @@ public class InputIllegalImport { }
         <p>
           In the next examples usage of <code>strategyOnMismatch</code> property is shown.
           This property defines strategy in a case when no matching allow/disallow rule was found.
-          Property <code>strategyOnMismatch</code> is attribute of <code>import-control</code> and <code>subpackage</code> tags.
+          Property <code>strategyOnMismatch</code> is attribute of <code>import-control</code> and
+          <code>subpackage</code> tags.
           Property can have following values for <code>import-control</code> tag:
           <ul>
-            <li>disallowed (default value) - if there is no matching allow/disallow rule in any of the subpackages, including the root level (import-control), then the import is disallowed.</li>
-            <li>allowed - if there is no matching allow/disallow rule in any of the subpackages, including the root level, then the import is allowed.</li>
+            <li>disallowed (default value) - if there is no matching allow/disallow rule in any of
+                the subpackages, including the root level (import-control), then the import is
+                disallowed.</li>
+            <li>allowed - if there is no matching allow/disallow rule in any of the subpackages,
+                including the root level, then the import is allowed.</li>
           </ul>
           And following values for <code>subpackage</code> tags:
           <ul>
-            <li>delegateToParent (default value) - if there is no matching allow/disallow rule inside the current subpackage, then it continues checking in the parent subpackage.</li>
-            <li>allowed - if there is no matching allow/disallow rule inside the current subpackage, then the import is allowed.</li>
-            <li>disallowed - if there is no matching allow/disallow rule inside the current subpackage, then the import is disallowed.</li>
+            <li>delegateToParent (default value) - if there is no matching allow/disallow rule
+                inside the current subpackage, then it continues checking in the parent
+                subpackage.</li>
+            <li>allowed - if there is no matching allow/disallow rule inside the current
+                subpackage, then the import is allowed.</li>
+            <li>disallowed - if there is no matching allow/disallow rule inside the current
+                subpackage, then the import is disallowed.</li>
           </ul>
         </p>
 
         <p>
-          The following example demonstrates usage of <code>strategyOnMismatch</code> property for <code>import-control</code> tag. Here all imports are allowed except <code>java.awt.Image</code> and <code>java.io.File</code> classes.
+          The following example demonstrates usage of <code>strategyOnMismatch</code> property for
+          <code>import-control</code> tag. Here all imports are allowed except
+          <code>java.awt.Image</code> and <code>java.io.File</code> classes.
         </p>
         <source>
 &lt;import-control pkg=&quot;com.puppycrawl.tools.checkstyle.checks&quot; strategyOnMismatch=&quot;allowed&quot;&gt;
@@ -1039,8 +1070,11 @@ public class InputIllegalImport { }
         </source>
 
         <p>
-          In the example below, any import is disallowed inside <code>com.puppycrawl.tools.checkstyle.checks.imports</code> package except imports from package <code>javax.swing</code> and class <code>java.io.File</code>.
-          However, any import is allowed in the classes outside of <code>com.puppycrawl.tools.checkstyle.checks.imports</code> package.
+          In the example below, any import is disallowed inside
+          <code>com.puppycrawl.tools.checkstyle.checks.imports</code> package except imports from
+          package <code>javax.swing</code> and class <code>java.io.File</code>.
+          However, any import is allowed in the classes outside of
+          <code>com.puppycrawl.tools.checkstyle.checks.imports</code> package.
         </p>
         <source>
 &lt;import-control pkg=&quot;com.puppycrawl.tools.checkstyle.checks&quot; strategyOnMismatch=&quot;allowed&quot;&gt;
@@ -1052,8 +1086,14 @@ public class InputIllegalImport { }
         </source>
 
         <p>
-          When <code>strategyOnMismatch</code> has <code>allowed</code> or <code>disallowed</code> value for <code>subpackage</code> tag, it makes <code>subpackage</code> isolated from parent rules.
-          In the next example, if no matching rule was found inside <code>com.puppycrawl.tools.checkstyle.checks.filters</code> then it continues checking in the parent subpackage, while for <code>com.puppycrawl.tools.checkstyle.checks.imports</code> import will be allowed by default.
+          When <code>strategyOnMismatch</code> has <code>allowed</code> or <code>disallowed</code>
+          value for <code>subpackage</code> tag, it makes <code>subpackage</code> isolated from
+          parent rules.
+          In the next example, if no matching rule was found inside
+          <code>com.puppycrawl.tools.checkstyle.checks.filters</code> then it continues checking
+          in the parent subpackage, while for
+          <code>com.puppycrawl.tools.checkstyle.checks.imports</code> import will be allowed by
+          default.
         </p>
         <source>
 &lt;import-control pkg=&quot;com.puppycrawl.tools.checkstyle.checks&quot;&gt;
@@ -1061,7 +1101,8 @@ public class InputIllegalImport { }
     &lt;allow class=&quot;java\..*\.File&quot; local-only=&quot;true&quot; regex=&quot;true&quot;/&gt;
     &lt;subpackage name=&quot;imports&quot; strategyOnMismatch=&quot;allowed&quot;&gt;
         &lt;allow pkg=&quot;javax\.swing&quot; regex=&quot;true&quot;/&gt;
-        &lt;allow pkg=&quot;java\.io&quot; exact-match=&quot;true&quot; local-only=&quot;true&quot; regex=&quot;true&quot;/&gt;
+        &lt;allow pkg=&quot;java\.io&quot; exact-match=&quot;true&quot;
+            local-only=&quot;true&quot; regex=&quot;true&quot;/&gt;
     &lt;/subpackage&gt;
     &lt;subpackage name=&quot;filters&quot;&gt;
         &lt;allow class=&quot;javax.util.Date&quot;/&gt;
@@ -1077,8 +1118,17 @@ public class InputIllegalImport { }
         </p>
 
         <h4 id="blacklist-example">Example of blacklist mode</h4>
-        <p>To have a <b>blacklist mode</b>, it is required to have disallows inside subpackage and to have allow rule inside parent of the current subpackage to catch classes and packages those are not in the blacklist.</p>
-        <p>In the example below any import from <code>java.util</code> (<code>java.util.List</code>, <code>java.util.Date</code>) package is allowed except <code>java.util.Map</code> inside subpackage <code>com.puppycrawl.tools.checkstyle.filters</code>.</p>
+        <p>
+          To have a <b>blacklist mode</b>, it is required to have disallows inside subpackage
+          and to have allow rule inside parent of the current subpackage to catch classes and
+          packages those are not in the blacklist.
+        </p>
+        <p>
+          In the example below any import from <code>java.util</code>
+          (<code>java.util.List</code>, <code>java.util.Date</code>) package is allowed except
+          <code>java.util.Map</code> inside subpackage
+          <code>com.puppycrawl.tools.checkstyle.filters</code>.
+        </p>
         <source>
 &lt;import-control pkg=&quot;com.puppycrawl.tools.checkstyle&quot;&gt;
     &lt;allow pkg=&quot;java.util&quot;/&gt;
@@ -1088,8 +1138,11 @@ public class InputIllegalImport { }
 &lt;/import-control&gt;
         </source>
         <p>
-          In the next example imports <code>java.util.stream.Stream</code> and <code>java.util.stream.Collectors</code> are disallowed inside <code>com.puppycrawl.tools.checkstyle.checks.imports</code> package,
-          but because of <code>&lt;allow pkg=&quot;java.util.stream&quot;/&gt;</code> every import from <code>java.util.stream</code> is allowed except described ones.
+          In the next example imports <code>java.util.stream.Stream</code> and
+          <code>java.util.stream.Collectors</code> are disallowed inside
+          <code>com.puppycrawl.tools.checkstyle.checks.imports</code> package,
+          but because of <code>&lt;allow pkg=&quot;java.util.stream&quot;/&gt;</code> every import
+          from <code>java.util.stream</code> is allowed except described ones.
         </p>
         <source>
 &lt;import-control pkg=&quot;com.puppycrawl.tools.checkstyle.checks&quot;&gt;
@@ -1109,7 +1162,8 @@ import java.util.stream.Collectors; // violation here
 import java.util.stream.IntStream;
         </source>
         <p>
-          In the following example, all imports are allowed except the classes <code>java.util.Date</code>, <code>java.util.List</code> and package <code>sun</code>.
+          In the following example, all imports are allowed except the classes
+          <code>java.util.Date</code>, <code>java.util.List</code> and package <code>sun</code>.
         </p>
         <source>
 &lt;import-control pkg=&quot;com.puppycrawl.tools.checkstyle.checks&quot;&gt;

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -611,10 +611,12 @@ public boolean isSomething()
         </p>
         <ul>
           <li>
-            There is one blank line between each of two paragraphs and one blank line before the at-clauses block if it is present.
+            There is one blank line between each of two paragraphs and one blank line before the
+            at-clauses block if it is present.
           </li>
           <li>
-            Each paragraph but the first has &lt;p&gt; immediately before the first word, with no space after.
+            Each paragraph but the first has &lt;p&gt; immediately before the first word, with
+            no space after.
           </li>
         </ul>
       </subsection>
@@ -913,7 +915,8 @@ public boolean isSomething()
         </source>
 
         <p>
-          To configure the check for javadoc which is in <code>private</code>, but not in <code>package</code> scope:
+          To configure the check for javadoc which is in <code>private</code>, but not in
+          <code>package</code> scope:
         </p>
 
         <source>
@@ -1369,7 +1372,8 @@ public boolean isSomething()
         </source>
 
         <p>
-          To configure the check for members which are in <code>private</code>, but not in <code>protected</code> scope:
+          To configure the check for members which are in <code>private</code>, but not in
+          <code>protected</code> scope:
         </p>
 
         <source>
@@ -1380,7 +1384,8 @@ public boolean isSomething()
         </source>
 
         <p>
-            To ignore absence of Javadoc comments for variables with names <code>log</code> or <code>logger</code>:
+            To ignore absence of Javadoc comments for variables with names <code>log</code> or
+            <code>logger</code>:
         </p>
 
         <source>
@@ -1658,9 +1663,11 @@ public boolean isSomething()
       <subsection name="Description">
         <p>Since Checkstyle 6.0</p>
         <p>
-          Checks that <a href="http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html#firstsentence">
-          Javadoc summary sentence</a> does not contain phrases that are not recommended to use. Summaries that contain
-          only the <code>{@inheritDoc}</code> tag are skipped. Check also violate javadoc that does not contain first sentence.
+          Checks that <a
+          href="http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html#firstsentence">
+          Javadoc summary sentence</a> does not contain phrases that are not recommended to use.
+          Summaries that contain only the <code>{@inheritDoc}</code> tag are skipped. Check also
+          violate javadoc that does not contain first sentence.
         </p>
       </subsection>
 

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -291,7 +291,8 @@
         </source>
 
         <p>
-          The following example demonstrates usage of <b>excludedClasses</b> and <b>excludeClassesRegexps</b> properties
+          The following example demonstrates usage of <b>excludedClasses</b> and
+          <b>excludeClassesRegexps</b> properties
         </p>
         <p>
           Expected result is one class <code>Date</code>
@@ -330,7 +331,8 @@
         </source>
 
         <p>
-          The following example demonstrates usage of <b>excludedClasses</b> and <b>excludeClassesRegexps</b> properties
+          The following example demonstrates usage of <b>excludedClasses</b> and
+          <b>excludeClassesRegexps</b> properties
         </p>
         <p>
           Expected result is one class <code>Date</code>
@@ -377,7 +379,8 @@ public class InputClassCoupling {
         </p>
         <p>
           Also note, that checkstyle will not exlude classes within the same file
-          even if it was listed in the <code>excludedPackages</code> parameter. For example, assuming the config is
+          even if it was listed in the <code>excludedPackages</code> parameter. For example,
+          assuming the config is
 
           <source>
 &lt;module name=&quot;ClassDataAbstractionCoupling&quot;&gt;
@@ -607,7 +610,8 @@ public class Foo {
         </p>
         <p>
           Also note, that checkstyle will not exlude classes within the same file
-          even if it was listed in the <code>excludedPackages</code> parameter. For example, assuming the config is
+          even if it was listed in the <code>excludedPackages</code> parameter. For example,
+          assuming the config is
 
           <source>
 &lt;module name=&quot;ClassDataAbstractionCoupling&quot;&gt;
@@ -1072,15 +1076,19 @@ class SwitchExample {
         <table>
         <thead><tr><th>Structure</th><th> Complexity expression </th></tr></thead>
         <tr><td>if ([expr]) { [if-range] }</td><td>NP(if-range) + 1 + NP(expr)</td></tr>
-        <tr><td>if ([expr]) { [if-range] } else { [else-range] }</td><td>NP(if-range) + NP(else-range) + NP(expr)</td></tr>
+        <tr><td>if ([expr]) { [if-range] } else { [else-range] }</td><td>NP(if-range)
+                + NP(else-range) + NP(expr)</td></tr>
         <tr><td>while ([expr]) { [while-range] } </td><td>NP(while-range) + NP(expr) + 1</td></tr>
         <tr><td>do { [do-range] } while ([expr])</td><td>NP(do-range) + NP(expr) + 1</td></tr>
-        <tr><td>for([expr1]; [expr2]; [expr3]) { [for-range] }</td><td>NP(for-range) + NP(expr1) + NP(expr2) + NP(expr3) + 1</td></tr>
-        <tr><td>switch ([expr]) { case : [case-range] default: [default-range] }</td><td>S(i=1:i=n)NP(case-range[i]) + NP(default-range) + NP(expr)</td></tr>
+        <tr><td>for([expr1]; [expr2]; [expr3]) { [for-range] }</td><td>NP(for-range) + NP(expr1)
+                + NP(expr2) + NP(expr3) + 1</td></tr>
+        <tr><td>switch ([expr]) { case : [case-range] default: [default-range] }</td>
+            <td>S(i=1:i=n)NP(case-range[i]) + NP(default-range) + NP(expr)</td></tr>
         <tr><td>[expr1] ? [expr2] : [expr3]</td><td>NP(expr1) + NP(expr2) + NP(expr3) + 2</td></tr>
         <tr><td>goto label</td><td>1</td></tr>
         <tr><td>break</td><td>1</td></tr>
-        <tr><td>Expressions</td><td>Number of &amp;&amp; and || operators in expression. No operators - 0</td></tr>
+        <tr><td>Expressions</td><td>Number of &amp;&amp; and || operators in expression. No
+                operators - 0</td></tr>
         <tr><td>continue</td><td>1</td></tr>
         <tr><td>return</td><td>1</td></tr>
         <tr><td>Statement (even sequential statements)</td><td>1</td></tr>

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -678,7 +678,8 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
         </source>
 
         <p>
-          The initialiser in <code>for</code> performs no setup (where a <code>while</code> statement could be used instead):
+          The initialiser in <code>for</code> performs no setup (where a <code>while</code>
+          statement could be used instead):
         </p>
         <source>
 &lt;module name="DescendantToken"&gt;
@@ -1038,7 +1039,8 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
           <tr>
             <td>forceStrictCondition</td>
             <td>force strict indent level in line wrapping case. If value is true, line wrap indent
-                have to be same as lineWrappingIndentation parameter. If value is false, line wrap indent could be bigger on any value user would like.</td>
+                have to be same as lineWrappingIndentation parameter. If value is false, line wrap
+                indent could be bigger on any value user would like.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
             <td>6.3</td>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -1161,12 +1161,13 @@ class MyClass {
 
       <subsection name="Examples">
         <p>
-          The default value of <code>format</code> for module <code>PackageName</code> has been chosen to match the
-          requirements in the <a
+          The default value of <code>format</code> for module <code>PackageName</code> has been
+          chosen to match the requirements in the <a
           href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-6.html#jls-6.5.3">Java
           Language specification</a> and the Sun coding conventions. However
           both underscores and uppercase letters are rather uncommon, so most
-          configurations should probably assign value <code>^[a-z]+(\.[a-z][a-z0-9]*)*$</code> to <code>format</code> for module <code>PackageName</code>, as in
+          configurations should probably assign value <code>^[a-z]+(\.[a-z][a-z0-9]*)*$</code> to
+          <code>format</code> for module <code>PackageName</code>, as in
         </p>
 
         <source>

--- a/src/xdocs/config_regexp.xml
+++ b/src/xdocs/config_regexp.xml
@@ -976,7 +976,8 @@
         <p>
           This class is variation on <a
           href="#RegexpSingleline">RegexpSingleline</a> for detecting
-          single lines that match a supplied regular expression in Java files. It supports suppressing matches in Java comments.
+          single lines that match a supplied regular expression in Java files. It supports
+          suppressing matches in Java comments.
         </p>
       </subsection>
 

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -358,13 +358,15 @@
         <ul>
           <li>
             The calculation of the length of a line takes into account the
-            number of expanded spaces for a tab character (<code>'\t'</code>). The default number of spaces is <code>8</code>.  To specify a different number of spaces,
-            the user can set <a href="config.html#TreeWalker"><code>TreeWalker</code></a> property <code>tabWidth</code> which applies to all Checks,
-            including <code>LineLength</code>; or can set
-            property <code>tabWidth</code> for <code>LineLength</code> alone.
+            number of expanded spaces for a tab character (<code>'\t'</code>). The default number
+            of spaces is <code>8</code>.  To specify a different number of spaces, the user can set
+            <a href="config.html#TreeWalker"><code>TreeWalker</code></a> property
+            <code>tabWidth</code> which applies to all Checks, including <code>LineLength</code>;
+            or can set property <code>tabWidth</code> for <code>LineLength</code> alone.
           </li>
           <li>
-            Package and import statements (lines matching pattern <code>^(package|import) .*</code>) are not verified by
+            Package and import statements (lines matching pattern
+            <code>^(package|import) .*</code>) are not verified by
             this check.
           </li>
         </ul>
@@ -900,7 +902,8 @@ public class ExampleClass {
 &lt;/module&gt;
         </source>
           <p>
-              To configure the check to ignore number of parameters for methods with @Override or @java.lang.Override annotation.
+              To configure the check to ignore number of parameters for methods with @Override
+              or @java.lang.Override annotation.
           </p>
           <p>
               Rationale: developer may need to override method with many parameters from 3-rd party library.

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -578,7 +578,8 @@ class Foo
         </p>
         <ul>
           <li> should not be preceded with whitespace in all cases.</li>
-          <li> should be followed with whitespace in almost all cases, except diamond operators and when preceding method name.</li>
+          <li> should be followed with whitespace in almost all cases, except diamond operators
+               and when preceding method name.</li>
         </ul>
 
         <p>

--- a/src/xdocs/contributing.xml
+++ b/src/xdocs/contributing.xml
@@ -131,12 +131,15 @@
         feature of <a href="https://github.com/">Github</a>.<br/>
         Please provide wide description of update with detailed explanation of problem
         and how you propose to resolve it.
-        <b>ATTENTION:</b> Please recheck that in your Pull Request there is ONLY your changes and all of them are rebased from most recent HEAD of our master branch.
+        <b>ATTENTION:</b> Please recheck that in your Pull Request there is ONLY your changes and
+        all of them are rebased from most recent HEAD of our master branch.
       </p>
 
       <p>
-        <b>ATTENTION:</b> Please provide single-line meaningful message for commit with reference to github issue or Pull Request for more details.<br/>
-        Ideal format for message is "Issue #Number: Brief single-line message ..... .". Where NUMBER is Issue or Pull Request number at github.
+        <b>ATTENTION:</b> Please provide single-line meaningful message for commit with reference
+        to github issue or Pull Request for more details.<br/>
+        Ideal format for message is "Issue #Number: Brief single-line message ..... .". Where
+        NUMBER is Issue or Pull Request number at github.
         <a href="https://github.com/checkstyle/checkstyle/commit/9303fd9d971eb55cdfd62686ba2f5698edb2c83e">Good example</a>
       </p>
 

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -983,7 +983,8 @@
                                 <a
                                     href="config_coding.html#MissingSwitchDefault">MissingSwitchDefault</a>
                                 <br />
-                                "Exception: enum type may omit the default statement group" requirement can not be covered as we can not distinguish types,
+                                "Exception: enum type may omit the default statement group"
+                                requirement can not be covered as we can not distinguish types,
                                 enum values may look the same as static final String constants.
                             </td>
                             <td>
@@ -1168,7 +1169,8 @@
                                     src="images/ok_blue.png"
                                     alt="" />
                                 <a href="config_naming.html#MethodName">MethodName</a>
-                                <br/> No ability to distinguish verb at the beginning of name, no way distinguish Test method from others so "_" is allowed in names
+                                <br/> No ability to distinguish verb at the beginning of name, no
+                                way distinguish Test method from others so "_" is allowed in names
                             </td>
                             <td>
                                 <a
@@ -1188,7 +1190,8 @@
                                 <img
                                     src="images/ban_red.png"
                                     alt="" />
-                                Every constant is a static final field, but not all static final fields are constants - impossible to check such rule.
+                                Every constant is a static final field, but not all static final
+                                fields are constants - impossible to check such rule.
                             </td>
                             <td/>
                         </tr>
@@ -1318,8 +1321,9 @@
                                     alt="" />
                                 <a href="config_naming.html#AbbreviationAsWordInName">AbbreviationAsWordInName</a>
                                 <br />
-                                Non covered: Some words are ambiguously hyphenated in the English language. No way to
-                                distinguish "YouTubeImporter" or "YoutubeImporter".
+                                Non covered: Some words are ambiguously hyphenated in the English
+                                language. No way to distinguish "YouTubeImporter" or
+                                "YoutubeImporter".
                             </td>
                             <td>
                                 <a

--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -225,10 +225,14 @@
                   <td/>
               </tr>
               <tr>
-                  <td><a href="https://wiki.jenkins.io/display/JENKINS/Checkstyle+Plugin">Jenkins Checkstyle plug-in</a></td>
+                  <td><a href="https://wiki.jenkins.io/display/JENKINS/Checkstyle+Plugin">Jenkins
+                  Checkstyle plug-in</a></td>
                   <td/>
-                  <td><a href="https://wiki.jenkins.io/display/JENKINS/Checkstyle+Plugin">Jenkins Checkstyle plug-in Home Page</a></td>
-                  <td>This plug-in is supported by the Static Analysis Collector plug-in that collects different analysis results and shows the results in aggregated trend graphs.</td>
+                  <td><a href="https://wiki.jenkins.io/display/JENKINS/Checkstyle+Plugin">Jenkins
+                  Checkstyle plug-in Home Page</a></td>
+                  <td>This plug-in is supported by the Static Analysis Collector plug-in that
+                  collects different analysis results and shows the results in aggregated trend
+                  graphs.</td>
               </tr>
               <tr>
                   <td><a href="http://maven.apache.org/">Maven</a></td>
@@ -304,7 +308,8 @@
                   <td><a href="https://github.com/nidi3/code-assert">code-assert</a></td>
                   <td>Stefan Niederhauser</td>
                   <td><a href="https://github.com/nidi3/code-assert#checkstyle-checks">code-assert</a></td>
-                  <td>Assert that the java code of a project satisfies certain checks. Launch checkstyle validation from UTs</td>
+                  <td>Assert that the java code of a project satisfies certain checks. Launch
+                      checkstyle validation from UTs</td>
               </tr>
               <tr>
                   <td><a href="http://jdee.sourceforge.net/">Emacs JDE</a></td>

--- a/src/xdocs/releasenotes.xml
+++ b/src/xdocs/releasenotes.xml
@@ -203,7 +203,8 @@
             ImportControl: unable to disallow static import. Author: Jochen Van de Velde, Roman Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/4284">#4284</a>
           </li>
           <li>
-            doc: Removed maxLineLength property from javadoc, the property itself had been removed earlier. Author: Balazs Nemeth
+            doc: Removed maxLineLength property from javadoc, the property itself had been removed
+            earlier. Author: Balazs Nemeth
           </li>
           <li>
             wercker build is unstable for htmlunit project due to SNAPSHOT dependency . Author: Roman Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/5251">#5251</a>
@@ -1076,7 +1077,8 @@
                 <a href="https://github.com/checkstyle/checkstyle/issues/3950">#3950</a>
           </li>
           <li>
-            LocalFinalVariableName: not validating try-with-resource variables (new Acceptable token). Author: vasilyeva
+            LocalFinalVariableName: not validating try-with-resource variables (new Acceptable
+            token). Author: vasilyeva
                 <a href="https://github.com/checkstyle/checkstyle/issues/3348">#3348</a>
           </li>
           <li>
@@ -1099,7 +1101,8 @@
                 <a href="https://github.com/checkstyle/checkstyle/issues/4350">#4350</a>
           </li>
           <li>
-            CacheFile: violation on external resource will invalidate entire cache even if no changes are made. Author: rnveach
+            CacheFile: violation on external resource will invalidate entire cache even if no
+            changes are made. Author: rnveach
                 <a href="https://github.com/checkstyle/checkstyle/issues/4101">#4101</a>
           </li>
           <li>
@@ -1148,7 +1151,8 @@
                 <a href="https://github.com/checkstyle/checkstyle/issues/4313">#4313</a>
           </li>
           <li>
-            Revert &quot;Revert &quot;config: bump maven-surefire-xxxxxx to 2.20&quot; due to unstable locale UTs #4316&quot;. Author: Roman Ivanov
+            Revert &quot;Revert &quot;config: bump maven-surefire-xxxxxx to 2.20&quot; due to
+            unstable locale UTs #4316&quot;. Author: Roman Ivanov
           </li>
           <li>
             moved variables inside if blocks to reduce execution time. Author: rnveach
@@ -1170,7 +1174,8 @@
                 <a href="https://github.com/checkstyle/checkstyle/issues/4329">#4329</a>
           </li>
           <li>
-            Revert &quot;config: bump maven-surefire-xxxxxx to 2.20&quot; due to unstable locale UTs #4316. Author: Roman Ivanov
+            Revert &quot;config: bump maven-surefire-xxxxxx to 2.20&quot; due to unstable locale
+            UTs #4316. Author: Roman Ivanov
           </li>
           <li>
             Split and Organize Checkstyle inputs by Test for PackageName. Author: Dmytro Kytsmen
@@ -1211,11 +1216,13 @@
                 <a href="https://github.com/checkstyle/checkstyle/issues/3546">#3546</a>
           </li>
           <li>
-            ParenPad: thinks precedence parens are a METHOD_CALL instead of an EXPR, new token TokenTypes.DOT should be supported. Author: Subbu Dantu
+            ParenPad: thinks precedence parens are a METHOD_CALL instead of an EXPR, new token
+            TokenTypes.DOT should be supported. Author: Subbu Dantu
                 <a href="https://github.com/checkstyle/checkstyle/issues/3048">#3048</a>
           </li>
           <li>
-            DefaultComesLast: new option skipIfLastAndSharedWithCase to raise violation if default doesn&#39;t share case. Author: Sagar
+            DefaultComesLast: new option skipIfLastAndSharedWithCase to raise violation if default
+            doesn&#39;t share case. Author: Sagar
                 <a href="https://github.com/checkstyle/checkstyle/issues/4078">#4078</a>
           </li>
           <li>
@@ -1258,7 +1265,8 @@
                 <a href="https://github.com/checkstyle/checkstyle/issues/3839">#3839</a>
           </li>
           <li>
-            RightCurly: False negative on multiblock tokens with ALONE_OR_SINGLELINE option. Author: Vladislav Lisetskii
+            RightCurly: False negative on multiblock tokens with ALONE_OR_SINGLELINE option.
+            Author: Vladislav Lisetskii
                 <a href="https://github.com/checkstyle/checkstyle/issues/4091">#4091</a>
           </li>
         </ul>
@@ -1273,7 +1281,8 @@
                 <a href="https://github.com/checkstyle/checkstyle/issues/3496">#3496</a>
           </li>
           <li>
-            Split and Organize Checkstyle inputs by Test in the blocks package. Author: Subbu Dantu, Dmytro Kytsmen
+            Split and Organize Checkstyle inputs by Test in the blocks package.
+            Author: Subbu Dantu, Dmytro Kytsmen
                 <a href="https://github.com/checkstyle/checkstyle/issues/4220">#4220</a>
           </li>
           <li>
@@ -1386,7 +1395,8 @@
                 <a href="https://github.com/checkstyle/checkstyle/issues/3930">#3930</a>
           </li>
           <li>
-            Enforce EndOfLine symbols at the end of  all files in checkstyle repository. Author: Vikramaditya Kukreja
+            Enforce EndOfLine symbols at the end of  all files in checkstyle repository.
+            Author: Vikramaditya Kukreja
                 <a href="https://github.com/checkstyle/checkstyle/issues/3072">#3072</a>
           </li>
           <li>
@@ -2059,10 +2069,12 @@
       <p>Notes:</p>
         <ul>
           <li>
-            Revert &quot;Pull #3162: Update version of commons-collections to 3.2.2 to fix security vulnerability CVE-2015-6420&quot;. Author: Roman Ivanov
+            Revert &quot;Pull #3162: Update version of commons-collections to 3.2.2 to fix security
+            vulnerability CVE-2015-6420&quot;. Author: Roman Ivanov
           </li>
           <li>
-            Cut down on Checkstyle&#39;s dependencies on Guava. Author: Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/3433">#3433</a>
+            Cut down on Checkstyle&#39;s dependencies on Guava. Author: Andrei Selkin
+            <a href="https://github.com/checkstyle/checkstyle/issues/3433">#3433</a>
           </li>
           <li>
             doc: fixed the wording in javadoc for TrailingCommentCheck. Author: José Castro
@@ -2422,7 +2434,8 @@
             Use Distelli CI for testing of Javadoc Checks. Author: Baratali Izmailov, Roman Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/2825">#2825</a>
           </li>
           <li>
-            doc: DesignForExtension documentation is extended to warn user about possible misusage of this Check. Author: Roman Ivanov
+            doc: DesignForExtension documentation is extended to warn user about possible misusage
+            of this Check. Author: Roman Ivanov
           </li>
           <li>
             Fund raising pages for checkstyle. Author: Roman Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/3057">#3057</a>
@@ -3616,7 +3629,8 @@
           Detect public constructors in non-public classes in RedundantModifier. Author: liscju <a href="https://github.com/checkstyle/checkstyle/issues/1537">#1537</a>
         </li>
         <li>
-          Fixes logic bug in gui ParseTreeInfoPanel making linesToPositions assign lines to inappropriate positions. Author: liscju
+          Fixes logic bug in gui ParseTreeInfoPanel making linesToPositions assign lines to
+          inappropriate positions. Author: liscju
         </li>
         <li>
           Fix RightCurlyCheck with same option not to rise expression in single-line blocks. Author: liscju <a href="https://github.com/checkstyle/checkstyle/issues/1416">#1416</a>
@@ -3908,7 +3922,8 @@
           BaseCheckTestSupport.verify fails on Windows. Author: WonderCsabo <a href="https://github.com/checkstyle/checkstyle/issues/1388">#1388</a>
         </li>
         <li>
-          check for connection is done by our website URL, as resource file is there. That let pass test when sourceforge web site is down. Author: Roman Ivanov
+          check for connection is done by our website URL, as resource file is there. That let
+          pass test when sourceforge web site is down. Author: Roman Ivanov
         </li>
         <li>
           Switch options reoganized for easier reading. Author: Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/pull/1376">#1376</a>
@@ -3938,7 +3953,8 @@
           Fix failing of ITs for OneStatementPerLineCheck. Author: Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1348">#1348</a>
         </li>
         <li>
-          surefire and failsafe plugins are moved above checkstyle validation to run before long checkstyle execution. Author: Roman Ivanov
+          surefire and failsafe plugins are moved above checkstyle validation to run before long
+          checkstyle execution. Author: Roman Ivanov
         </li>
         <li>
           add IT to validate google_checks config. Author: Vladislav Lisetskii <a href="https://github.com/checkstyle/checkstyle/issues/1275">#1275</a>
@@ -3959,7 +3975,8 @@
           Restore checkstyle validation on https://sonarcloud.io. Author: Roman Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1319">#1319</a>
         </li>
         <li>
-          Update Maven Shade Plugin, EqualsVerifier, antlr, system-rules and Maven PMD Plugin to latest versions. Author: Michal Kordas
+          Update Maven Shade Plugin, EqualsVerifier, antlr, system-rules and Maven PMD Plugin to
+          latest versions. Author: Michal Kordas
         </li>
         <li>
           system-rules, ant were updated to latest version. Author: Roman Ivanov
@@ -4085,7 +4102,8 @@
       <p>Notes:</p>
       <ul>
         <li>
-          .gitignore with Eclipse's .externalToolBuilders and .checkstyle from Checkstyle CS Eclipse Plug-in. Author: Michael Vorburger
+          .gitignore with Eclipse's .externalToolBuilders and .checkstyle from Checkstyle CS
+          Eclipse Plug-in. Author: Michael Vorburger
         </li>
         <li>
            100% test coverage for com.puppycrawl.tools.checkstyle.checks.sizes. Author: Andrei Selkin <a href="https://github.com/checkstyle/checkstyle/issues/1024">#1024</a>
@@ -4115,7 +4133,8 @@
           Changed Integration Tests to use /src/it/. Author: Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1200">#1200</a>
         </li>
         <li>
-          Updated description for UnusedImports, RedundantImport , Change "Beginning Development" page to reference JDK1.8. Author: Aleksandr Ivanov
+          Updated description for UnusedImports, RedundantImport , Change "Beginning Development"
+          page to reference JDK1.8. Author: Aleksandr Ivanov
         </li>
         <li>
           UT coverage for RedundantImport. AvoidStarImportCheck check, Added UTs for getAcceptableTokens() and getRequiredTokens(). Author: Aleksandr Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1128">#1128</a>
@@ -4136,7 +4155,8 @@
           Ordering issue with nested classes in static imports - xdoc was extended. Author: Roman Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/1239">#1239</a>
         </li>
         <li>
-          Update ant to 1.9.5, update for maven-eclipse-plugin to 2.10, system-rules updated to 1.11.0, commons-cli to 1.3.1. Author: Roman Ivanov
+          Update ant to 1.9.5, update for maven-eclipse-plugin to 2.10, system-rules updated to
+          1.11.0, commons-cli to 1.3.1. Author: Roman Ivanov
         </li>
         <li>
           Integrate google-style-config-test as Integration Test. Author: Roman Ivanov <a href="https://github.com/checkstyle/checkstyle/issues/863">#863</a>
@@ -4769,8 +4789,9 @@
           New option to JavadocMethod Name Check - ignore method name regex. Author: Alex Kravin <a href="https://github.com/checkstyle/checkstyle/issues/430">#430</a>
         </li>
         <li>
-          New option to IllegalType Check to control validation based on modifiers - memberModifiers, updated default illegal types. Author: Alex Kravin <a
-                href="https://github.com/checkstyle/checkstyle/issues/567">#567</a>
+          New option to IllegalType Check to control validation based on modifiers -
+          memberModifiers, updated default illegal types. Author: Alex Kravin
+          <a href="https://github.com/checkstyle/checkstyle/issues/567">#567</a>
         </li>
       </ul>
 
@@ -4937,7 +4958,8 @@
           All UTs Inputs are now compilable. Author: Alex Kravin <a href="https://github.com/checkstyle/checkstyle/issues/308">#308</a>
         </li>
         <li>
-          Fix for typos in documentation, fixes for Sonar violations, pom formatting, latest JUnit 4.12, ..... Author: Michal Kordas
+          Fix for typos in documentation, fixes for Sonar violations, pom formatting, latest
+          JUnit 4.12, ..... Author: Michal Kordas
         </li>
         <li>
           <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/java/com/google/checkstyle/test">google-style-config-test</a> project for Google style is introduces, google_style wiki was updated. Author: Max Vetrenko
@@ -5075,7 +5097,8 @@
           Enormous update on Indentation Check. Author: Max Vetrenko. <a href="https://github.com/checkstyle/checkstyle/issues/294">#294</a>
         </li>
         <li>
-          Fixed IllegalInstantiationCheck, so it won't recognize a constructor reference (Java8) as instantiation. Author: Ryszard Wisniewski.
+          Fixed IllegalInstantiationCheck, so it won't recognize a constructor reference (Java8)
+          as instantiation. Author: Ryszard Wisniewski.
         </li>
         <li>
           Since Java 8 we can have methods body in interfaces. Author: Ilja Dubinin. <a href="https://github.com/checkstyle/checkstyle/issues/282">#282</a>
@@ -5123,7 +5146,8 @@
           New: EmptyLineSeparator check. Author: Max Vetrenko. <a href="https://github.com/checkstyle/checkstyle/issues/186">#186</a>
         </li>
         <li> Enable array initialisation indentation settings. Author: Vaclav Chalupa. </li>
-        <li> Enhance WhitespaceAroundCheck to ignore Annotation Array Initialization curlies as it does for Array Initialization outside of annotations.. Author: Jacob Tomaw </li>
+        <li> Enhance WhitespaceAroundCheck to ignore Annotation Array Initialization curlies as it
+        does for Array Initialization outside of annotations.. Author: Jacob Tomaw </li>
         <li>
           ignore option to the JavadocVariable check. Author: Yuriy Chulovskyy. <a href="https://github.com/checkstyle/checkstyle/issues/98">#98</a>
         </li>
@@ -5263,11 +5287,13 @@
       <p>Notes:</p>
       <ul>
         <li>
-          dsm-maven-plugin is used to show dsm/index.html dependency structure of project on site. Author: Ilja Dubinin.
+          dsm-maven-plugin is used to show dsm/index.html dependency structure of project on site.
+          Author: Ilja Dubinin.
         </li>
         <li>
-          Added and updated documentation/messages for number of Checks. Authors: Max Vetrenko, Thomas Jensen, Yuriy Chulovskyy, Jarmo Isotalo
-          , Peter O, Ryszard Wisniewski, Ilja Gubins, Baratali Izmailov, Jan Schafer, Niklas Walter, Andrew Gaul.
+          Added and updated documentation/messages for number of Checks. Authors: Max Vetrenko,
+          Thomas Jensen, Yuriy Chulovskyy, Jarmo Isotalo, Peter O, Ryszard Wisniewski, Ilja Gubins,
+          Baratali Izmailov, Jan Schafer, Niklas Walter, Andrew Gaul.
         </li>
         <li>
           Moving to standard directory layout. Author: Ivan Sopov.

--- a/src/xdocs/releasenotes_old.xml
+++ b/src/xdocs/releasenotes_old.xml
@@ -2279,20 +2279,27 @@
       </p>
 
       <ul>
-        <li>Completely new architecture based around pluggable modules. This means that users can now write their own checks without changing the source code of checkstyle itself (request 578712).</li>
-        <li>Users can specify the Java token types for which a check must be performed. For example users can now control that there should be whitespace after 'synchronized' but not after 'if' (request 536385).</li>
+        <li>Completely new architecture based around pluggable modules. This means that users can
+        now write their own checks without changing the source code of checkstyle itself (request
+        578712).</li>
+        <li>Users can specify the Java token types for which a check must be performed. For example
+        users can now control that there should be whitespace after 'synchronized' but not after
+        'if' (request 536385).</li>
         <li>Detect classes that override 'equals()' but not 'hashCode()' (request 554373).</li>
-        <li>Detect inner assignments, e.g. 'this.add(label = new JLabel("yes, I'm a C hacker"));' (request 521325).</li>
+        <li>Detect inner assignments, e.g. 'this.add(label = new JLabel("yes, I'm a C hacker"));'
+        (request 521325).</li>
         <li>Detect matches of generic regular expressions (requests 595254, 621247, 630536).</li>
         <li>Find empty blocks (not only empty catch blocks, request 609523).</li>
         <li>Check spaces at empty for iterators (requests 565666, 583725).</li>
         <li>Detect missing property file keys in internationalized applications (request 634966).</li>
         <li>Check content of @author and @version tag against a regular expression.</li>
-        <li>Detect hiding of fields by parameters or local variables with the same name (request 471897).</li>
+        <li>Detect hiding of fields by parameters or local variables with the same name (request
+        471897).</li>
         <li>Detect obsolete final modifier in interfaces (request 651121).</li>
         <li>Detect whitespace before ';' (request 521323).</li>
         <li>Added DTD for XML output (request 622157).</li>
-        <li>Added an XSL stylesheet to convert XML output to plain text, contributed by Jon Scott Stevens.</li>
+        <li>Added an XSL stylesheet to convert XML output to plain text, contributed by Jon Scott
+        Stevens.</li>
         <li>Added a Portuguese localization, contributed by Pedro Morais.</li>
         <li>Added a Finnish localization, contributed by Ville SkyttÃ¤.</li>
         <li>Added a French localization, contributed by Pierre Dittgen.</li>
@@ -2323,7 +2330,9 @@
         API changes (only relevant for IDE plugin authors):
       </p>
       <ul>
-        <li>Configuration is not based on Properties any more. Instead a Configuration interface is used, IDE plugins can define their own way of creating Configurations or they can reuse the provided ConfigurationLoader to read checkstyle's standard XML config files.</li>
+        <li>Configuration is not based on Properties any more. Instead a Configuration interface is
+        used, IDE plugins can define their own way of creating Configurations or they can reuse the
+        provided ConfigurationLoader to read checkstyle's standard XML config files.</li>
       </ul>
 
       <p>
@@ -2339,15 +2348,24 @@
         New features:
       </p>
       <ul>
-        <li>Major refactoring on the way Checkstyle is configured. It is now completely based around properties. Big thanks to Vincent Massol for the suggestion on how to refactor the ANT task (bug 605141).</li>
-        <li>Check the package name against a pattern (request 597787). Patch provided by Simon Langford.</li>
-        <li>Detect the number of parameters in a declaration exceeding a specified amount (request 582144).</li>
+        <li>Major refactoring on the way Checkstyle is configured. It is now completely based
+        around properties. Big thanks to Vincent Massol for the suggestion on how to refactor the
+        ANT task (bug 605141).</li>
+        <li>Check the package name against a pattern (request 597787). Patch provided by Simon
+        Langford.</li>
+        <li>Detect the number of parameters in a declaration exceeding a specified amount (request
+        582144).</li>
         <li>Inspired by patch 580410 from Shinya Ohnuma, now the error messages are localised.</li>
-        <li>Support checking to determine if an unused <code>@throws</code> exception is a subclass of <code>java.lang.Error</code> (request 583719).</li>
-        <li>Incorporate patch 555878 from Rick Giles to allow pattern for local final variables to be specified.</li>
-        <li>Incorporate patch 566855 from Rob Worth to optionally check that parenthesis are padded with spaces.</li>
-        <li>Incorporate patch 590931 from Vijay Aravamudhan to improve documentation of the build.xml file.</li>
-        <li>Incorporate patch from Vijay Aravamudhan to enforce requiring @version tag (request 543964).</li>
+        <li>Support checking to determine if an unused <code>@throws</code> exception is a subclass
+        of <code>java.lang.Error</code> (request 583719).</li>
+        <li>Incorporate patch 555878 from Rick Giles to allow pattern for local final variables to be
+        specified.</li>
+        <li>Incorporate patch 566855 from Rob Worth to optionally check that parenthesis are padded
+        with spaces.</li>
+        <li>Incorporate patch 590931 from Vijay Aravamudhan to improve documentation of the build.xml
+        file.</li>
+        <li>Incorporate patch from Vijay Aravamudhan to enforce requiring @version tag (request
+        543964).</li>
         <li>Incorporate patch 607481 from Ville SkyttÃ¤ to enforce wrap on operator at EOL.</li>
       </ul>
 
@@ -2355,7 +2373,8 @@
         Resolved bugs:
       </p>
       <ul>
-        <li>Incorporate a patch from Ronald Hastings (Boeing) to correctly handle C++ style comments being between Javadoc comments and declarations.</li>
+        <li>Incorporate a patch from Ronald Hastings (Boeing) to correctly handle C++ style
+        comments being between Javadoc comments and declarations.</li>
       </ul>
 
       <p>
@@ -2371,9 +2390,12 @@
         New features:
       </p>
       <ul>
-        <li>Support checking to determine if an unused <code>@throws</code> exception is a subclass of <code>java.lang.RuntimeException</code> (request 540382).</li>
-        <li>Detect instantiations of classes that should not be instantiated (e.g. java.lang.Boolean) (request 550205).</li>
-        <li>Added ability to specify the base directory for reporting file names (request 571161).</li>
+        <li>Support checking to determine if an unused <code>@throws</code> exception is a subclass
+        of <code>java.lang.RuntimeException</code> (request 540382).</li>
+        <li>Detect instantiations of classes that should not be instantiated (e.g.
+        java.lang.Boolean) (request 550205).</li>
+        <li>Added ability to specify the base directory for reporting file names (request
+        571161).</li>
         <li>Check for line wrapping on operators (request 553160).</li>
         <li>Detect empty <code>try</code> blocks.</li>
         <li>Detect empty <code>catch</code> blocks (request 516255).</li>
@@ -2400,8 +2422,11 @@
         API changes (only relevant for IDE plugin authors):
       </p>
       <ul>
-        <li>The get/setOutputStream methods have been removed from the AuditListener interface. The XMLLogger and DefaultLogger implementations now expect OutputStreams to be provided as a constructor argument.</li>
-        <li>The DefaultLogger now differentiates between info messages ("started checking file ...", etc.)  and error messages (style errors found by checkstyle).</li>
+        <li>The get/setOutputStream methods have been removed from the AuditListener interface.
+        The XMLLogger and DefaultLogger implementations now expect OutputStreams to be provided
+        as a constructor argument.</li>
+        <li>The DefaultLogger now differentiates between info messages ("started checking
+        file ...", etc.)  and error messages (style errors found by checkstyle).</li>
       </ul>
     </section>
 
@@ -2413,9 +2438,13 @@
         <li>The cache was not invalidated upon parameter change (Bug 522282).</li>
         <li>Tabs were not counted correctly in line length checks (Bug 524671).</li>
         <li>Problem when a Checker could not be created (Bug 528358).</li>
-        <li>The documentation of the command line property names did not list the property checkstyle.allow.tabs (Bug 529975).</li>
-        <li>The default regular expression for constant names allowed consecutive '_' characters to occur (Bug 540358).</li>
-        <li>Checkstyle reported unused @throws tag for multiple declarations of the same Exception. According to the Java BugParade this is incorrect, multiple @throws tags for the same exception are OK (Bug 540384).</li>
+        <li>The documentation of the command line property names did not list the property
+        checkstyle.allow.tabs (Bug 529975).</li>
+        <li>The default regular expression for constant names allowed consecutive '_' characters to
+        occur (Bug 540358).</li>
+        <li>Checkstyle reported unused @throws tag for multiple declarations of the same Exception.
+        According to the Java BugParade this is incorrect, multiple @throws tags for the same
+        exception are OK (Bug 540384).</li>
       </ul>
 
       <p>
@@ -2435,12 +2464,17 @@
         <!--(Feature request 534038)-->
         <li>added failureProperty to ANT task</li>
         <!--(Feature request 537107)-->
-        <li>added check for 'public' modifier in interface method declarations, following the recommendation in chapter 9.4 of the Java Language Specification</li>
+        <li>added check for 'public' modifier in interface method declarations, following the
+        recommendation in chapter 9.4 of the Java Language Specification</li>
         <!--(Feature request 545128)-->
-        <li>added -r "dir" option to the commandline frontend, checkstyle will find all Java files contained in the specified directory</li>
+        <li>added -r "dir" option to the commandline frontend, checkstyle will find all Java files
+        contained in the specified directory</li>
         <!--(Patch 531230 + enhancements)-->
-        <li>incorporated patch from Warner Onstine to configure the ANT task by means of a property file</li>
-        <li>added 'contrib' directory, contains XSL stylesheets for formatting checkstyle's XML output (contributions by Ingmar Stein, Stephane Bailliez, Scott McCrory and Gray Herter)</li>
+        <li>incorporated patch from Warner Onstine to configure the ANT task by means of a property
+        file</li>
+        <li>added 'contrib' directory, contains XSL stylesheets for formatting checkstyle's XML
+        output (contributions by Ingmar Stein, Stephane Bailliez, Scott McCrory and Gray
+        Herter)</li>
       </ul>
     </section>
 
@@ -2455,7 +2489,8 @@
         <li>added support for specifying the file header by means of regular expressions</li>
         <li>added whitespace checks around '.', e.g. System . out . println()</li>
         <li>added check for names of methods and local variables</li>
-        <li>check the order of modifiers (public, static, etc.) against the recommendation in the Java Language specification</li>
+        <li>check the order of modifiers (public, static, etc.) against the recommendation in the
+            Java Language specification</li>
         <li>added checks for curly braces placement</li>
         <li>incorporated patch from Andrew Lang for more robust Javadoc parsing</li>
       </ul>

--- a/src/xdocs/report_issue.xml
+++ b/src/xdocs/report_issue.xml
@@ -62,7 +62,8 @@
       </p>
 
       <p>
-        Example of report that we expect (you can skip <code>-Duser.language=en -Duser.country=US</code> if your default locale is English):
+        Example of report that we expect (you can skip <code>-Duser.language=en
+        -Duser.country=US</code> if your default locale is English):
 
         <source><![CDATA[
 /var/tmp $ javac Test.java
@@ -114,7 +115,8 @@ Audit done.
       </p>
 
       <p>
-        Imagine that everything is possible and propose name of the new option and its behaviour. Do not think that your issue is so obvious.
+        Imagine that everything is possible and propose name of the new option and its behaviour.
+        Do not think that your issue is so obvious.
       </p>
     </section>
 

--- a/src/xdocs/sponsoring.xml
+++ b/src/xdocs/sponsoring.xml
@@ -32,7 +32,8 @@
       </p>
 
       <p>
-        For any other proposal please do not hesitate to contact me (Roman Ivanov) by email "ivanov-jr['a']mail[dot]ru".
+        For any other proposal please do not hesitate to contact me (Roman Ivanov) by email
+        "ivanov-jr['a']mail[dot]ru".
       </p>
 
     </section>

--- a/src/xdocs/writingchecks.xml
+++ b/src/xdocs/writingchecks.xml
@@ -116,7 +116,8 @@
     </section>
       <section name="Tool to print Java tree structure">
           <p>
-              Checkstyle can print Abstract Syntax Tree for Java trees. You need to run checkstyle jar file with <b>-t</b> or <b>-T</b> argument, providing java file.
+              Checkstyle can print Abstract Syntax Tree for Java trees. You need to run checkstyle
+              jar file with <b>-t</b> or <b>-T</b> argument, providing java file.
           </p>
           <p>For example, here is MyClass.java file:</p>
           <source><![CDATA[
@@ -173,7 +174,9 @@ CLASS_DEF -> CLASS_DEF [5:0]
               </tr>
           </table>
           <p>
-            As you can see very small java file transforms to a huge Abstract Syntax Tree, because that is the most detailed tree including all components of the java file: object block, comments, modifiers, etc.
+            As you can see very small java file transforms to a huge Abstract Syntax Tree, because
+            that is the most detailed tree including all components of the java file: object block,
+            comments, modifiers, etc.
           </p>
       </section>
 
@@ -229,10 +232,10 @@ java -cp checkstyle-${projectVersion}-all.jar com.puppycrawl.tools.checkstyle.gu
       </p>
 
       <p>
-        We&#39;ll get back to the details in the other columns later, they
-        are important for implementing Checks but not for understanding
-        the basic concepts. For now it is sufficient to know that the
-        gui is a tool that lets you look at the structure of a Java file, i.e. you can see the Java grammar &#39;in action&#39;.
+        We&#39;ll get back to the details in the other columns later, they are important for
+        implementing Checks but not for understanding the basic concepts. For now it is sufficient
+        to know that the gui is a tool that lets you look at the structure of a Java file, i.e. you
+        can see the Java grammar &#39;in action&#39;.
       </p>
 
       <p> If you use <a href="https://eclipse.org">Eclipse</a> you can install
@@ -399,23 +402,31 @@ public class MethodLimitCheck extends AbstractCheck
     <section name="Comment Tokens in AST">
 
       <p>
-        Before <a href="releasenotes.html#Release_6.0">Checkstyle 6.0</a>, there was no comments in AST tree
-        as comments are not a code and ignored by compiler, so it was not a primary focus of Checkstyle.
+        Before <a href="releasenotes.html#Release_6.0">Checkstyle 6.0</a>, there was no comments
+        in AST tree as comments are not a code and ignored by compiler, so it was not a primary
+        focus of Checkstyle.
         But more and more requests appear to do validation of code vs javadoc or comments.
-        So there was a simple solution to receive plain text of file in Check, do own parsing and searching for required comments in file.
+        So there was a simple solution to receive plain text of file in Check, do own parsing and
+        searching for required comments in file.
       </p>
       <p>
-        Since 6.0, there is a new method in AbstractCheck class that allow you to see or not comment nodes in AST Tree -
-        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractCheck.html#isCommentNodesRequired--">
-        isCommentNodesRequired()</a>. It should return TRUE if Check want to see comments in AST Tree.
+        Since 6.0, there is a new method in AbstractCheck class that allow you to see or not
+        comment nodes in AST Tree - <a
+        href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractCheck.html#isCommentNodesRequired--">
+        isCommentNodesRequired()</a>. It should return TRUE if Check want to see comments in AST
+        Tree.
       </p>
       <p>
-        It is done as optional because it is change for a AST Tree structure, and non of existing Checks ready for this.
-        Checkstyle does not do re-parse file one more time, comments were already in grammar and parsed, but skipped during AST nodes creation.
+        It is done as optional because it is change for a AST Tree structure, and non of existing
+        Checks ready for this.
+        Checkstyle does not do re-parse file one more time, comments were already in grammar and
+        parsed, but skipped during AST nodes creation.
       </p>
       <p>
-        Before execution, all Checks are divided into 2 groups (base on isCommentNodesRequired method): "java only Checks", "comments Checks".
-        Checkstyle execute "java only Checks" first, as all them finish, append to AST Tree missed comment AST nodes and call "comments Checks".
+        Before execution, all Checks are divided into 2 groups (base on isCommentNodesRequired
+        method): "java only Checks", "comments Checks".
+        Checkstyle execute "java only Checks" first, as all them finish, append to AST Tree missed
+        comment AST nodes and call "comments Checks".
         All Javadoc Checks that are child of AbstractJavadocCheck are "comments Checks".
       </p>
       <p>
@@ -599,7 +610,8 @@ java -classpath mycompanychecks.jar;checkstyle-${projectVersion}-all.jar com.pup
       <p>
         Please consult the <a href="config.html#Packages">Checkstyle
         configuration manual</a> to learn how to integrate your Checks
-        into the package configuration so that you can use <code>MethodLimit</code> instead of the full class name.
+        into the package configuration so that you can use <code>MethodLimit</code> instead of the
+        full class name.
       </p>
 
     </section>
@@ -619,11 +631,16 @@ java -classpath mycompanychecks.jar;checkstyle-${projectVersion}-all.jar com.pup
         There are basically only few of them:
       </p>
       <ul>
-        <li>Java code should be written with <a href="https://en.wikipedia.org/wiki/ASCII">ASCII</a> characters only, no UTF-8 support.</li>
-        <li>To get valid violations, code have to be compilable, in other case you can get not easy to understand parse errors.</li>
-        <li>You cannot determine the type of an expression. Example: "getValue() + getValue2()"</li>
+        <li>Java code should be written with
+        <a href="https://en.wikipedia.org/wiki/ASCII">ASCII</a> characters only, no UTF-8
+        support.</li>
+        <li>To get valid violations, code have to be compilable, in other case you can get not easy
+        to understand parse errors.</li>
+        <li>You cannot determine the type of an expression.
+        Example: "getValue() + getValue2()"</li>
         <li>You cannot determine the full inheritance hierarchy of type.</li>
-        <li>You cannot see the content of other files. You have content of one file only during all Checks execution. All files are processed one by one.</li>
+        <li>You cannot see the content of other files. You have content of one file only during all
+        Checks execution. All files are processed one by one.</li>
       </ul>
       <p>
         This means that you cannot implement some of the code inspection

--- a/src/xdocs/writingfilefilters.xml
+++ b/src/xdocs/writingfilefilters.xml
@@ -23,18 +23,24 @@
 
     <section name="Overview">
       <p>
-        A <code>Checker</code> has a set of <code>BeforeExecutionFileFilter</code>s that decide which files the <code>Checker</code> processes.  Interface
-        <code>BeforeExecutionFileFilter</code> and class <code>BeforeExecutionFileFilterSet</code> are intended to support general file uri filtering using a set of <code>BeforeExecutionFileFilter</code>s.
+        A <code>Checker</code> has a set of <code>BeforeExecutionFileFilter</code>s that decide
+        which files the <code>Checker</code> processes.  Interface
+        <code>BeforeExecutionFileFilter</code> and class <code>BeforeExecutionFileFilterSet</code>
+        are intended to support general file uri filtering using a set of
+        <code>BeforeExecutionFileFilter</code>s.
       </p>
 
       <p>
-        A <code>BeforeExecutionFileFilter</code> has <code>boolean</code> method <code>accept(String uri)</code> that returns <code>true</code> if the <code>BeforeExecutionFileFilter</code>
-        accepts the <code>file uri</code> parameter and returns
-        <code>false</code> if the <code>file uri</code> rejects it.
+        A <code>BeforeExecutionFileFilter</code> has <code>boolean</code> method
+        <code>accept(String uri)</code> that returns <code>true</code> if the
+        <code>BeforeExecutionFileFilter</code> accepts the <code>file uri</code> parameter and
+        returns <code>false</code> if the <code>file uri</code> rejects it.
       </p>
 
       <p>
-        A <code>BeforeExecutionFileFilterSet</code> is a particular <code>BeforeExecutionFileFilter</code> that contains a set of <code>BeforeExecutionFileFilter</code>s. A <code>BeforeExecutionFileFilterSet</code>
+        A <code>BeforeExecutionFileFilterSet</code> is a particular
+        <code>BeforeExecutionFileFilter</code> that contains a set of
+        <code>BeforeExecutionFileFilter</code>s. A <code>BeforeExecutionFileFilterSet</code>
         accepts an <code>file uri</code> if and only if all
         <code>BeforeExecutionFileFilter</code>s in the set accept the <code>file uri</code>.
       </p>

--- a/src/xdocs/writingfilters.xml
+++ b/src/xdocs/writingfilters.xml
@@ -23,20 +23,22 @@
 
     <section name="Overview">
       <p>
-        A <code>Checker</code> has a set of <code>Filter</code>s that decide which audit events the <code>Checker</code> reports through its listeners.  Interface
-        <code>Filter</code> and class <code>FilterSet</code> are intended to support general <code>AuditEvent</code> filtering using a set of <code>Filter</code>s.
+        A <code>Checker</code> has a set of <code>Filter</code>s that decide which audit events
+        the <code>Checker</code> reports through its listeners.  Interface <code>Filter</code>
+        and class <code>FilterSet</code> are intended to support general <code>AuditEvent</code>
+        filtering using a set of <code>Filter</code>s.
       </p>
 
       <p>
-        A <code>Filter</code> has <code>boolean</code> method <code>accept(AuditEvent)</code> that returns <code>true</code> if the <code>Filter</code>
-        accepts the <code>AuditEvent</code> parameter and returns
-        <code>false</code> if the <code>Filter</code> rejects it.
+        A <code>Filter</code> has <code>boolean</code> method <code>accept(AuditEvent)</code> that
+        returns <code>true</code> if the <code>Filter</code> accepts the <code>AuditEvent</code>
+        parameter and returns <code>false</code> if the <code>Filter</code> rejects it.
       </p>
 
       <p>
-        A <code>FilterSet</code> is a particular <code>Filter</code> that contains a set of <code>Filter</code>s. A <code>FilterSet</code>
-        accepts an <code>AuditEvent</code> if and only if all
-        <code>Filter</code>s in the set accept the <code>AuditEvent</code>.
+        A <code>FilterSet</code> is a particular <code>Filter</code> that contains a set of
+        <code>Filter</code>s. A <code>FilterSet</code> accepts an <code>AuditEvent</code> if and
+        only if all <code>Filter</code>s in the set accept the <code>AuditEvent</code>.
       </p>
 
       <p>

--- a/src/xdocs/writingjavadocchecks.xml.vm
+++ b/src/xdocs/writingjavadocchecks.xml.vm
@@ -88,14 +88,18 @@ public class MyClass {
     @return double value.
       ]]></source>
       <p>
-      Attention that java comment starts with <code>/*</code>, following with Identificator of comment type. Javadoc Identificator is <code>*</code>. All symbols after Javadoc Identificator till <code>*/</code> are part of javadoc comment.
+      Attention that java comment starts with <code>/*</code>, following with Identificator of
+      comment type. Javadoc Identificator is <code>*</code>. All symbols after Javadoc
+      Identificator till <code>*/</code> are part of javadoc comment.
       </p>
-      <p>Please note that javadoc-like (miltiline comment with javdoc identificator) comment inside a method is not a javadoc comment and skipped by
-         Sun/Oracle javadoc tool and by our javadoc comment matcher, but such comment will be in AST.
+      <p>Please note that javadoc-like (miltiline comment with javdoc identificator) comment inside
+      a method is not a javadoc comment and skipped by Sun/Oracle javadoc tool and by our javadoc
+      comment matcher, but such comment will be in AST.
       </p>
       <p>In internet you can find different types of documentation
       generation tools similar to javadoc. Such tools rely on specific Identificator: "!", "#", "$".
-      Comments looks like <code>"/*! some comment */"</code> , <code>"/*# some comment */"</code> , <code>"/*$ some comment */"</code>. Such multiline comments are not a javadoc.
+      Comments looks like <code>"/*! some comment */"</code> , <code>"/*# some comment */"</code> ,
+      <code>"/*$ some comment */"</code>. Such multiline comments are not a javadoc.
       </p>
     </section>
 
@@ -140,10 +144,12 @@ public class MyClass {
 
     <section name="How to create Javadoc Check">
       <p>
-        Principle of writing Javadoc Checks is similar to writing regular Checks. You just extend another abstract class and use another token types.
+        Principle of writing Javadoc Checks is similar to writing regular Checks. You just extend
+        another abstract class and use another token types.
       </p>
       <p>
-      To start implementing new Check create a new class and extend <a href='apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html'>AbstractJavadocCheck</a>.
+      To start implementing new Check create a new class and extend <a
+      href='apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html'>AbstractJavadocCheck</a>.
       It has two abstract methods you should implement:
       </p>
       <ul>
@@ -157,7 +163,8 @@ public class MyClass {
         </li>
         <li>
           <a href="apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html#visitJavadocToken-com.puppycrawl.tools.checkstyle.api.DetailNode-">
-          visitJavadocToken(DetailNode)</a> - it's a place you should put tree nodes processing. The argument is Javadoc tree node of type you described before in
+          visitJavadocToken(DetailNode)</a> - it's a place you should put tree nodes processing.
+          The argument is Javadoc tree node of type you described before in
           <a href="apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html#getDefaultJavadocTokens--">getDefaultJavadocTokens()</a> method.
         </li>
       </ul>
@@ -165,27 +172,36 @@ public class MyClass {
 
     <section name="Difference between Java Grammar and Javadoc comments Grammar">
       <p>
-        Java grammar parses java file base on Java language specifications. So, there are singleline comments and multiline/block comments in it.
+        Java grammar parses java file base on Java language specifications. So, there are
+        singleline comments and multiline/block comments in it.
         Java compiler doesn't know about Javadoc because it is just a multiline comment.
         To parse multiline comment as a Javadoc comment, checkstyle has special Parser
         that is based on ANTLR Javadoc grammar. So, it's supposed to process block comments
         that start with Javadoc Identificator and parse them to Abstract Syntax Tree (AST).
       </p>
       <p>
-        The difference is that Java grammar uses ANTLR v2, while Javadoc grammar uses ANTLR v4. Because of that, these two grammars and their trees are not compatible.
-        Java AST consists of <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailAST.html">DetailAST</a> objects, while Javadoc AST consists of <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailNode.html">DetailNode</a> objects.
+        The difference is that Java grammar uses ANTLR v2, while Javadoc grammar uses ANTLR v4.
+        Because of that, these two grammars and their trees are not compatible.
+        Java AST consists of
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailAST.html">DetailAST</a>
+        objects, while Javadoc AST consists of
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailNode.html">DetailNode</a>
+        objects.
       </p>
       <p>
-        Main Java grammar skips any whitespaces and newlines, so in Java Abstract Syntax Tree there are no whitespace/newline nodes.
-        In Javadoc comment every whitespace matters, and Javadoc Checks need all those whitespaces and newline nodes to verify format and content of the Javadoc comment.
-        Because of that Javadoc grammar includes all whitespaces, newlines to the parse tree
+        Main Java grammar skips any whitespaces and newlines, so in Java Abstract Syntax Tree there
+        are no whitespace/newline nodes. In Javadoc comment every whitespace matters, and Javadoc
+        Checks need all those whitespaces and newline nodes to verify format and content of the
+        Javadoc comment. Because of that Javadoc grammar includes all whitespaces, newlines to
+        the parse tree
         (<a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#WS">WS</a>, <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#NEWLINE">NEWLINE</a>).
       </p>
     </section>
 
     <section name="Tool to print Javadoc tree structure">
       <p>
-      Checkstyle can print Abstract Syntax Tree for Java and Javadoc trees. You need to run checkstyle jar file with <b>-J</b> argument, providing java file.
+      Checkstyle can print Abstract Syntax Tree for Java and Javadoc trees. You need to run
+      checkstyle jar file with <b>-J</b> argument, providing java file.
       </p>
       <p>For example, here is MyClass.java file:</p>
       <source><![CDATA[
@@ -242,10 +258,15 @@ CLASS_DEF -> CLASS_DEF [5:0]
     `--RCURLY -> } [7:0]
       ]]></source>
       <p>
-      As you see very small java file transforms to a huge Abstract Syntax Tree, because that is the most detailed tree including all components of the java file: classes, methods, comments, etc.
+        As you see very small java file transforms to a huge Abstract Syntax Tree, because that is
+        the most detailed tree including all components of the java file: classes, methods,
+        comments, etc.
       </p>
-      <p>In most cases while developing Javadoc Check, you need to only parse the tree of the exact Javadoc comment.
-      To do that just copy Javadoc comment to separate file and remove <b>/**</b> at the beginning and <b>*/</b> at the end. After that, run checkstyle with <b>-j</b> argument.
+      <p>
+        In most cases while developing Javadoc Check, you need to only parse the tree of the exact
+        Javadoc comment. To do that just copy Javadoc comment to separate file and remove <b>/**</b>
+        at the beginning and <b>*/</b> at the end. After that, run checkstyle with <b>-j</b>
+        argument.
       </p>
       <p>MyJavadocComment.javadoc file:</p>
       <source><![CDATA[
@@ -285,10 +306,19 @@ JAVADOC -> JAVADOC [0:0]
     </section>
 
     <section name="Access Java AST from Javadoc Check">
-      As you already know Javadoc parse tree is a result of parsing block comment. There is a method to get the original block comment from Javadoc Check.
-      You may need this block comment to check its position or something else in java <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailAST.html">DetailAST</a> tree.
+      As you already know Javadoc parse tree is a result of parsing block comment. There is a
+      method to get the original block comment from Javadoc Check.
+      You may need this block comment to check its position or something else in java
+      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailAST.html">DetailAST</a> tree.
       <p>
-      For example, to write a JavadocCheck that verifies @param tags in Javadoc comment of a method definition, you also need all method's parameter names. To get method definition AST you should access java <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailAST.html">DetailAST</a> tree from javadoc Check. For this purpose use <a href="apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html#getBlockCommentAst--">getBlockCommentAst()</a> method that returns <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailAST.html">DetailAST</a> node.
+      For example, to write a JavadocCheck that verifies @param tags in Javadoc comment of
+      a method definition, you also need all method's parameter names. To get method
+      definition AST you should access java
+      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailAST.html">DetailAST</a> tree
+      from javadoc Check. For this purpose use
+      <a href="apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html#getBlockCommentAst--">getBlockCommentAst()</a>
+      method that returns
+      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailAST.html">DetailAST</a> node.
       </p>
       <p>
         Example:
@@ -327,22 +357,31 @@ class MyCheck extends AbstractJavadocCheck {
         Checkstyle supports HTML4 tags in Javadoc comments: <a href="https://www.w3.org/TR/html4/index/elements.html">all HTML4 elements</a>.
       </p>
       <p>
-        HTML4 is picked just to have a list of elements whose end tag is optional(omittable) and a list of <a href="https://www.w3.org/TR/html/syntax.html#void-elements">void elements</a> (also known as <a href="https://www.w3schools.com/html/html_elements.asp">empty html tags</a>, for example <a href="https://www.w3.org/TR/html4/struct/text.html#edef-BR">BR tag</a>).
+        HTML4 is picked just to have a list of elements whose end tag is optional(omittable) and a
+        list of <a href="https://www.w3.org/TR/html/syntax.html#void-elements">void elements</a>
+        (also known as <a href="https://www.w3schools.com/html/html_elements.asp">empty html
+        tags</a>, for example <a href="https://www.w3.org/TR/html4/struct/text.html#edef-BR">BR
+        tag</a>).
       </p>
       <p>
-        HTML4 elements whose end tag is optional (omittable): &lt;P&gt;, &lt;LI&gt;, &lt;TR&gt;, &lt;TD&gt;, &lt;TH&gt;, &lt;BODY&gt;, &lt;COLGROUP&gt;, &lt;DD&gt;,
-        &lt;DT&gt;, &lt;HEAD&gt;, &lt;HTML&gt;, &lt;OPTION&gt;, &lt;TBODY&gt;, &lt;THEAD&gt;, &lt;TFOOT&gt;.
+        HTML4 elements whose end tag is optional (omittable): &lt;P&gt;, &lt;LI&gt;, &lt;TR&gt;,
+        &lt;TD&gt;, &lt;TH&gt;, &lt;BODY&gt;, &lt;COLGROUP&gt;, &lt;DD&gt;, &lt;DT&gt;,
+        &lt;HEAD&gt;, &lt;HTML&gt;, &lt;OPTION&gt;, &lt;TBODY&gt;, &lt;THEAD&gt;, &lt;TFOOT&gt;.
       </p>
       <p>
-        Void HTML4 elements: &lt;AREA&gt;, &lt;BASE&gt;, &lt;BASEFONT&gt;, &lt;BR&gt;, &lt;COL&gt;, &lt;FRAME&gt;,
-        &lt;HR&gt;, &lt;IMG&gt;, &lt;INPUT&gt;, &lt;ISINDEX&gt;, &lt;LINK&gt;, &lt;META&gt;, &lt;PARAM&gt;.
+        Void HTML4 elements: &lt;AREA&gt;, &lt;BASE&gt;, &lt;BASEFONT&gt;, &lt;BR&gt;, &lt;COL&gt;,
+        &lt;FRAME&gt;, &lt;HR&gt;, &lt;IMG&gt;, &lt;INPUT&gt;, &lt;ISINDEX&gt;, &lt;LINK&gt;,
+        &lt;META&gt;, &lt;PARAM&gt;.
       </p>
 
       <p>
-        To make Checkstyle support HTML5 tags whose end tag is optional (omittable) and HTML5 void elements we should update Javadoc Parser
-        because each element that breaks <a href="#Tight-HTML_rules">Tight-HTML rules</a> have to be defined in Javadoc grammar.
-        In future we should update Javadoc grammar if those tag lists extend (new tags, new HTML standard, etc.).
-        (We already have an <a href='https://github.com/checkstyle/checkstyle/issues/3332'>issue on updating Javadoc grammar to HTML5</a>)
+        To make Checkstyle support HTML5 tags whose end tag is optional (omittable) and HTML5 void
+        elements we should update Javadoc Parser because each element that breaks
+        <a href="#Tight-HTML_rules">Tight-HTML rules</a> have to be defined in Javadoc grammar.
+        In future we should update Javadoc grammar if those tag lists extend (new tags, new HTML
+        standard, etc.).
+        (We already have an <a href='https://github.com/checkstyle/checkstyle/issues/3332'>issue
+        on updating Javadoc grammar to HTML5</a>)
       </p>
 
       <p>
@@ -388,12 +427,17 @@ JAVADOC -> JAVADOC [0:0]
       </p>
 
     <p>
-      Here is what you get if unknown tag doesn't have matching end tag (for example, HTML5 tag &lt;audio&gt;): <br/>
+      Here is what you get if unknown tag doesn't have matching end tag (for example, HTML5 tag
+      &lt;audio&gt;): <br/>
       Input:
       <source>&lt;audio&gt;test</source>
       Output:
-      <source class="wrap-content">[ERROR:0] Javadoc comment at column 1 has parse error. Missed HTML close tag 'audio'. Sometimes it means that close tag missed for one of previous tags.</source>
-      As you see Javadoc parser prints error and doesn't build AST if unknown HTML tag doesn't have matching end tag. If that a case please create an issue against Checkstyle to upgrade parser.
+      <source class="wrap-content">[ERROR:0] Javadoc comment at column 1 has parse error. Missed
+      HTML close tag 'audio'. Sometimes it means that close tag missed for one of previous
+      tags.</source>
+      As you see Javadoc parser prints error and doesn't build AST if unknown HTML tag doesn't
+      have matching end tag. If that a case please create an issue against Checkstyle to
+      upgrade parser.
     </p>
 
     <p>
@@ -436,8 +480,10 @@ JAVADOC -> JAVADOC [0:0]
     <table style="table-layout: fixed;">
       <tr>
         <td>
-          1) Unclosed paragraph HTML tag. As you see in the tree, content of the paragraph tag is not nested to this tag.
-          That is because HTML tags are not closed by pair tag &lt;/p&gt;, and Checkstyle requires <a href="#Tight-HTML_rules">Tight-HTML</a> code to predictably parse Javadoc comments.
+          1) Unclosed paragraph HTML tag. As you see in the tree, content of the paragraph tag is
+          not nested to this tag.
+          That is because HTML tags are not closed by pair tag &lt;/p&gt;, and Checkstyle requires
+          <a href="#Tight-HTML_rules">Tight-HTML</a> code to predictably parse Javadoc comments.
         </td>
         <td>
           2) Here is correct version with open and closed HTML tags.
@@ -549,7 +595,8 @@ java -cp checkstyle-${projectVersion}-all.jar com.puppycrawl.tools.checkstyle.gu
         Java checks controlled by method <a href="writingchecks.html#Understanding_token_sets">setTokens(), getDefaultTokens(), getAccessibleTokens(), getRequiredTokens(). </a>
         JavaDoc checks use the same model plus extra 4 methods for Javadoc tokens.
         As Java AST and Javadoc AST are not binded.
-        It is highly recommended for Javadoc checks do not use customization of java tokens and expect to be executed only on javadoc tokens.
+        It is highly recommended for Javadoc checks do not use customization of java tokens and
+        expect to be executed only on javadoc tokens.
       </p>
       <p>
         There are four methods in AbstractJavadocCheck class to control the processed
@@ -582,16 +629,18 @@ java -cp checkstyle-${projectVersion}-all.jar com.puppycrawl.tools.checkstyle.gu
 
         <li>
           <a href="apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html#getRequiredJavadocTokens--">
-          getRequiredJavadocTokens()</a> - returns a set of JavadocTokenTypes which Check must be subscribed to for
-          a valid execution. If the user wants to specify a custom set of JavadocTokenTypes then
-          this set must contain all the JavadocTokenTypes from RequiredJavadocTokens.
+          getRequiredJavadocTokens()</a> - returns a set of JavadocTokenTypes which Check must
+          be subscribed to for a valid execution. If the user wants to specify a custom set of
+          JavadocTokenTypes then this set must contain all the JavadocTokenTypes from
+          RequiredJavadocTokens.
         </li>
 
         <li>
           <a href="apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html#getAcceptableJavadocTokens--">
-          getAcceptableJavadocTokens()</a> - returns a set, which contains all the JavadocTokenTypes that
-          can be processed by the check. Both DefaultJavadocTokens and RequiredJavadocTokens and any custom
-          set of JavadocTokenTypes are subsets of AcceptableJavadocTokens.
+          getAcceptableJavadocTokens()</a> - returns a set, which contains all the
+          JavadocTokenTypes that can be processed by the check. Both DefaultJavadocTokens and
+          RequiredJavadocTokens and any custom set of JavadocTokenTypes are subsets of
+          AcceptableJavadocTokens.
         </li>
 
       </ul>
@@ -602,7 +651,8 @@ java -cp checkstyle-${projectVersion}-all.jar com.puppycrawl.tools.checkstyle.gu
     </section>
 
     <section name="Declare check's external resource locations">
-        See <a href="writingchecks.html#Declare_checks_external_resource_locations">Declare check's external resource locations</a>.
+        See <a href="writingchecks.html#Declare_checks_external_resource_locations">Declare check's
+        external resource locations</a>.
     </section>
 
     <section name="Examples of Javadoc Checks">
@@ -613,7 +663,9 @@ java -cp checkstyle-${projectVersion}-all.jar com.puppycrawl.tools.checkstyle.gu
     </section>
 
     <section name="Javadoc parser behavior for current HTML version and new HTML version">
-      This section shows how parser should/will behave during parsing of current HTML version and any new HTML version. Current version is HTML4, new version that need to be supported is HTML5.
+      This section shows how parser should/will behave during parsing of current HTML version
+      and any new HTML version. Current version is HTML4, new version that need to be supported
+      is HTML5.
       GeneralToken - mean that after parsing there will be general AstToken - HTML_TAG.
       SpecialToken - mean that after parsing there will be special AstToken - PARAGRAPH, .... .
       <p><b>Tags with optional (omittable) end tag:</b></p>
@@ -682,7 +734,8 @@ java -cp checkstyle-${projectVersion}-all.jar com.puppycrawl.tools.checkstyle.gu
       </table>
       <br/>
       <p><b>Void tags:</b></p>
-      Note: "Nested"/"Non-Nested" is not applicable for this type of tags - all of them are looks like Non-Nested. Flas "hasUnclosedTag" is "false" for all cases.
+      Note: "Nested"/"Non-Nested" is not applicable for this type of tags - all of them are looks
+      like Non-Nested. Flas "hasUnclosedTag" is "false" for all cases.
       <table style="table-layout: fixed;">
         <tr>
           <th>Input</th>

--- a/src/xdocs/writinglisteners.xml.vm
+++ b/src/xdocs/writinglisteners.xml.vm
@@ -17,7 +17,8 @@
 
     <section name="Overview">
       <p>
-        A Checkstyle listener monitors the progress of a <code>Checker</code> during the audit of files. The <code>Checker</code> notifies its attached listeners of
+        A Checkstyle listener monitors the progress of a <code>Checker</code> during the audit
+        of files. The <code>Checker</code> notifies its attached listeners of
         significant events such as the start of the audit of a file and
         the logging of a Check error, and the listeners respond
         appropriately.  Any number of listeners can be attached to a
@@ -62,8 +63,9 @@
         error logging has a message, a severity level, a message source
         such as the name of a <code>Check</code>, and file
         line and column numbers that may be relevant to the error. The
-        notification of an exception to a <code>AuditListener</code> includes an error <code>AuditEvent</code> and the details of the
-        exception. Here is a UML diagram for classes <code>AuditListener</code> and <code>AuditEvent</code>.
+        notification of an exception to a <code>AuditListener</code> includes an error
+        <code>AuditEvent</code> and the details of the exception. Here is a UML diagram for
+        classes <code>AuditListener</code> and <code>AuditEvent</code>.
       </p>
 
       <img src="images/AuditListener.gif" width="381" height="488"
@@ -86,8 +88,10 @@
         The custom listener that we demonstrate here is a verbose
         listener that simply prints each event notification to an output
         stream, and reports the number of errors per audited file and
-        the total number of errors. The default output stream is <code>System.out</code>. In order to enable the
-        specification of output to a file through property <code>file</code>, the class extends <code>AutomaticBean</code> and defines method <code>setFile(String)</code>.
+        the total number of errors. The default output stream is <code>System.out</code>.
+        In order to enable the specification of output to a file through property
+        <code>file</code>, the class extends <code>AutomaticBean</code> and defines method
+        <code>setFile(String)</code>.
       </p>
 
       <source>
@@ -233,7 +237,8 @@ Audit finished. Total errors: 1
         listener, <code> CommonsLoggingListener</code>,
         hands off events to the <a
         href="http://commons.apache.org/proper/commons-logging/">Apache
-        Commons Logging</a> facade and the second, <code>MailLogger</code>, sends a report of an audit via
+        Commons Logging</a> facade and the second, <code>MailLogger</code>,
+        sends a report of an audit via
         e-mail. The discussion of these examples and how to use them is
         derived from material in <a
         href="https://www.manning.com/books/java-development-with-ant">&quot;Java Development
@@ -250,8 +255,8 @@ Audit finished. Total errors: 1
         Commons Logging</a> provides a facade for logging tools
         <a
         href="http://logging.apache.org/log4j/2.x/index.html">log4j</a>,
-        , J2SE 1.4, and others. Checkstyle listener <code> CommonsLoggingListener</code> responds to an
-        AuditEvent by handing it off to the current Commons Logging Log.
+        J2SE 1.4, and others. Checkstyle listener <code>CommonsLoggingListener</code>
+        responds to an AuditEvent by handing it off to the current Commons Logging Log.
       </p>
 
       <p>
@@ -265,7 +270,8 @@ Audit finished. Total errors: 1
       </p>
 
       <p>
-        The easiest way to use <code>CommonsLoggingListener</code> is to include <code>checkstyle-${projectVersion}-all.jar</code>
+        The easiest way to use <code>CommonsLoggingListener</code> is to include
+        <code>checkstyle-${projectVersion}-all.jar</code>
         in the classpath because that jar file contains all the Commons
         Logging classes.  The default Log under J2SE 1.4 is wrapper
         class <a


### PR DESCRIPTION
Issue #5291

I tried to format as best I could.

@romani 
How do we want to handle xdoc comments that are too long? Should I split comment into 2 so `Warning here` stays on line with warning?
https://github.com/checkstyle/checkstyle/blob/master/src/xdocs/config_filters.xml#L305
Or linux commands too long:
https://github.com/checkstyle/checkstyle/blob/master/src/xdocs/cmdline.xml.vm#L180