### PR TITLE
Issue #5582: Remove usage of javax.xml.bind.XmlElement

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationFromGuava.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationFromGuava.java
@@ -5,7 +5,6 @@ import java.util.List; //indent:0 exp:0
 import java.util.Set; //indent:0 exp:0
 import java.util.concurrent.ConcurrentMap; //indent:0 exp:0
 
-import javax.xml.bind.annotation.XmlElement; //indent:0 exp:0
 
 
 /**                                                                           //indent:0 exp:0
@@ -283,4 +282,8 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
   private static class StrongEntry<T1, T2> { //indent:2 exp:2
 
   } //indent:2 exp:2
+
+  public @interface XmlElement { //indent:2 exp:2
+  } //indent:2 exp:2
+
 } //indent:0 exp:0


### PR DESCRIPTION
Issue #5582

Drop `javax.xml.bind.annotation.XmlElement` import and replace with an inner annotation.
