### PR TITLE
minor: Move all parseXXX methods to the Parser class

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -167,7 +167,7 @@
     <allow pkg="java.util" exact-match="true"/>
     <allow pkg="com.puppycrawl.tools.checkstyle.api" local-only="true"/>
     <allow pkg="com.puppycrawl.tools.checkstyle.utils" local-only="true"/>
-    <allow class="com.puppycrawl.tools.checkstyle.TreeWalker" local-only="true"/>
+    <allow class="com.puppycrawl.tools.checkstyle.Parser" local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.gui.MainFrameModel.ParseMode"
            local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser" local-only="true"/>

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -135,7 +135,7 @@
     <properties>
       <!-- TreeWalker integrates Checkstyle and antlr and CheckstyleAntTask integrates Checkstyle
        with Ant. Checker collects external resource locations and setup configuration. -->
-      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='TreeWalker' or @Image='CheckstyleAntTask' or @Image='Checker' or @Image='Main']"/>
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='CheckstyleAntTask' or @Image='Checker' or @Image='Main']"/>
     </properties>
   </rule>
   <rule ref="rulesets/java/coupling.xml/CouplingBetweenObjects">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java
@@ -21,16 +21,11 @@ package com.puppycrawl.tools.checkstyle;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Locale;
 import java.util.regex.Pattern;
 
-import antlr.RecognitionException;
-import antlr.TokenStreamException;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtils;
@@ -41,22 +36,6 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtils;
  * @author Vladislav Lisetskii
  */
 public final class AstTreeStringPrinter {
-
-    /**
-     * Enum to be used for test if comments should be printed.
-     */
-    public enum PrintOptions {
-
-        /**
-         * Comments has to be printed.
-         */
-        WITH_COMMENTS,
-        /**
-         * Comments has NOT to be printed.
-         */
-        WITHOUT_COMMENTS
-
-    }
 
     /** Newline pattern. */
     private static final Pattern NEWLINE = Pattern.compile("\n");
@@ -76,14 +55,14 @@ public final class AstTreeStringPrinter {
     /**
      * Parse a file and print the parse tree.
      * @param file the file to print.
-     * @param withComments true to include comments to AST
+     * @param withComments {@link Parser.Options#WITH_COMMENTS} to include comment nodes to the AST.
      * @return the AST of the file in String form.
      * @throws IOException if the file could not be read.
      * @throws CheckstyleException if the file is not a Java source.
      */
-    public static String printFileAst(File file, PrintOptions withComments)
+    public static String printFileAst(File file, Parser.Options withComments)
             throws IOException, CheckstyleException {
-        return printTree(parseFile(file, withComments));
+        return printTree(Parser.parseFile(file, withComments));
     }
 
     /**
@@ -95,7 +74,7 @@ public final class AstTreeStringPrinter {
      */
     public static String printJavaAndJavadocTree(File file)
             throws IOException, CheckstyleException {
-        final DetailAST tree = parseFile(file, PrintOptions.WITH_COMMENTS);
+        final DetailAST tree = Parser.parseFileWithComments(file);
         return printJavaAndJavadocTree(tree);
     }
 
@@ -143,13 +122,13 @@ public final class AstTreeStringPrinter {
     /**
      * Parse a file and print the parse tree.
      * @param text the text to parse.
-     * @param withComments true to include comments to AST
+     * @param withComments {@link Parser.Options#WITH_COMMENTS} to include comment nodes to the AST.
      * @return the AST of the file in String form.
      * @throws CheckstyleException if the file is not a Java source.
      */
     public static String printAst(FileText text,
-                                  PrintOptions withComments) throws CheckstyleException {
-        return printTree(parseFileText(text, withComments));
+                                  Parser.Options withComments) throws CheckstyleException {
+        return printTree(Parser.parseFileText(text, withComments));
     }
 
     /**
@@ -224,50 +203,6 @@ public final class AstTreeStringPrinter {
         final String textWithoutNewlines = NEWLINE.matcher(text).replaceAll("\\\\n");
         final String textWithoutReturns = RETURN.matcher(textWithoutNewlines).replaceAll("\\\\r");
         return TAB.matcher(textWithoutReturns).replaceAll("\\\\t");
-    }
-
-    /**
-     * Parse a file and return the parse tree.
-     * @param file the file to parse.
-     * @param withComments true to include comment nodes to the tree
-     * @return the root node of the parse tree.
-     * @throws IOException if the file could not be read.
-     * @throws CheckstyleException if the file is not a Java source.
-     */
-    private static DetailAST parseFile(File file, PrintOptions withComments)
-            throws IOException, CheckstyleException {
-        final FileText text = new FileText(file.getAbsoluteFile(),
-            System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
-        return parseFileText(text, withComments);
-    }
-
-    /**
-     * Parse a text and return the parse tree.
-     * @param text the text to parse.
-     * @param withComments true to include comment nodes to the tree
-     * @return the root node of the parse tree.
-     * @throws CheckstyleException if the file is not a Java source.
-     */
-    private static DetailAST parseFileText(FileText text, PrintOptions withComments)
-            throws CheckstyleException {
-        final FileContents contents = new FileContents(text);
-        final DetailAST result;
-        try {
-            if (withComments == PrintOptions.WITH_COMMENTS) {
-                result = TreeWalker.parseWithComments(contents);
-            }
-            else {
-                result = TreeWalker.parse(contents);
-            }
-        }
-        catch (RecognitionException | TokenStreamException ex) {
-            final String exceptionMsg = String.format(Locale.ROOT,
-                "%s occurred during the analysis of file %s.",
-                ex.getClass().getSimpleName(), text.getFile().getPath());
-            throw new CheckstyleException(exceptionMsg, ex);
-        }
-
-        return result;
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -393,13 +393,13 @@ public final class Main {
             // print AST
             final File file = config.files.get(0);
             final String stringAst = AstTreeStringPrinter.printFileAst(file,
-                    AstTreeStringPrinter.PrintOptions.WITHOUT_COMMENTS);
+                    Parser.Options.WITHOUT_COMMENTS);
             System.out.print(stringAst);
         }
         else if (commandLine.hasOption(OPTION_CAPITAL_T_NAME)) {
             final File file = config.files.get(0);
             final String stringAst = AstTreeStringPrinter.printFileAst(file,
-                    AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                    Parser.Options.WITH_COMMENTS);
             System.out.print(stringAst);
         }
         else if (commandLine.hasOption(OPTION_J_NAME)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Parser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Parser.java
@@ -1,0 +1,282 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2018 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import antlr.CommonHiddenStreamToken;
+import antlr.RecognitionException;
+import antlr.Token;
+import antlr.TokenStreamException;
+import antlr.TokenStreamHiddenTokenFilter;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.FileContents;
+import com.puppycrawl.tools.checkstyle.api.FileText;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaLexer;
+import com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaRecognizer;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+/**
+ * Helper methods to parse java source files.
+ *
+ * @author Oliver Burn
+ * @author Pavel Bludov
+ */
+public final class Parser {
+
+    /**
+     * Enum to be used for test if comments should be used.
+     */
+    public enum Options {
+
+        /**
+         * Comments nodes should be processed.
+         */
+        WITH_COMMENTS,
+
+        /**
+         * Comments nodes should be ignored.
+         */
+        WITHOUT_COMMENTS
+
+    }
+
+    /** Stop instances being created. **/
+    private Parser() {
+
+    }
+
+    /**
+     * Static helper method to parses a Java source file.
+     * @param contents contains the contents of the file
+     * @return the root of the AST
+     * @throws CheckstyleException if the contents is not a valid Java source
+     */
+    public static DetailAST parse(FileContents contents)
+            throws CheckstyleException {
+        final String fullText = contents.getText().getFullText().toString();
+        final Reader reader = new StringReader(fullText);
+        final GeneratedJavaLexer lexer = new GeneratedJavaLexer(reader);
+        lexer.setCommentListener(contents);
+        lexer.setTokenObjectClass("antlr.CommonHiddenStreamToken");
+
+        final TokenStreamHiddenTokenFilter filter =
+                new TokenStreamHiddenTokenFilter(lexer);
+        filter.hide(TokenTypes.SINGLE_LINE_COMMENT);
+        filter.hide(TokenTypes.BLOCK_COMMENT_BEGIN);
+
+        final GeneratedJavaRecognizer parser =
+            new GeneratedJavaRecognizer(filter);
+        parser.setFilename(contents.getFileName());
+        parser.setASTNodeClass(DetailAST.class.getName());
+        try {
+            parser.compilationUnit();
+        }
+        catch (RecognitionException | TokenStreamException ex) {
+            final String exceptionMsg = String.format(Locale.ROOT,
+                "%s occurred during the analysis of file %s.",
+                ex.getClass().getSimpleName(), contents.getFileName());
+            throw new CheckstyleException(exceptionMsg, ex);
+        }
+
+        return (DetailAST) parser.getAST();
+    }
+
+    /**
+     * Parses Java source file.
+     * @param file the file to parse
+     * @param withComments {@link Options#WITH_COMMENTS} to include comment nodes to the AST
+     * @return DetailAST tree
+     * @throws IOException if the file could not be read
+     * @throws CheckstyleException if the file is not a valid Java source file
+     */
+    public static DetailAST parseFile(File file, Options withComments)
+            throws IOException, CheckstyleException {
+        final FileText text = new FileText(file.getAbsoluteFile(),
+            System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
+        return parseFileText(text, withComments);
+    }
+
+    /**
+     * Parses Java source file. Result AST does not contains comment nodes.
+     * @param file the file to parse
+     * @return DetailAST tree
+     * @throws IOException if the file could not be read
+     * @throws CheckstyleException if the file is not a valid Java source file
+     */
+    public static DetailAST parseFile(File file)
+            throws IOException, CheckstyleException {
+        return parseFile(file, Options.WITHOUT_COMMENTS);
+    }
+
+    /**
+     * Parses Java source file. Result AST contains comment nodes.
+     * @param file the file to parse.
+     * @return DetailAST tree
+     * @throws IOException if the file could not be read
+     * @throws CheckstyleException if the file is not a valid Java source file
+     */
+    public static DetailAST parseFileWithComments(File file)
+            throws IOException, CheckstyleException {
+        return parseFile(file, Options.WITH_COMMENTS);
+    }
+
+    /**
+     * Parse a text and return the parse tree.
+     * @param text the text to parse
+     * @param withComments {@link Options#WITH_COMMENTS} to include comment nodes to the AST
+     * @return the root node of the parse tree
+     * @throws CheckstyleException if the text is not a valid Java source
+     */
+    public static DetailAST parseFileText(FileText text, Options withComments)
+            throws CheckstyleException {
+        final FileContents contents = new FileContents(text);
+        DetailAST ast = parse(contents);
+        if (withComments == Options.WITH_COMMENTS) {
+            ast = appendHiddenCommentNodes(ast);
+        }
+        return ast;
+    }
+
+    /**
+     * Appends comment nodes to existing AST.
+     * It traverses each node in AST, looks for hidden comment tokens
+     * and appends found comment tokens as nodes in AST.
+     * @param root of AST
+     * @return root of AST with comment nodes
+     */
+    public static DetailAST appendHiddenCommentNodes(DetailAST root) {
+        DetailAST result = root;
+        DetailAST curNode = root;
+        DetailAST lastNode = root;
+
+        while (curNode != null) {
+            if (isPositionGreater(curNode, lastNode)) {
+                lastNode = curNode;
+            }
+
+            CommonHiddenStreamToken tokenBefore = curNode.getHiddenBefore();
+            DetailAST currentSibling = curNode;
+            while (tokenBefore != null) {
+                final DetailAST newCommentNode =
+                         createCommentAstFromToken(tokenBefore);
+
+                currentSibling.addPreviousSibling(newCommentNode);
+
+                if (currentSibling == result) {
+                    result = newCommentNode;
+                }
+
+                currentSibling = newCommentNode;
+                tokenBefore = tokenBefore.getHiddenBefore();
+            }
+
+            DetailAST toVisit = curNode.getFirstChild();
+            while (curNode != null && toVisit == null) {
+                toVisit = curNode.getNextSibling();
+                if (toVisit == null) {
+                    curNode = curNode.getParent();
+                }
+            }
+            curNode = toVisit;
+        }
+        if (lastNode != null) {
+            CommonHiddenStreamToken tokenAfter = lastNode.getHiddenAfter();
+            DetailAST currentSibling = lastNode;
+            while (tokenAfter != null) {
+                final DetailAST newCommentNode =
+                        createCommentAstFromToken(tokenAfter);
+
+                currentSibling.addNextSibling(newCommentNode);
+
+                currentSibling = newCommentNode;
+                tokenAfter = tokenAfter.getHiddenAfter();
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Checks if position of first DetailAST is greater than position of
+     * second DetailAST. Position is line number and column number in source file.
+     * @param ast1 first DetailAST node
+     * @param ast2 second DetailAST node
+     * @return true if position of ast1 is greater than position of ast2
+     */
+    private static boolean isPositionGreater(DetailAST ast1, DetailAST ast2) {
+        boolean isGreater = ast1.getLineNo() > ast2.getLineNo();
+        if (!isGreater && ast1.getLineNo() == ast2.getLineNo()) {
+            isGreater = ast1.getColumnNo() > ast2.getColumnNo();
+        }
+        return isGreater;
+    }
+
+    /**
+     * Create comment AST from token. Depending on token type
+     * SINGLE_LINE_COMMENT or BLOCK_COMMENT_BEGIN is created.
+     * @param token to create the AST
+     * @return DetailAST of comment node
+     */
+    private static DetailAST createCommentAstFromToken(Token token) {
+        final DetailAST commentAst;
+        if (token.getType() == TokenTypes.SINGLE_LINE_COMMENT) {
+            commentAst = createSlCommentNode(token);
+        }
+        else {
+            commentAst = CommonUtils.createBlockCommentNode(token);
+        }
+        return commentAst;
+    }
+
+    /**
+     * Create single-line comment from token.
+     * @param token to create the AST
+     * @return DetailAST with SINGLE_LINE_COMMENT type
+     */
+    private static DetailAST createSlCommentNode(Token token) {
+        final DetailAST slComment = new DetailAST();
+        slComment.setType(TokenTypes.SINGLE_LINE_COMMENT);
+        slComment.setText("//");
+
+        // column counting begins from 0
+        slComment.setColumnNo(token.getColumn() - 1);
+        slComment.setLineNo(token.getLine());
+
+        final DetailAST slCommentContent = new DetailAST();
+        slCommentContent.setType(TokenTypes.COMMENT_CONTENT);
+
+        // column counting begins from 0
+        // plus length of '//'
+        slCommentContent.setColumnNo(token.getColumn() - 1 + 2);
+        slCommentContent.setLineNo(token.getLine());
+        slCommentContent.setText(token.getText());
+
+        slComment.addChild(slCommentContent);
+        return slComment;
+    }
+
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java
@@ -26,12 +26,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import antlr.ANTLRException;
 import com.google.common.collect.ImmutableList;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 
 /**
@@ -199,11 +197,11 @@ public class MainFrameModel {
 
                 switch (parseMode) {
                     case PLAIN_JAVA:
-                        parseTree = parseFile(file);
+                        parseTree = Parser.parseFile(file);
                         break;
                     case JAVA_WITH_COMMENTS:
                     case JAVA_WITH_JAVADOC_AND_COMMENTS:
-                        parseTree = parseFileWithComments(file);
+                        parseTree = Parser.parseFileWithComments(file);
                         break;
                     default:
                         throw new IllegalArgumentException("Unknown mode: " + parseMode);
@@ -226,39 +224,13 @@ public class MainFrameModel {
                 linesToPosition = ImmutableList.copyOf(linesToPositionTemp);
                 text = sb.toString();
             }
-            catch (IOException | ANTLRException ex) {
+            catch (IOException ex) {
                 final String exceptionMsg = String.format(Locale.ROOT,
                     "%s occurred while opening file %s.",
                     ex.getClass().getSimpleName(), file.getPath());
                 throw new CheckstyleException(exceptionMsg, ex);
             }
         }
-    }
-
-    /**
-     * Parse a file and return the parse tree.
-     * @param file the file to parse.
-     * @return the root node of the parse tree.
-     * @throws IOException if the file could not be read.
-     * @throws ANTLRException if the file is not a Java source.
-     */
-    private static DetailAST parseFile(File file) throws IOException, ANTLRException {
-        final FileText fileText = getFileText(file);
-        final FileContents contents = new FileContents(fileText);
-        return TreeWalker.parse(contents);
-    }
-
-    /**
-     * Parse a file and return the parse tree with comment nodes.
-     * @param file the file to parse.
-     * @return the root node of the parse tree.
-     * @throws IOException if the file could not be read.
-     * @throws ANTLRException if the file is not a Java source.
-     */
-    private static DetailAST parseFileWithComments(File file) throws IOException, ANTLRException {
-        final FileText fileText = getFileText(file);
-        final FileContents contents = new FileContents(fileText);
-        return TreeWalker.parseWithComments(contents);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractTreeTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractTreeTestSupport.java
@@ -48,7 +48,7 @@ public abstract class AbstractTreeTestSupport extends AbstractPathTestSupport {
      * @throws Exception if exception occurs during verification.
      */
     protected static void verifyAst(String expectedTextPrintFileName, String actualJavaFileName,
-                                    AstTreeStringPrinter.PrintOptions withComments)
+                                    Parser.Options withComments)
             throws Exception {
         final String expectedContents = readFile(expectedTextPrintFileName);
 
@@ -62,7 +62,7 @@ public abstract class AbstractTreeTestSupport extends AbstractPathTestSupport {
     /**
      * Performs verification of the given text ast tree representation.
      * This implementation uses
-     * {@link AbstractTreeTestSupport#verifyAst(String, String, AstTreeStringPrinter.PrintOptions)}
+     * {@link AbstractTreeTestSupport#verifyAst(String, String, Parser.Options)}
      * method inside.
      * @param expectedTextPrintFileName expected text ast tree representation.
      * @param actualJavaFileName actual text ast tree representation.
@@ -71,7 +71,7 @@ public abstract class AbstractTreeTestSupport extends AbstractPathTestSupport {
     protected static void verifyAst(String expectedTextPrintFileName, String actualJavaFileName)
             throws Exception {
         verifyAst(expectedTextPrintFileName, actualJavaFileName,
-                AstTreeStringPrinter.PrintOptions.WITHOUT_COMMENTS);
+                Parser.Options.WITHOUT_COMMENTS);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
@@ -51,8 +51,7 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
     public void testParseFileThrowable() throws Exception {
         final File input = new File(getNonCompilablePath("InputAstTreeStringPrinter.java"));
         try {
-            AstTreeStringPrinter.printFileAst(input,
-                    AstTreeStringPrinter.PrintOptions.WITHOUT_COMMENTS);
+            AstTreeStringPrinter.printFileAst(input, Parser.Options.WITHOUT_COMMENTS);
             Assert.fail("exception expected");
         }
         catch (CheckstyleException ex) {
@@ -67,8 +66,7 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
     @Test
     public void testParseFile() throws Exception {
         verifyAst(getPath("ExpectedAstTreeStringPrinter.txt"),
-                getPath("InputAstTreeStringPrinterComments.java"),
-                AstTreeStringPrinter.PrintOptions.WITHOUT_COMMENTS);
+                getPath("InputAstTreeStringPrinterComments.java"), Parser.Options.WITHOUT_COMMENTS);
     }
 
     @Test
@@ -76,8 +74,7 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
         final FileText text = new FileText(
                 new File(getPath("InputAstTreeStringPrinterComments.java")).getAbsoluteFile(),
                 System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
-        final String actual = AstTreeStringPrinter.printAst(text,
-                AstTreeStringPrinter.PrintOptions.WITHOUT_COMMENTS);
+        final String actual = AstTreeStringPrinter.printAst(text, Parser.Options.WITHOUT_COMMENTS);
         final String expected = new String(Files.readAllBytes(Paths.get(
                 getPath("ExpectedAstTreeStringPrinter.txt"))), StandardCharsets.UTF_8);
 
@@ -88,7 +85,7 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
     public void testParseFileWithComments() throws Exception {
         verifyAst(getPath("ExpectedAstTreeStringPrinterComments.txt"),
                 getPath("InputAstTreeStringPrinterComments.java"),
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
     @Test
@@ -121,21 +118,21 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
     public void testAstTreeBlockComments() throws Exception {
         verifyAst(getPath("ExpectedAstTreeStringPrinterFullOfBlockComments.txt"),
                 getPath("InputAstTreeStringPrinterFullOfBlockComments.java"),
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
     @Test
     public void testAstTreeBlockCommentsCarriageReturn() throws Exception {
         verifyAst(getPath("ExpectedAstTreeStringPrinterFullOfBlockCommentsCR.txt"),
                 getPath("InputAstTreeStringPrinterFullOfBlockCommentsCR.java"),
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
     @Test
     public void testAstTreeSingleLineComments() throws Exception {
         verifyAst(getPath("ExpectedAstTreeStringPrinterFullOfSinglelineComments.txt"),
                 getPath("InputAstTreeStringPrinterFullOfSinglelineComments.java"),
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
@@ -30,7 +30,6 @@ import java.nio.file.Paths;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class JavadocDetailNodeParserTest extends AbstractModuleTestSupport {
 
@@ -43,9 +42,9 @@ public class JavadocDetailNodeParserTest extends AbstractModuleTestSupport {
 
     @Test
     public void testParseJavadocAsDetailNode() throws Exception {
-        final DetailAST ast = TestUtil
-                .parseFile(new File(getPath("InputJavadocDetailNodeParser.java"))).getNextSibling()
-                .getFirstChild().getFirstChild();
+        final DetailAST ast = Parser
+                .parseFileWithComments(new File(getPath("InputJavadocDetailNodeParser.java")))
+                .getNextSibling().getFirstChild().getFirstChild();
         final JavadocDetailNodeParser parser = new JavadocDetailNodeParser();
         final JavadocDetailNodeParser.ParseStatus status = parser.parseJavadocAsDetailNode(ast);
         final String actual = DetailNodeTreeStringPrinter.printTree(status.getTree(), "", "");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ParserTest.java
@@ -1,0 +1,118 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2018 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
+
+public class ParserTest extends AbstractModuleTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/parser";
+    }
+
+    @Test
+    public void testIsProperUtilsClass() throws ReflectiveOperationException {
+        assertTrue("Constructor is not private", TestUtil.isUtilsClassHasPrivateConstructor(
+            Parser.class, false));
+    }
+
+    @Test
+    public void testAppendHiddenBlockCommentNodes() throws Exception {
+        final DetailAST root = Parser.parseFileWithComments(
+            new File(getPath("InputParserHiddenComments.java")));
+
+        final Optional<DetailAST> blockComment = TestUtil.findTokenInAstByPredicate(root,
+            ast -> ast.getType() == TokenTypes.BLOCK_COMMENT_BEGIN);
+
+        assertTrue("Block comment should be present", blockComment.isPresent());
+
+        final DetailAST commentContent = blockComment.get().getFirstChild();
+        final DetailAST commentEnd = blockComment.get().getLastChild();
+
+        assertEquals("Unexpected line number", 3, commentContent.getLineNo());
+        assertEquals("Unexpected column number", 2, commentContent.getColumnNo());
+        assertEquals("Unexpected line number", 9, commentEnd.getLineNo());
+        assertEquals("Unexpected column number", 1, commentEnd.getColumnNo());
+    }
+
+    @Test
+    public void testAppendHiddenSingleLineCommentNodes() throws Exception {
+        final DetailAST root = Parser.parseFileWithComments(
+            new File(getPath("InputParserHiddenComments.java")));
+
+        final Optional<DetailAST> singleLineComment = TestUtil.findTokenInAstByPredicate(root,
+            ast -> ast.getType() == TokenTypes.SINGLE_LINE_COMMENT);
+        assertTrue("Single line comment should be present", singleLineComment.isPresent());
+
+        final DetailAST commentContent = singleLineComment.get().getFirstChild();
+
+        assertEquals("Unexpected token type", TokenTypes.COMMENT_CONTENT, commentContent.getType());
+        assertEquals("Unexpected line number", 13, commentContent.getLineNo());
+        assertEquals("Unexpected column number", 2, commentContent.getColumnNo());
+        assertTrue("Unexpected comment content",
+            commentContent.getText().startsWith(" inline comment"));
+    }
+
+    /**
+     * Could not find proper test case to test pitest mutations functionally.
+     * Should be rewritten during grammar update.
+     *
+     * @throws Exception when code tested throws exception
+     */
+    @Test
+    public void testIsPositionGreater() throws Exception {
+        final DetailAST ast1 = createAst(1, 3);
+        final DetailAST ast2 = createAst(1, 2);
+        final DetailAST ast3 = createAst(2, 2);
+
+        final TreeWalker treeWalker = new TreeWalker();
+        final Method isPositionGreater = Whitebox.getMethod(Parser.class,
+                "isPositionGreater", DetailAST.class, DetailAST.class);
+
+        assertTrue("Should return true when lines are equal and column is greater",
+                (boolean) isPositionGreater.invoke(treeWalker, ast1, ast2));
+        assertFalse("Should return false when lines are equal columns are equal",
+                (boolean) isPositionGreater.invoke(treeWalker, ast1, ast1));
+        assertTrue("Should return true when line is greater",
+                (boolean) isPositionGreater.invoke(treeWalker, ast3, ast1));
+    }
+
+    private static DetailAST createAst(int line, int column) {
+        final DetailAST ast = new DetailAST();
+        ast.setLineNo(line);
+        ast.setColumnNo(column);
+        return ast;
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle;
 
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -30,7 +29,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -38,7 +36,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -52,7 +49,6 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.Context;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck;
@@ -64,7 +60,6 @@ import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck;
 import com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter;
 import com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class TreeWalkerTest extends AbstractModuleTestSupport {
@@ -453,43 +448,6 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testAppendHiddenBlockCommentNodes() throws Exception {
-        final DetailAST root =
-            TestUtil.parseFile(new File(getPath("InputTreeWalkerHiddenComments.java")));
-
-        final Optional<DetailAST> blockComment = TestUtil.findTokenInAstByPredicate(root,
-            ast -> ast.getType() == TokenTypes.BLOCK_COMMENT_BEGIN);
-
-        assertTrue("Block comment should be present", blockComment.isPresent());
-
-        final DetailAST commentContent = blockComment.get().getFirstChild();
-        final DetailAST commentEnd = blockComment.get().getLastChild();
-
-        assertEquals("Unexpected line number", 3, commentContent.getLineNo());
-        assertEquals("Unexpected column number", 2, commentContent.getColumnNo());
-        assertEquals("Unexpected line number", 9, commentEnd.getLineNo());
-        assertEquals("Unexpected column number", 1, commentEnd.getColumnNo());
-    }
-
-    @Test
-    public void testAppendHiddenSingleLineCommentNodes() throws Exception {
-        final DetailAST root =
-            TestUtil.parseFile(new File(getPath("InputTreeWalkerHiddenComments.java")));
-
-        final Optional<DetailAST> singleLineComment = TestUtil.findTokenInAstByPredicate(root,
-            ast -> ast.getType() == TokenTypes.SINGLE_LINE_COMMENT);
-        assertTrue("Single line comment should be present", singleLineComment.isPresent());
-
-        final DetailAST commentContent = singleLineComment.get().getFirstChild();
-
-        assertEquals("Unexpected token type", TokenTypes.COMMENT_CONTENT, commentContent.getType());
-        assertEquals("Unexpected line number", 13, commentContent.getLineNo());
-        assertEquals("Unexpected column number", 2, commentContent.getColumnNo());
-        assertTrue("Unexpected comment content",
-            commentContent.getText().startsWith(" inline comment"));
-    }
-
-    @Test
     public void testFinishLocalSetupFullyInitialized() {
         final TreeWalker treeWalker = new TreeWalker();
         final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
@@ -561,37 +519,6 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
                 new String(Files.readAllBytes(cacheFile.toPath()),
                         StandardCharsets.UTF_8).contains(
                                 "InputTreeWalkerSuppressionXpathFilter.xml"));
-    }
-
-    /**
-     * Could not find proper test case to test pitest mutations functionally.
-     * Should be rewritten during grammar update.
-     *
-     * @throws Exception when code tested throws exception
-     */
-    @Test
-    public void testIsPositionGreater() throws Exception {
-        final DetailAST ast1 = createAst(1, 3);
-        final DetailAST ast2 = createAst(1, 2);
-        final DetailAST ast3 = createAst(2, 2);
-
-        final TreeWalker treeWalker = new TreeWalker();
-        final Method isPositionGreater = Whitebox.getMethod(TreeWalker.class,
-                "isPositionGreater", DetailAST.class, DetailAST.class);
-
-        assertTrue("Should return true when lines are equal and column is greater",
-                (boolean) isPositionGreater.invoke(treeWalker, ast1, ast2));
-        assertFalse("Should return false when lines are equal columns are equal",
-                (boolean) isPositionGreater.invoke(treeWalker, ast1, ast1));
-        assertTrue("Should return true when line is greater",
-                (boolean) isPositionGreater.invoke(treeWalker, ast3, ast1));
-    }
-
-    private static DetailAST createAst(int line, int column) {
-        final DetailAST ast = new DetailAST();
-        ast.setLineNo(line);
-        ast.setColumnNo(column);
-        return ast;
     }
 
     private static class BadJavaDocCheck extends AbstractCheck {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/DetailASTTest.java
@@ -45,7 +45,7 @@ import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
@@ -293,10 +293,7 @@ public class DetailASTTest extends AbstractModuleTestSupport {
     }
 
     private static void checkFile(String filename) throws Exception {
-        final FileText text = new FileText(new File(filename),
-                           System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
-        final FileContents contents = new FileContents(text);
-        final DetailAST rootAST = TreeWalker.parse(contents);
+        final DetailAST rootAST = Parser.parseFile(new File(filename));
         if (rootAST != null) {
             checkTree(filename, rootAST);
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -143,7 +144,7 @@ public class ModifiedControlVariableCheckTest
     public void testClearState() throws Exception {
         final ModifiedControlVariableCheck check = new ModifiedControlVariableCheck();
         final Optional<DetailAST> methodDef = TestUtil.findTokenInAstByPredicate(
-            TestUtil.parseFile(new File(
+            Parser.parseFile(new File(
                 getPath("InputModifiedControlVariableEnhancedForLoopVariable.java"))),
             ast -> ast.getType() == TokenTypes.OBJBLOCK);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -110,7 +111,7 @@ public class ParameterAssignmentCheckTest extends AbstractModuleTestSupport {
     public void testClearState() throws Exception {
         final ParameterAssignmentCheck check = new ParameterAssignmentCheck();
         final Optional<DetailAST> methodDef = TestUtil.findTokenInAstByPredicate(
-            TestUtil.parseFile(new File(getPath("InputParameterAssignmentReceiver.java"))),
+            Parser.parseFile(new File(getPath("InputParameterAssignmentReceiver.java"))),
             ast -> ast.getType() == TokenTypes.METHOD_DEF);
 
         assertTrue("Ast should contain METHOD_DEF", methodDef.isPresent());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -169,7 +170,7 @@ public class ReturnCountCheckTest extends AbstractModuleTestSupport {
     public void testClearState() throws Exception {
         final ReturnCountCheck check = new ReturnCountCheck();
         final Optional<DetailAST> methodDef = TestUtil.findTokenInAstByPredicate(
-            TestUtil.parseFile(new File(getPath("InputReturnCountVoid.java"))),
+            Parser.parseFile(new File(getPath("InputReturnCountVoid.java"))),
             ast -> ast.getType() == TokenTypes.METHOD_DEF);
 
         assertTrue("Ast should contain METHOD_DEF", methodDef.isPresent());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -86,7 +87,7 @@ public class SuperCloneCheckTest
     public void testClearState() throws Exception {
         final AbstractSuperCheck check = new SuperCloneCheck();
         final Optional<DetailAST> methodDef = TestUtil.findTokenInAstByPredicate(
-            TestUtil.parseFile(new File(getPath("InputSuperCloneWithoutWarnings.java"))),
+            Parser.parseFile(new File(getPath("InputSuperCloneWithoutWarnings.java"))),
             ast -> ast.getType() == TokenTypes.METHOD_DEF);
 
         assertTrue("Ast should contain METHOD_DEF", methodDef.isPresent());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -34,9 +34,9 @@ import org.powermock.reflect.Whitebox;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 public class VisibilityModifierCheckTest
@@ -455,7 +455,7 @@ public class VisibilityModifierCheckTest
      */
     @Test
     public void testIsStarImportNullAst() throws Exception {
-        final DetailAST importAst = TestUtil.parseFile(new File(getPath(
+        final DetailAST importAst = Parser.parseFile(new File(getPath(
             "InputVisibilityModifierIsStarImport.java"))).getNextSibling();
         final VisibilityModifierCheck check = new VisibilityModifierCheck();
         final Method isStarImport = Whitebox.getMethod(VisibilityModifierCheck.class,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.Context;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
@@ -148,7 +149,7 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
     public void testStatefulFieldsClearedOnBeginTree3() throws Exception {
         final NPathComplexityCheck check = new NPathComplexityCheck();
         final Optional<DetailAST> question = TestUtil.findTokenInAstByPredicate(
-            TestUtil.parseFile(new File(getPath("InputNPathComplexity.java"))),
+            Parser.parseFile(new File(getPath("InputNPathComplexity.java"))),
             ast -> ast.getType() == TokenTypes.QUESTION);
 
         Assert.assertTrue("Ast should contain QUESTION", question.isPresent());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
@@ -32,11 +32,11 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 
@@ -149,7 +149,7 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
         final LocalizedMessage message = new LocalizedMessage(3, 0, TokenTypes.CLASS_DEF, "", "",
                 null, null, "777", getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(null, "file1.java",
-                message, TestUtil.parseFile(file));
+                message, Parser.parseFile(file));
 
         assertFalse("TreeWalker audit event should be rejected",
                 filter.accept(ev));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterTest.java
@@ -30,12 +30,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import net.sf.saxon.sxpath.XPathEvaluator;
 import net.sf.saxon.sxpath.XPathExpression;
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -177,7 +177,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
                 new LocalizedMessage(3, 0, TokenTypes.CLASS_DEF, "", "", null, null, "id20",
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents,
-                file.getName(), message, TestUtil.parseFile(file));
+                file.getName(), message, Parser.parseFile(file));
         assertTrue("Event should be accepted", filter.accept(ev));
     }
 
@@ -190,7 +190,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
                 new LocalizedMessage(3, 0, TokenTypes.CLASS_DEF, "", "", null, null, "id19",
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents,
-                file.getName(), message, TestUtil.parseFile(file));
+                file.getName(), message, Parser.parseFile(file));
         assertFalse("Event should be rejected", filter.accept(ev));
     }
 
@@ -203,7 +203,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
                 new LocalizedMessage(3, 0, TokenTypes.CLASS_DEF, "", "", null, null, "id19",
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents,
-                file.getName(), message, TestUtil.parseFile(file));
+                file.getName(), message, Parser.parseFile(file));
         assertTrue("Event should be accepted", filter.accept(ev));
     }
 
@@ -232,7 +232,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
         final LocalizedMessage message = new LocalizedMessage(0, 0, TokenTypes.CLASS_DEF, "", "",
                 null, null, null, getClass(), "Test");
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents, file.getName(),
-                message, TestUtil.parseFile(file));
+                message, Parser.parseFile(file));
         final XpathFilter filter1 = new XpathFilter(null, null, "Test", null, null);
         final XpathFilter filter2 = new XpathFilter(null, null, "Bad", null, null);
         assertFalse("Message match", filter1.accept(ev));
@@ -276,7 +276,7 @@ public class XpathFilterTest extends AbstractModuleTestSupport {
                 new LocalizedMessage(line, column, tokenType, "", "", null, null, null,
                         getClass(), null);
         return new TreeWalkerAuditEvent(fileContents, file.getName(), message,
-                TestUtil.parseFile(file));
+            Parser.parseFile(file));
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/AstRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/AstRegressionTest.java
@@ -40,6 +40,7 @@ import antlr.SemanticException;
 import antlr.TokenBuffer;
 import com.puppycrawl.tools.checkstyle.AbstractTreeTestSupport;
 import com.puppycrawl.tools.checkstyle.AstTreeStringPrinter;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 
 public class AstRegressionTest extends AbstractTreeTestSupport {
@@ -139,25 +140,23 @@ public class AstRegressionTest extends AbstractTreeTestSupport {
         verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "\r\r");
         verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "\r");
         verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "\u000c\f");
-        verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "// \n",
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
-        verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "// \r",
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+        verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "// \n", Parser.Options.WITH_COMMENTS);
+        verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "// \r", Parser.Options.WITH_COMMENTS);
         verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "// \r\n",
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
         verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "/* \n */",
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
         verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "/* \r\n */",
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
         verifyAstRaw(getPath("InputRegressionEmptyAst.txt"), "/* \r" + "\u0000\u0000" + " */",
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
     @Test
     public void testNewlineCr() throws Exception {
         verifyAst(getPath("InputNewlineCrAtEndOfFileAst.txt"),
                 getPath("InputAstRegressionNewlineCrAtEndOfFile.java"),
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
     @Test
@@ -211,12 +210,11 @@ public class AstRegressionTest extends AbstractTreeTestSupport {
 
     private static void verifyAstRaw(String expectedTextPrintFileName, String actualJava)
             throws Exception {
-        verifyAstRaw(expectedTextPrintFileName, actualJava,
-                AstTreeStringPrinter.PrintOptions.WITHOUT_COMMENTS);
+        verifyAstRaw(expectedTextPrintFileName, actualJava, Parser.Options.WITHOUT_COMMENTS);
     }
 
     private static void verifyAstRaw(String expectedTextPrintFileName, String actualJava,
-            AstTreeStringPrinter.PrintOptions withComments) throws Exception {
+            Parser.Options withComments) throws Exception {
         final File expectedFile = new File(expectedTextPrintFileName);
         final String expectedContents = new FileText(expectedFile, System.getProperty(
                 "file.encoding", StandardCharsets.UTF_8.name()))

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/comments/CommentsTest.java
@@ -23,7 +23,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractTreeTestSupport;
-import com.puppycrawl.tools.checkstyle.AstTreeStringPrinter;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.Comment;
 
 public class CommentsTest extends AbstractTreeTestSupport {
@@ -36,13 +36,13 @@ public class CommentsTest extends AbstractTreeTestSupport {
     @Test
     public void testCompareExpectedTreeWithInput1() throws Exception {
         verifyAst(getPath("InputComments1Ast.txt"), getPath("InputComments1.java"),
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
     @Test
     public void testCompareExpectedTreeWithInput2() throws Exception {
         verifyAst(getPath("InputComments2Ast.txt"), getPath("InputComments2.java"),
-                AstTreeStringPrinter.PrintOptions.WITH_COMMENTS);
+                Parser.Options.WITH_COMMENTS);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModelTest.java
@@ -197,7 +197,7 @@ public class MainFrameModelTest extends AbstractModuleTestSupport {
         }
         catch (CheckstyleException ex) {
             final String expectedMsg = String.format(Locale.ROOT,
-                    "NoViableAltException occurred while opening file %s.",
+                    "NoViableAltException occurred during the analysis of file %s.",
                     nonCompilableFile.getPath());
 
             assertEquals("Invalid exception message", expectedMsg, ex.getMessage());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.gui;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -28,11 +27,9 @@ import org.junit.Test;
 
 import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
-import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.gui.MainFrameModel.ParseMode;
@@ -47,18 +44,10 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
         return "com/puppycrawl/tools/checkstyle/gui/parsetreetablepresentation";
     }
 
-    private static DetailAST parseFile(File file) throws Exception {
-        final FileContents contents = new FileContents(
-                new FileText(file.getAbsoluteFile(),
-                        System.getProperty("file.encoding",
-                        StandardCharsets.UTF_8.name())));
-        return TreeWalker.parseWithComments(contents);
-    }
-
     @Before
     public void loadTree() throws Exception {
-        tree = parseFile(
-                new File(getPath("InputParseTreeTablePresentation.java")));
+        tree = Parser.parseFileWithComments(
+            new File(getPath("InputParseTreeTablePresentation.java")));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
@@ -19,28 +19,20 @@
 
 package com.puppycrawl.tools.checkstyle.internal.utils;
 
-import static com.puppycrawl.tools.checkstyle.TreeWalker.parseWithComments;
-
-import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
-import antlr.ANTLRException;
 import com.puppycrawl.tools.checkstyle.PackageNamesLoader;
 import com.puppycrawl.tools.checkstyle.PackageObjectFactory;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
-import com.puppycrawl.tools.checkstyle.api.FileText;
 
 public final class TestUtil {
 
@@ -179,20 +171,6 @@ public final class TestUtil {
             curNode = toVisit;
         }
         return Optional.ofNullable(curNode);
-    }
-
-    /**
-     * Parses Java source file. Results in AST which contains comment nodes.
-     * @param file file to parse
-     * @return DetailAST tree
-     * @throws NullPointerException if the text is null
-     * @throws IOException          if the file could not be read
-     * @throws ANTLRException       if parser or lexer failed
-     */
-    public static DetailAST parseFile(File file) throws IOException, ANTLRException {
-        final FileText text = new FileText(file.getAbsoluteFile(), StandardCharsets.UTF_8.name());
-        final FileContents contents = new FileContents(text);
-        return parseWithComments(contents);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -67,9 +68,8 @@ public class BlockCommentPositionTest extends AbstractPathTestSupport {
         );
 
         for (BlockCommentPositionTestMetadata metadata : metadataList) {
-            final DetailAST ast = TestUtil.parseFile(
-                    new File(getPath(metadata.getFileName()))
-            );
+            final DetailAST ast = Parser.parseFileWithComments(
+                new File(getPath(metadata.getFileName())));
             final int matches = getJavadocsCount(ast, metadata.getAssertion());
             assertEquals("Invalid javadoc count", metadata.getMatchesNum(), matches);
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilsTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.findTokenInAstByPredicate;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
-import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.parseFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -37,6 +36,7 @@ import java.util.Set;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifier;
@@ -370,7 +370,8 @@ public class CheckUtilsTest extends AbstractPathTestSupport {
     }
 
     private DetailAST getNodeFromFile(int type) throws Exception {
-        return getNode(parseFile(new File(getPath("InputCheckUtilsTest.java"))), type);
+        return getNode(Parser.parseFileWithComments(
+            new File(getPath("InputCheckUtilsTest.java"))), type);
     }
 
     private static DetailAST getNode(DetailAST root, int type) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/ElementNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/ElementNodeTest.java
@@ -30,9 +30,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import net.sf.saxon.om.Item;
 import net.sf.saxon.om.NodeInfo;
 
@@ -48,7 +48,7 @@ public class ElementNodeTest extends AbstractPathTestSupport {
     @Before
     public void init() throws Exception {
         final File file = new File(getPath("InputXpathMapperAst.java"));
-        final DetailAST rootAst = TestUtil.parseFile(file);
+        final DetailAST rootAst = Parser.parseFile(file);
         rootNode = new RootNode(rootAst);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
@@ -32,9 +32,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import net.sf.saxon.om.AxisInfo;
 import net.sf.saxon.om.Item;
 import net.sf.saxon.om.NamespaceBinding;
@@ -52,7 +52,7 @@ public class RootNodeTest extends AbstractPathTestSupport {
     @Before
     public void init() throws Exception {
         final File file = new File(getPath("InputXpathMapperAst.java"));
-        final DetailAST rootAst = TestUtil.parseFile(file);
+        final DetailAST rootAst = Parser.parseFile(file);
         rootNode = new RootNode(rootAst);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
@@ -32,9 +32,9 @@ import java.util.List;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import net.sf.saxon.om.AxisInfo;
 import net.sf.saxon.om.Item;
 import net.sf.saxon.trans.XPathException;
@@ -527,7 +527,7 @@ public class XpathMapperTest extends AbstractPathTestSupport {
 
     private RootNode getRootNode(String fileName) throws Exception {
         final File file = new File(getPath(fileName));
-        final DetailAST rootAst = TestUtil.parseFile(file);
+        final DetailAST rootAst = Parser.parseFile(file);
         return new RootNode(rootAst);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java
@@ -32,9 +32,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.Parser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileText;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
 
@@ -54,7 +54,7 @@ public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
         final File file = new File(getPath("InputXpathQueryGenerator.java"));
         fileText = new FileText(file,
                 StandardCharsets.UTF_8.name());
-        rootAst = TestUtil.parseFile(file);
+        rootAst = Parser.parseFileWithComments(file);
     }
 
     @Test
@@ -322,7 +322,7 @@ public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
         final File testFile = new File(getPath("InputXpathQueryGeneratorTabWidth.java"));
         final FileText testFileText = new FileText(testFile,
                 StandardCharsets.UTF_8.name());
-        final DetailAST detailAst = TestUtil.parseFile(testFile);
+        final DetailAST detailAst = Parser.parseFile(testFile);
         final int lineNumber = 4;
         final int columnNumber = 13;
         final int tabWidth = 4;
@@ -344,7 +344,7 @@ public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
         final File testFile = new File(getPath("InputXpathQueryGeneratorTabWidth.java"));
         final FileText testFileText = new FileText(testFile,
                 StandardCharsets.UTF_8.name());
-        final DetailAST detailAst = TestUtil.parseFile(testFile);
+        final DetailAST detailAst = Parser.parseFile(testFile);
         final int lineNumber = 8;
         final int columnNumber = 41;
         final int tabWidth = 8;
@@ -364,7 +364,7 @@ public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
         final File testFile = new File(getPath("InputXpathQueryGeneratorTabWidth.java"));
         final FileText testFileText = new FileText(testFile,
                 StandardCharsets.UTF_8.name());
-        final DetailAST detailAst = TestUtil.parseFile(testFile);
+        final DetailAST detailAst = Parser.parseFile(testFile);
         final int lineNumber = 12;
         final int columnNumber = 57;
         final int tabWidth = 8;
@@ -382,7 +382,7 @@ public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
         final File testFile = new File(getPath("InputXpathQueryGeneratorTabWidth.java"));
         final FileText testFileText = new FileText(testFile,
                 StandardCharsets.UTF_8.name());
-        final DetailAST detailAst = TestUtil.parseFile(testFile);
+        final DetailAST detailAst = Parser.parseFile(testFile);
         final int lineNumber = 16;
         final int columnNumber = 58;
         final int tabWidth = 8;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/parser/InputParserHiddenComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/parser/InputParserHiddenComments.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.treewalker;
+package com.puppycrawl.tools.checkstyle.parser;
 
 /**
  * Some Javadoc.
@@ -7,7 +7,7 @@ package com.puppycrawl.tools.checkstyle.treewalker;
  *
  * @since 8.0
  */
-public class InputTreeWalkerHiddenComments {
+public class InputParserHiddenComments {
 
 }
 // inline comment


### PR DESCRIPTION
minor: Move all parseXXX methods to the Parser class

There is a lot of duplicated code for parsing a java file into the AST in the project. #5102 need another one. 
To get rid of unnecessary copy'n'paste, duplicate code is need to be extracted into  an utility class.
Also, the TreeWalker class is too complicated and requires a split to allow future refactoring.

This PR solves both issues.