### PR TITLE
config: Remove duplicate entry for PMD plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,6 @@
     <antlr4.version>4.7.1</antlr4.version>
     <maven.site.plugin.version>3.7</maven.site.plugin.version>
     <maven.spotbugs.plugin.version>3.1.3</maven.spotbugs.plugin.version>
-    <maven.pmd.plugin.version>3.9.0</maven.pmd.plugin.version>
     <maven.pmd.plugin.version>3.8</maven.pmd.plugin.version>
     <pmd.version>5.8.1</pmd.version>
     <maven.jacoco.plugin.version>0.8.0</maven.jacoco.plugin.version>


### PR DESCRIPTION
Related to #5603

After reverting cba0f56054b402311cba2b2acb1e26e0c1506b13 there are two entries for maven.pmd.plugin.version in the pom.xml