### PR TITLE
Issue #2974: Fix EmptyLineSeparator check when class members are separated by comments

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -20,6 +20,8 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
@@ -476,23 +478,25 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
      * @return true, if token has empty two lines before and allowMultipleEmptyLines is false
      */
     private boolean hasNotAllowedTwoEmptyLinesBefore(DetailAST token) {
-        return !allowMultipleEmptyLines && hasEmptyLineBefore(token)
-                && isPrePreviousLineEmpty(token);
-    }
-
-    /**
-     * Checks if a token has empty pre-previous line.
-     * @param token DetailAST token.
-     * @return true, if token has empty lines before.
-     */
-    private boolean isPrePreviousLineEmpty(DetailAST token) {
         boolean result = false;
-        final int lineNo = token.getLineNo();
-        // 3 is the number of the pre-previous line because the numbering starts from zero.
-        final int number = 3;
-        if (lineNo >= number) {
-            final String prePreviousLine = getLines()[lineNo - number];
-            result = CommonUtils.isBlank(prePreviousLine);
+        if (!allowMultipleEmptyLines && hasEmptyLineBefore(token)) {
+            final List<EnumSet<LineFlag>> lineFlags = categorizeLines();
+            for (int i = token.getLineNo() - 2; i > 0 && !result; i--) {
+                final EnumSet<LineFlag> flags = lineFlags.get(i);
+                if (flags.contains(LineFlag.EMPTY)) {
+                    // 1 line above line being checked is empty.
+                    final EnumSet<LineFlag> previousLineFlags = lineFlags.get(i - 1);
+                    if (previousLineFlags.contains(LineFlag.EMPTY)) {
+                        // 2 lines above the line being checked
+                        // and after the previous token are empty.
+                        result = true;
+                    }
+                }
+                else if (flags.contains(LineFlag.CODE)) {
+                    // We've hit some code, there aren't multiple adjacent empty lines.
+                    break;
+                }
+            }
         }
         return result;
     }
@@ -551,9 +555,17 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
         boolean result = false;
         final int lineNo = token.getLineNo();
         if (lineNo != 1) {
-            // [lineNo - 2] is the number of the previous line as the numbering starts from zero.
-            final String lineBefore = getLines()[lineNo - 2];
-            result = CommonUtils.isBlank(lineBefore);
+            final List<EnumSet<LineFlag>> flags = categorizeLines();
+            for (int i = lineNo - 2; i >= 0; i--) {
+                final EnumSet<LineFlag> lineFlags = flags.get(i);
+                if (!lineFlags.contains(LineFlag.COMMENT)) {
+                    if (lineFlags.contains(LineFlag.EMPTY)) {
+                        // Line is empty.
+                        result = true;
+                        break;
+                    }
+                }
+            }
         }
         return result;
     }
@@ -593,4 +605,252 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
         return parentType == TokenTypes.CLASS_DEF;
     }
 
+    /**
+     * Parses the files lines and assigns them flags depending on whether the line is code,
+     * comment, and/or empty.
+     *
+     * @return list of flags for each line.
+     */
+    private List<EnumSet<LineFlag>> categorizeLines() {
+        final EmptyLineSeparatorParser parser = new EmptyLineSeparatorParser();
+        parser.processLines(getLines());
+        return parser.getFlags();
+    }
+
+    /**
+     * Flags that apply to source code file lines.
+     */
+    private enum LineFlag {
+
+        /**
+         * Line contains code.
+         */
+        CODE,
+
+        /**
+         * Line contains a comment.
+         */
+        COMMENT,
+
+        /**
+         * Line leaves a comment open.
+         */
+        COMMENT_OPEN,
+
+        /**
+         * Line is empty. It doesn't contain any comments or code, but may contain whitespace.
+         */
+        EMPTY
+    }
+
+    /**
+     * Parses a Java source file to assign each line a set of flags based on whether they have code,
+     * comments, and if they leave a multi-line comment open.
+     */
+    private static class EmptyLineSeparatorParser {
+
+        /**
+         * List of flags for each line.
+         */
+        private final List<EnumSet<LineFlag>> flags = new ArrayList<>();
+
+        /**
+         * The flags for the previously parsed line.
+         */
+        private EnumSet<LineFlag> previousLineFlags;
+
+        /**
+         * The flags for the line currently being processed.
+         */
+        private EnumSet<LineFlag> currentLineFlags;
+
+        /**
+         * The current line being processed.
+         */
+        private String currentLine;
+
+        /**
+         * The index of the current character being checked.
+         */
+        private int currentCharIndex;
+
+        /**
+         * Processes each given line up to the specified line.
+         *
+         * @param lines      the lines to process.
+         */
+        public void processLines(final String... lines) {
+            for (final String line : lines) {
+                processLine(line);
+            }
+        }
+
+        /**
+         * Processes the given line.
+         *
+         * @param line the line to process.
+         */
+        public void processLine(final String line) {
+            currentLine = line;
+            currentCharIndex = 0;
+            startLine();
+            while (currentCharIndex < line.length()) {
+                processChar();
+                currentCharIndex++;
+            }
+            endLine();
+        }
+
+        /**
+         * Method called at the start of each line.
+         */
+        private void startLine() {
+            currentLineFlags = EnumSet.noneOf(LineFlag.class);
+            if (previousLineFlags != null && previousLineFlags.contains(LineFlag.COMMENT_OPEN)) {
+                currentLineFlags.add(LineFlag.COMMENT);
+                currentLineFlags.add(LineFlag.COMMENT_OPEN);
+            }
+            else {
+                currentLineFlags.add(LineFlag.EMPTY);
+            }
+        }
+
+        /**
+         * Processes the current character.
+         */
+        private void processChar() {
+            checkEmpty();
+        }
+
+        /**
+         * Checks whether the current character means that the line is not empty.
+         */
+        private void checkEmpty() {
+            if (!Character.isWhitespace(currentChar())) {
+                // Line contains non-whitespace character, it isn't empty.
+                currentLineFlags.remove(LineFlag.EMPTY);
+                checkQuoteEscape();
+            }
+        }
+
+        /**
+         * Checks whether the current character escapes the following character in a string literal.
+         */
+        private void checkQuoteEscape() {
+            if (currentChar() == '\\') {
+                // Skip current and next char, it won't terminate the string.
+                currentCharIndex++;
+            }
+            else {
+                checkEndComment();
+            }
+        }
+
+        /**
+         * Checks whether the current character terminates a multi-line comment.
+         */
+        private void checkEndComment() {
+            if (currentLineFlags.contains(LineFlag.COMMENT_OPEN) && currentChar() == '*'
+                    && lineHasNextChar() && nextChar() == '/') {
+                // End of multi-line comment.
+                currentLineFlags.remove(LineFlag.COMMENT_OPEN);
+                // Skip current and next char.
+                currentCharIndex++;
+            }
+            else {
+                checkStartComment();
+            }
+        }
+
+        /**
+         * Checks whether the current character marks the start of a multi-line comment.
+         */
+        private void checkStartComment() {
+            if (currentChar() == '/' && lineHasNextChar() && nextChar() == '*') {
+                // Start of multi-line comment.
+                currentLineFlags.add(LineFlag.COMMENT);
+                currentLineFlags.add(LineFlag.COMMENT_OPEN);
+                // Skip next character.
+                currentCharIndex++;
+            }
+            else {
+                checkStartSingleLineComment();
+            }
+        }
+
+        /**
+         * Checks whether the current character marks the start of a single-line comment.
+         */
+        private void checkStartSingleLineComment() {
+            if (currentChar() == '/' && lineHasNextChar()
+                && !currentLineFlags.contains(LineFlag.COMMENT_OPEN)) {
+                // nextChar() can only be another slash for a valid Java file
+                // since it's not a multi-line comment.
+                currentLineFlags.add(LineFlag.COMMENT);
+
+                // Skip the rest of the line.
+                currentCharIndex = currentLine.length();
+            }
+            else {
+                checkCode();
+            }
+        }
+
+        /**
+         * Checks whether the current character is normal source code.
+         */
+        private void checkCode() {
+            if (!currentLineFlags.contains(LineFlag.COMMENT_OPEN)) {
+                // Line contains non-whitespace character outside of comment, this is code.
+                currentLineFlags.add(LineFlag.CODE);
+            }
+        }
+
+        /**
+         * Method called after the current line has finished processing.
+         */
+        private void endLine() {
+            flags.add(currentLineFlags);
+            previousLineFlags = currentLineFlags;
+            currentLineFlags = null;
+        }
+
+        /**
+         * Returns the current character being processed.
+         *
+         * @return the current character.
+         */
+        private char currentChar() {
+            return currentLine.charAt(currentCharIndex);
+        }
+
+        /**
+         * Returns the character that immediately follows the character currently being processed.
+         *
+         * @return the next character.
+         */
+        private char nextChar() {
+            return currentLine.charAt(currentCharIndex + 1);
+        }
+
+        /**
+         * Determines whether the current line has a character immediately following the character
+         * currently being processed.
+         *
+         * @return whether there is a next character.
+         */
+        private boolean lineHasNextChar() {
+            return currentCharIndex < currentLine.length() - 1;
+        }
+
+        /**
+         * Returns the flags for the lines that have been processed.
+         *
+         * @return the line flags.
+         */
+        public List<EnumSet<LineFlag>> getFlags() {
+            return Collections.unmodifiableList(flags);
+        }
+
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -256,4 +256,20 @@ public class EmptyLineSeparatorCheckTest
                 expected);
     }
 
+    @Test
+    public void testNotAllowMultipleEmptyLinesPrecedingMemberComment() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addAttribute("allowMultipleEmptyLines", "false");
+        final String[] expected = {
+            "10: " + getCheckMessage(MSG_MULTIPLE_LINES, "METHOD_DEF"),
+            "15: " + getCheckMessage(MSG_MULTIPLE_LINES, "METHOD_DEF"),
+            "22: " + getCheckMessage(MSG_MULTIPLE_LINES, "METHOD_DEF"),
+            "45: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "48: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "56: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+        };
+        verify(checkConfig,
+                getPath("InputEmptyLineSeparatorCommentsBetweenMembers.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorCommentsBetweenMembers.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorCommentsBetweenMembers.java
@@ -1,0 +1,59 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+public class InputEmptyLineSeparatorCommentsBetweenMembers {
+
+    public static void method1() { }
+
+
+
+    // Method 2 must fail
+    public static void method2() { }
+
+
+
+    // Method 3 must fail
+    public static void method3() { }
+
+
+
+    /**
+     * Method 4 must fail
+     */
+    public static void method4() { }
+
+    /*
+     * Allow comments to have empty lines before and after.
+     */
+
+    public static void method5() { }
+
+    /**
+     * Should not fail because space before
+     */
+    public static void method6() { }
+    /**
+     * Should not fail because there is only one space between
+     * method6 and method7
+     */
+
+    public static void method7() { }
+
+    public static void method8() { } /**
+     * Should fail because there is no space
+     * between method8 and method9
+     */
+    public static void method9() { }
+
+    private static final String STRING = "Comment doesn't start inside string literal:  \"/*\"";
+    public static void method10() { } // Should fail because there is no space between STRING and method10.
+
+    /**
+     * Should be able to handle a trailing slash within a comment /
+     */
+    public static void method11() { }
+
+    private static final String STRING2 = "\"/*";
+    public static void method12() { } // Should fail because there is no space between STRING and method10.
+
+    /* // means nothing inside a multi-line comment */
+}


### PR DESCRIPTION
Hi, 

I've attempted to fix issue #2974. I think I've managed to capture all of the edge cases by parsing comments from the beginning of the file. The code is quite complex, but I think that it needs to be due to all of the possible edge cases.

My test case covers all by 2 conditional branches in the new code. This means that the coverage check is failing.

I'm not expecting this pull-request to be merged at this stage, but as someone who hasn't contributed to Checkstyle before, I think I need some help with how to cover these 2 conditions. They only occur with invalid Java source files that have a single trailing slash at the end of a line. I can't work out how to add an invalid Java source file without the compiler complaining in the IDE. I tried giving the source file the extension ".txt", but the `TreeWalker` filters out files not ending with ".java".

As far as I am aware, all of the other checks are passing.

Thanks