### PR TITLE
config: print diff between pitest actual and ignored

### DIFF
--- a/.ci/shippable.sh
+++ b/.ci/shippable.sh
@@ -8,7 +8,7 @@ function checkPitestReport() {
   fail=0
   SEARCH_REGEXP="(span  class='survived'|class='uncovered'><pre>)"
   grep -irE "$SEARCH_REGEXP" target/pit-reports | sed -E 's/.*\/([A-Za-z]+.java.html)/\1/' | sort > target/actual.txt
-  printf "%s\n" "${ignored[@]}" > target/ignored.txt
+  printf "%s\n" "${ignored[@]}" | sed '/^$/d' > target/ignored.txt
   if [ "$(diff --unified target/ignored.txt target/actual.txt)" != "" ] ; then
       fail=1
       echo "Actual:" ;

--- a/.ci/shippable.sh
+++ b/.ci/shippable.sh
@@ -7,21 +7,19 @@ function checkPitestReport() {
   ignored=("$@")
   fail=0
   SEARCH_REGEXP="(span  class='survived'|class='uncovered'><pre>)"
-  actual=($(grep -irE "$SEARCH_REGEXP" target/pit-reports | sed -E 's/.*\/([A-Za-z]+.java.html)/\1/' | sort))
-  A=${actual[@]};
-  B=${ignored[@]};
-  if [ "$(diff -q -u -w <( echo "$A" ) <( echo "$B" ))" != "" ] ; then
+  grep -irE "$SEARCH_REGEXP" target/pit-reports | sed -E 's/.*\/([A-Za-z]+.java.html)/\1/' | sort > target/actual.txt
+  printf "%s\n" "${ignored[@]}" > target/ignored.txt
+  if [ "$(diff --unified target/ignored.txt target/actual.txt)" != "" ] ; then
       fail=1
-      echo "Diff:"
-      diff -u -w <( echo "$A" ) <( echo "$B" ) | cat
       echo "Actual:" ;
       grep -irE "$SEARCH_REGEXP" target/pit-reports | sed -E 's/.*\/([A-Za-z]+.java.html)/\1/' | sort
       echo "Ignore:" ;
       printf '%s\n' "${ignored[@]}"
+      echo "Diff:"
+      diff --unified target/ignored.txt target/actual.txt | cat
   fi;
   if [ "$fail" -ne "0" ]; then
     echo "Difference between 'Actual' and 'Ignore' lists is detected, lists should be equal, build will be failed."
-    echo "To find what is different copy content of 'Actual' and 'Ignore' to https://www.diffchecker.com/"
   fi
   sleep 5s
   exit $fail


### PR DESCRIPTION
output will be like:
```
Diff:
--- target/ignored.txt	2018-03-24 17:26:30.374575943 -0700
+++ target/actual.txt	2018-03-24 17:26:30.374575943 -0700
@@ -25,6 +25,7 @@
 JavadocTagContinuationIndentationCheck.java.html:<td class='covered'><pre><span  class='survived'>                            &#38;&#38; (text.length() &#60;= offset</span></pre></td></tr>
 JavadocTagContinuationIndentationCheck.java.html:<td class='covered'><pre><span  class='survived'>        while (inlineTag != null) {</span></pre></td></tr>
 JavadocTagInfo.java.html:<td class='covered'><pre><span  class='survived'>            .collect(Collectors.toMap(JavadocTagInfo::getName, tagName -&#62; tagName)));</span></pre></td></tr>
+JavadocTagInfo.java.html:<td class='covered'><pre><span  class='survived'>            .collect(Collectors.toMap(JavadocTagInfo::getText, tagText -&#62; tagText)));</span></pre></td></tr>
 JavadocTag.java.html:<td class='uncovered'><pre><span  class='survived'>        return tagInfo == JavadocTagInfo.SEE</span></pre></td></tr>
 JavadocTypeCheck.java.html:<td class='covered'><pre><span  class='survived'>                    tagCount++;</span></pre></td></tr>
 SummaryJavadocCheck.java.html:<td class='covered'><pre><span  class='survived'>        for (int i = 0; !found &#38;&#38; i &#60; children.length - 1; i++) {</span></pre></td></tr>
Difference between 'Actual' and 'Ignore' lists is detected, lists should be equal, build will be failed.
```