### PR TITLE
spelling: code

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -677,11 +677,11 @@ public class WhitespaceAroundCheck extends AbstractCheck {
     private static boolean isPartOfDoubleBraceInitializerForNextToken(DetailAST ast) {
         final boolean classBeginBeforeInitializerBegin = ast.getType() == TokenTypes.LCURLY
             && ast.getNextSibling().getType() == TokenTypes.INSTANCE_INIT;
-        final boolean initalizerEndsBeforeClassEnds = ast.getType() == TokenTypes.RCURLY
+        final boolean initializerEndsBeforeClassEnds = ast.getType() == TokenTypes.RCURLY
             && ast.getParent().getType() == TokenTypes.SLIST
             && ast.getParent().getParent().getType() == TokenTypes.INSTANCE_INIT
             && ast.getParent().getParent().getNextSibling().getType() == TokenTypes.RCURLY;
-        return classBeginBeforeInitializerBegin || initalizerEndsBeforeClassEnds;
+        return classBeginBeforeInitializerBegin || initializerEndsBeforeClassEnds;
     }
 
 }


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`

note that this conflicts with #5654 (because there are 2 lines in a row, one's a comment, one's code). It's trivially resolvable. My original commit sequence has this change built on top of that change, but for "independent" (conflicting) PRs, that progression can't be followed.

split from #5647 