### PR TITLE
Issue #5706: fixed FinalClassCheck extracting qualified names

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -21,12 +21,11 @@ package com.puppycrawl.tools.checkstyle.checks.design;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.LinkedList;
-import java.util.List;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtils;
 
@@ -92,7 +91,7 @@ public class FinalClassCheck
 
         switch (ast.getType()) {
             case TokenTypes.PACKAGE_DEF:
-                packageName = extractQualifiedName(ast);
+                packageName = extractQualifiedName(ast.getFirstChild().getNextSibling());
                 break;
 
             case TokenTypes.CLASS_DEF:
@@ -140,31 +139,12 @@ public class FinalClassCheck
     }
 
     /**
-     * Get name of class(with qualified package if specified) in extend clause.
-     * @param classExtend extend clause to extract class name
-     * @return super class name
+     * Get name of class (with qualified package if specified) in {@code ast}.
+     * @param ast ast to extract class name from
+     * @return qualified name
      */
-    private static String extractQualifiedName(DetailAST classExtend) {
-        final String className;
-
-        if (classExtend.findFirstToken(TokenTypes.IDENT) == null) {
-            // Name specified with packages, have to traverse DOT
-            final DetailAST firstChild = classExtend.findFirstToken(TokenTypes.DOT);
-            final List<String> qualifiedNameParts = new LinkedList<>();
-
-            qualifiedNameParts.add(0, firstChild.findFirstToken(TokenTypes.IDENT).getText());
-            DetailAST traverse = firstChild.findFirstToken(TokenTypes.DOT);
-            while (traverse != null) {
-                qualifiedNameParts.add(0, traverse.findFirstToken(TokenTypes.IDENT).getText());
-                traverse = traverse.findFirstToken(TokenTypes.DOT);
-            }
-            className = String.join(PACKAGE_SEPARATOR, qualifiedNameParts);
-        }
-        else {
-            className = classExtend.findFirstToken(TokenTypes.IDENT).getText();
-        }
-
-        return className;
+    private static String extractQualifiedName(DetailAST ast) {
+        return FullIdent.createFullIdent(ast).getText();
     }
 
     /**
@@ -236,7 +216,7 @@ public class FinalClassCheck
         String superClassName = null;
         final DetailAST classExtend = classAst.findFirstToken(TokenTypes.EXTENDS_CLAUSE);
         if (classExtend != null) {
-            superClassName = extractQualifiedName(classExtend);
+            superClassName = extractQualifiedName(classExtend.getFirstChild());
         }
         return superClassName;
     }


### PR DESCRIPTION
Issue #5706

I will run regression to see if there are any affected cases.
Most likely it will only happen with very similar package/class names like `com.company.A` and `com.A`.