### PR TITLE
Issue #5916: fix Eclipse error Plugin execution not covered by lifecycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -506,6 +506,19 @@
                 </pluginExecution>
                 <pluginExecution>
                   <pluginExecutionFilter>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <versionRange>[1.0,)</versionRange>
+                    <goals>
+                      <goal>java</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <execute />
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <versionRange>[1.2,)</versionRange>


### PR DESCRIPTION
Issue #5916

I am not completely sure that this is right update, but it helps to resolve problem in Eclipse.