### PR TITLE
Issue #5584: Switch to Powermock 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
     <maven.pmd.plugin.version>3.9.0</maven.pmd.plugin.version>
     <pmd.version>6.1.0</pmd.version>
     <maven.jacoco.plugin.version>0.8.0</maven.jacoco.plugin.version>
-    <powermock.version>1.7.3</powermock.version>
+    <powermock.version>2.0.0-beta.5</powermock.version>
     <saxon.version>9.8.0-8</saxon.version>
     <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
     <maven.sevntu.checkstyle.plugin.version>1.28.0</maven.sevntu.checkstyle.plugin.version>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
@@ -49,11 +49,11 @@ public class AllTestsTest {
 
         Assert.assertTrue("found tests", !allTests.keySet().isEmpty());
 
-        Files.walk(Paths.get("src/test/resources"))
+        Files.walk(Paths.get("src/test/resources/com/puppycrawl"))
             .forEach(filePath -> {
                 verifyInputFile(allTests, filePath.toFile());
             });
-        Files.walk(Paths.get("src/test/resources-noncompilable"))
+        Files.walk(Paths.get("src/test/resources-noncompilable/com/puppycrawl"))
             .forEach(filePath -> {
                 verifyInputFile(allTests, filePath.toFile());
             });

--- a/src/test/resources/org/powermock/extensions/configuration.properties
+++ b/src/test/resources/org/powermock/extensions/configuration.properties
@@ -1,0 +1,1 @@
+powermock.global-ignore=com.sun.org.apache.xerces.*,javax.xml.parsers.*,org.w3c.dom.*,org.xml.sax.*


### PR DESCRIPTION
Issue #5584

We need the file `org/powermock/extensions/configuration.properties` in the resources.
So, the test `AllTestsTest` should be fixed.

Note that this is a temporary solution. Once the Powermock issue will be fixed, the file `org/powermock/extensions/configuration.properties` will not be required.