### PR TITLE
Issue #5603: Use category/java/design in the PMD config

### DIFF
--- a/config/pmd-main.xml
+++ b/config/pmd-main.xml
@@ -11,14 +11,6 @@
     <exclude-pattern>.*/src/test/.*</exclude-pattern>
     <rule ref="config/pmd.xml"/>
 
-    <rule ref="rulesets/java/unusedcode.xml/UnusedPrivateMethod">
-        <properties>
-            <!-- generates false-positives on private methods called within a file -->
-            <property name="violationSuppressXPath" value="
-            //MethodDeclaration[@Name='countTokens' and ../../..[@Image='DescendantTokenCheck']]
-            | //MethodDeclaration[@Name='getHashCodeBasedOnObjectContent' and ../../..[@Image='PropertyCacheFile']]"/>
-        </properties>
-    </rule>
     <rule ref="rulesets/java/basic.xml/CollapsibleIfStatements">
         <properties>
             <!-- till https://github.com/hcoles/pitest/issues/377 -->

--- a/config/pmd-test.xml
+++ b/config/pmd-test.xml
@@ -32,8 +32,6 @@
         <exclude name="ExcessivePublicCount"/>
         <!--we have too much UTs for each main class, it is better to keep all tests in one file to ease navigation and search for test-->
         <exclude name="ExcessiveClassLength"/>
-        <!--we want to keep it all in one place-->
-        <exclude name="NcssTypeCount"/>
         <!--we want to avoid wide throws signature, it is just test-->
         <exclude name="AvoidCatchingGenericException"/>
         <!--we do not want invest extra time to make logic ideal in test method, may be later...-->
@@ -44,49 +42,61 @@
         <exclude name="NonThreadSafeSingleton"/>
     </rule>
 
-    <rule ref="rulesets/java/codesize.xml/NcssMethodCount">
+    <rule ref="category/java/design.xml/NcssCount">
         <properties>
-            <!-- 'testTokenNumbering' method is simple but long as it recheck each token one by one -->
-            <!-- 'testNospaceWithComplexInput' it is intended to keep all in one method. -->
-            <!--Method `testTokenValues` in JavadocTokenTypes contains several asserts as it checks each token explicitly-->
-            <!-- XdocsPagesTest is a complicated list of different checks -->
-            <property name="violationSuppressXPath" value="
-            //ClassOrInterfaceDeclaration[@Image='GeneratedJavaTokenTypesTest']//MethodDeclarator[@Image='testTokenNumbering']
-            | //ClassOrInterfaceDeclaration[@Image='ParenPadCheckTest']//MethodDeclarator[@Image='testNospaceWithComplexInput']
-            | //MethodDeclaration[@Name='testTokenValues' and ../../..[@Image='JavadocTokenTypesTest']]
-            | //MethodDeclaration[@Name='getModulePropertyExpectedValue' and ../../..[@Image='XdocsPagesTest']]"/>
+            <!-- We want to keep it all in one place. -->
+            <property name="classReportLevel" value="1000"/>
+            <!-- A big enough value to satisfy the most cases. -->
+            <property name="methodReportLevel" value="100"/>
+            <!-- GeneratedJavaTokenTypesTest.testTokenNumbering' is simple but long as it recheck
+                   each token one by one.
+                 JavadocTokenTypesTest.TokenValues contains several asserts as it checks each
+                   token explicitly.
+                 XdocsPagesTest.getModulePropertyExpectedTypeName is a complicated list of
+                   different checks. -->
+            <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='JavadocTokenTypesTest']//MethodDeclaration[@Name='testTokenValues']
+            | //ClassOrInterfaceDeclaration[@Image='GeneratedJavaTokenTypesTest']//MethodDeclaration[@Name='testTokenNumbering']
+            | //ClassOrInterfaceDeclaration[@Image='XdocsPagesTest']//MethodDeclaration[@Name='getModulePropertyExpectedTypeName']"/>
         </properties>
     </rule>
 
-    <rule ref="rulesets/java/codesize.xml/ExcessiveMethodLength">
+    <rule ref="category/java/design.xml/ExcessiveMethodLength">
         <properties>
-            <!-- 'testTokenNumbering' method is simple but long as it recheck each token one by one -->
-            <!-- 'testNospaceWithComplexInput' it is intended to keep all in one method. -->
-            <!--Method `testTokenValues` in JavadocTokenTypes contains several asserts as it checks each token explicitly-->
-            <!-- XdocsPagesTest is a complicated list of different checks -->
+            <!-- GeneratedJavaTokenTypesTest.testTokenNumbering' is simple but long as it recheck
+                   each token one by one.
+                 ParenPadCheckTest.testNospaceWithComplexInput is intended to keep all in one
+                   method.
+                 JavadocTokenTypesTest.TokenValues contains several asserts as it checks each
+                   token explicitly.
+                 XdocsPagesTest.getModulePropertyExpectedTypeName is a complicated list of
+                   different checks. -->
             <property name="violationSuppressXPath" value="
-            //ClassOrInterfaceDeclaration[@Image='GeneratedJavaTokenTypesTest']//MethodDeclarator[@Image='testTokenNumbering']
-            | //ClassOrInterfaceDeclaration[@Image='ParenPadCheckTest']//MethodDeclarator[@Image='testNospaceWithComplexInput']
-            | //ClassOrInterfaceDeclaration[@Image='ParenPadTest']//MethodDeclarator[@Image='testMethodParen']
-            | //MethodDeclaration[@Name='testTokenValues' and ../../..[@Image='JavadocTokenTypesTest']]
-            | //MethodDeclaration[@Name='getModulePropertyExpectedTypeName' and ../../..[@Image='XdocsPagesTest']]"/>
+            //ClassOrInterfaceDeclaration[@Image='GeneratedJavaTokenTypesTest']//MethodDeclaration[@Name='testTokenNumbering']
+            | //ClassOrInterfaceDeclaration[@Image='ParenPadCheckTest']//MethodDeclaration[@Name='testNospaceWithComplexInput']
+            | //ClassOrInterfaceDeclaration[@Image='ParenPadTest']//MethodDeclaration[@Name='testMethodParen']
+            | //ClassOrInterfaceDeclaration[@Image='JavadocTokenTypesTest']//MethodDeclaration[@Name='testTokenValues']
+            | //ClassOrInterfaceDeclaration[@Image='XdocsPagesTest']//MethodDeclaration[@Name='getModulePropertyExpectedTypeName']"/>
         </properties>
     </rule>
 
-    <rule ref="rulesets/java/junit.xml/JUnitTestsShouldIncludeAssert">
-        <!-- pmd cannot find assert if it is located in private method of this class called from the test
-        method or method of another class -->
+    <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert">
+        <!-- PMD cannot find assert if it is located in private method of this class called from
+               the test method or method of another class. -->
         <properties>
-            <!-- in AllChecksTest, AstRegressionTest, DetailASTTest and ImportControlCheckTest
-                 pmd does not find asserts in private methods of the test class called from the test method -->
-            <!-- in MainTest pmd does not find asserts in lambdas called in the method exit.checkAssertionAfterwards -->
-            <!-- in FilterSetTest, LineColumnTest, LocalizedMessageTest, CsvFilterTest, IntMatchFilterTest
-                 IntRangeFilterTest, SuppressElementTest, SuppressWithNearbyCommentFilterTest
-                 SuppressWithPlainTextCommentFilterTest, SuppressionCommentFilterTest, SuppressionFilterTest
-                 SuppressionXpathFilterTest, XpathFilterTest pmd does not accept
-                 nl.jqno.equalsverifier.EqualsVerifier#.verify() as correctness check method -->
-            <!-- in AstRegressionTest pmd does not find asserts in inner classes methods called from the test method -->
-            <!-- in XdocsPagesTest pmd does not find asserts in lambdas -->
+            <!-- In AllChecksTest, AstRegressionTest, DetailASTTest and ImportControlCheckTest
+                   PMD does not find asserts in private methods of the test class called from the
+                   test method.
+                 In MainTest PMD does not find asserts in lambdas called in the method
+                   exit.checkAssertionAfterwards.
+                 In FilterSetTest, LineColumnTest, LocalizedMessageTest, CsvFilterTest,
+                   IntMatchFilterTest, IntRangeFilterTest, SuppressElementTest,
+                   SuppressWithNearbyCommentFilterTest, SuppressWithPlainTextCommentFilterTest,
+                   SuppressionCommentFilterTest, SuppressionFilterTest, SuppressionXpathFilterTest,
+                   XpathFilterTest PMD does not accept nl.jqno.equalsverifier.EqualsVerifier.verify
+                   as correctness check method.
+                 In AstRegressionTest PMD does not find asserts in inner classes methods called
+                   from the test method.
+                 In XdocsPagesTest PMD does not find asserts in lambdas. -->
             <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='AllChecksTest'
               or @Image='AstRegressionTest' or @Image='DetailASTTest'
               or @Image='ImportControlCheckTest']//PrimaryPrefix/Name[@Image='verify']
@@ -97,7 +107,7 @@
               or @Image='SuppressWithNearbyCommentFilterTest' or @Image='SuppressionCommentFilterTest'
               or @Image='SuppressionFilterTest' or @Image='SuppressionXpathFilterTest'
               or @Image='SuppressWithPlainTextCommentFilterTest' or @Image='XpathFilterTest']//PrimarySuffix[@Image='verify']
-            | //ClassOrInterfaceDeclaration[@Image='XdocsPagesTest']//MethodDeclarator[@Image='testAllChecksPresentOnAvailableChecksPage']
+            | //ClassOrInterfaceDeclaration[@Image='XdocsPagesTest']//MethodDeclaration[@Name='testAllChecksPresentOnAvailableChecksPage']
             "/>
         </properties>
     </rule>
@@ -109,20 +119,22 @@
         </properties>
     </rule>
 
-    <rule ref="rulesets/java/migrating.xml/JUnit4TestShouldUseBeforeAnnotation">
+    <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseBeforeAnnotation">
         <properties>
-            <!-- false positive -->
+            <!-- A false positive. -->
             <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='CommitValidationTest']"/>
         </properties>
     </rule>
-    <rule ref="rulesets/java/junit.xml/JUnitTestContainsTooManyAsserts">
+    <rule ref="category/java/bestpractices.xml/JUnitTestContainsTooManyAsserts">
         <properties>
             <property name="maximumAsserts" value="11"/>
-            <!--Methods `testTokenNumbers` and `testRuleNumbers` in GeneratedJavadocTokenTypesTest contain several asserts as they check each token and each rule explicitly-->
-            <!--Method `testTokenValues` in JavadocTokenTypes contains several asserts as it checks each token explicitly-->
-            <property name="violationSuppressXPath" value="
-            //ClassOrInterfaceDeclaration[@Image='GeneratedJavadocTokenTypesTest']
-            | //MethodDeclaration[@Name='testTokenValues' and ../../..[@Image='JavadocTokenTypesTest']]"/>
+            <!-- GeneratedJavadocTokenTypesTest.testTokenNumbers and
+                   GeneratedJavadocTokenTypesTest.testRuleNumbers contains several asserts
+                   as they check each token and each rule explicitly.
+                 JavadocTokenTypes.testTokenValues contains several asserts as it checks each
+                   token explicitly. -->
+            <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='JavadocTokenTypesTest']//MethodDeclaration[@Name='testTokenValues']
+            | //ClassOrInterfaceDeclaration[@Image='GeneratedJavadocTokenTypesTest']//MethodDeclaration[@Name='testTokenNumbers' or @Name='testRuleNumbers']"/>
         </properties>
     </rule>
 
@@ -134,14 +146,4 @@
         </properties>
     </rule>
 
-    <rule ref="rulesets/java/unusedcode.xml/UnusedPrivateMethod">
-        <properties>
-            <!-- generates false-positives on private methods called within a file -->
-            <property name="violationSuppressXPath" value="
-            //ClassOrInterfaceDeclaration[@Image='IndentationCheckTest']//MethodDeclarator[@Image='verifyWarns']
-            | //ClassOrInterfaceDeclaration[@Image='SuppressWarningsFilterTest']//MethodDeclarator[@Image='verifySuppressed']
-            | //ClassOrInterfaceDeclaration[@Image='SuppressWithNearbyCommentFilterTest']//MethodDeclarator[@Image='verifySuppressed']
-            | //ClassOrInterfaceDeclaration[@Image='SuppressionCommentFilterTest']//MethodDeclarator[@Image='verifySuppressed']"/>
-        </properties>
-    </rule>
 </ruleset>

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -70,29 +70,54 @@
 
   <rule ref="rulesets/java/basic.xml"/>
   <rule ref="rulesets/java/braces.xml"/>
-  <rule ref="rulesets/java/codesize.xml">
-    <!-- we are using CyclomaticComplexity -->
-    <exclude name="ModifiedCyclomaticComplexity"/>
-    <!-- we are using CyclomaticComplexity -->
-    <exclude name="StdCyclomaticComplexity"/>
-  </rule>
 
-  <rule ref="rulesets/java/codesize.xml/NcssCount">
+  <rule ref="category/java/design.xml">
+    <!-- Too much false-positives on the check classes.
+         We do not follow the philosophy of complete encapsulation, we like data classes
+         (preferable immutable) to transfer content from one part to another.
+         There is no way to configure the rule (it has no properties). -->
+    <exclude name="DataClass"/>
+    <!-- Too much alarms on the check classes, we will never move logic out of the check,
+         each check is an independent logic container. -->
+    <exclude name="GodClass"/>
+    <!-- Too many violations, will be suppressed until we find out how use these metrics. -->
+    <exclude name="LawOfDemeter"/>
+  </rule>
+  <rule ref="category/java/design.xml/AvoidCatchingGenericException">
+    <properties>
+      <!-- There is no other way to deliver the filename that was under processing.
+           See https://github.com/checkstyle/checkstyle/issues/2285 -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='Checker']//MethodDeclaration[@Name='processFiles']"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes">
+    <properties>
+      <!-- There is no other way to deliver the filename that was under processing.
+           See https://github.com/checkstyle/checkstyle/issues/2285 -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='Checker']//MethodDeclaration[@Name='processFiles']"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/design.xml/CouplingBetweenObjects">
+    <properties>
+      <!-- I do not see any problem, looks like a false positive. -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='HandlerFactory']"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/design.xml/NcssCount">
     <properties>
       <property name="methodReportLevel" value="32"/>
-      <!-- The classes Main, PackageObjectFactory, CheckstyleAntTask, RequireThisCheck,
+      <!-- Main, PackageObjectFactory, CheckstyleAntTask, RequireThisCheck, HandlerFactory,
              VariableDeclarationUsageDistanceCheck, CommentsIndentationCheck, JavadocMethodCheck,
-             HandlerFactory are big and should not be split without a good reason.
-           The test classes should be one whole piece of code.
+             are big and should not be split without a good reason.
            The methods visitToken/leaveToken are a big SWITCH block with a number of IF blocks.
              If we split the block to several methods it will damage the readability.
-           The methods XMLLogger.encode, FallThroughCheck.isTerminated, ElementNode.iterateAxis,
+           XMLLogger.encode, FallThroughCheck.isTerminated, ElementNode.iterateAxis,
              NoWhitespaceAfterCheck.getArrayDeclaratorPreviousElement are also huge switches,
              they has to be monolithic. -->
       <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='Main'
         or @Image='PackageObjectFactory' or @Image='CheckstyleAntTask' or @Image='RequireThisCheck'
         or @Image='VariableDeclarationUsageDistanceCheck' or @Image='CommentsIndentationCheck'
-        or @Image='JavadocMethodCheck' or @Image='HandlerFactory' or ends-with(@Image,'Test')]
+        or @Image='JavadocMethodCheck' or @Image='HandlerFactory']
       | //ClassOrInterfaceDeclaration[@Image='XMLLogger']//MethodDeclaration[@Name='encode']
       | //ClassOrInterfaceDeclaration[@Image='LeftCurlyCheck' or @Image='FinalLocalVariableCheck'
         or @Image='ImportOrderCheck' or @Image='NPathComplexityCheck']//MethodDeclaration[@Name='visitToken']
@@ -104,66 +129,82 @@
       "/>
     </properties>
   </rule>
-
-  <rule ref="rulesets/java/codesize.xml/CyclomaticComplexity">
+  <rule ref="category/java/design.xml/CyclomaticComplexity">
     <properties>
       <property name="classReportLevel" value="76"/>
       <property name="methodReportLevel" value="11"/>
-      <!-- DeclarationOrder - 'visitToken' has just big SWITCH block which contains IF blocks.
-           If we split the block to several methods it will damage readability.
-           validateCli is not reasonable to split as encapsulation of logic will be damaged
-           getDetails - huge Switch, it has to be monolithic
-           JavadocMethodCheck, JavadocStyleCheck, JavadocUtils.getJavadocTags() - deprecated
-           FinalLocalVariableCheck.visitToken() - it is just big switch , not could be done
-           GenericWhitespaceCheck.processSingleGeneric() - it contains a lot of similar to each other and very simple condition
-           VariableDeclarationUsageDistanceCheck, CustomImportOrderCheck - it is not OK to have such a complicated logic need to be refactored.
-      -->
-      <property name="violationSuppressXPath" value="//DeclarationOrder[@Name='visitToken'] and //MethodDeclaration[@Name='validateCli' and ../../..[@Image='Main']] | //MethodDeclaration[@Name='processSingleGeneric' and ../../..[@Image='GenericWhitespaceCheck']] | //MethodDeclaration[@Name='visitToken' and ../../..[@Image='FinalLocalVariableCheck']] | //MethodDeclaration[@Name='getJavadocTags' and ../../..[@Image='JavadocUtils']] | //MethodDeclaration[@Name='getDetails' and ../../..[@Image='RightCurlyCheck']] | //ClassOrInterfaceDeclaration[@Image='JavadocMethodCheck' or @Image='JavadocStyleCheck' or @Image='VariableDeclarationUsageDistanceCheck' or @Image='CustomImportOrderCheck']"/>
+      <!-- RequireThisCheck, VariableDeclarationUsageDistanceCheck, XdocsPagesTest,
+             JavadocMethodCheck and CommentsIndentationCheck are big classes and should not
+             be split without a good reason.
+           Main.validateCli is not reasonable to split as encapsulation of the logic will be
+             damaged.
+           *.visitToken are a big SWITCH block with a number of IF blocks.
+             If we split the block to several methods it will damage the readability.
+           JavadocStyleCheck is deprecated.
+           SuppressWarningsHolder.getAcceptableParent, FallThroughCheck.isTerminated,
+             ElementNode.iterateAxis, RootNode.iterateAxis are also huge switches,
+             they has to be monolithic.
+           CustomImportOrderCheck.finishImportList, CustomImportOrderCheck.getImportGroup are
+             validated by checkstyle version of Npath, we think that pmd is wrong here.
+           Checker.processFiles is validated by checkstyle version of Npath, we think that pmd is
+             wrong here. -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='RequireThisCheck'
+      or @Image='VariableDeclarationUsageDistanceCheck' or @Image='XdocsPagesTest'
+      or @Image='JavadocMethodCheck' or @Image='CommentsIndentationCheck']
+    | //ClassOrInterfaceDeclaration[@Image='Main']//MethodDeclaration[@Name='validateCli']
+    | //ClassOrInterfaceDeclaration[@Image='Checker']//MethodDeclaration[@Name='processFiles']
+    | //ClassOrInterfaceDeclaration[@Image='FallThroughCheck']//MethodDeclaration[@Name='isTerminated']
+    | //ClassOrInterfaceDeclaration[@Image='SuppressWarningsHolder']//MethodDeclaration[@Name='getAcceptableParent']
+    | //ClassOrInterfaceDeclaration[@Image='CustomImportOrderCheck']//MethodDeclaration[@Name='finishImportList' or @Name='getImportGroup']
+    | //ClassOrInterfaceDeclaration[@Image='JavadocStyleCheck']//MethodDeclaration[@Name='checkHtmlTags']
+    | //ClassOrInterfaceDeclaration[@Image='ElementNode' or @Image='RootNode']//MethodDeclaration[@Name='iterateAxis']
+    | //ClassOrInterfaceDeclaration[@Image='NPathComplexityCheck'
+      or @Image='EmptyLineSeparatorCheck' or @Image='LeftCurlyCheck' or @Image='ImportOrderCheck'
+      or @Image='DeclarationOrderCheck' or @Image='MissingOverrideCheck'
+      or @Image='FinalLocalVariableCheck' or @Image='ModifiedControlVariableCheck'
+      or @Image='ParameterAssignmentCheck' or @Image='UnnecessaryParenthesesCheck'
+      or @Image='AbstractClassCouplingCheck' or @Image='BooleanExpressionComplexityCheck'
+      or @Image='ParenPadCheck']//MethodDeclaration[@Name='visitToken']"/>
     </properties>
   </rule>
-  <rule ref="rulesets/java/codesize.xml/NPathComplexity">
+  <rule ref="category/java/design.xml/TooManyFields">
     <properties>
-      <!-- JavadocMethodCheck - deprecated
-           WhitespaceAroundCheck.isNotRelevantSituation - npath = 216, but additional extraction
-                                of expression to separate method does not make sense as it will
-                                damage encapsulation of that check.
-      -->
-      <property name="violationSuppressXPath" value="//MethodDeclaration[@Name='isNotRelevantSituation' and ../../..[@Image='WhitespaceAroundCheck']] | //MethodDeclaration[@Name='validateCli' and ../../..[@Image='Main']] | //ClassOrInterfaceDeclaration[@Image='JavadocMethodCheck' or @Image='JavadocStyleCheck']"/>
-    </properties>
-  </rule>
-  <rule ref="rulesets/java/codesize.xml/TooManyFields">
-    <properties>
-      <!-- Unable to split fields out of class. -->
+      <!-- Unable to split fields out of the class. -->
       <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='Checker']"/>
     </properties>
   </rule>
-  <rule ref="rulesets/java/codesize.xml/TooManyMethods">
+  <rule ref="category/java/design.xml/TooManyMethods">
     <properties>
       <property name="maxmethods" value="20"/>
-      <!-- Reducing the number of methods in RequireThisCheck requires making excess hierarchy or duplicating code, or making existing methods too complex. -->
-      <!-- PackageObjectFactory has many boilerplate methods. -->
-      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='RequireThisCheck' or @Image='PackageObjectFactory']"/>
+      <!-- Reducing the number of methods in RequireThisCheck requires making an excessive hierarchy
+             or duplicating the code, or making existing methods too complex.
+           The class PackageObjectFactory has many boilerplate methods. -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='RequireThisCheck'
+        or @Image='PackageObjectFactory']"/>
     </properties>
   </rule>
-  <rule ref="rulesets/java/codesize.xml/ExcessiveClassLength">
+  <rule ref="category/java/design.xml/ExcessiveClassLength">
     <properties>
-      <!-- *TokenTypes are special classes that a big due to a lot of description comments -->
-      <!-- JavadocMethodCheck is deprecated class, till it is redone to use JavadocAst -->
-      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='JavadocTokenTypes' or @Image='TokenTypes' or @Image='JavadocMethodCheck' or @Image='RequireThisCheck']"/>
+      <!-- *TokenTypes are special classes that are big due to a lot of description comments.
+           JavadocMethodCheck is a deprecated class, till it is redone to use JavadocAst.
+           RequireThisCheck has to work with and identify many frames. -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='JavadocTokenTypes'
+        or @Image='TokenTypes' or @Image='JavadocMethodCheck' or @Image='RequireThisCheck']"/>
     </properties>
   </rule>
-  <rule ref="rulesets/java/codesize.xml/ExcessiveMethodLength">
+  <rule ref="category/java/design.xml/ExcessiveParameterList">
     <properties>
-      <!-- JavadocMethodCheck is deprecated class, till it is redone to use JavadocAst -->
-      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='JavadocMethodCheck']"/>
-      <!-- getDetails() method is a huge SWITCH, it has to be monolithic -->
-      <property name="violationSuppressXPath" value="//MethodDeclaration[@Name='getDetails' and ../../..[@Image='RightCurlyCheck']]"/>
-    </properties>
-  </rule>
-  <rule ref="rulesets/java/codesize.xml/ExcessiveParameterList">
-    <properties>
-      <!-- LocalizedMessage class has constructor with many parameters -->
+      <!-- The class LocalizedMessage has a constructor with many parameters by design. -->
       <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='LocalizedMessage']"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/design.xml/ExcessiveImports">
+    <properties>
+      <!-- Main actively uses Checkstyle, logging and command line parsing API.
+           CheckstyleAntTask integrates Checkstyle with Ant.
+           Checker collects external resource locations and sets up the configuration. -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='Main'
+        or @Image='Checker' or @Image='CheckstyleAntTask']"/>
     </properties>
   </rule>
 
@@ -213,25 +254,6 @@
     <properties>
       <!-- that class integrates checkstyle and antlr that is why it has a lot of imports -->
       <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='AutomaticBean']"/>
-    </properties>
-  </rule>
-  <rule ref="rulesets/java/coupling.xml">
-    <!-- produce too much violations, suppressed till we figure out how useful that metrics-->
-    <exclude name="LawOfDemeter"/>
-    <!-- this rule is for managing import, we have special Check for that -->
-    <exclude name="LoosePackageCoupling"/>
-  </rule>
-  <rule ref="rulesets/java/coupling.xml/ExcessiveImports">
-    <properties>
-      <!-- TreeWalker integrates Checkstyle and antlr and CheckstyleAntTask integrates Checkstyle
-       with Ant. Checker collects external resource locations and setup configuration. -->
-      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='CheckstyleAntTask' or @Image='Checker' or @Image='Main']"/>
-    </properties>
-  </rule>
-  <rule ref="rulesets/java/coupling.xml/CouplingBetweenObjects">
-    <properties>
-      <!-- I do not see any problem , looks like false positive -->
-      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='HandlerFactory']"/>
     </properties>
   </rule>
 
@@ -372,20 +394,6 @@
     <!--not configurable, decreases readability-->
     <exclude name="UseStringBufferForStringAppends"/>
   </rule>
-  <rule ref="rulesets/java/strictexception.xml/AvoidCatchingGenericException">
-    <properties>
-      <!-- There is no other way to deliver filename that was under processing.
-           See https://github.com/checkstyle/checkstyle/issues/2285-->
-      <property name="violationSuppressXPath" value="//MethodDeclaration[@Name='processFiles' and ../../..[@Image='Checker']]"/>
-    </properties>
-  </rule>
-  <rule ref="rulesets/java/strictexception.xml/AvoidThrowingRawExceptionTypes">
-    <properties>
-      <!-- There is no other way to deliver filename that was under processing.
-           See https://github.com/checkstyle/checkstyle/issues/2285-->
-      <property name="violationSuppressXPath" value="//MethodDeclaration[@Name='processFiles' and ../../..[@Image='Checker']]"/>
-    </properties>
-  </rule>
 
   <rule ref="rulesets/java/strings.xml"/>
   <rule ref="rulesets/java/strings.xml/AvoidDuplicateLiterals">
@@ -395,7 +403,6 @@
       <property name="skipAnnotations" value="true"/>
     </properties>
   </rule>
-  <rule ref="rulesets/java/typeresolution.xml"/>
   <rule ref="rulesets/java/unnecessary.xml"/>
 
 </ruleset>


### PR DESCRIPTION
Issue #5603

Part 4.
All the rulesets that are completely absorbed by the category `design` have been removed.
Rulesets that are partially moved to the category `design` will be retained until they are completely absorbed.
For the transition time some rules will be are excluded twice: one for the old ruleset, another for the new category.

Absorbed rulesets:
- rulesets/java/codesize.xml
- rulesets/java/coupling.xml
- rulesets/java/junit.xml
- rulesets/java/strictexception.xml
- rulesets/java/typeresolution.xml
