### PR TITLE
Issue #5558: Switch to powermock-api-mockito2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@
     <maven.pmd.plugin.version>3.9.0</maven.pmd.plugin.version>
     <pmd.version>6.1.0</pmd.version>
     <maven.jacoco.plugin.version>0.8.0</maven.jacoco.plugin.version>
+    <powermock.version>1.7.3</powermock.version>
     <saxon.version>9.8.0-8</saxon.version>
     <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
     <maven.sevntu.checkstyle.plugin.version>1.28.0</maven.sevntu.checkstyle.plugin.version>
@@ -295,14 +296,14 @@
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>1.7.3</version>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.7.3</version>
+      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -62,8 +62,8 @@ import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
@@ -299,8 +299,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         // comparing to 1 as there is only one legal file in input
         final int numLegalFiles = 1;
-        final PropertyCacheFile cache =
-                (PropertyCacheFile) Whitebox.getInternalState(checker, "cacheFile");
+        final PropertyCacheFile cache = Whitebox.getInternalState(checker, "cacheFile");
         assertEquals("There were more legal files than expected",
                 numLegalFiles, counter);
         assertEquals("Audit was started on larger amount of files than expected",
@@ -389,7 +388,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         checker.setModuleClassLoader(classLoader);
         checker.finishLocalSetup();
-        final Context actualCtx = (Context) Whitebox.getInternalState(checker, "childContext");
+        final Context actualCtx = Whitebox.getInternalState(checker, "childContext");
 
         assertNotNull("Default module factory should be created when it is not specified",
             actualCtx.get("moduleFactory"));
@@ -409,7 +408,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.setLocaleCountry("IT");
         checker.finishLocalSetup();
 
-        final Context context = (Context) Whitebox.getInternalState(checker, "childContext");
+        final Context context = Whitebox.getInternalState(checker, "childContext");
         assertEquals("Charset was different than expected",
                 System.getProperty("file.encoding", StandardCharsets.UTF_8.name()),
                 context.get("charset"));
@@ -445,7 +444,6 @@ public class CheckerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testSetupChildListener() throws Exception {
         final Checker checker = new Checker();
         final PackageObjectFactory factory = new PackageObjectFactory(
@@ -456,8 +454,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
             DebugAuditAdapter.class.getCanonicalName());
         checker.setupChild(config);
 
-        final List<AuditListener> listeners =
-            (List<AuditListener>) Whitebox.getInternalState(checker, "listeners");
+        final List<AuditListener> listeners = Whitebox.getInternalState(checker, "listeners");
         assertTrue("Invalid child listener class",
             listeners.get(listeners.size() - 1) instanceof DebugAuditAdapter);
     }
@@ -615,8 +612,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.process(Collections.singletonList(new File("dummy.java")));
         checker.clearCache();
         // invoke destroy to persist cache
-        final PropertyCacheFile cache =
-                (PropertyCacheFile) Whitebox.getInternalState(checker, "cacheFile");
+        final PropertyCacheFile cache = Whitebox.getInternalState(checker, "cacheFile");
         cache.persist();
 
         final Properties cacheAfterClear = new Properties();
@@ -630,8 +626,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
     public void setFileExtension() {
         final Checker checker = new Checker();
         checker.setFileExtensions(".test1", "test2");
-        final String[] actual =
-                (String[]) Whitebox.getInternalState(checker, "fileExtensions");
+        final String[] actual = Whitebox.getInternalState(checker, "fileExtensions");
         assertArrayEquals("Extensions are not expected",
                 new String[] {".test1", ".test2"}, actual);
     }
@@ -1015,8 +1010,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.configure(root);
         // BriefUtLogger does not print the module name or id postfix,
         // so we need to set logger manually
-        final ByteArrayOutputStream out =
-                (ByteArrayOutputStream) Whitebox.getInternalState(this, "stream");
+        final ByteArrayOutputStream out = Whitebox.getInternalState(this, "stream");
         final DefaultLogger logger =
                 new DefaultLogger(out, true, out, false, new AuditEventDefaultFormatter());
         checker.addListener(logger);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -620,12 +620,6 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             0, children[0].getChildren().length);
     }
 
-    /**
-     * This SuppressWarning("unchecked") required to suppress
-     * "Unchecked generics array creation for varargs parameter" during mock.
-     * @throws Exception could happen from PowerMokito calls and getAttribute
-     */
-    @SuppressWarnings("unchecked")
     @Test
     public void testConfigWithIgnoreExceptionalAttributes() throws Exception {
         // emulate exception from unrelated code, but that is same try-catch

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -416,7 +416,7 @@ public class MainTest {
                 "-p", getPath("InputMainMycheckstyle.properties"),
                 getPath("InputMain.java"));
 
-        verifyStatic(times(1));
+        verifyStatic(Closeables.class, times(1));
         Closeables.closeQuietly(any(InputStream.class));
     }
 
@@ -571,7 +571,7 @@ public class MainTest {
                     ex.getCause() instanceof IllegalStateException);
         }
         finally {
-            verifyStatic(times(1));
+            verifyStatic(CommonUtils.class, times(1));
             final ArgumentCaptor<OutputStream> out =
                     ArgumentCaptor.forClass(OutputStream.class);
             CommonUtils.close(out.capture());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -131,7 +131,7 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
                 new HashSet<>(Arrays.asList(expectedPackageNames));
         assertEquals("Invalid names set.", checkstylePackagesSet, actualPackageNames);
 
-        verifyStatic(times(1));
+        verifyStatic(Closeables.class, times(1));
         Closeables.closeQuietly(any(InputStream.class));
     }
 
@@ -206,7 +206,6 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testPackagesWithIoExceptionGetResources() throws Exception {
         final ClassLoader classLoader = mock(ClassLoader.class);
         when(classLoader.getResources("checkstyle_packages.xml")).thenThrow(IOException.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -57,7 +57,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -132,20 +132,20 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     public void testCloseAndFlushOutputStreamAfterCreatingHashCode() throws IOException {
         mockStatic(Closeables.class);
         doNothing().when(Closeables.class);
-        Closeables.close(any(ObjectOutputStream.class), Matchers.eq(false));
+        Closeables.close(any(ObjectOutputStream.class), ArgumentMatchers.eq(false));
         mockStatic(Flushables.class);
         doNothing().when(Flushables.class);
-        Flushables.flush(any(ObjectOutputStream.class), Matchers.eq(false));
+        Flushables.flush(any(ObjectOutputStream.class), ArgumentMatchers.eq(false));
 
         final Configuration config = new DefaultConfiguration("myName");
         final PropertyCacheFile cache = new PropertyCacheFile(config, "fileDoesNotExist.txt");
         cache.load();
 
-        verifyStatic(times(1));
+        verifyStatic(Closeables.class, times(1));
+        Closeables.close(any(ObjectOutputStream.class), ArgumentMatchers.eq(false));
 
-        Closeables.close(any(ObjectOutputStream.class), Matchers.eq(false));
-        verifyStatic(times(1));
-        Flushables.flush(any(ObjectOutputStream.class), Matchers.eq(false));
+        verifyStatic(Flushables.class, times(1));
+        Flushables.flush(any(ObjectOutputStream.class), ArgumentMatchers.eq(false));
     }
 
     @Test
@@ -170,7 +170,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
         assertNotNull("Config hash key should not be null",
                 cache.get(PropertyCacheFile.CONFIG_HASH_KEY));
 
-        verifyStatic(times(2));
+        verifyStatic(Closeables.class, times(2));
         Closeables.closeQuietly(any(FileInputStream.class));
     }
 
@@ -248,7 +248,6 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
      * "Unchecked generics array creation for varargs parameter" during mock.
      * @throws IOException when smth wrong with file creation or cache.load
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testNonExistentResource() throws IOException {
         final Configuration config = new DefaultConfiguration("myName");
@@ -284,10 +283,10 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     public void testFlushAndCloseCacheFileOutputStream() throws IOException {
         mockStatic(Closeables.class);
         doNothing().when(Closeables.class);
-        Closeables.close(any(FileOutputStream.class), Matchers.eq(false));
+        Closeables.close(any(FileOutputStream.class), ArgumentMatchers.eq(false));
         mockStatic(Flushables.class);
         doNothing().when(Flushables.class);
-        Flushables.flush(any(FileOutputStream.class), Matchers.eq(false));
+        Flushables.flush(any(FileOutputStream.class), ArgumentMatchers.eq(false));
 
         final Configuration config = new DefaultConfiguration("myName");
         final PropertyCacheFile cache = new PropertyCacheFile(config,
@@ -296,10 +295,10 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
         cache.put("CheckedFileName.java", System.currentTimeMillis());
         cache.persist();
 
-        verifyStatic(times(1));
-        Closeables.close(any(FileOutputStream.class), Matchers.eq(false));
-        verifyStatic(times(1));
-        Flushables.flush(any(FileOutputStream.class), Matchers.eq(false));
+        verifyStatic(Closeables.class, times(1));
+        Closeables.close(any(FileOutputStream.class), ArgumentMatchers.eq(false));
+        verifyStatic(Flushables.class, times(1));
+        Flushables.flush(any(FileOutputStream.class), ArgumentMatchers.eq(false));
     }
 
     @Test
@@ -328,7 +327,6 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testExceptionNoSuchAlgorithmException() throws Exception {
         final Configuration config = new DefaultConfiguration("myName");
         final String filePath = temporaryFolder.newFile().getPath();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
@@ -53,10 +53,10 @@ import org.apache.tools.ant.types.Reference;
 import org.apache.tools.ant.types.resources.FileResource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
@@ -486,7 +486,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
 
         assertEquals("Property is not set",
                 "ignore", TestRootModuleChecker.getProperty());
-        verifyStatic(times(1));
+        verifyStatic(Closeables.class, times(1));
         Closeables.closeQuietly(any(InputStream.class));
     }
 
@@ -652,7 +652,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
 
         assertNotNull("Classpath should not be null",
                 Whitebox.getInternalState(antTask, "classpath"));
-        final Path classpath = (Path) Whitebox.getInternalState(antTask, "classpath");
+        final Path classpath = Whitebox.getInternalState(antTask, "classpath");
         assertTrue("Classpath contain provided path", classpath.toString().contains(path1));
         assertTrue("Classpath contain provided path", classpath.toString().contains(path2));
     }
@@ -677,7 +677,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         try {
             assertNotNull("Classpath should not be null",
                     Whitebox.getInternalState(antTask, "classpath"));
-            final Path classpath = (Path) Whitebox.getInternalState(antTask, "classpath");
+            final Path classpath = Whitebox.getInternalState(antTask, "classpath");
             classpath.list();
             fail("Exception is expected");
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.api;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -76,7 +76,7 @@ public class FileTextTest extends AbstractPathTestSupport {
                 charsetName);
         assertEquals("Invalid charset name", charsetName, fileText.getCharset().name());
 
-        verifyStatic(times(2));
+        verifyStatic(CommonUtils.class, times(2));
         CommonUtils.close(any(Reader.class));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
@@ -24,8 +24,8 @@ import static com.puppycrawl.tools.checkstyle.utils.CommonUtils.EMPTY_OBJECT_ARR
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -98,7 +98,7 @@ public class LocalizedMessageTest {
         final InputStream inputStreamMock = mock(InputStream.class);
         when(classloader.getResource(resource)).thenReturn(url);
         when(mockUrlCon.getInputStream()).thenReturn(inputStreamMock);
-        when(inputStreamMock.read(anyObject(), anyInt(), anyInt())).thenReturn(-1);
+        when(inputStreamMock.read(any(), anyInt(), anyInt())).thenReturn(-1);
 
         final LocalizedMessage.Utf8Control control = new LocalizedMessage.Utf8Control();
         control.newBundle("com.puppycrawl.tools.checkstyle.checks.coding.messages",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -25,8 +25,8 @@ import static java.util.Locale.ENGLISH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -100,7 +100,7 @@ public class NewlineAtEndOfFileCheckTest
                 getPath("InputNewlineAtEndOfFileLf.java"),
                 expected);
 
-        verifyStatic(times(1));
+        verifyStatic(Closeables.class, times(1));
         Closeables.close(any(RandomAccessFile.class), anyBoolean());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
@@ -36,7 +36,6 @@ import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
@@ -409,8 +408,8 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
             propertyFiles,
             getPath(""),
             expected);
-        verifyStatic(times(2));
-        Closeables.closeQuietly(any(FileInputStream.class));
+        verifyStatic(Closeables.class, times(2));
+        Closeables.closeQuietly(any(InputStream.class));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -22,7 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 import static com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck.MSG_IO_EXCEPTION_KEY;
 import static com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck.MSG_KEY;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -106,7 +106,7 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
         final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputUniquePropertiesWithoutErrors.properties"), expected);
 
-        verifyStatic(times(1));
+        verifyStatic(Closeables.class, times(1));
         Closeables.closeQuietly(any(FileInputStream.class));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -24,7 +24,7 @@ import static com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck.MSG_MISS
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 
 import java.io.File;
 import java.io.IOException;
@@ -199,7 +199,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
     public void testIoExceptionWhenLoadingHeader() throws Exception {
         final HeaderCheck check = PowerMockito.spy(new HeaderCheck());
         PowerMockito.doThrow(new IOException("expected exception")).when(check, "loadHeader",
-                anyObject());
+                any());
 
         try {
             check.setHeader("header");
@@ -215,7 +215,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
     public void testIoExceptionWhenLoadingHeaderFile() throws Exception {
         final HeaderCheck check = PowerMockito.spy(new HeaderCheck());
         PowerMockito.doThrow(new IOException("expected exception")).when(check, "loadHeader",
-                anyObject());
+                any());
 
         check.setHeaderFile(CommonUtils.getUriByFilename(getPath("InputHeaderRegexp.java")));
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
@@ -24,13 +24,12 @@ import static com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck.MS
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
-import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.List;
 import java.util.Locale;
@@ -38,9 +37,9 @@ import java.util.regex.Pattern;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -65,15 +64,13 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
      * Test of setHeader method, of class RegexpHeaderCheck.
      */
     @Test
-    @SuppressWarnings("unchecked")
     public void testSetHeaderNull() {
         // check null passes
         final RegexpHeaderCheck instance = new RegexpHeaderCheck();
         // recreate for each test because multiple invocations fail
         final String header = null;
         instance.setHeader(header);
-        final List<Pattern> headerRegexps =
-            (List<Pattern>) Whitebox.getInternalState(instance, "headerRegexps");
+        final List<Pattern> headerRegexps = Whitebox.getInternalState(instance, "headerRegexps");
 
         assertTrue("When header is null regexps should not be set", headerRegexps.isEmpty());
     }
@@ -82,15 +79,13 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
      * Test of setHeader method, of class RegexpHeaderCheck.
      */
     @Test
-    @SuppressWarnings("unchecked")
     public void testSetHeaderEmpty() {
         // check null passes
         final RegexpHeaderCheck instance = new RegexpHeaderCheck();
         // check empty string passes
         final String header = "";
         instance.setHeader(header);
-        final List<Pattern> headerRegexps =
-            (List<Pattern>) Whitebox.getInternalState(instance, "headerRegexps");
+        final List<Pattern> headerRegexps = Whitebox.getInternalState(instance, "headerRegexps");
 
         assertTrue("When header is empty regexps should not be set", headerRegexps.isEmpty());
     }
@@ -110,7 +105,7 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
         final String header = "abc.*";
         instance.setHeader(header);
 
-        verifyStatic(times(2));
+        verifyStatic(Closeables.class, times(2));
         Closeables.closeQuietly(any(Reader.class));
     }
 
@@ -383,15 +378,15 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
     public void testReaderClosedAfterHeaderRead() throws Exception {
         mockStatic(Closeables.class);
         doNothing().when(Closeables.class);
-        Closeables.closeQuietly(any(InputStreamReader.class));
+        Closeables.closeQuietly(any(Reader.class));
 
         final DefaultConfiguration checkConfig = createModuleConfig(RegexpHeaderCheck.class);
         checkConfig.addAttribute("headerFile", getPath("InputRegexpHeader.header"));
         createChecker(checkConfig);
 
         //check if reader finally closed
-        verifyStatic(times(2));
-        Closeables.closeQuietly(any(InputStreamReader.class));
+        verifyStatic(Closeables.class, times(2));
+        Closeables.closeQuietly(any(Reader.class));
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -28,10 +28,10 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/ClassResolverTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/ClassResolverTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -139,8 +139,8 @@ public class ClassResolverTest {
                 .currentThread().getContextClassLoader(), "", imports));
 
         PowerMockito.doThrow(new ClassNotFoundException("expected exception"))
-                .when(classResolver, "safeLoad", anyObject());
-        PowerMockito.doReturn(true).when(classResolver, "isLoadable", anyObject());
+                .when(classResolver, "safeLoad", any());
+        PowerMockito.doReturn(true).when(classResolver, "isLoadable", any());
 
         try {
             classResolver.resolve("someClass", "");
@@ -172,7 +172,7 @@ public class ClassResolverTest {
                 .currentThread().getContextClassLoader(), "", imports));
 
         PowerMockito.doThrow(new NoClassDefFoundError("expected exception"))
-                .when(classResolver, "safeLoad", anyObject());
+                .when(classResolver, "safeLoad", any());
 
         final boolean result = classResolver.isLoadable("someClass");
         assertFalse("result should be false", result);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilsTest.java
@@ -430,7 +430,6 @@ public class CommonUtilsTest {
 
     @Test
     @PrepareForTest({ CommonUtils.class, CommonUtilsTest.class })
-    @SuppressWarnings("unchecked")
     public void testLoadSuppressionsUriSyntaxException() throws Exception {
         final URL configUrl = mock(URL.class);
 


### PR DESCRIPTION
Issue #5558

Note that we are still using the PowerMock 1.x release. To compile the Checkstyle with JDK9 use
```
export MAVEN_OPTS='--add-opens java.xml/jdk.xml.internal=ALL-UNNAMED'
mvn clean verify -Dpowermock.version=2.0.0-beta.5
```