### PR TITLE
Issue #5613: Replace InputEvent#getModifiers with getModifiersEx

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java
@@ -284,7 +284,7 @@ public final class TreeTable extends JTable {
                     if (getColumnClass(counter) == ParseTreeTableModel.class) {
                         final MouseEvent mouseEvent = (MouseEvent) event;
                         final MouseEvent newMouseEvent = new MouseEvent(tree, mouseEvent.getID(),
-                                mouseEvent.getWhen(), mouseEvent.getModifiers(),
+                                mouseEvent.getWhen(), mouseEvent.getModifiersEx(),
                                 mouseEvent.getX() - getCellRect(0, counter, true).x,
                                 mouseEvent.getY(), mouseEvent.getClickCount(),
                                 mouseEvent.isPopupTrigger());


### PR DESCRIPTION
Issue #5613

Solves the Spotbugs error
```
[ERROR] Forbidden method invocation: java.awt.event.InputEvent#getModifiers() [Deprecated in Java 9]
[ERROR]   in com.puppycrawl.tools.checkstyle.gui.TreeTable$TreeTableCellEditor (TreeTable.java:287)
```