### PR TITLE
Issue #5592: Split pitest-checkstyle-common

### DIFF
--- a/.ci/shippable.sh
+++ b/.ci/shippable.sh
@@ -29,11 +29,12 @@ function checkPitestReport() {
 
 case $1 in
 
-pitest-checkstyle-xpath|pitest-checkstyle-filters|pitest-checks-imports|pitest-checkstyle-api \
-|pitest-checks-metrics|pitest-checks-regexp|pitest-checks-sizes|pitest-checks-misc \
-|pitest-checks-design|pitest-checks-annotation|pitest-checks-header \
-|pitest-checks-modifier|pitest-checks-naming|pitest-checkstyle-tree-walker|pitest-checkstyle-main \
-|pitest-checks-whitespace|pitest-checkstyle-utils|pitest-checkstyle-common)
+pitest-checks-annotation|pitest-checks-design|pitest-checks-header|pitest-checks-imports \
+|pitest-checks-metrics|pitest-checks-misc|pitest-checks-modifier|pitest-checks-naming \
+|pitest-checks-regexp|pitest-checks-sizes|pitest-checks-whitespace|pitest-checkstyle-ant \
+|pitest-checkstyle-api|pitest-checkstyle-common|pitest-checkstyle-filters|pitest-checkstyle-main \
+|pitest-checkstyle-packagenamesloader|pitest-checkstyle-tree-walker|pitest-checkstyle-utils \
+|pitest-checkstyle-xpath)
   mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
   declare -a ignoredItems=();
   checkPitestReport "${ignoredItems[@]}"

--- a/pom.xml
+++ b/pom.xml
@@ -2357,6 +2357,56 @@
     </profile>
    <!-- Non-checks code profiles -->
     <profile>
+      <id>pitest-checkstyle-ant</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-maven</artifactId>
+            <version>${pitest.plugin.version}</version>
+            <configuration>
+              <targetClasses>
+                <param>com.puppycrawl.tools.checkstyle.ant.*</param>
+              </targetClasses>
+              <targetTests>
+                <param>com.puppycrawl.tools.checkstyle.ant.*</param>
+              </targetTests>
+              <coverageThreshold>100</coverageThreshold>
+              <mutationThreshold>100</mutationThreshold>
+              <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
+              <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
+              <threads>${pitest.plugin.threads}</threads>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>pitest-checkstyle-packagenamesloader</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-maven</artifactId>
+            <version>${pitest.plugin.version}</version>
+            <configuration>
+              <targetClasses>
+                <param>com.puppycrawl.tools.checkstyle.PackageNamesLoader</param>
+              </targetClasses>
+              <targetTests>
+                <param>com.puppycrawl.tools.checkstyle.PackageNamesLoaderTest</param>
+              </targetTests>
+              <coverageThreshold>100</coverageThreshold>
+              <mutationThreshold>100</mutationThreshold>
+              <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
+              <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
+              <threads>${pitest.plugin.threads}</threads>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>pitest-checkstyle-common</id>
       <build>
         <plugins>
@@ -2368,7 +2418,6 @@
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatter</param>
                 <param>com.puppycrawl.tools.checkstyle.ConfigurationLoader*</param>
-                <param>com.puppycrawl.tools.checkstyle.PackageNamesLoader</param>
                 <param>com.puppycrawl.tools.checkstyle.DefaultConfiguration</param>
                 <param>com.puppycrawl.tools.checkstyle.DefaultContext</param>
                 <param>com.puppycrawl.tools.checkstyle.DefaultLogger</param>
@@ -2378,13 +2427,11 @@
                 <param>com.puppycrawl.tools.checkstyle.PropertiesExpander</param>
                 <param>com.puppycrawl.tools.checkstyle.PropertyCacheFile</param>
                 <param>com.puppycrawl.tools.checkstyle.Checker</param>
-                <param>com.puppycrawl.tools.checkstyle.ant.*</param>
                 <param>com.puppycrawl.tools.checkstyle.ThreadModeSettings</param>
               </targetClasses>
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatterTest</param>
                 <param>com.puppycrawl.tools.checkstyle.ConfigurationLoaderTest</param>
-                <param>com.puppycrawl.tools.checkstyle.PackageNamesLoaderTest</param>
                 <param>com.puppycrawl.tools.checkstyle.DefaultConfigurationTest</param>
                 <param>com.puppycrawl.tools.checkstyle.DefaultLoggerTest</param>
                 <param>com.puppycrawl.tools.checkstyle.DefinitionsTest</param>
@@ -2393,7 +2440,6 @@
                 <param>com.puppycrawl.tools.checkstyle.PropertiesExpanderTest</param>
                 <param>com.puppycrawl.tools.checkstyle.PropertyCacheFileTest</param>
                 <param>com.puppycrawl.tools.checkstyle.CheckerTest</param>
-                <param>com.puppycrawl.tools.checkstyle.ant.*</param>
                 <param>com.puppycrawl.tools.checkstyle.ThreadModeSettingsTest</param>
               </targetTests>
               <coverageThreshold>100</coverageThreshold>

--- a/shippable.yml
+++ b/shippable.yml
@@ -24,6 +24,8 @@ env:
     - PROFILE="pitest-checks-naming"
     - PROFILE="pitest-checks-indentation"
     - PROFILE="pitest-checkstyle-tree-walker"
+    - PROFILE="pitest-checkstyle-ant"
+    - PROFILE="pitest-checkstyle-packagenamesloader"
     - PROFILE="pitest-checkstyle-common"
     - PROFILE="pitest-checkstyle-main"
     - PROFILE="pitest-checkstyle-api"


### PR DESCRIPTION
Issue #5592

The largest part of `pitest-checkstyle-common` is the ANT test. Extracting this test to a dedicated profile will give more resources to the rest of `pitest-checkstyle-common`