### PR TITLE
Issue #5633: Fix PMD6 violations (bestpractices)

### DIFF
--- a/.ci/shippable.sh
+++ b/.ci/shippable.sh
@@ -143,7 +143,6 @@ pitest-javadoc)
   "AbstractTypeAwareCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (dotIdx == -1) {</span></pre></td></tr>"
   "AbstractTypeAwareCheck.java.html:<td class='covered'><pre><span  class='survived'>        imports.clear();</span></pre></td></tr>"
   "AbstractTypeAwareCheck.java.html:<td class='covered'><pre><span  class='survived'>        typeParams.clear();</span></pre></td></tr>"
-  "ClassResolver.java.html:<td class='covered'><pre><span  class='survived'>                if (clazz != null) {</span></pre></td></tr>"
   "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>        final int col = noargMultilineStart.start(1) - 1;</span></pre></td></tr>"
   "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>        return (ast.getType() == TokenTypes.METHOD_DEF || ast.getType() == TokenTypes.CTOR_DEF)</span></pre></td></tr>"
   "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>        return true;</span></pre></td></tr>"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
@@ -484,13 +484,14 @@ public class JavadocDetailNodeParser {
         final List<Token> tokenList = ((BufferedTokenStream) exception.getInputStream())
                 .getTokens(sourceInterval.a, sourceInterval.b);
         final Deque<Token> stack = new ArrayDeque<>();
-        for (int i = 0; i < tokenList.size(); i++) {
-            final Token token = tokenList.get(i);
-            if (token.getType() == JavadocTokenTypes.HTML_TAG_NAME
-                    && tokenList.get(i - 1).getType() == JavadocTokenTypes.START) {
+        int prevTokenType = JavadocTokenTypes.EOF;
+        for (final Token token : tokenList) {
+            final int tokenType = token.getType();
+            if (tokenType == JavadocTokenTypes.HTML_TAG_NAME
+                    && prevTokenType == JavadocTokenTypes.START) {
                 stack.push(token);
             }
-            else if (token.getType() == JavadocTokenTypes.HTML_TAG_NAME && !stack.isEmpty()) {
+            else if (tokenType == JavadocTokenTypes.HTML_TAG_NAME && !stack.isEmpty()) {
                 if (stack.peek().getText().equals(token.getText())) {
                     stack.pop();
                 }
@@ -498,6 +499,7 @@ public class JavadocDetailNodeParser {
                     htmlTagNameStart = stack.pop();
                 }
             }
+            prevTokenType = tokenType;
         }
         if (htmlTagNameStart == null) {
             htmlTagNameStart = stack.pop();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Comment.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Comment.java
@@ -52,9 +52,8 @@ public class Comment implements TextBlock {
      */
     public Comment(final String[] text, final int firstCol,
             final int lastLine, final int lastCol) {
-        this.text = new String[text.length];
-        System.arraycopy(text, 0, this.text, 0, this.text.length);
-        startLineNo = lastLine - this.text.length + 1;
+        this.text = text.clone();
+        startLineNo = lastLine - text.length + 1;
         endLineNo = lastLine;
         startColNo = firstCol;
         endColNo = lastCol;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
@@ -78,6 +78,7 @@ public class AbstractFileSetCheckTest {
         }
         catch (IllegalArgumentException ex) {
             // exception is expected
+            assertEquals("Invalid exception message", "Test", ex.getMessage());
         }
 
         final Field field = AbstractFileSetCheck.class.getDeclaredField("MESSAGE_COLLECTOR");
@@ -95,6 +96,7 @@ public class AbstractFileSetCheckTest {
         }
         catch (IllegalArgumentException ex) {
             // exception is expected
+            assertEquals("Invalid exception message", "Test", ex.getMessage());
         }
 
         @SuppressWarnings("unchecked")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.design;
 
 import static com.puppycrawl.tools.checkstyle.checks.design.MutableExceptionCheck.MSG_KEY;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -125,7 +126,8 @@ public class MutableExceptionCheckTest extends AbstractModuleTestSupport {
             fail("IllegalStateException is expected");
         }
         catch (IllegalStateException ex) {
-            //expected
+            // exception is expected
+            assertEquals("Invalid exception message", "interface[0x-1]", ex.getMessage());
         }
     }
 


### PR DESCRIPTION
Issue #5633 

- `for` loop in `JavadocDetailNodeParser` replaced with `foreach` loop
- `ClassResolverTest::TestMess` split into three different tests
- The garbage in `Comment` ctor replaced with some code
- `MutableExceptionCheckTest::testWrongTokenType` checks the exception message