### PR TITLE
Issue #5750: abstract class name

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -102,6 +102,7 @@ baz
 bbb
 BBBB
 bc
+bcff
 BCA
 BClass
 bdc
@@ -277,6 +278,7 @@ dcm
 DDDD
 Ddry
 declarationorder
+ded
 DECOMPRESSOR
 defau
 defaultcasepresent

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -53,28 +53,28 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * </p>
  * <ul>
  * <li>
- * Option {@code allowedAbbreviationLength} - indicates on the number of consecutive capital
+ * Property {@code allowedAbbreviationLength} - Indicate the number of consecutive capital
  * letters allowed in targeted identifiers (abbreviations in the classes, interfaces, variables
  * and methods names, ... ). Default value is {@code 3}.
  * </li>
  * <li>
- * Option {@code allowedAbbreviations} - list of abbreviations that must be skipped for checking.
- * Abbreviations should be separated by comma. Default value is {@code {}}.
+ * Property {@code allowedAbbreviations} - Specify list of abbreviations that must be skipped for
+ * checking. Abbreviations should be separated by comma. Default value is {@code {}}.
  * </li>
  * <li>
- * Option {@code ignoreFinal} - allow to skip variables with {@code final} modifier. Default value
- * is {@code true}.
- * </li>
- * <li>
- * Option {@code ignoreStatic} - allow to skip variables with {@code static} modifier. Default
+ * Property {@code ignoreFinal} - Allow to skip variables with {@code final} modifier. Default
  * value is {@code true}.
  * </li>
  * <li>
- * Option {@code ignoreOverriddenMethods} - allow to ignore methods tagged with {@code @Override}
+ * Property {@code ignoreStatic} - Allow to skip variables with {@code static} modifier. Default
+ * value is {@code true}.
+ * </li>
+ * <li>
+ * Property {@code ignoreOverriddenMethods} - Allow to ignore methods tagged with {@code @Override}
  * annotation (that usually mean inherited name). Default value is {@code true}.
  * </li>
  * <li>
- * Option {@code tokens} - tokens to check Default value is:
+ * Property {@code tokens} - tokens to check Default value is:
  * <a href="http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
  * <a href="http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
  * <a href="http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
@@ -82,7 +82,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * <a href="http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">ANNOTATION_FIELD_DEF</a>,
  * <a href="http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">PARAMETER_DEF</a>,
  * <a href="http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">VARIABLE_DEF</a>,
- * <a href="http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>.}.
+ * <a href="http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">METHOD_DEF</a>.
  * </li>
  * </ul>
  * <p>
@@ -122,7 +122,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
     private static final int DEFAULT_ALLOWED_ABBREVIATIONS_LENGTH = 3;
 
     /**
-     * Indicates on the number of consecutive capital letters allowed in
+     * Indicate the number of consecutive capital letters allowed in
      * targeted identifiers (abbreviations in the classes, interfaces, variables
      * and methods names, ... ).
      */
@@ -130,7 +130,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
             DEFAULT_ALLOWED_ABBREVIATIONS_LENGTH;
 
     /**
-     * List of abbreviations that must be skipped for checking. Abbreviations
+     * Specify list of abbreviations that must be skipped for checking. Abbreviations
      * should be separated by comma.
      */
     private Set<String> allowedAbbreviations = new HashSet<>();
@@ -176,7 +176,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
     }
 
     /**
-     * Setter to indicates on the number of consecutive capital letters allowed
+     * Setter to indicate the number of consecutive capital letters allowed
      * in targeted identifiers (abbreviations in the classes, interfaces,
      * variables and methods names, ... ).
      * @param allowedAbbreviationLength amount of allowed capital letters in
@@ -187,8 +187,8 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
     }
 
     /**
-     * Setter to set a list of abbreviations that must be skipped for checking.
-     * Abbreviations should be separated by comma, no spaces is allowed.
+     * Setter to specify list of abbreviations that must be skipped for checking.
+     * Abbreviations should be separated by comma.
      * @param allowedAbbreviations an string of abbreviations that must be
      *        skipped from checking, each abbreviation separated by comma.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
@@ -28,17 +28,41 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * <p>
- * Ensures that the names of abstract classes conforming to some
- * regular expression and check that {@code abstract} modifier exists.
+ * Ensures that the names of abstract classes conforming to some regular
+ * expression and check that {@code abstract} modifier exists.
  * </p>
  * <p>
- * Rationale: Abstract classes are convenience base class
- * implementations of interfaces, not types as such. As such
- * they should be named to indicate this. Also if names of classes
- * starts with 'Abstract' it's very convenient that they will
- * have abstract modifier.
+ * Rationale: Abstract classes are convenience base class implementations of
+ * interfaces, not types as such. As such they should be named to indicate this.
+ * Also if names of classes starts with 'Abstract' it's very convenient that
+ * they will have abstract modifier.
+ * </p>
+ * <ul>
+ * <li>
+ * Property {@code format} - Specify valid identifiers. Default value is
+ * {@code "^Abstract.+$"}.</li>
+ * <li>
+ * Property {@code ignoreModifier} - Control whether to ignore checking for the
+ * {@code abstract} modifier on classes that match the name. Default value is
+ * {@code false}.</li>
+ * <li>
+ * Property {@code ignoreName} - Control whether to ignore checking the name.
+ * Realistically only useful if using the check to identify that match name and
+ * do not have the {@code abstract} modifier. Default value is
+ * {@code false}.</li>
+ * </ul>
+ * <p>
+ * The following example shows how to configure the {@code AbstractClassName} to
+ * checks names, but ignore missing {@code abstract} modifiers:
  * </p>
  *
+ * <pre>
+ * &lt;module name="AbstractClassName"&gt;
+ *   &lt;property name="ignoreModifier" value="true"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ *
+ * @since 3.2
  */
 @StatelessCheck
 public final class AbstractClassNameCheck extends AbstractCheck {
@@ -55,17 +79,25 @@ public final class AbstractClassNameCheck extends AbstractCheck {
      */
     public static final String MSG_NO_ABSTRACT_CLASS_MODIFIER = "no.abstract.class.modifier";
 
-    /** Whether to ignore checking the modifier. */
+    /**
+     * Control whether to ignore checking for the {@code abstract} modifier on
+     * classes that match the name.
+     */
     private boolean ignoreModifier;
 
-    /** Whether to ignore checking the name. */
+    /**
+     * Control whether to ignore checking the name. Realistically only useful
+     * if using the check to identify that match name and do not have the
+     * {@code abstract} modifier.
+     */
     private boolean ignoreName;
 
-    /** The regexp to match against. */
+    /** Specify valid identifiers. */
     private Pattern format = Pattern.compile("^Abstract.+$");
 
     /**
-     * Whether to ignore checking for the {@code abstract} modifier.
+     * Setter to control whether to ignore checking for the {@code abstract} modifier on
+     * classes that match the name.
      * @param value new value
      */
     public void setIgnoreModifier(boolean value) {
@@ -73,7 +105,8 @@ public final class AbstractClassNameCheck extends AbstractCheck {
     }
 
     /**
-     * Whether to ignore checking the name.
+     * Setter to control whether to ignore checking the name. Realistically only useful if
+     * using the check to identify that match name and do not have the {@code abstract} modifier.
      * @param value new value.
      */
     public void setIgnoreName(boolean value) {
@@ -81,7 +114,7 @@ public final class AbstractClassNameCheck extends AbstractCheck {
     }
 
     /**
-     * Set the format for the specified regular expression.
+     * Setter to specify valid identifiers.
      * @param pattern the new pattern
      */
     public void setFormat(Pattern pattern) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -103,7 +103,9 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
 
                 if ("Content".equals(sectionName) || "Overview".equals(sectionName)
                         // suppression list
-                        || !"AbbreviationAsWordInName".equals(sectionName)) {
+                        || !"AbbreviationAsWordInName".equals(sectionName)
+                                && !"AbstractClassName".equals(sectionName)
+                ) {
                     continue;
                 }
 

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -39,8 +39,8 @@
       <tr>
         <td><a href="config_naming.html#AbstractClassName">AbstractClassName</a></td>
         <td>
-          Ensures that the names of abstract classes conforming to some
-          regular expression.
+          Ensures that the names of abstract classes conforming to some regular expression and
+          check that <code>abstract</code> modifier exists.
         </td>
       </tr>
       <tr>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -191,9 +191,18 @@
     </section>
 
     <section name="AbstractClassName">
+      <p>Since Checkstyle 3.2</p>
       <subsection name="Description">
-        <p>Since Checkstyle 3.2</p>
-        <p>Validates identifiers for <code>abstract</code> classes.</p>
+        <p>
+          Ensures that the names of abstract classes conforming to some regular expression and
+          check that <code>abstract</code> modifier exists.
+        </p>
+        <p>
+          Rationale: Abstract classes are convenience base class implementations of
+          interfaces, not types as such. As such they should be named to indicate this.
+          Also if names of classes starts with 'Abstract' it's very convenient that
+          they will have abstract modifier.
+        </p>
       </subsection>
 
       <subsection name="Properties">
@@ -207,7 +216,7 @@
           </tr>
           <tr>
             <td>format</td>
-            <td>Specifies valid identifiers.</td>
+            <td>Specify valid identifiers.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^Abstract.+$"</code></td>
             <td>3.2</td>
@@ -215,7 +224,7 @@
           <tr>
             <td>ignoreModifier</td>
             <td>
-              Controls whether to ignore checking for the
+              Control whether to ignore checking for the
               <code>abstract</code> modifier on classes that match the
               name.
             </td>
@@ -226,9 +235,9 @@
           <tr>
             <td>ignoreName</td>
             <td>
-              Controls whether to ignore checking the name. Realistically
+              Control whether to ignore checking the name. Realistically
               only useful if using the check to identify that match name
-              and do not have the <code>abstract</code> modifier.  name.
+              and do not have the <code>abstract</code> modifier.
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -65,41 +65,41 @@
           </tr>
           <tr>
             <td>allowedAbbreviationLength</td>
-            <td>indicates on the number of consecutive capital letters allowed in targeted
+            <td>Indicate the number of consecutive capital letters allowed in targeted
              identifiers (abbreviations in the classes, interfaces, variables and methods
              names, ... ).</td>
             <td><a href="property_types.html#integer">Integer</a></td>
-            <td>3</td>
+            <td><code>3</code></td>
             <td>5.8</td>
           </tr>
           <tr>
             <td>allowedAbbreviations</td>
-            <td>list of abbreviations that must be skipped for checking.
+            <td>Specify list of abbreviations that must be skipped for checking.
             Abbreviations should be separated by comma.</td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td>{}</td>
+            <td><code>{}</code></td>
             <td>5.8</td>
           </tr>
           <tr>
             <td>ignoreFinal</td>
-            <td>allow to skip variables with <code>final</code> modifier.</td>
+            <td>Allow to skip variables with <code>final</code> modifier.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td>true</td>
+            <td><code>true</code></td>
             <td>5.8</td>
           </tr>
           <tr>
             <td>ignoreStatic</td>
-            <td>allow to skip variables with <code>static</code> modifier.</td>
+            <td>Allow to skip variables with <code>static</code> modifier.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td>true</td>
+            <td><code>true</code></td>
             <td>5.8</td>
           </tr>
           <tr>
             <td>ignoreOverriddenMethods</td>
-            <td>allow to ignore methods tagged with <code>@Override</code> annotation
+            <td>Allow to ignore methods tagged with <code>@Override</code> annotation
             (that usually mean inherited name).</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td>true</td>
+            <td><code>true</code></td>
             <td>5.8</td>
           </tr>
           <tr>


### PR DESCRIPTION
Issue #5750

Changed AbstractClassNameCheck.

Fixed bug in UT on how a setter is identified.
Slightly modified UT to specify property descriptions as first case upper.
Also modified AbbreviationAsWordInNameCheck again to make first word of property a singluar verb so it flows better for setter text.