### PR TITLE
Issue #5599: 100% coverage for Checker

### DIFF
--- a/.ci/shippable.sh
+++ b/.ci/shippable.sh
@@ -85,10 +85,6 @@ pitest-checkstyle-common)
   mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
   # Format of ignored items: <report_name>:<survived line>
   declare -a ignoredItems=(
-  "Checker.java.html:<td class='uncovered'><pre><span  class=''>                    + &#34; - &#34; + ex.getMessage(), ex);</span></pre></td></tr>"
-  "Checker.java.html:<td class='uncovered'><pre><span  class=''>        catch (final CheckstyleException ex) {</span></pre></td></tr>"
-  "Checker.java.html:<td class='uncovered'><pre><span  class=''>                throw ex;</span></pre></td></tr>"
-  "Checker.java.html:<td class='uncovered'><pre><span  class=''>            throw new CheckstyleException(&#34;cannot initialize module &#34; + name</span></pre></td></tr>"
   "DefaultConfiguration.java.html:<td class='uncovered'><pre><span  class=''>            attributeMap.put(attributeName, current + &#34;,&#34; + value);</span></pre></td></tr>"
   );
   checkPitestReport "${ignoredItems[@]}"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -444,6 +444,22 @@ public class CheckerTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testSetupChildInvalidProperty() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(HiddenFieldCheck.class);
+        checkConfig.addAttribute("$$No such property", null);
+        try {
+            createChecker(checkConfig);
+            fail("Exception is expected");
+        }
+        catch (CheckstyleException ex) {
+            assertEquals("Error message is not expected",
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker"
+                        + " - Property '$$No such property' in module " + checkConfig.getName()
+                        + " does not exist, please check the documentation", ex.getMessage());
+        }
+    }
+
+    @Test
     public void testSetupChildListener() throws Exception {
         final Checker checker = new Checker();
         final PackageObjectFactory factory = new PackageObjectFactory(
@@ -838,6 +854,21 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
             assertNotNull("suppressed violation file saved in cache",
                     details.getProperty(fileViolationPath));
+        }
+    }
+
+    @Test
+    public void testHaltOnException() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(CheckWhichThrowsError.class);
+        final String filePath = getPath("InputChecker.java");
+        try {
+            verify(checkConfig, filePath);
+            fail("Exception is expected");
+        }
+        catch (CheckstyleException ex) {
+            assertEquals("Error message is not expected",
+                    "Exception was thrown while processing " + filePath, ex.getMessage());
         }
     }
 


### PR DESCRIPTION
Issue #5599

This is related to #5592. I'm going to extract some classes to a dedicated profile, but the Pitest complains on missing coverage for some classes.