### PR TITLE
Issue #3492: add ability to control imports in certain classes

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -605,7 +605,7 @@ JCheck
 JCombo
 JComponent
 jcp
-JDBC
+jdbc
 JDE
 jdee
 jdepend

--- a/config/catalog.xml
+++ b/config/catalog.xml
@@ -15,4 +15,5 @@
     <system systemId="http://checkstyle.sourceforge.net/dtds/import_control_1_1.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_1.dtd"/>
     <system systemId="http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_2.dtd"/>
     <system systemId="http://checkstyle.sourceforge.net/dtds/import_control_1_3.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_3.dtd"/>
+    <system systemId="http://checkstyle.sourceforge.net/dtds/import_control_1_4.dtd" uri="./../src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_4.dtd"/>
 </catalog>

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE import-control PUBLIC
-    "-//Puppy Crawl//DTD Import Control 1.3//EN"
-    "http://checkstyle.sourceforge.net/dtds/import_control_1_3.dtd">
+    "-//Puppy Crawl//DTD Import Control 1.4//EN"
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_4.dtd">
 
 <import-control pkg="com.puppycrawl.tools.checkstyle">
 
@@ -45,14 +45,18 @@
   <!-- allowed till https://github.com/checkstyle/checkstyle/issues/3455 -->
   <allow class="com.google.common.base.CaseFormat" local-only="true"/>
   <allow class="com.google.common.io.BaseEncoding" local-only="true"/>
-  <allow class="com.google.common.io.Closeables" local-only="true"/>
-  <allow class="com.google.common.io.Flushables" local-only="true"/>
   <allow class="com.google.common.collect.HashMultimap" local-only="true"/>
   <allow class="com.google.common.collect.ImmutableCollection" local-only="true"/>
   <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
   <allow class="com.google.common.collect.ImmutableMap" local-only="true"/>
   <allow class="com.google.common.collect.Multimap" local-only="true"/>
   <allow class="com.google.common.io.ByteStreams" local-only="true"/>
+
+  <file name="PropertyCacheFile">
+    <!-- allowed till https://github.com/checkstyle/checkstyle/issues/3455 -->
+    <allow class="com.google.common.io.Closeables"/>
+    <allow class="com.google.common.io.Flushables"/>
+  </file>
 
   <subpackage name="utils">
     <allow pkg="java.lang.reflect" local-only="true" />
@@ -158,13 +162,20 @@
     <allow pkg="javax.swing"/>
     <allow pkg="java.util" exact-match="true"/>
     <allow pkg="com.puppycrawl.tools.checkstyle.api" local-only="true"/>
-    <allow pkg="com.puppycrawl.tools.checkstyle.utils" local-only="true"/>
-    <allow class="com.puppycrawl.tools.checkstyle.JavaParser" local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.gui.MainFrameModel.ParseMode"
            local-only="true"/>
-    <allow class="com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser" local-only="true"/>
     <allow class="com.google.common.collect.ImmutableList" local-only="true"/>
-    <allow class="java.nio.charset.StandardCharsets" local-only="true" />
+    <disallow pkg="com\.puppycrawl\.tools\.checkstyle\.(checks|ant|doclets|filters)" regex="true"/>
+
+    <file name=".*(Model|Presentation)" regex="true">
+      <disallow pkg="java.awt.Graphics"/>
+      <disallow pkg="java.awt.Component"/>
+      <disallow pkg="javax\.swing\.J.*" regex="true"/>
+      <allow class="java.nio.charset.StandardCharsets" />
+      <allow class="com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser"/>
+      <allow class="com.puppycrawl.tools.checkstyle.JavaParser"/>
+      <allow pkg="com.puppycrawl.tools.checkstyle.utils"/>
+    </file>
   </subpackage>
 
   <subpackage name="xpath">

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -88,7 +88,7 @@
       <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='XMLLogger']//MethodDeclarator[@Image='isReference']
       | //ClassOrInterfaceDeclaration[@Image='DetailAST']//MethodDeclarator[@Image='addPreviousSibling']
       | //ClassOrInterfaceDeclaration[@Image='AnnotationLocationCheck']//MethodDeclarator[@Image='checkAnnotations']
-      | //ClassOrInterfaceDeclaration[@Image='ImportControl']//MethodDeclarator[@Image='checkAccess']
+      | //ClassOrInterfaceDeclaration[@Image='AbstractImportControl']//MethodDeclarator[@Image='checkAccess']
       | //ClassOrInterfaceDeclaration[@Image='HandlerFactory']//MethodDeclarator[@Image='getHandler']"/>
     </properties>
   </rule>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AbstractImportControl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AbstractImportControl.java
@@ -1,0 +1,135 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2018 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.imports;
+
+import java.util.Deque;
+import java.util.LinkedList;
+
+/**
+ * Represents a tree of import rules for controlling whether packages or
+ * classes are allowed to be used. Each instance must have a single parent or
+ * be the root node.
+ */
+abstract class AbstractImportControl {
+
+    /** List of {@link AbstractImportRule} objects to check. */
+    private final Deque<AbstractImportRule> rules = new LinkedList<>();
+    /** The parent. Null indicates we are the root node. */
+    private final AbstractImportControl parent;
+    /** Strategy in a case if matching allow/disallow rule was not found. */
+    private final MismatchStrategy strategyOnMismatch;
+
+    /**
+     * Construct a child node.
+     * @param parent the parent node.
+     * @param strategyOnMismatch strategy in a case if matching allow/disallow rule was not found.
+     */
+    AbstractImportControl(AbstractImportControl parent, MismatchStrategy strategyOnMismatch) {
+        this.parent = parent;
+        this.strategyOnMismatch = strategyOnMismatch;
+    }
+
+    /**
+     * Search down the tree to locate the finest match for a supplied package.
+     * @param forPkg the package to search for.
+     * @param forFileName the file name to search for.
+     * @return the finest match, or null if no match at all.
+     */
+    public abstract AbstractImportControl locateFinest(String forPkg, String forFileName);
+
+    /**
+     * Check for equality of this with pkg.
+     * @param pkg the package to compare with.
+     * @param fileName the file name to compare with.
+     * @return if it matches.
+     */
+    protected abstract boolean matchesExactly(String pkg, String fileName);
+
+    /**
+     * Adds an {@link AbstractImportRule} to the node.
+     * @param rule the rule to be added.
+     */
+    protected void addImportRule(AbstractImportRule rule) {
+        rules.addLast(rule);
+    }
+
+    /**
+     * Returns whether a package or class is allowed to be imported.
+     * The algorithm checks with the current node for a result, and if none is
+     * found then calls its parent looking for a match. This will recurse
+     * looking for match. If there is no clear result then
+     * {@link AccessResult#UNKNOWN} is returned.
+     * @param inPkg the package doing the import.
+     * @param inFileName the file name doing the import.
+     * @param forImport the import to check on.
+     * @return an {@link AccessResult}.
+     */
+    public AccessResult checkAccess(String inPkg, String inFileName, String forImport) {
+        final AccessResult result;
+        final AccessResult returnValue = localCheckAccess(inPkg, inFileName, forImport);
+        if (returnValue != AccessResult.UNKNOWN) {
+            result = returnValue;
+        }
+        else if (parent == null) {
+            if (strategyOnMismatch == MismatchStrategy.ALLOWED) {
+                result = AccessResult.ALLOWED;
+            }
+            else {
+                result = AccessResult.DISALLOWED;
+            }
+        }
+        else {
+            if (strategyOnMismatch == MismatchStrategy.ALLOWED) {
+                result = AccessResult.ALLOWED;
+            }
+            else if (strategyOnMismatch == MismatchStrategy.DISALLOWED) {
+                result = AccessResult.DISALLOWED;
+            }
+            else {
+                result = parent.checkAccess(inPkg, inFileName, forImport);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Checks whether any of the rules for this node control access to
+     * a specified package or file.
+     * @param inPkg the package doing the import.
+     * @param inFileName the file name doing the import.
+     * @param forImport the import to check on.
+     * @return an {@link AccessResult}.
+     */
+    private AccessResult localCheckAccess(String inPkg, String inFileName, String forImport) {
+        AccessResult localCheckAccessResult = AccessResult.UNKNOWN;
+        for (AbstractImportRule importRule : rules) {
+            // Check if an import rule is only meant to be applied locally.
+            if (!importRule.isLocalOnly() || matchesExactly(inPkg, inFileName)) {
+                final AccessResult result = importRule.verifyImport(forImport);
+                if (result != AccessResult.UNKNOWN) {
+                    localCheckAccessResult = result;
+                    break;
+                }
+            }
+        }
+        return localCheckAccessResult;
+    }
+
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/FileImportControl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/FileImportControl.java
@@ -1,0 +1,100 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2018 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.imports;
+
+import java.util.regex.Pattern;
+
+/**
+ * Represents an import rules for a specific file. Only the file name is
+ * considered and only files processed by TreeWalker. The file's
+ * extension is ignored.
+ */
+class FileImportControl extends AbstractImportControl {
+    /** The name for the file. */
+    private final String name;
+    /** The regex pattern for exact matches - only not null if regex is true. */
+    private final Pattern patternForExactMatch;
+    /** If this file name represents a regular expression. */
+    private final boolean regex;
+
+    /**
+     * Construct a file node.
+     * @param parent the parent node.
+     * @param name the name of the file.
+     * @param regex flags interpretation of name as regex pattern.
+     */
+    FileImportControl(PkgImportControl parent, String name, boolean regex) {
+        super(parent, MismatchStrategy.DELEGATE_TO_PARENT);
+
+        this.regex = regex;
+        if (regex) {
+            this.name = encloseInGroup(name);
+            patternForExactMatch = createPatternForExactMatch(this.name);
+        }
+        else {
+            this.name = name;
+            patternForExactMatch = null;
+        }
+    }
+
+    /**
+     * Enclose {@code expression} in a (non-capturing) group.
+     * @param expression the input regular expression
+     * @return a grouped pattern.
+     */
+    private static String encloseInGroup(String expression) {
+        return "(?:" + expression + ")";
+    }
+
+    /**
+     * Creates a Pattern from {@code expression}.
+     * @param expression a self-contained regular expression matching the full
+     *     file name exactly.
+     * @return a Pattern.
+     */
+    private static Pattern createPatternForExactMatch(String expression) {
+        return Pattern.compile(expression);
+    }
+
+    @Override
+    public AbstractImportControl locateFinest(String forPkg, String forFileName) {
+        AbstractImportControl finestMatch = null;
+        // Check if we are a match.
+        if (matchesExactly(forPkg, forFileName)) {
+            finestMatch = this;
+        }
+        return finestMatch;
+    }
+
+    @Override
+    protected boolean matchesExactly(String pkg, String fileName) {
+        final boolean result;
+        if (fileName == null) {
+            result = false;
+        }
+        else if (regex) {
+            result = patternForExactMatch.matcher(fileName).matches();
+        }
+        else {
+            result = name.equals(fileName);
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -58,6 +58,10 @@ final class ImportControlLoader extends XmlLoader {
     private static final String DTD_PUBLIC_ID_1_3 =
             "-//Puppy Crawl//DTD Import Control 1.3//EN";
 
+    /** The public ID for the configuration dtd. */
+    private static final String DTD_PUBLIC_ID_1_4 =
+        "-//Puppy Crawl//DTD Import Control 1.4//EN";
+
     /** The resource for the configuration dtd. */
     private static final String DTD_RESOURCE_NAME_1_0 =
         "com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_0.dtd";
@@ -74,11 +78,18 @@ final class ImportControlLoader extends XmlLoader {
     private static final String DTD_RESOURCE_NAME_1_3 =
             "com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_3.dtd";
 
+    /** The resource for the configuration dtd. */
+    private static final String DTD_RESOURCE_NAME_1_4 =
+        "com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_4.dtd";
+
     /** The map to lookup the resource name by the id. */
     private static final Map<String, String> DTD_RESOURCE_BY_ID = new HashMap<>();
 
     /** Name for attribute 'pkg'. */
     private static final String PKG_ATTRIBUTE_NAME = "pkg";
+
+    /** Name for attribute 'name'. */
+    private static final String NAME_ATTRIBUTE_NAME = "name";
 
     /** Name for attribute 'strategyOnMismatch'. */
     private static final String STRATEGY_ON_MISMATCH_ATTRIBUTE_NAME = "strategyOnMismatch";
@@ -92,17 +103,21 @@ final class ImportControlLoader extends XmlLoader {
     /** Qualified name for element 'subpackage'. */
     private static final String SUBPACKAGE_ELEMENT_NAME = "subpackage";
 
+    /** Qualified name for element 'file'. */
+    private static final String FILE_ELEMENT_NAME = "file";
+
     /** Qualified name for element 'allow'. */
     private static final String ALLOW_ELEMENT_NAME = "allow";
 
-    /** Used to hold the {@link ImportControl} objects. */
-    private final Deque<ImportControl> stack = new ArrayDeque<>();
+    /** Used to hold the {@link AbstractImportControl} objects. */
+    private final Deque<AbstractImportControl> stack = new ArrayDeque<>();
 
     static {
         DTD_RESOURCE_BY_ID.put(DTD_PUBLIC_ID_1_0, DTD_RESOURCE_NAME_1_0);
         DTD_RESOURCE_BY_ID.put(DTD_PUBLIC_ID_1_1, DTD_RESOURCE_NAME_1_1);
         DTD_RESOURCE_BY_ID.put(DTD_PUBLIC_ID_1_2, DTD_RESOURCE_NAME_1_2);
         DTD_RESOURCE_BY_ID.put(DTD_PUBLIC_ID_1_3, DTD_RESOURCE_NAME_1_3);
+        DTD_RESOURCE_BY_ID.put(DTD_PUBLIC_ID_1_4, DTD_RESOURCE_NAME_1_4);
     }
 
     /**
@@ -125,40 +140,63 @@ final class ImportControlLoader extends XmlLoader {
             final String pkg = safeGet(attributes, PKG_ATTRIBUTE_NAME);
             final MismatchStrategy strategyOnMismatch = getStrategyForImportControl(attributes);
             final boolean regex = containsRegexAttribute(attributes);
-            stack.push(new ImportControl(pkg, regex, strategyOnMismatch));
+            stack.push(new PkgImportControl(pkg, regex, strategyOnMismatch));
         }
         else if (SUBPACKAGE_ELEMENT_NAME.equals(qName)) {
-            final String name = safeGet(attributes, "name");
+            final String name = safeGet(attributes, NAME_ATTRIBUTE_NAME);
             final MismatchStrategy strategyOnMismatch = getStrategyForSubpackage(attributes);
             final boolean regex = containsRegexAttribute(attributes);
-            final ImportControl parentImportControl = stack.peek();
-            final ImportControl importControl = new ImportControl(parentImportControl, name,
-                    regex, strategyOnMismatch);
+            final PkgImportControl parentImportControl = (PkgImportControl) stack.peek();
+            final AbstractImportControl importControl = new PkgImportControl(parentImportControl,
+                    name, regex, strategyOnMismatch);
+            parentImportControl.addChild(importControl);
+            stack.push(importControl);
+        }
+        else if (FILE_ELEMENT_NAME.equals(qName)) {
+            final String name = safeGet(attributes, NAME_ATTRIBUTE_NAME);
+            final boolean regex = containsRegexAttribute(attributes);
+            final PkgImportControl parentImportControl = (PkgImportControl) stack.peek();
+            final AbstractImportControl importControl = new FileImportControl(parentImportControl,
+                    name, regex);
             parentImportControl.addChild(importControl);
             stack.push(importControl);
         }
         else if (ALLOW_ELEMENT_NAME.equals(qName) || "disallow".equals(qName)) {
-            // Need to handle either "pkg" or "class" attribute.
-            // May have "exact-match" for "pkg"
-            // May have "local-only"
-            final boolean isAllow = ALLOW_ELEMENT_NAME.equals(qName);
-            final boolean isLocalOnly = attributes.getValue("local-only") != null;
-            final String pkg = attributes.getValue(PKG_ATTRIBUTE_NAME);
-            final boolean regex = containsRegexAttribute(attributes);
-            final AbstractImportRule rule;
-            if (pkg == null) {
-                // handle class names which can be normal class names or regular
-                // expressions
-                final String clazz = safeGet(attributes, "class");
-                rule = new ClassImportRule(isAllow, isLocalOnly, clazz, regex);
-            }
-            else {
-                final boolean exactMatch =
-                        attributes.getValue("exact-match") != null;
-                rule = new PkgImportRule(isAllow, isLocalOnly, pkg, exactMatch, regex);
-            }
+            final AbstractImportRule rule = createImportRule(qName, attributes);
             stack.peek().addImportRule(rule);
         }
+    }
+
+    /**
+     * Constructs an instance of an import rule based on the given {@code name} and
+     * {@code attributes}.
+     * @param qName The qualified name.
+     * @param attributes The attributes attached to the element.
+     * @return The created import rule.
+     * @throws SAXException if an error occurs.
+     */
+    private static AbstractImportRule createImportRule(String qName, Attributes attributes)
+            throws SAXException {
+        // Need to handle either "pkg" or "class" attribute.
+        // May have "exact-match" for "pkg"
+        // May have "local-only"
+        final boolean isAllow = ALLOW_ELEMENT_NAME.equals(qName);
+        final boolean isLocalOnly = attributes.getValue("local-only") != null;
+        final String pkg = attributes.getValue(PKG_ATTRIBUTE_NAME);
+        final boolean regex = containsRegexAttribute(attributes);
+        final AbstractImportRule rule;
+        if (pkg == null) {
+            // handle class names which can be normal class names or regular
+            // expressions
+            final String clazz = safeGet(attributes, "class");
+            rule = new ClassImportRule(isAllow, isLocalOnly, clazz, regex);
+        }
+        else {
+            final boolean exactMatch =
+                    attributes.getValue("exact-match") != null;
+            rule = new PkgImportRule(isAllow, isLocalOnly, pkg, exactMatch, regex);
+        }
+        return rule;
     }
 
     /**
@@ -173,7 +211,7 @@ final class ImportControlLoader extends XmlLoader {
     @Override
     public void endElement(String namespaceUri, String localName,
         String qName) {
-        if (SUBPACKAGE_ELEMENT_NAME.equals(qName)) {
+        if (SUBPACKAGE_ELEMENT_NAME.equals(qName) || FILE_ELEMENT_NAME.equals(qName)) {
             stack.pop();
         }
     }
@@ -181,10 +219,10 @@ final class ImportControlLoader extends XmlLoader {
     /**
      * Loads the import control file from a file.
      * @param uri the uri of the file to load.
-     * @return the root {@link ImportControl} object.
+     * @return the root {@link PkgImportControl} object.
      * @throws CheckstyleException if an error occurs.
      */
-    public static ImportControl load(URI uri) throws CheckstyleException {
+    public static PkgImportControl load(URI uri) throws CheckstyleException {
         try (InputStream inputStream = uri.toURL().openStream()) {
             final InputSource source = new InputSource(inputStream);
             return load(source, uri);
@@ -201,10 +239,10 @@ final class ImportControlLoader extends XmlLoader {
      * Loads the import control file from a {@link InputSource}.
      * @param source the source to load from.
      * @param uri uri of the source being loaded.
-     * @return the root {@link ImportControl} object.
+     * @return the root {@link PkgImportControl} object.
      * @throws CheckstyleException if an error occurs.
      */
-    private static ImportControl load(InputSource source,
+    private static PkgImportControl load(InputSource source,
         URI uri) throws CheckstyleException {
         try {
             final ImportControlLoader loader = new ImportControlLoader();
@@ -221,11 +259,11 @@ final class ImportControlLoader extends XmlLoader {
     }
 
     /**
-     * Returns root ImportControl.
-     * @return the root {@link ImportControl} object loaded.
+     * Returns root PkgImportControl.
+     * @return the root {@link PkgImportControl} object loaded.
      */
-    private ImportControl getRoot() {
-        return stack.peek();
+    private PkgImportControl getRoot() {
+        return (PkgImportControl) stack.peek();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/MismatchStrategy.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/MismatchStrategy.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.imports;
 
 /**
  * Represents the strategy when none of the rules (allow/disallow tags) match
- * inside subpackage and import-control tag of ImportControl config.
+ * inside subpackage and import-control tag of ImportControlCheck config.
  * @see ImportControlCheck
  */
 public enum MismatchStrategy {

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_4.dtd
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/imports/import_control_1_4.dtd
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Add the following to any file that is to be validated against this DTD:
+
+<!DOCTYPE import-control PUBLIC
+    "-//Puppy Crawl//DTD Import Control 1.4//EN"
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_4.dtd">
+-->
+
+<!--
+  The root element of the configuration file.
+-->
+<!ELEMENT import-control ((allow|disallow)*,(subpackage|file)*)>
+
+<!--
+  pkg - The root package to be checked. For example "com.puppycrawl".
+
+  regex - Root package name has to be interpreted as
+  regular expression.
+
+  strategyOnMismatch - Strategy in a case if matching allow/disallow rule
+  was not found. Possible values: allowed, disallowed.
+  If not defined explicitly, has "disallowed" value by default.
+-->
+<!ATTLIST import-control
+  pkg CDATA #REQUIRED
+  strategyOnMismatch (allowed|disallowed) #IMPLIED
+  regex (true) #IMPLIED>
+
+<!--
+  Represents a subpackage of the parent element.
+-->
+<!ELEMENT subpackage ((allow|disallow)*,(subpackage|file)*)>
+
+<!--
+  name - The name of the subpackage. For example if the name is "tools"
+  and the parent is "com.puppycrawl", then it corresponds to the
+  package "com.puppycrawl.tools". If the regex attribute is "true" the
+  name is interpreted as a regular expression.
+
+  regex - Subpackage name has to be interpreted as
+  regular expression.
+
+  strategyOnMismatch - Strategy in a case if matching allow/disallow rule
+  was not found. Possible values: allowed, disallowed, delegateToParent.
+  If not defined explicitly, has "delegateToParent" value by default.
+-->
+<!ATTLIST subpackage
+  name CDATA #REQUIRED
+  strategyOnMismatch (delegateToParent|allowed|disallowed) #IMPLIED
+  regex (true) #IMPLIED>
+
+<!--
+  Represents a file of the parent element.
+-->
+<!ELEMENT file (allow|disallow)*>
+
+<!--
+  name - The name of the file.
+  If the regex attribute is "true" the name is interpreted as a regular expression.
+
+  regex - File name has to be interpreted as regular expression.
+-->
+<!ATTLIST file
+  name CDATA #REQUIRED
+  regex (true) #IMPLIED>
+
+<!--
+  Represents attributes for an import rule which can either allow or
+  disallow access.
+
+  pkg - The fully qualified name of the package to allow/disallow.
+  Cannot be specified in conjunction with "class".
+
+  class - The fully qualified name of the class to allow/disallow.
+  Cannot be specified in conjunction with "pkg".
+
+  exact-match - Only valid with "pkg". Specifies whether the package
+  name matching should be exact. For example, the pkg
+  "com.puppycrawl.tools" will match the import
+  "com.puppycrawl.tools.checkstyle.api.*" when the option is not set,
+  but will not match if the option is set.
+
+  local-only - Indicates that the rule is to apply only to the current
+  package and not to subpackages.
+
+  regex - Indicates that the class or package name has to be interpreted as
+  regular expression.
+-->
+<!ENTITY % attlist.importrule "
+  pkg CDATA #IMPLIED
+  exact-match (true) #IMPLIED
+  class CDATA #IMPLIED
+  local-only (true) #IMPLIED
+  regex (true) #IMPLIED">
+
+<!--
+  Represents an import rule that will allow access.
+-->
+<!ELEMENT allow EMPTY>
+<!ATTLIST allow
+  %attlist.importrule;>
+
+<!--
+  Represents an import rule that will disallow access.
+-->
+<!ELEMENT disallow EMPTY>
+<!ATTLIST disallow
+  %attlist.importrule;>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/FileImportControlTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/FileImportControlTest.java
@@ -1,0 +1,61 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2018 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.imports;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class FileImportControlTest {
+
+    private final PkgImportControl root = new PkgImportControl("com.kazgroup.courtlink",
+            false, MismatchStrategy.DISALLOWED);
+
+    private final FileImportControl fileNode = new FileImportControl(root, "MyClass",
+            false);
+    private final FileImportControl fileRegexpNode = new FileImportControl(root, ".*Other.*",
+            true);
+
+    @Before
+    public void setUp() {
+        root.addChild(fileNode);
+        root.addChild(fileRegexpNode);
+
+        root.addImportRule(
+            new PkgImportRule(false, false, "org.springframework", false, false));
+        root.addImportRule(
+            new PkgImportRule(false, false, "org.hibernate", false, false));
+        root.addImportRule(
+            new PkgImportRule(true, false, "org.apache.commons", false, false));
+    }
+
+    @Test
+    public void testLocateFinest() {
+        assertEquals("Unexpected response", root, root
+                .locateFinest("com.kazgroup.courtlink.domain", "Random"));
+        assertEquals("Unexpected response", fileNode, root
+                .locateFinest("com.kazgroup.courtlink.common.api", "MyClass"));
+        assertEquals("Unexpected response", fileRegexpNode, root
+                .locateFinest("com.kazgroup.courtlink.common.api", "SomeOtherName"));
+        assertEquals("Unexpected response", root, root
+                .locateFinest("com.kazgroup.courtlink", null));
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -407,6 +407,32 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
                 expected);
     }
 
+    @Test
+    public void testFileName() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(ImportControlCheck.class);
+        checkConfig.addAttribute("file", getResourcePath("InputImportControlFileName.xml"));
+        final String[] expected = {
+            "3:1: " + getCheckMessage(MSG_DISALLOWED, "java.awt.Image"),
+        };
+
+        verify(checkConfig, getPath("InputImportControlFileName.java"), expected);
+    }
+
+    @Test
+    public void testFileNameNoExtension() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(ImportControlCheck.class);
+        checkConfig.addAttribute("file",
+                getResourcePath("InputImportControlFileNameNoExtension.xml"));
+        final DefaultConfiguration treewalkerConfig = createModuleConfig(TreeWalker.class);
+        treewalkerConfig.addAttribute("fileExtensions", "");
+        treewalkerConfig.addChild(checkConfig);
+        final String[] expected = {
+            "3:1: " + getCheckMessage(MSG_DISALLOWED, "java.awt.Image"),
+        };
+
+        verify(treewalkerConfig, getPath("InputImportControlFileNameNoExtension"), expected);
+    }
+
     /**
      * Returns String message of original exception that was thrown in
      * ImportControlCheck.setUrl or ImportControlCheck.setFile

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
@@ -60,7 +60,7 @@ public class ImportControlLoaderTest {
 
     @Test
     public void testLoad() throws CheckstyleException {
-        final ImportControl root =
+        final AbstractImportControl root =
                 ImportControlLoader.load(
                 new File(getPath("InputImportControlLoaderComplete.xml")).toURI());
         assertNotNull("Import root should not be null", root);
@@ -83,7 +83,7 @@ public class ImportControlLoaderTest {
 
     @Test
     public void testExtraElementInConfig() throws Exception {
-        final ImportControl root =
+        final AbstractImportControl root =
                 ImportControlLoader.load(
                     new File(getPath("InputImportControlLoaderWithNewElement.xml")).toURI());
         assertNotNull("Import root should not be null", root);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlFileName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlFileName.java
@@ -1,0 +1,6 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.importcontrol;
+
+import java.awt.Image;
+
+public interface InputImportControlFileName {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlFileName.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlFileName.xml
@@ -1,0 +1,14 @@
+<!DOCTYPE import-control PUBLIC
+    "-//Puppy Crawl//DTD Import Control 1.4//EN"
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_4.dtd">
+
+<import-control pkg="com.puppycrawl.tools.checkstyle.checks.imports">
+  <allow class="java.awt.Image"/>
+
+  <file name="InputImportControlFileName">
+    <disallow class="java.awt.Image"/>
+  </file>
+  <subpackage name="importcontrol">
+    <allow class="java.awt.Image"/>
+  </subpackage>
+</import-control>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlFileNameNoExtension
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlFileNameNoExtension
@@ -1,0 +1,6 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.importcontrol;
+
+import java.awt.Image;
+
+public @interface InputImportControlFileNameNoExtension {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlFileNameNoExtension.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlFileNameNoExtension.xml
@@ -1,0 +1,14 @@
+<!DOCTYPE import-control PUBLIC
+    "-//Puppy Crawl//DTD Import Control 1.4//EN"
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_4.dtd">
+
+<import-control pkg="com.puppycrawl.tools.checkstyle.checks.imports">
+  <allow class="java.awt.Image"/>
+
+  <file name="InputImportControlFileNameNoExtension">
+    <disallow class="java.awt.Image"/>
+  </file>
+  <subpackage name="importcontrol">
+    <allow class="java.awt.Image"/>
+  </subpackage>
+</import-control>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrolloader/InputImportControlLoaderComplete.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrolloader/InputImportControlLoaderComplete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE import-control PUBLIC
-    "-//Puppy Crawl//DTD Import Control 1.0//EN"
-    "http://checkstyle.sourceforge.net/dtds/import_control_1_0.dtd">
+    "-//Puppy Crawl//DTD Import Control 1.4//EN"
+    "http://checkstyle.sourceforge.net/dtds/import_control_1_4.dtd">
 
 <import-control pkg="com">
   <allow class="some.class"/>
@@ -13,4 +13,11 @@
     <disallow pkg="some.pkg"/>
     <disallow class="some.class"/>
   </subpackage>
+  <file name="Class">
+    <disallow pkg="some.pkg"/>
+  </file>
+  <file name=".*Class.*" regex="true">
+    <allow class="some.class"/>
+    <disallow class="some.class"/>
+  </file>
 </import-control>

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -313,7 +313,7 @@
       </tr>
       <tr>
         <td><a href="config_imports.html#ImportControl">ImportControl</a></td>
-        <td>Check that controls what packages can be imported in each package.</td>
+        <td>Check that controls what can be imported in each package and file.</td>
       </tr>
       <tr>
         <td><a href="config_imports.html#ImportOrder">ImportOrder</a></td>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -881,32 +881,54 @@ public class InputIllegalImport { }
       <subsection name="Description">
         <p>Since Checkstyle 4.0</p>
         <p>
-          Controls what can be imported in each package. Useful for
+          Controls what can be imported in each package and file. Useful for
           ensuring that application layering rules are not violated,
           especially on large projects.
+        </p>
+        <p>
+          You can control imports based on the a package name or based on the file
+          name. When controlling packages, all files and sub-packages in the declared
+          package will be controlled by this check. To specify differences between a main package
+          and a sub-package, you must define the sub-package inside the main package. When
+          controlling file, only the file name is considered and only files processed by
+          <a href="config.html#TreeWalker">TreeWalker</a>. The file's extension is ignored.
         </p>
 
         <p>
           Short description of the behaviour:
           <ul>
               <li>Check starts checking from the longest matching subpackage (later 'current
-                  subpackage') described inside import control file to package defined in class
-                  file.</li>
+                  subpackage') or the first file name match described inside import
+                  control file to package defined in class file.
+                  <ul>
+                    <li>The longest matching subpackage is found by starting with the root package
+                        and examining if the any of the sub-packages or file definitions match the
+                        current class' package or file name.</li>
+                    <li>If a file name is matched first, that is considered the longest
+                        match and becomes the current file/subpackage.</li>
+                    <li>If another subpackage is matched, then it's subpackages and file
+                        names are examined for the next longest match and the process repeats
+                        recursively.</li>
+                    <li>If no subpackages or file names are matched, the current subpackage
+                        is then used.</li>
+                  </ul>
+              </li>
               <li>Order of rules in the same subpackage/root are defined by the order of
                   declaration in the XML file, which is from top (first) to bottom (last).</li>
-              <li>If there is matching allow/disallow rule inside the current subpackage then the
-                  Check returns the first "allowed" or "disallowed" message.</li>
-              <li>If there is no matching allow/disallow rule inside the current subpackage then it
-                  continues checking in the parent subpackage.</li>
-              <li>If there is no matching allow/disallow rule in any of the subpackages, including
-                  the root level (import-control), then the import is disallowed by default.</li>
+              <li>If there is matching allow/disallow rule inside the current file/subpackage
+                  then the Check returns the first "allowed" or "disallowed" message.</li>
+              <li>If there is no matching allow/disallow rule inside the current file/subpackage
+                  then it continues checking in the parent subpackage.</li>
+              <li>If there is no matching allow/disallow rule in any of the files/subpackages,
+                  including the root level (import-control), then the import is disallowed by
+                  default.</li>
           </ul>
         </p>
 
         <p>
           The DTD for a import control XML document is at <a
-          href="http://checkstyle.sourceforge.net/dtds/import_control_1_3.dtd">
-          http://checkstyle.sourceforge.net/dtds/import_control_1_3.dtd</a>. It
+          href="http://checkstyle.sourceforge.net/dtds/import_control_1_4.dtd">
+          http://checkstyle.sourceforge.net/dtds/import_control_1_4.dtd</a>. It
           contains documentation on each of the elements and attributes.
         </p>
 
@@ -918,8 +940,8 @@ public class InputIllegalImport { }
 
         <pre>
 &lt;!DOCTYPE import-control PUBLIC
-    &quot;-//Puppy Crawl//DTD Import Control 1.3//EN&quot;
-    &quot;http://checkstyle.sourceforge.net/dtds/import_control_1_3.dtd&quot;&gt;
+    &quot;-//Puppy Crawl//DTD Import Control 1.4//EN&quot;
+    &quot;http://checkstyle.sourceforge.net/dtds/import_control_1_4.dtd&quot;&gt;
         </pre>
       </subsection>
 
@@ -1111,6 +1133,27 @@ public class InputIllegalImport { }
   &lt;/subpackage&gt;
   &lt;subpackage name=&quot;filters&quot;&gt;
     &lt;allow class=&quot;javax.util.Date&quot;/&gt;
+  &lt;/subpackage&gt;
+&lt;/import-control&gt;
+        </source>
+        <p>
+          In the example below, only file names that end with "Panel", "View", or "Dialog"
+          in the package <code>gui</code> are disallowed to have imports from
+          <code>com.mycompany.dao</code> and any <code>jdbc</code> package. In addition, only
+          the file name named "PresentationModel" in the package <code>gui</code> are
+          disallowed to have imports that match <code>javax.swing.J*</code>.
+          All other imports in the package are allowed.
+        </p>
+        <source>
+&lt;import-control pkg=&quot;com.mycompany.billing&quot;&gt;
+  &lt;subpackage name=&quot;gui&quot; strategyOnMismatch=&quot;allowed&quot;&gt;
+    &lt;file name=&quot;.*(Panel|View|Dialog)&quot; regex=&quot;true&quot;&gt;
+      &lt;disallow pkg=&quot;com.mycompany.dao&quot;/&gt;
+      &lt;disallow pkg=&quot;.*\.jdbc&quot; regex=&quot;true&quot;/&gt;
+    &lt;/file&gt;
+    &lt;file name=&quot;PresentationModel&quot;&gt;
+      &lt;disallow pkg=&quot;javax\.swing\.J.*&quot; regex=&quot;true&quot;/&gt;
+    &lt;/file&gt;
   &lt;/subpackage&gt;
 &lt;/import-control&gt;
         </source>


### PR DESCRIPTION
Issue #3492

ImportControl -> AbstractImportControl with original code for abstract methods being placed inside PkgImportControl.
ClassImportControl is similar to PkgImportControl except there are no children and it is based on the class name and not the package. It must be declared next to other package definitions and not be mixed in with the current allow/disallow list just like packages. Packages and classes have the same priority. If they both match, then whichever one written in the XML file first will be used.

Class name is based on the first class found in the file. Other class names in the same file will be ignored.