### PR TITLE
Issue #4058: xdocs update for right curly check

### DIFF
--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -867,6 +867,8 @@ for(int i = 0; i &lt; 10; value.incrementValue()); // OK
           method definitions, class definitions, constructor definitions,
           instance and static initialization blocks.
           The policy to verify is specified using the property <code> option</code>.
+          For right curly brace of expression blocks please follow issue
+          <a href="https://github.com/checkstyle/checkstyle/issues/5945">#5945</a>.
         </p>
       </subsection>
 

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -313,8 +313,10 @@
     <section name="rcurly">
       <p>
         This property represents the policy for checking the placement of a
-        right curly brace (<code>'}'</code>). The following table
-        describes the valid options:
+        right curly brace (<code>'}'</code>) in blocks but not blocks of expressions.
+        For right curly brace of expression blocks please follow issue
+        <a href="https://github.com/checkstyle/checkstyle/issues/5945">#5945</a>. The following
+        table describes the valid options:
       </p>
 
       <table summary="right curly options">


### PR DESCRIPTION
Issue #4058: Updated xdocs to denote that RightCurlyCheck does not process right curly brace of expression blocks.