### PR TITLE
Issue #5663: Add openjdk8/9 to Travis/AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -177,11 +177,17 @@ matrix:
         - DESC="print versions to update"
         - CMD="./.ci/travis/travis.sh versions"
 
-    # JDK9 build
+    # OpenJDK8 build
+    - jdk: openjdk8
+      env:
+        - DESC="build with OpenJDK8"
+        - CMD="mvn -e package -Passembly && mvn -e site -Dlinkcheck.skip=true"
+
+    # OracleJDK9 build
     - jdk: oraclejdk9
       env:
-        - DESC="build with JDK9"
-        - CMD="mvn -e package -Passembly"
+        - DESC="build with OracleJDK9"
+        - CMD="mvn -e package -Passembly && mvn -e site -Dlinkcheck.skip=true"
 
 script:
   - SKIP_FILES=".github|appveyor.yml|circle.yml|distelli-manifest.yml|fast-forward-merge.sh|LICENSE|LICENSE.apache20|README.md|release.sh|RIGHTS.antlr|shippable.yml|shippable.sh|wercker.yml|wercker.sh|intellij-idea-inspections.xml"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,13 +69,21 @@ environment:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
       DESC: "checkstyle and sevntu.checkstyle"
       CMD1: "mvn -e verify -DskipTests -DskipITs -Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dxml.skip=true"
-    # verify without checkstyle
+    # verify without checkstyle (JDK8)
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-      DESC: "verify without checkstyle"
+      DESC: "verify without checkstyle (JDK8)"
       CMD1: "mvn -e verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true"
-    # site, without verify
+    # verify without checkstyle (JDK9)
+    - JAVA_HOME: C:\Program Files\Java\jdk9
+      DESC: "verify without checkstyle (JDK9)"
+      CMD1: "mvn -e verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true"
+    # site, without verify (JDK8)
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-      DESC: "site, without verify"
+      DESC: "site, without verify (JDK8)"
+      CMD1: "mvn -e -Pno-validations site"
+    # site, without verify (JDK9)
+    - JAVA_HOME: C:\Program Files\Java\jdk9
+      DESC: "site, without verify (JDK9)"
       CMD1: "mvn -e -Pno-validations site"
 
 build_script:


### PR DESCRIPTION
Issue #5663

OracleJDK8 is the default environment for the time being.

For the other (OpenJDK8/9, OracleJDK9) we need a build step to make sure that our code is not JDK depended.