### PR TITLE
Use StringBuilder instead of StringBuffer as it offers high performan…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
@@ -223,7 +223,7 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
         // now needs 10'000 or 100'000, as just 1000 is no longer enough today to provoke the
         // StackOverflowError
         final int size = 100000;
-        final StringBuffer largeString = new StringBuffer(size);
+        final StringBuilder largeString = new StringBuilder(size);
         for (int i = 0; i < size / 2; i++) {
             largeString.append("xy");
         }


### PR DESCRIPTION
…ce in a single thread locations as is generally the case.

This edit was done in other pull request: https://github.com/checkstyle/checkstyle/pull/646
