### PR TITLE
Issue #5597: 100% coverage for XMLLogger

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractXmlTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractXmlTestSupport.java
@@ -60,6 +60,10 @@ public abstract class AbstractXmlTestSupport extends AbstractModuleTestSupport {
                 expectedContents);
         final Document actualDocument = getOutputStreamXml(actualOutputStream);
 
+        Assert.assertEquals("xml encoding should be the same", expectedDocument.getXmlEncoding(),
+                actualDocument.getXmlEncoding());
+        Assert.assertEquals("xml version should be the same", expectedDocument.getXmlVersion(),
+                actualDocument.getXmlVersion());
         verifyXmlNode(expectedDocument, actualDocument, "/", ordered);
     }
 


### PR DESCRIPTION
Issue #5597

This is related to #5592. I'm going to extract some classes to a dedicated profile, but the Pitest complains on missing coverage for some classes.
