### PR TITLE
Issue #5616: Remove remnants of cobertura usage

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -125,17 +125,6 @@
             <property name="forbiddenImportsExcludesRegexp"
                       value="^com.puppycrawl.tools.checkstyle.checks.naming.AccessModifier$"/>
         </module>
-        <module name="ForbidCertainImports">
-            <property name="packageNameRegexp" value=".+"/>
-            <property name="id" value="ForbidInterfacesImportFromJavaUtilStream"/>
-            <!--Disallowed till https://github.com/mojohaus/cobertura-maven-plugin/issues/29-->
-            <property name="forbiddenImportsRegexp" value="java\.util\.stream\.Stream|
-            java\.util\.stream\.Stream\.Builder|java\.util\.stream\.DoubleStream|
-            java\.util\.stream\.DoubleStream\.Builder|java\.util\.stream\.IntStream|
-            java\.util\.stream\.IntStream\.Builder|java\.util\.stream\.LongStream|
-            java\.util\.stream\.LongStream\.Builder|java\.util\.stream\.BaseStream|
-            java\.util\.stream\.Collector"/>
-        </module>
         <module name="LineLengthExtended">
             <property name="max" value="100"/>
             <property name="ignoreClass" value="true"/>

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -10,18 +10,6 @@
          See https://github.com/checkstyle/checkstyle/issues/5638 -->
   <disallow class="java.io.FileInputStream"/>
   <disallow class="java.io.FileOutputStream"/>
-  <!--Disallowed till https://github.com/mojohaus/cobertura-maven-plugin/issues/29-->
-  <disallow class="java.util.stream.Stream"/>
-  <disallow class="java.util.stream.Stream.Builder"/>
-  <disallow class="java.util.stream.DoubleStream"/>
-  <disallow class="java.util.stream.DoubleStream.Builder"/>
-  <disallow class="java.util.stream.IntStream"/>
-  <disallow class="java.util.stream.IntStream.Builder"/>
-  <disallow class="java.util.stream.LongStream"/>
-  <disallow class="java.util.stream.LongStream.Builder"/>
-  <disallow class="java.util.stream.BaseStream"/>
-  <disallow class="java.util.stream.Collector"/>
-  <disallow class="java.util.Comparator"/>
 
   <allow pkg="antlr"/>
   <allow pkg="com.puppycrawl.tools.checkstyle.api"/>

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -27,11 +27,6 @@
     <suppress checks="ForbidCertainImports"
               files="JavadocUtils\.java|JavadocUtilsTest\.java"/>
 
-    <!--ITs and UTs are not included in Cobertura coverage report
-    and do not have coverage problems due to imports from java.util.stream. -->
-    <suppress id="ForbidInterfacesImportFromJavaUtilStream"
-              files=".*[\\/]src[\\/](test|it)[\\/]"/>
-
     <!-- Tone down the checking for test code -->
     <suppress checks="ForbidCertainImports"
               files="DetailASTTest\.java"/>

--- a/src/it/java/com/google/checkstyle/test/base/AbstractModuleTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/AbstractModuleTestSupport.java
@@ -247,9 +247,9 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
         final int errs = checker.process(theFiles);
 
         // process each of the lines
-        final ByteArrayInputStream inputStream =
+        try (ByteArrayInputStream inputStream =
                 new ByteArrayInputStream(stream.toByteArray());
-        try (LineNumberReader lnr = new LineNumberReader(
+            LineNumberReader lnr = new LineNumberReader(
                 new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
             int previousLineNumber = 0;
             for (int i = 0; i < expected.length; i++) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java
@@ -39,7 +39,6 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtils;
 
 /**
@@ -102,10 +101,7 @@ public final class JavadocPropertiesGenerator {
      */
     private static void writePropertiesFile(File inputFile, File outputFile)
             throws CheckstyleException {
-        PrintWriter writer = null;
-        try {
-            writer = new PrintWriter(outputFile, StandardCharsets.UTF_8.name());
-
+        try (PrintWriter writer = new PrintWriter(outputFile, StandardCharsets.UTF_8.name())) {
             final DetailAST top = JavaParser.parseFile(inputFile, JavaParser.Options.WITH_COMMENTS);
             final DetailAST objBlock = getClassBody(top);
             if (objBlock != null) {
@@ -115,9 +111,6 @@ public final class JavadocPropertiesGenerator {
         catch (IOException ex) {
             throw new CheckstyleException("Failed to write javadoc properties of '" + inputFile
                 + "' to '" + outputFile + "'", ex);
-        }
-        finally {
-            CommonUtils.close(writer);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -45,7 +45,6 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -589,19 +588,14 @@ public final class Main {
             throws CheckstyleException {
         final Properties properties = new Properties();
 
-        InputStream fis = null;
-        try {
-            fis = Files.newInputStream(file.toPath());
-            properties.load(fis);
+        try (InputStream stream = Files.newInputStream(file.toPath())) {
+            properties.load(stream);
         }
         catch (final IOException ex) {
             final LocalizedMessage loadPropertiesExceptionMessage = new LocalizedMessage(0,
                     Definitions.CHECKSTYLE_BUNDLE, LOAD_PROPERTIES_EXCEPTION,
                     new String[] {file.getAbsolutePath()}, null, Main.class, null);
             throw new CheckstyleException(loadPropertiesExceptionMessage.getMessage(), ex);
-        }
-        finally {
-            Closeables.closeQuietly(fis);
         }
 
         return properties;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -36,7 +36,6 @@ import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
@@ -162,17 +161,12 @@ public final class PackageNamesLoader
      */
     private static void processFile(URL packageFile, PackageNamesLoader namesLoader)
             throws SAXException, CheckstyleException {
-        InputStream stream = null;
-        try {
-            stream = new BufferedInputStream(packageFile.openStream());
+        try (InputStream stream = new BufferedInputStream(packageFile.openStream())) {
             final InputSource source = new InputSource(stream);
             namesLoader.parseInputSource(source);
         }
         catch (IOException ex) {
             throw new CheckstyleException("unable to open " + packageFile, ex);
-        }
-        finally {
-            Closeables.closeQuietly(stream);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java
@@ -114,18 +114,13 @@ final class PropertyCacheFile {
         configHash = getHashCodeBasedOnObjectContent(config);
         final File file = new File(fileName);
         if (file.exists()) {
-            InputStream inStream = null;
-            try {
-                inStream = Files.newInputStream(file.toPath());
+            try (InputStream inStream = Files.newInputStream(file.toPath())) {
                 details.load(inStream);
                 final String cachedConfigHash = details.getProperty(CONFIG_HASH_KEY);
                 if (!configHash.equals(cachedConfigHash)) {
                     // Detected configuration change - clear cache
                     reset();
                 }
-            }
-            finally {
-                Closeables.closeQuietly(inStream);
             }
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -44,7 +44,6 @@ import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.types.Path;
 import org.apache.tools.ant.types.Reference;
 
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
 import com.puppycrawl.tools.checkstyle.DefaultLogger;
@@ -323,18 +322,9 @@ public class CheckstyleAntTask extends Task {
             processFiles(rootModule, warningCounter, checkstyleVersion);
         }
         finally {
-            destroyRootModule(rootModule);
-        }
-    }
-
-    /**
-     * Destroy root module. This method exists only due to bug in cobertura library
-     * https://github.com/cobertura/cobertura/issues/170
-     * @param rootModule Root module that was used to process files
-     */
-    private static void destroyRootModule(RootModule rootModule) {
-        if (rootModule != null) {
-            rootModule.destroy();
+            if (rootModule != null) {
+                rootModule.destroy();
+            }
         }
     }
 
@@ -443,17 +433,12 @@ public class CheckstyleAntTask extends Task {
 
         // Load the properties file if specified
         if (properties != null) {
-            InputStream inStream = null;
-            try {
-                inStream = Files.newInputStream(properties.toPath());
+            try (InputStream inStream = Files.newInputStream(properties.toPath())) {
                 returnValue.load(inStream);
             }
             catch (final IOException ex) {
                 throw new BuildException("Error loading Properties file '"
                         + properties + "'", ex, getLocation());
-            }
-            finally {
-                Closeables.closeQuietly(inStream);
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -38,8 +38,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
-
 /**
  * Represents the text contents of a file of arbitrary plain text type.
  * <p>
@@ -126,8 +124,7 @@ public final class FileText {
         // Use the BufferedReader to break down the lines as this
         // is about 30% faster than using the
         // LINE_TERMINATOR.split(fullText, -1) method
-        final BufferedReader reader = new BufferedReader(new StringReader(fullText));
-        try {
+        try (BufferedReader reader = new BufferedReader(new StringReader(fullText))) {
             final ArrayList<String> textLines = new ArrayList<>();
             while (true) {
                 final String line = reader.readLine();
@@ -137,9 +134,6 @@ public final class FileText {
                 textLines.add(line);
             }
             lines = textLines.toArray(new String[textLines.size()]);
-        }
-        finally {
-            CommonUtils.close(reader);
         }
     }
 
@@ -197,8 +191,7 @@ public final class FileText {
         }
         final StringBuilder buf = new StringBuilder(1024);
         final InputStream stream = Files.newInputStream(inputFile.toPath());
-        final Reader reader = new InputStreamReader(stream, decoder);
-        try {
+        try (Reader reader = new InputStreamReader(stream, decoder)) {
             final char[] chars = new char[READ_BUFFER_SIZE];
             while (true) {
                 final int len = reader.read(chars);
@@ -207,9 +200,6 @@ public final class FileText {
                 }
                 buf.append(chars, 0, len);
             }
-        }
-        finally {
-            CommonUtils.close(reader);
         }
         return buf.toString();
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.Locale;
 
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
@@ -110,16 +109,10 @@ public class NewlineAtEndOfFileCheck
      */
     private void readAndCheckFile(File file) throws IOException {
         // Cannot use lines as the line separators have been removed!
-        final RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r");
-        boolean threw = true;
-        try {
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
             if (!endsWithNewline(randomAccessFile)) {
                 log(0, MSG_KEY_NO_NEWLINE_EOF, file.getPath());
             }
-            threw = false;
-        }
-        finally {
-            Closeables.close(randomAccessFile, threw);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -42,7 +42,6 @@ import org.apache.commons.logging.LogFactory;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.Definitions;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
@@ -477,18 +476,13 @@ public class TranslationCheck extends AbstractFileSetCheck {
      */
     private Set<String> getTranslationKeys(File file) {
         Set<String> keys = new HashSet<>();
-        InputStream inStream = null;
-        try {
-            inStream = Files.newInputStream(file.toPath());
+        try (InputStream inStream = Files.newInputStream(file.toPath())) {
             final Properties translations = new Properties();
             translations.load(inStream);
             keys = translations.stringPropertyNames();
         }
         catch (final IOException ex) {
             logIoException(ex, file);
-        }
-        finally {
-            Closeables.closeQuietly(inStream);
         }
         return keys;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -31,7 +31,6 @@ import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multiset.Entry;
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
@@ -68,17 +67,12 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
     @Override
     protected void processFiltered(File file, FileText fileText) {
         final UniqueProperties properties = new UniqueProperties();
-        InputStream inputStream = null;
-        try {
-            inputStream = Files.newInputStream(file.toPath());
+        try (InputStream inputStream = Files.newInputStream(file.toPath())) {
             properties.load(inputStream);
         }
         catch (IOException ex) {
             log(0, MSG_IO_EXCEPTION_KEY, file.getPath(),
                     ex.getLocalizedMessage());
-        }
-        finally {
-            Closeables.closeQuietly(inputStream);
         }
 
         for (Entry<String> duplication : properties

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.ExternalResourceHolder;
@@ -109,18 +108,13 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
      */
     private void loadHeaderFile() throws CheckstyleException {
         checkHeaderNotInitialized();
-        Reader headerReader = null;
-        try {
-            headerReader = new InputStreamReader(new BufferedInputStream(
-                    headerFile.toURL().openStream()), charset);
+        try (Reader headerReader = new InputStreamReader(new BufferedInputStream(
+                    headerFile.toURL().openStream()), charset)) {
             loadHeader(headerReader);
         }
         catch (final IOException ex) {
             throw new CheckstyleException(
                     "unable to load header file " + headerFile, ex);
-        }
-        finally {
-            Closeables.closeQuietly(headerReader);
         }
     }
 
@@ -149,15 +143,11 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
             final String headerExpandedNewLines = ESCAPED_LINE_FEED_PATTERN
                     .matcher(header).replaceAll("\n");
 
-            final Reader headerReader = new StringReader(headerExpandedNewLines);
-            try {
+            try (Reader headerReader = new StringReader(headerExpandedNewLines)) {
                 loadHeader(headerReader);
             }
             catch (final IOException ex) {
                 throw new IllegalArgumentException("unable to load header", ex);
-            }
-            finally {
-                Closeables.closeQuietly(headerReader);
             }
         }
     }
@@ -168,8 +158,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
      * @throws IOException if
      */
     private void loadHeader(final Reader headerReader) throws IOException {
-        final LineNumberReader lnr = new LineNumberReader(headerReader);
-        try {
+        try (LineNumberReader lnr = new LineNumberReader(headerReader)) {
             String line;
             do {
                 line = lnr.readLine();
@@ -178,9 +167,6 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
                 }
             } while (line != null);
             postProcessHeaderLines();
-        }
-        finally {
-            Closeables.closeQuietly(lnr);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -185,9 +185,7 @@ final class ImportControlLoader extends XmlLoader {
      * @throws CheckstyleException if an error occurs.
      */
     public static ImportControl load(URI uri) throws CheckstyleException {
-        InputStream inputStream = null;
-        try {
-            inputStream = uri.toURL().openStream();
+        try (InputStream inputStream = uri.toURL().openStream()) {
             final InputSource source = new InputSource(inputStream);
             return load(source, uri);
         }
@@ -196,9 +194,6 @@ final class ImportControlLoader extends XmlLoader {
         }
         catch (IOException ex) {
             throw new CheckstyleException("unable to find " + uri, ex);
-        }
-        finally {
-            closeStream(inputStream);
         }
     }
 
@@ -222,23 +217,6 @@ final class ImportControlLoader extends XmlLoader {
         }
         catch (IOException ex) {
             throw new CheckstyleException("unable to read " + uri, ex);
-        }
-    }
-
-    /**
-     * This method exists only due to bug in cobertura library
-     * https://github.com/cobertura/cobertura/issues/170
-     * @param inputStream the InputStream to close
-     * @throws CheckstyleException if an error occurs.
-     */
-    private static void closeStream(InputStream inputStream) throws CheckstyleException {
-        if (inputStream != null) {
-            try {
-                inputStream.close();
-            }
-            catch (IOException ex) {
-                throw new CheckstyleException("unable to close input stream", ex);
-            }
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/FilterUtils.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/FilterUtils.java
@@ -21,8 +21,6 @@ package com.puppycrawl.tools.checkstyle.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
-import java.net.URL;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
@@ -42,41 +40,14 @@ public final class FilterUtils {
      * @return true if suppression file exists, otherwise false
      */
     public static boolean isFileExists(String fileName) {
-        boolean suppressionSourceExists = true;
-        InputStream sourceInput = null;
-        try {
-            final URI uriByFilename = CommonUtils.getUriByFilename(fileName);
-            final URL url = uriByFilename.toURL();
-            sourceInput = url.openStream();
+        boolean suppressionSourceExists;
+        try (InputStream stream = CommonUtils.getUriByFilename(fileName).toURL().openStream()) {
+            suppressionSourceExists = true;
         }
         catch (CheckstyleException | IOException ignored) {
             suppressionSourceExists = false;
         }
-        finally {
-            suppressionSourceExists = closeQuietlyWithResult(sourceInput, suppressionSourceExists);
-        }
         return suppressionSourceExists;
-    }
-
-    /**
-     * Close input.
-     * This method is required till https://github.com/cobertura/cobertura/issues/170
-     * @param sourceInput stream to close
-     * @param suppressionSourceExists previous state of flag
-     * @return result of close operation
-     */
-    private static boolean closeQuietlyWithResult(InputStream sourceInput,
-                                                  boolean suppressionSourceExists) {
-        boolean closed = suppressionSourceExists;
-        if (sourceInput != null) {
-            try {
-                sourceInput.close();
-            }
-            catch (IOException ignored) {
-                closed = false;
-            }
-        }
-        return closed;
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -278,9 +278,9 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
         final int errs = checker.process(theFiles);
 
         // process each of the lines
-        final ByteArrayInputStream inputStream =
+        try (ByteArrayInputStream inputStream =
                 new ByteArrayInputStream(stream.toByteArray());
-        try (LineNumberReader lnr = new LineNumberReader(
+            LineNumberReader lnr = new LineNumberReader(
                 new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
             final List<String> actuals = lnr.lines().limit(expected.length)
                     .sorted().collect(Collectors.toList());
@@ -355,10 +355,9 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
 
     private Map<String, List<String>> getActualViolations(int errorCount) throws IOException {
         // process each of the lines
-        final ByteArrayInputStream inputStream =
+        try (ByteArrayInputStream inputStream =
                 new ByteArrayInputStream(stream.toByteArray());
-
-        try (LineNumberReader lnr = new LineNumberReader(
+            LineNumberReader lnr = new LineNumberReader(
                 new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
             final Map<String, List<String>> actualViolations = new HashMap<>();
             for (String line = lnr.readLine(); line != null && lnr.getLineNumber() <= errorCount;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -982,47 +982,49 @@ public class CheckerTest extends AbstractModuleTestSupport {
     @Test
     public void testDefaultLoggerClosesItStreams() throws Exception {
         final Checker checker = new Checker();
-        final CloseAndFlushTestByteArrayOutputStream testInfoOutputStream =
-            new CloseAndFlushTestByteArrayOutputStream();
-        final CloseAndFlushTestByteArrayOutputStream testErrorOutputStream =
-            new CloseAndFlushTestByteArrayOutputStream();
-        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
-        checker.addListener(new DefaultLogger(testInfoOutputStream,
-            true, testErrorOutputStream, true));
+        try (CloseAndFlushTestByteArrayOutputStream testInfoOutputStream =
+                new CloseAndFlushTestByteArrayOutputStream();
+            CloseAndFlushTestByteArrayOutputStream testErrorOutputStream =
+                new CloseAndFlushTestByteArrayOutputStream()) {
+            checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+            checker.addListener(new DefaultLogger(testInfoOutputStream,
+                true, testErrorOutputStream, true));
 
-        final File tmpFile = temporaryFolder.newFile("file.java");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+            final File tmpFile = temporaryFolder.newFile("file.java");
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checker, tmpFile.getPath(), expected);
+            verify(checker, tmpFile.getPath(), expected);
 
-        assertEquals("Close count was not expected",
-                1, testInfoOutputStream.getCloseCount());
-        assertEquals("Flush count was not expected",
-                3, testInfoOutputStream.getFlushCount());
-        assertEquals("Close count was not expected",
-                1, testErrorOutputStream.getCloseCount());
-        assertEquals("Flush count was not expected",
-                1, testErrorOutputStream.getFlushCount());
+            assertEquals("Close count was not expected",
+                    1, testInfoOutputStream.getCloseCount());
+            assertEquals("Flush count was not expected",
+                    3, testInfoOutputStream.getFlushCount());
+            assertEquals("Close count was not expected",
+                    1, testErrorOutputStream.getCloseCount());
+            assertEquals("Flush count was not expected",
+                    1, testErrorOutputStream.getFlushCount());
+        }
     }
 
     // -@cs[CheckstyleTestMakeup] must use raw class to directly initialize DefaultLogger
     @Test
     public void testXmlLoggerClosesItStreams() throws Exception {
         final Checker checker = new Checker();
-        final CloseAndFlushTestByteArrayOutputStream testInfoOutputStream =
-            new CloseAndFlushTestByteArrayOutputStream();
-        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
-        checker.addListener(new XMLLogger(testInfoOutputStream, true));
+        try (CloseAndFlushTestByteArrayOutputStream testInfoOutputStream =
+                new CloseAndFlushTestByteArrayOutputStream()) {
+            checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+            checker.addListener(new XMLLogger(testInfoOutputStream, true));
 
-        final File tmpFile = temporaryFolder.newFile("file.java");
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+            final File tmpFile = temporaryFolder.newFile("file.java");
+            final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
 
-        verify(checker, tmpFile.getPath(), tmpFile.getPath(), expected);
+            verify(checker, tmpFile.getPath(), tmpFile.getPath(), expected);
 
-        assertEquals("Close count was not expected",
-                1, testInfoOutputStream.getCloseCount());
-        assertEquals("Flush count was not expected",
-                0, testInfoOutputStream.getFlushCount());
+            assertEquals("Close count was not expected",
+                    1, testInfoOutputStream.getCloseCount());
+            assertEquals("Flush count was not expected",
+                    0, testInfoOutputStream.getFlushCount());
+        }
     }
 
     @Test
@@ -1057,9 +1059,9 @@ public class CheckerTest extends AbstractModuleTestSupport {
         // super.verify does not work here, for we change the logger
         out.flush();
         final int errs = checker.process(Collections.singletonList(new File(path)));
-        final ByteArrayInputStream inputStream =
+        try (ByteArrayInputStream inputStream =
                 new ByteArrayInputStream(out.toByteArray());
-        try (LineNumberReader lnr = new LineNumberReader(
+            LineNumberReader lnr = new LineNumberReader(
                 new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
             // we need to ignore the unrelated lines
             final List<String> actual = lnr.lines()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -35,7 +35,6 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -64,7 +63,6 @@ import org.mockito.ArgumentCaptor;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
@@ -72,7 +70,7 @@ import com.puppycrawl.tools.checkstyle.internal.testmodules.TestRootModuleChecke
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Main.class, CommonUtils.class, Closeables.class})
+@PrepareForTest({Main.class, CommonUtils.class})
 public class MainTest {
 
     private static final String USAGE = String.format(Locale.ROOT,
@@ -412,10 +410,6 @@ public class MainTest {
 
     @Test
     public void testExistingTargetFilePlainOutputProperties() throws Exception {
-        mockStatic(Closeables.class);
-        doNothing().when(Closeables.class);
-        Closeables.closeQuietly(any(InputStream.class));
-
         //exit.expectSystemExitWithStatus(0);
         exit.checkAssertionAfterwards(() -> {
             assertEquals("Unexpected output log", auditStartMessage.getMessage() + EOL
@@ -425,9 +419,6 @@ public class MainTest {
         Main.main("-c", getPath("InputMainConfig-classname-prop.xml"),
                 "-p", getPath("InputMainMycheckstyle.properties"),
                 getPath("InputMain.java"));
-
-        verifyStatic(Closeables.class, times(1));
-        Closeables.closeQuietly(any(InputStream.class));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -24,17 +24,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.net.URL;
@@ -55,14 +49,13 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
 /**
  * Enter a description of class PackageNamesLoaderTest.java.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({PackageNamesLoader.class, Closeables.class})
+@PrepareForTest(PackageNamesLoader.class)
 public class PackageNamesLoaderTest extends AbstractPathTestSupport {
 
     @Override
@@ -90,10 +83,6 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
     @Test
     @SuppressWarnings("unchecked")
     public void testPackagesFile() throws Exception {
-        mockStatic(Closeables.class);
-        doNothing().when(Closeables.class);
-        Closeables.closeQuietly(any(InputStream.class));
-
         final URLConnection mockConnection = Mockito.mock(URLConnection.class);
         when(mockConnection.getInputStream()).thenReturn(
             Files.newInputStream(Paths.get(getPath("InputPackageNamesLoaderFile.xml"))));
@@ -134,9 +123,6 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
         final Set<String> checkstylePackagesSet =
                 new HashSet<>(Arrays.asList(expectedPackageNames));
         assertEquals("Invalid names set.", checkstylePackagesSet, actualPackageNames);
-
-        verifyStatic(Closeables.class, times(1));
-        Closeables.closeQuietly(any(InputStream.class));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -37,7 +37,6 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
@@ -150,10 +149,6 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
 
     @Test
     public void testPopulateDetails() throws IOException {
-        mockStatic(Closeables.class);
-        doNothing().when(Closeables.class);
-        Closeables.closeQuietly(any(InputStream.class));
-
         final Configuration config = new DefaultConfiguration("myName");
         final PropertyCacheFile cache = new PropertyCacheFile(config,
                 getPath("InputPropertyCacheFile"));
@@ -169,9 +164,6 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
         assertEquals("Invalid cache value", "value", cache.get("key"));
         assertNotNull("Config hash key should not be null",
                 cache.get(PropertyCacheFile.CONFIG_HASH_KEY));
-
-        verifyStatic(Closeables.class, times(2));
-        Closeables.closeQuietly(any(InputStream.class));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -25,16 +25,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -58,7 +53,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultLogger;
 import com.puppycrawl.tools.checkstyle.Definitions;
@@ -68,7 +62,7 @@ import com.puppycrawl.tools.checkstyle.internal.testmodules.CheckerStub;
 import com.puppycrawl.tools.checkstyle.internal.testmodules.TestRootModuleChecker;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({CheckstyleAntTask.class, Closeables.class})
+@PrepareForTest(CheckstyleAntTask.class)
 public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
 
     private static final String FLAWLESS_INPUT =
@@ -471,11 +465,6 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
 
     @Test
     public final void testSetPropertiesFile() throws IOException {
-        //check if input stream finally closed
-        mockStatic(Closeables.class);
-        doNothing().when(Closeables.class);
-        Closeables.closeQuietly(any(InputStream.class));
-
         TestRootModuleChecker.reset();
 
         final CheckstyleAntTask antTask = getCheckstyleAntTask(CUSTOM_ROOT_CONFIG_FILE);
@@ -486,8 +475,6 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
 
         assertEquals("Property is not set",
                 "ignore", TestRootModuleChecker.getProperty());
-        verifyStatic(Closeables.class, times(1));
-        Closeables.closeQuietly(any(InputStream.class));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -21,28 +21,16 @@ package com.puppycrawl.tools.checkstyle.api;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(CommonUtils.class)
 public class FileTextTest extends AbstractPathTestSupport {
 
     @Override
@@ -66,18 +54,10 @@ public class FileTextTest extends AbstractPathTestSupport {
 
     @Test
     public void testSupportedCharset() throws IOException {
-        //check if reader finally closed
-        mockStatic(CommonUtils.class);
-        doNothing().when(CommonUtils.class);
-        CommonUtils.close(any(Reader.class));
-
         final String charsetName = StandardCharsets.ISO_8859_1.name();
         final FileText fileText = new FileText(new File(getPath("InputFileTextImportControl.xml")),
                 charsetName);
         assertEquals("Invalid charset name", charsetName, fileText.getCharset().name());
-
-        verifyStatic(CommonUtils.class, times(2));
-        CommonUtils.close(any(Reader.class));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
-import static com.puppycrawl.tools.checkstyle.utils.CommonUtils.EMPTY_BYTE_ARRAY;
 import static com.puppycrawl.tools.checkstyle.utils.CommonUtils.EMPTY_OBJECT_ARRAY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -31,7 +30,6 @@ import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -43,7 +41,6 @@ import java.util.ResourceBundle;
 
 import org.junit.After;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.powermock.reflect.Whitebox;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -160,26 +157,6 @@ public class LocalizedMessageTest {
         final LocalizedMessage localizedMessage = createSampleLocalizedMessage();
 
         assertEquals("Invalid message", "Empty statement.", localizedMessage.getMessage());
-    }
-
-    @Test
-    public void testBundleWithoutReload() throws IOException {
-        final ClassLoader classloader = mock(ClassLoader.class);
-        final URLConnection mockConnection = Mockito.mock(URLConnection.class);
-        when(mockConnection.getInputStream()).thenReturn(
-                new ByteArrayInputStream(EMPTY_BYTE_ARRAY));
-
-        final URL url = getMockUrl(mockConnection);
-        final String resource =
-                "com/puppycrawl/tools/checkstyle/checks/coding/messages_en.properties";
-        when(classloader.getResource(resource)).thenReturn(url);
-
-        final LocalizedMessage.Utf8Control control = new LocalizedMessage.Utf8Control();
-        final ResourceBundle resourceBundle = control.newBundle(
-                "com.puppycrawl.tools.checkstyle.checks.coding.messages",
-                Locale.ENGLISH, "java.class", classloader, false);
-
-        assertNull("Resource bundle should not be null", resourceBundle);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -25,13 +25,7 @@ import static java.util.Locale.ENGLISH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.Mockito.times;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.io.File;
@@ -45,11 +39,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -57,8 +47,6 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(Closeables.class)
 public class NewlineAtEndOfFileCheckTest
     extends AbstractModuleTestSupport {
 
@@ -77,31 +65,6 @@ public class NewlineAtEndOfFileCheckTest
             createChecker(checkConfig),
             getPath("InputNewlineAtEndOfFileLf.java"),
             expected);
-    }
-
-    /**
-     * Pitest requires all closes of streams and readers to be verified. Using PowerMock
-     * is almost only possibility to check it without rewriting production code.
-     *
-     * @throws Exception when code tested throws some exception
-     */
-    @Test
-    public void testCloseRandomAccessFile() throws Exception {
-        mockStatic(Closeables.class);
-        doNothing().when(Closeables.class);
-        Closeables.close(any(RandomAccessFile.class), anyBoolean());
-
-        final DefaultConfiguration checkConfig =
-                createModuleConfig(NewlineAtEndOfFileCheck.class);
-        checkConfig.addAttribute("lineSeparator", LineSeparatorOption.LF.toString());
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
-        verify(
-                createChecker(checkConfig),
-                getPath("InputNewlineAtEndOfFileLf.java"),
-                expected);
-
-        verifyStatic(Closeables.class, times(1));
-        Closeables.close(any(RandomAccessFile.class), anyBoolean());
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -30,14 +30,10 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
@@ -51,11 +47,9 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.AbstractXmlTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -71,7 +65,6 @@ import com.puppycrawl.tools.checkstyle.internal.utils.XmlUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Closeables.class)
 public class TranslationCheckTest extends AbstractXmlTestSupport {
 
     @Captor
@@ -380,36 +373,6 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
             propertyFiles,
             getPath(""),
             expected);
-    }
-
-    /**
-     * Pitest requires all closes of streams and readers to be verified. Using PowerMock
-     * is almost only possibility to check it without rewriting production code.
-     *
-     * @throws Exception when code tested throws some exception
-     */
-    @Test
-    public void testResourcesAreClosed() throws Exception {
-        mockStatic(Closeables.class);
-        doNothing().when(Closeables.class);
-        Closeables.closeQuietly(any(InputStream.class));
-
-        final DefaultConfiguration checkConfig = createModuleConfig(TranslationCheck.class);
-        checkConfig.addAttribute("requiredTranslations", "es");
-
-        final File[] propertyFiles = {
-            new File(getPath("messages_home.properties")),
-            new File(getPath("messages_home_es_US.properties")),
-            };
-
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
-        verify(
-            createChecker(checkConfig),
-            propertyFiles,
-            getPath(""),
-            expected);
-        verifyStatic(Closeables.class, times(2));
-        Closeables.closeQuietly(any(InputStream.class));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -22,11 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks;
 import static com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck.MSG_IO_EXCEPTION_KEY;
 import static com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck.MSG_KEY;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,19 +39,13 @@ import java.util.SortedSet;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(Closeables.class)
 public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
 
     @Override
@@ -89,26 +78,6 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
             "34: " + getCheckMessage(MSG_KEY, "failed", 2),
         };
         verify(checkConfig, getPath("InputUniqueProperties.properties"), expected);
-    }
-
-    /**
-     * Pitest requires all closes of streams and readers to be verified. Using PowerMock
-     * is almost only possibility to check it without rewriting production code.
-     *
-     * @throws Exception when code tested throws some exception
-     */
-    @Test
-    public void testCloseInputStream() throws Exception {
-        mockStatic(Closeables.class);
-        doNothing().when(Closeables.class);
-        Closeables.closeQuietly(any(InputStream.class));
-
-        final DefaultConfiguration checkConfig = createModuleConfig(UniquePropertiesCheck.class);
-        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("InputUniquePropertiesWithoutErrors.properties"), expected);
-
-        verifyStatic(Closeables.class, times(1));
-        Closeables.closeQuietly(any(InputStream.class));
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
@@ -154,7 +154,9 @@ public class ImportControlLoaderTest {
             fail("exception expected " + available);
         }
         catch (CheckstyleException ex) {
-            assertSame("Invalid exception class", IOException.class, ex.getCause().getClass());
+            final Throwable[] suppressed = ex.getSuppressed();
+            assertEquals("Expected one suppressed exception", 1, suppressed.length);
+            assertSame("Invalid exception class", IOException.class, suppressed[0].getClass());
         }
         Mockito.verify(inputStream).close();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -216,9 +216,9 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
         final int errs = checker.process(theFiles);
 
         // process each of the lines
-        final ByteArrayInputStream localStream =
-            new ByteArrayInputStream(getStream().toByteArray());
-        try (LineNumberReader lnr = new LineNumberReader(
+        try (ByteArrayInputStream localStream =
+                new ByteArrayInputStream(getStream().toByteArray());
+            LineNumberReader lnr = new LineNumberReader(
                 new InputStreamReader(localStream, StandardCharsets.UTF_8))) {
             for (int i = 0; i < expected.length; i++) {
                 final String expectedResult = messageFileName + ":" + expected[i];

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
@@ -33,7 +33,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import com.google.common.io.Closeables;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
@@ -223,10 +222,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
             int attemptCount = 0;
 
             while (attemptCount <= attemptLimit) {
-                InputStream stream = null;
-                try {
-                    final URL address = new URL(url);
-                    stream = address.openStream();
+                try (InputStream stream = new URL(url).openStream()) {
                     // Attempt to read a byte in order to check whether file content is available
                     available = stream.read() != -1;
                     break;
@@ -240,12 +236,8 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
                         Thread.sleep(1000);
                     }
                     else {
-                        Closeables.closeQuietly(stream);
                         throw ex;
                     }
-                }
-                finally {
-                    Closeables.closeQuietly(stream);
                 }
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/FilterUtilsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/FilterUtilsTest.java
@@ -24,22 +24,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URL;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.mockito.BDDMockito;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
 public class FilterUtilsTest {
 
     @Rule
@@ -62,27 +51,6 @@ public class FilterUtilsTest {
     public void testNonExistentFile() {
         assertFalse("Suppression file does not exist",
                 FilterUtils.isFileExists("non-existent.xml"));
-    }
-
-    @Test
-    @PrepareForTest({FilterUtils.class, CommonUtils.class})
-    public void testExceptionOnClosing() throws Exception {
-        final File file = temporaryFolder.newFile("existing.xml");
-        final InputStream inputStream = PowerMockito.mock(InputStream.class);
-        Mockito.doThrow(IOException.class).when(inputStream).close();
-
-        final URL url = PowerMockito.mock(URL.class);
-        BDDMockito.given(url.openStream()).willReturn(inputStream);
-
-        final URI uri = PowerMockito.mock(URI.class);
-        BDDMockito.given(uri.toURL()).willReturn(url);
-
-        PowerMockito.mockStatic(CommonUtils.class);
-
-        final String fileName = file.getPath();
-        BDDMockito.given(CommonUtils.getUriByFilename(fileName)).willReturn(uri);
-        assertFalse("Should be false, because error on close",
-                FilterUtils.isFileExists(fileName));
     }
 
 }


### PR DESCRIPTION
Issue #5616 

- Stream classes were enabled in the `import-control.xml` and `checkstyle_sevntu_checks.xml/ForbidCertainImports`.

- Wherever there is `try-with-resources` compatible code, refactoring is performed.

- Enabled Idea inspections `AutoCloseableResource` and `TryFinallyCanBeTryWithResources`

- Enabled Eclipse JDT problem `explicitlyClosedAutoCloseable`. This lead to two false positives:
  `Main.createListener` and `LocalizedMessage$Utf8Control.newBundle` Both of them were suppressed.

- (as a consequence of the previous action) the `resource` warning was allowed for suppression in `checkstyle_checks.xml//SuppressWarnings`

- Obsolete checks (in order to make sure that the resource is closed) were removed, since the code being checked (`Closables`) is no longer used. As a free bonus, the number of uses of `PoverMock` decreased.