### PR TITLE
minor: remove unsupported checks from SuppressionXpathFilter xdoc

### DIFF
--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -682,9 +682,6 @@ public class UserService {
           <li>DefaultComesLastCheck</li>
           <li>ExplicitInitializationCheck</li>
           <li>FallThroughCheck</li>
-          <li>HiddenFieldCheck</li>
-          <li>IllegalCatchCheck</li>
-          <li>IllegalThrowsCheck</li>
           <li>JavadocVariableCheck</li>
           <li>ImportControlCheck</li>
           <li>LeftCurlyCheck</li>


### PR DESCRIPTION
#5517 

Based on https://github.com/checkstyle/checkstyle/pull/5464#issuecomment-362374643 and https://github.com/checkstyle/checkstyle/pull/5464#issuecomment-363918259 I removed unsupported checks from SuppressionXpathFilter xdoc.

Till https://github.com/checkstyle/checkstyle/pull/5509