### PR TITLE
Issue #5881: False positive for multiline imports

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -361,6 +361,7 @@ public class ImportOrderCheck
     // -@cs[CyclomaticComplexity] SWITCH was transformed into IF-ELSE.
     @Override
     public void visitToken(DetailAST ast) {
+        final int line = ast.getLineNo();
         final FullIdent ident;
         final boolean isStatic;
 
@@ -384,7 +385,7 @@ public class ImportOrderCheck
                 lastGroup = Integer.MIN_VALUE;
                 lastImport = "";
             }
-            doVisitToken(ident, isStatic, isStaticAndNotLastImport);
+            doVisitToken(ident, isStatic, isStaticAndNotLastImport, line);
 
             if (isStaticAndNotLastImport && !beforeFirstImport) {
                 log(ident.getLineNo(), MSG_ORDERING, ident.getText());
@@ -395,7 +396,7 @@ public class ImportOrderCheck
                 lastGroup = Integer.MIN_VALUE;
                 lastImport = "";
             }
-            doVisitToken(ident, isStatic, isLastImportAndNonStatic);
+            doVisitToken(ident, isStatic, isLastImportAndNonStatic, line);
 
             if (isLastImportAndNonStatic) {
                 log(ident.getLineNo(), MSG_ORDERING, ident.getText());
@@ -403,14 +404,14 @@ public class ImportOrderCheck
         }
         else if (option == ImportOrderOption.ABOVE) {
             // previous non-static but current is static
-            doVisitToken(ident, isStatic, isStaticAndNotLastImport);
+            doVisitToken(ident, isStatic, isStaticAndNotLastImport, line);
         }
         else if (option == ImportOrderOption.UNDER) {
-            doVisitToken(ident, isStatic, isLastImportAndNonStatic);
+            doVisitToken(ident, isStatic, isLastImportAndNonStatic, line);
         }
         else if (option == ImportOrderOption.INFLOW) {
             // "previous" argument is useless here
-            doVisitToken(ident, isStatic, true);
+            doVisitToken(ident, isStatic, true, line);
         }
         else {
             throw new IllegalStateException(
@@ -429,12 +430,11 @@ public class ImportOrderCheck
      * @param isStatic whether the token is static or not.
      * @param previous previous non-static but current is static (above), or
      *                  previous static but current is non-static (under).
+     * @param line the line of the current import.
      */
-    private void doVisitToken(FullIdent ident, boolean isStatic,
-            boolean previous) {
+    private void doVisitToken(FullIdent ident, boolean isStatic, boolean previous, int line) {
         final String name = ident.getText();
         final int groupIdx = getGroupNumber(name);
-        final int line = ident.getLineNo();
 
         if (groupIdx > lastGroup) {
             if (!beforeFirstImport && separated && line - lastImportLine < 2

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -77,6 +77,14 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testMultilineImport() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(ImportOrderCheck.class);
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig, getNonCompilablePath("InputImportOrderMultiline.java"), expected);
+    }
+
+    @Test
     public void testGroups() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(ImportOrderCheck.class);
         checkConfig.addAttribute("groups", "java.awt");

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderMultiline.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderMultiline.java
@@ -1,0 +1,39 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
+/**
+ * This test-input is intended to be checked using following configuration:
+ *
+ * caseSensitive = true
+ * groups = {}
+ * option = UNDER
+ * ordered = true
+ * separated = false
+ * sortStaticImportsAlphabetically = false
+ * useContainerOrderingForStatic = false
+ *
+ */
+import
+    java.awt.Button;
+import java.awt.Dialog
+    ;
+import
+java.awt.Frame;
+import java
+    .awt.event.
+    ActionEvent
+    ;
+import
+java.io.File
+;
+import java.
+    io.
+    IOException;
+import java.io.InputStream;
+import
+  static java.awt.Button.ABORT;
+import static
+ java.io.File.createTempFile;
+import static javax.swing
+    .WindowConstants.*
+    ;
+public class InputImportOrderMultiline {
+}


### PR DESCRIPTION
Issue #5881 

When the `import` token and the imported package name are on different lines, the first line should be compared.