### PR TITLE
Issue #5655: Indentation: wrapped method name

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -141,6 +141,23 @@ public class MethodCallHandler extends AbstractExpressionHandler {
         return astNode;
     }
 
+    /**
+     * Returns method or constructor name. For {@code foo(arg)} it is `foo`, for
+     *     {@code foo.bar(arg)} it is `bar` for {@code super(arg)} it is 'super'.
+     *
+     * @return TokenTypes.IDENT node for a method call, TokenTypes.SUPER_CTOR_CALL otherwise.
+     */
+    private DetailAST getMethodIdentAst() {
+        DetailAST ast = getMainAst();
+        if (ast.getType() != TokenTypes.SUPER_CTOR_CALL) {
+            ast = ast.getFirstChild();
+            if (ast.getType() == TokenTypes.DOT) {
+                ast = ast.getLastChild();
+            }
+        }
+        return ast;
+    }
+
     @Override
     public IndentLevel getSuggestedChildIndent(AbstractExpressionHandler child) {
         // for whatever reason a method that crosses lines, like asList
@@ -149,10 +166,9 @@ public class MethodCallHandler extends AbstractExpressionHandler {
         //                new String[] {"method"}).toString());
         // will not have the right line num, so just get the child name
 
-        final DetailAST first = getMainAst().getFirstChild();
-        IndentLevel suggestedLevel = new IndentLevel(getLineStart(first));
-        if (!areOnSameLine(child.getMainAst().getFirstChild(),
-                           getMainAst().getFirstChild())) {
+        final DetailAST ident = getMethodIdentAst();
+        IndentLevel suggestedLevel = new IndentLevel(getLineStart(ident));
+        if (!areOnSameLine(child.getMainAst().getFirstChild(), ident)) {
             suggestedLevel = new IndentLevel(suggestedLevel,
                     getBasicOffset(),
                     getIndentCheck().getLineWrappingIndentation());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -288,8 +288,9 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("tabWidth", "4");
         checkConfig.addAttribute("throwsIndent", "4");
         final String[] expected = {
-            "51: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 18, 20),
-            "52: " + getCheckMessage(MSG_ERROR, "method call rparen", 14, 16),
+            "53: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 18, 20),
+            "54: " + getCheckMessage(MSG_ERROR, "method call rparen", 14, 16),
+            "75: " + getCheckMessage(MSG_ERROR, "lambda arguments", 12, 16),
         };
         verifyWarns(checkConfig, getPath("InputIndentationMethodCallLineWrap.java"), expected);
     }
@@ -472,6 +473,10 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             "52: " + getCheckMessage(MSG_ERROR, "x", 4, 8),
             "56: " + getCheckMessage(MSG_CHILD_ERROR, "ctor def", 4, 6),
             "57: " + getCheckMessage(MSG_ERROR, "method call lparen", 4, 6),
+            "62: " + getCheckMessage(MSG_ERROR, ".", 4, 10),
+            "63: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 4, 8),
+            "68: " + getCheckMessage(MSG_ERROR, "super", 4, 10),
+            "69: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 4, 8),
         };
         verifyWarns(checkConfig, getPath("InputIndentationCtorCall.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCtorCall.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCtorCall.java
@@ -57,6 +57,18 @@ class InputIndentationCtorCall { //indent:0 exp:0
     (); //indent:4 exp:6 warn
     } //indent:4 exp:4
 
+    public Invalid(InputIndentationCtorCall obj, int arg) { //indent:4 exp:4
+      obj //indent:6 exp:6
+    .super( //indent:4 exp:10 warn
+    arg); //indent:4 exp:8 warn
+    } //indent:4 exp:4
+
+    public Invalid(InputIndentationCtorCall obj, char arg) { //indent:4 exp:4
+      obj. //indent:6 exp:6
+    super( //indent:4 exp:10 warn
+    arg); //indent:4 exp:8 warn
+    } //indent:4 exp:4
+
   } //indent:2 exp:2
 
   class Valid extends Base { //indent:2 exp:2
@@ -83,9 +95,27 @@ class InputIndentationCtorCall { //indent:0 exp:0
           arg); //indent:10 exp:10
     } //indent:4 exp:4
 
-    public Valid(InputIndentationCtorCall arg) { //indent:4 exp:4
-      arg.super( //indent:6 exp:6
-          x -> x); //indent:10 exp:10
+    public Valid(InputIndentationCtorCall obj, char arg) { //indent:4 exp:4
+      obj.super( //indent:6 exp:6
+          x -> arg); //indent:10 exp:10
+    } //indent:4 exp:4
+
+    public Valid(InputIndentationCtorCall obj, int arg) { //indent:4 exp:4
+      obj //indent:6 exp:6
+          .super( //indent:10 exp:10
+            arg); //indent:12 exp:12
+    } //indent:4 exp:4
+
+    public Valid(InputIndentationCtorCall obj, float arg) { //indent:4 exp:4
+      obj. //indent:6 exp:6
+          super( //indent:10 exp:10
+              x -> arg); //indent:14 exp:14
+    } //indent:4 exp:4
+
+    public Valid(InputIndentationCtorCall obj, double arg) { //indent:4 exp:4
+      obj. //indent:6 exp:6
+          super( //indent:10 exp:10
+            x -> arg); //indent:12 exp:12
     } //indent:4 exp:4
 
   } //indent:2 exp:2

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationMethodCallLineWrap.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationMethodCallLineWrap.java
@@ -1,5 +1,7 @@
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
 
+import java.util.List; //indent:0 exp:0
+import java.util.function.Function; //indent:0 exp:0
 
 /**                                                                           //indent:0 exp:0
  * This test-input is intended to be checked using following configuration:   //indent:1 exp:1
@@ -61,5 +63,15 @@ public class InputIndentationMethodCallLineWrap { //indent:0 exp:0
                     "a" //indent:20 exp:20
             )//indent:12 exp:12
         ); //indent:8 exp:8
+    } //indent:4 exp:4
+
+    <U> void chainingWithLambda(Function<?, ? extends U> f) { //indent:4 exp:4
+        this.<Function<List<?>, Boolean>> //indent:8 exp:8
+            chainingWithLambda( //indent:12 exp:12
+                x -> //indent:16 exp:16
+                    y -> y.contains(0)); //indent:20 exp:20
+        this. //indent:8 exp:8
+            chainingWithLambda( //indent:12 exp:12
+            x -> x); //indent:12 exp:16 warn
     } //indent:4 exp:4
 } //indent:0 exp:0


### PR DESCRIPTION
Issue #5655

When a method name is on the next line from the dot, like this
```
a.
  method(
    someArg);
```
the indentation is calculated  in the wrong way. This PS fixes it.