### PR TITLE
config: turned on throws validation for JavadocMethod

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -392,6 +392,7 @@
       <property name="allowUndeclaredRTE" value="true"/>
       <property name="allowThrowsTagsForSubclasses" value="true"/>
       <property name="allowMissingPropertyJavadoc" value="true"/>
+      <property name="validateThrows" value="true"/>
     </module>
     <module name="JavadocParagraph"/>
     <module name="JavadocStyle">

--- a/src/it/java/com/google/checkstyle/test/base/AbstractModuleTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/AbstractModuleTestSupport.java
@@ -330,7 +330,6 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @param moduleName module name.
      * @param moduleId module id.
      * @return {@link Configuration} instance for the given module name.
-     * @throws CheckstyleException if exception occurs during configuration loading.
      */
     protected static Configuration getModuleConfig(String moduleName, String moduleId) {
         final Configuration result;


### PR DESCRIPTION
Identified by IntelliJ locally.