### PR TITLE
minor: move getParseErrorMessage method to ParseErrorMessage

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -135,7 +135,7 @@
     <properties>
       <!-- TreeWalker integrates Checkstyle and antlr and CheckstyleAntTask integrates Checkstyle
        with Ant. Checker collects external resource locations and setup configuration. -->
-      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='TreeWalker' or @Image='CheckstyleAntTask' or @Image='Checker' or @Image='Main']"/>
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='TreeWalker' or @Image='JavadocDetailNodeParser' or @Image='CheckstyleAntTask' or @Image='Checker' or @Image='Main']"/>
     </properties>
   </rule>
   <rule ref="rulesets/java/coupling.xml/CouplingBetweenObjects">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
@@ -23,13 +23,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseErrorMessage;
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseStatus;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
-import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtils;
 
@@ -66,7 +64,7 @@ public final class DetailNodeTreeStringPrinter {
         final JavadocDetailNodeParser parser = new JavadocDetailNodeParser();
         final ParseStatus status = parser.parseJavadocAsDetailNode(blockComment);
         if (status.getParseErrorMessage() != null) {
-            throw new IllegalArgumentException(getParseErrorMessage(status.getParseErrorMessage()));
+            throw new IllegalArgumentException(status.getParseErrorMessage().toString());
         }
         return status.getTree();
     }
@@ -79,23 +77,6 @@ public final class DetailNodeTreeStringPrinter {
     private static DetailNode parseJavadocAsDetailNode(String javadocComment) {
         final DetailAST blockComment = CommonUtils.createBlockCommentNode(javadocComment);
         return parseJavadocAsDetailNode(blockComment);
-    }
-
-    /**
-     * Builds error message base on ParseErrorMessage's message key, its arguments, etc.
-     * @param parseErrorMessage ParseErrorMessage
-     * @return error message
-     */
-    private static String getParseErrorMessage(ParseErrorMessage parseErrorMessage) {
-        final LocalizedMessage lmessage = new LocalizedMessage(
-                parseErrorMessage.getLineNumber(),
-                "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
-                parseErrorMessage.getMessageKey(),
-                parseErrorMessage.getMessageArguments(),
-                "",
-                DetailNodeTreeStringPrinter.class,
-                null);
-        return "[ERROR:" + parseErrorMessage.getLineNumber() + "] " + lmessage.getMessage();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
@@ -46,6 +46,7 @@ import com.google.common.base.CaseFormat;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
+import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl;
 import com.puppycrawl.tools.checkstyle.grammars.javadoc.JavadocLexer;
 import com.puppycrawl.tools.checkstyle.grammars.javadoc.JavadocParser;
@@ -741,6 +742,22 @@ public class JavadocDetailNodeParser {
             return messageArguments.clone();
         }
 
+        /**
+         * Builds a localized error message based on the message key, its arguments, etc.
+         * @return error message.
+         */
+        @Override
+        public String toString() {
+            final LocalizedMessage localizedMessage = new LocalizedMessage(
+                    lineNumber,
+                    "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
+                    messageKey,
+                    messageArguments,
+                    "",
+                    ParseErrorMessage.class,
+                    null);
+            return "[ERROR:" + lineNumber + "] " + localizedMessage.getMessage();
+        }
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -21,28 +21,18 @@ package com.puppycrawl.tools.checkstyle;
 
 import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_MISSED_HTML_CLOSE;
 import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_PARSE_RULE_ERROR;
-import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_WRONG_SINGLETON_TAG;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.lang.reflect.Method;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseErrorMessage;
-import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 
 public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
-
-    // [REFLECTION]
-    // DetailNodeTreeStringPrinter#getParseErrorMessage is used for creating error messages
-    // for validating those obtained in UTs against the ones created.
-    private static final Method GET_PARSE_ERROR_MESSAGE = Whitebox.getMethod(
-            DetailNodeTreeStringPrinter.class, "getParseErrorMessage", ParseErrorMessage.class);
 
     @Override
     protected String getPackageLocation() {
@@ -69,8 +59,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             Assert.fail("Javadoc parser didn't fail on missing end tag");
         }
         catch (IllegalArgumentException ex) {
-            final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
-                    new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 1, "qwe"));
+            final String expected =
+                    new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 1, "qwe").toString();
             assertEquals("Generated and expected parse error messages don't match",
                     expected, ex.getMessage());
         }
@@ -84,58 +74,6 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
     }
 
     @Test
-    public void testMissedHtmlTagParseErrorMessage() throws Exception {
-        final String actual = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
-                new ParseErrorMessage(35, MSG_JAVADOC_MISSED_HTML_CLOSE, 7, "xyz"));
-        final LocalizedMessage localizedMessage = new LocalizedMessage(
-                35,
-                "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
-                MSG_JAVADOC_MISSED_HTML_CLOSE,
-                new Object[] {7, "xyz"},
-                "",
-                DetailNodeTreeStringPrinter.class,
-                null);
-        final String expected = "[ERROR:35] " + localizedMessage.getMessage();
-        assertEquals("Javadoc parse error message for missed HTML tag doesn't meet expectations",
-                expected, actual);
-    }
-
-    @Test
-    public void testParseErrorMessage() throws Exception {
-        final String actual = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
-                new ParseErrorMessage(10, MSG_JAVADOC_PARSE_RULE_ERROR,
-                        9, "no viable alternative at input ' xyz'", "SOME_JAVADOC_ELEMENT"));
-        final LocalizedMessage localizedMessage = new LocalizedMessage(
-                10,
-                "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
-                MSG_JAVADOC_PARSE_RULE_ERROR,
-                new Object[] {9, "no viable alternative at input ' xyz'", "SOME_JAVADOC_ELEMENT"},
-                "",
-                DetailNodeTreeStringPrinter.class,
-                null);
-        final String expected = "[ERROR:10] " + localizedMessage.getMessage();
-        assertEquals("Javadoc parse error message doesn't meet expectations", expected, actual);
-    }
-
-    @Test
-    public void testWrongSingletonParseErrorMessage() throws Exception {
-        final String actual = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
-                new ParseErrorMessage(100, MSG_JAVADOC_WRONG_SINGLETON_TAG,
-                        9, "tag"));
-        final LocalizedMessage localizedMessage = new LocalizedMessage(
-                100,
-                "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
-                MSG_JAVADOC_WRONG_SINGLETON_TAG,
-                new Object[] {9, "tag"},
-                "",
-                DetailNodeTreeStringPrinter.class,
-                null);
-        final String expected = "[ERROR:100] " + localizedMessage.getMessage();
-        assertEquals("Javadoc parse error message for void elements with close tag "
-                + "doesn't meet expectations", expected, actual);
-    }
-
-    @Test
     public void testUnescapedJavaCodeWithGenericsInJavadoc() throws Exception {
         try {
             DetailNodeTreeStringPrinter.printFileAst(new File(
@@ -144,8 +82,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             Assert.fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
-            final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
-                    new ParseErrorMessage(35, MSG_JAVADOC_MISSED_HTML_CLOSE, 7, "parsing"));
+            final String expected = new ParseErrorMessage(35, MSG_JAVADOC_MISSED_HTML_CLOSE, 7,
+                    "parsing").toString();
             assertEquals("Generated and expected parse error messages don't match",
                     expected, ex.getMessage());
         }
@@ -159,9 +97,9 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             Assert.fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
-            final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
+            final String expected =
                     new ParseErrorMessage(0, MSG_JAVADOC_PARSE_RULE_ERROR,
-                            9, "no viable alternative at input '<<'", "HTML_ELEMENT"));
+                            9, "no viable alternative at input '<<'", "HTML_ELEMENT").toString();
             assertEquals("Generated and expected parse error messages don't match",
                     expected, ex.getMessage());
         }
@@ -176,9 +114,9 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             Assert.fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
-            final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
+            final String expected =
                     new ParseErrorMessage(0, MSG_JAVADOC_PARSE_RULE_ERROR,
-                            4, "no viable alternative at input '</tag'", "HTML_ELEMENT"));
+                            4, "no viable alternative at input '</tag'", "HTML_ELEMENT").toString();
             assertEquals("Generated and expected parse error messages don't match",
                     expected, ex.getMessage());
         }
@@ -193,8 +131,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             Assert.fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
-            final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
-                    new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 10, "tag2"));
+            final String expected =
+                    new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 10, "tag2").toString();
             assertEquals("Generated and expected parse error messages don't match",
                     expected, ex.getMessage());
         }
@@ -209,8 +147,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             Assert.fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
-            final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
-                    new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 3, "a"));
+            final String expected =
+                    new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 3, "a").toString();
             assertEquals("Generated and expected parse error messages don't match",
                     expected, ex.getMessage());
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
@@ -19,6 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_MISSED_HTML_CLOSE;
+import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_PARSE_RULE_ERROR;
+import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_WRONG_SINGLETON_TAG;
 import static java.util.Locale.ENGLISH;
 import static org.junit.Assert.assertEquals;
 
@@ -29,7 +32,9 @@ import java.nio.file.Paths;
 
 import org.junit.Test;
 
+import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseErrorMessage;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class JavadocDetailNodeParserTest extends AbstractModuleTestSupport {
@@ -66,6 +71,57 @@ public class JavadocDetailNodeParserTest extends AbstractModuleTestSupport {
         }
 
         assertEquals("Invalid parse result", expected, actual);
+    }
+
+    @Test
+    public void testMissedHtmlTagParseErrorMessage() {
+        final String actual =
+                new ParseErrorMessage(35, MSG_JAVADOC_MISSED_HTML_CLOSE, 7, "xyz").toString();
+        final LocalizedMessage localizedMessage = new LocalizedMessage(
+                35,
+                "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
+                MSG_JAVADOC_MISSED_HTML_CLOSE,
+                new Object[] {7, "xyz"},
+                "",
+                ParseErrorMessage.class,
+                null);
+        final String expected = "[ERROR:35] " + localizedMessage.getMessage();
+        assertEquals("Javadoc parse error message for missed HTML tag doesn't meet expectations",
+                expected, actual);
+    }
+
+    @Test
+    public void testParseErrorMessage() {
+        final String actual =
+                new ParseErrorMessage(10, MSG_JAVADOC_PARSE_RULE_ERROR, 9,
+                    "no viable alternative at input ' xyz'", "SOME_JAVADOC_ELEMENT").toString();
+        final LocalizedMessage localizedMessage = new LocalizedMessage(
+                10,
+                "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
+                MSG_JAVADOC_PARSE_RULE_ERROR,
+                new Object[] {9, "no viable alternative at input ' xyz'", "SOME_JAVADOC_ELEMENT"},
+                "",
+                ParseErrorMessage.class,
+                null);
+        final String expected = "[ERROR:10] " + localizedMessage.getMessage();
+        assertEquals("Javadoc parse error message doesn't meet expectations", expected, actual);
+    }
+
+    @Test
+    public void testWrongSingletonParseErrorMessage() {
+        final String actual =
+                new ParseErrorMessage(100, MSG_JAVADOC_WRONG_SINGLETON_TAG, 9, "tag").toString();
+        final LocalizedMessage localizedMessage = new LocalizedMessage(
+                100,
+                "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
+                MSG_JAVADOC_WRONG_SINGLETON_TAG,
+                new Object[] {9, "tag"},
+                "",
+                ParseErrorMessage.class,
+                null);
+        final String expected = "[ERROR:100] " + localizedMessage.getMessage();
+        assertEquals("Javadoc parse error message for void elements with close tag "
+                + "doesn't meet expectations", expected, actual);
     }
 
 }


### PR DESCRIPTION
minor: move getParseErrorMessage method to ParseErrorMessage

The DetailNodeTreeStringPrinter class has the method getParseErrorMessage to format a ParseErrorMessage into a readable string. This allows to make an exception from the ParseErrorMessage. But this code is not reusable outside of the DetailNodeTreeStringPrinter class.

This PR makes it easy to get an exception from ParseErrorMessage in any place:

```
        final ParseStatus status = parser.parseJavadocAsDetailNode(blockComment);
        if (status.getParseErrorMessage() != null) {
            throw new CheckstyleException(status.getParseErrorMessage().toString());
        }
```
