### PR TITLE
doc: update xdoc for ParameterName to clarify how to check catch parameter

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -32,7 +32,8 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * Checks that method parameter names conform to a format specified
  * by the format property. By using {@code accessModifiers} property it is possible
  * to specify different formats for methods at different visibility levels.
- * <br/>
+ * </p>
+ * <p>
  * To validate {@code catch} parameters please use
  * <a href="#CatchParameterName">CatchParameterName</a>.
  * </p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -29,9 +29,12 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
 
 /**
  * <p>
- * Checks that method and {@code catch} parameter names conform to a format specified
+ * Checks that method parameter names conform to a format specified
  * by the format property. By using {@code accessModifiers} property it is possible
  * to specify different formats for methods at different visibility levels.
+ * <br/>
+ * To validate {@code catch} parameters please use
+ * <a href="#CatchParameterName">CatchParameterName</a>.
  * </p>
  * <ul>
  * <li>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -1362,9 +1362,12 @@ class MyClass {
       <p>Since Checkstyle 3.0</p>
       <subsection name="Description">
         <p>
-          Checks that method and <code>catch</code> parameter names conform to a format specified
+          Checks that method parameter names conform to a format specified
           by the format property. By using <code>accessModifiers</code> property it is possible
           to specify different formats for methods at different visibility levels.
+          <br/>
+          To validate <code>catch</code> parameters please use
+          <a href="#CatchParameterName">CatchParameterName</a>.
         </p>
       </subsection>
 

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -1365,7 +1365,8 @@ class MyClass {
           Checks that method parameter names conform to a format specified
           by the format property. By using <code>accessModifiers</code> property it is possible
           to specify different formats for methods at different visibility levels.
-          <br/>
+        </p>
+        <p>
           To validate <code>catch</code> parameters please use
           <a href="#CatchParameterName">CatchParameterName</a>.
         </p>


### PR DESCRIPTION
```
$ cat config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>

    <module name="TreeWalker">
        <module name="ParameterName">
          <property name="format" value="^[a-z][a-zA-Z0-9]+$"/>
        </module>
    </module>
</module>

$ cat Test.java 
public class Test {
    boolean foo() {
        try {} catch (Exception e) {}
    }
}

$ java -jar checkstyle-8.10.1-all.jar -c config.xml Test.java
Starting audit...
Audit done.

```