### PR TITLE
config: bump spontbugs to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
     <antlr4.version>4.7.1</antlr4.version>
     <maven.site.plugin.version>3.7</maven.site.plugin.version>
     <maven.findbugs.plugin.version>3.0.5</maven.findbugs.plugin.version>
-    <maven.spotbugs.plugin.version>3.1.0-RC8</maven.spotbugs.plugin.version>
+    <maven.spotbugs.plugin.version>3.1.1</maven.spotbugs.plugin.version>
     <maven.pmd.plugin.version>3.9.0</maven.pmd.plugin.version>
     <pmd.version>6.1.0</pmd.version>
     <maven.jacoco.plugin.version>0.8.0</maven.jacoco.plugin.version>


### PR DESCRIPTION
NOT FOR MERGE.

IT WILL FAIL, it is required to investigate https://github.com/spotbugs/spotbugs-maven-plugin/issues/30

could be closed in 2 weeks, after 15 of March.