### PR TITLE
spelling: grammar singleton

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParser.g4
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammars/javadoc/JavadocParser.g4
@@ -843,7 +843,7 @@ thead: theadTagStart[false]
     ;
 
 //////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////  SINLETON HTML TAGS  //////////////////////////////////////
+//////////////////////////  SINGLETON HTML TAGS  /////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////
 singletonElement: emptyTag
             | areaTag
@@ -864,7 +864,7 @@ singletonElement: emptyTag
             | sourceTag
             | trackTag
             | wbrTag
-            | wrongSinletonTag
+            | wrongSingletonTag
             ;
 
 emptyTag: START
@@ -911,7 +911,7 @@ metaTag: START META_HTML_TAG_NAME (attribute | NEWLINE | LEADING_ASTERISK | WS)*
 paramTag: START PARAM_HTML_TAG_NAME (attribute | NEWLINE | LEADING_ASTERISK | WS)*
          (SLASH_END | END);
 
-wrongSinletonTag: START SLASH singletonTagName
+wrongSingletonTag: START SLASH singletonTagName
                   END {notifyErrorListeners($singletonTagName.start,
                              "javadoc.wrong.singleton.html.tag", null);}
                   ;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/GeneratedJavadocTokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammars/javadoc/GeneratedJavadocTokenTypesTest.java
@@ -220,7 +220,7 @@ public class GeneratedJavadocTokenTypesTest {
         assertEquals(MSG, 63, JavadocParser.RULE_linkTag);
         assertEquals(MSG, 64, JavadocParser.RULE_metaTag);
         assertEquals(MSG, 65, JavadocParser.RULE_paramTag);
-        assertEquals(MSG, 66, JavadocParser.RULE_wrongSinletonTag);
+        assertEquals(MSG, 66, JavadocParser.RULE_wrongSingletonTag);
         assertEquals(MSG, 67, JavadocParser.RULE_singletonTagName);
         assertEquals(MSG, 68, JavadocParser.RULE_description);
         assertEquals(MSG, 69, JavadocParser.RULE_reference);


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`

split from #5647 