### PR TITLE
Issue #5722: Update DTD public names (typo at ImportControlLoader)

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -64,7 +64,7 @@ final class ImportControlLoader extends XmlLoader {
 
     /** The new public ID for version 1_2 of the configuration dtd. */
     private static final String DTD_PUBLIC_CS_ID_1_2 =
-        "-//Checkstyle//DTD ImportControl Configuration 1.22//EN";
+        "-//Checkstyle//DTD ImportControl Configuration 1.2//EN";
 
     /** The public ID for the configuration dtd. */
     private static final String DTD_PUBLIC_ID_1_3 =


### PR DESCRIPTION
 Issue #5722 

identified at https://github.com/checkstyle/checkstyle/issues/5601#issuecomment-396120018

CI failures https://circleci.com/gh/checkstyle/checkstyle/5997 :
```
4:14:57 AM PIT >> INFO : MINION : ls.checkstyle.api.CheckstyleException: unable to read
file:/home/circleci/project/src/test/resources/com/puppycrawl/tools/checkstyle/
checks/imports/importcontrol/InputImportControlOneRegExp.xml
at com.puppycrawl.tools.checkstyle.checks.imports.ImportContr
4:14:57 AM PIT >> INFO : MINION : olLoader.load(ImportControlLoader.java:282)
at com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader.load(ImportControlLoader.java:253)
at com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck.setFile(ImportControlCheck.java:192)
4:14:57 AM PIT >> INFO : MINION : 
... 44 more
Caused by: java.io.IOException: Server returned HTTP response code: 503 for URL:
http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd
at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1876)
```

the same problem detected Travis https://travis-ci.org/checkstyle/checkstyle/jobs/390563236#L446