### PR TITLE
Issue #5949: disable bunch of unrelated to our project inspections

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inspections version="1.0">
+<profile version="1.0">
     <option name="myName" value="Checkstyle"/>
     <inspection_tool class="AbsoluteAlignmentInUserInterface" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="AbstractBeanReferencesInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="AbstractBeanReferencesInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="AbstractClassExtendsConcreteClass" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="AbstractClassNamingConvention" enabled="true" level="WARNING"
@@ -37,12 +37,594 @@
     </inspection_tool>
     <inspection_tool class="AccessToStaticFieldLockedOnInstance" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
+    <inspection_tool class="AddVarianceModifier" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="AlphaUnsortedPropertiesFile" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="AmbiguousFieldAccess" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="AmbiguousMethodCall" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
+    <inspection_tool class="AndroidDomInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidElementNotAllowed" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAaptCrash" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAccidentalOctal" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAdapterViewChildren" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAddJavascriptInterface" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAllCaps" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAllowAllHostnameVerifier" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAllowBackup" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAlwaysShowAction" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAnimatorKeep" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAppCompatCustomView" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAppCompatMethod" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAppCompatResource" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAppLinkUrlError" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintApplySharedPref" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAssert" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintAuthLeak" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintBadHostnameVerifier" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintBatteryLife" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintButtonCase" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintButtonOrder" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintButtonStyle" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintByteOrderMark" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintCheckResult" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintClickableViewAccessibility" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintCommitPrefEdits" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintCommitTransaction" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintContentDescription" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintCustomViewStyleable" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintCutPasteId" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintDefaultLocale" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintDeprecated" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintDevModeObsolete" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintDeviceAdmin" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintDisableBaselineAlignment" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintDrawAllocation" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintDuplicateActivity" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintDuplicateDefinition" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintDuplicateDivider" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintDuplicateIds" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintDuplicateIncludedIds" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintDuplicatePlatformClasses" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintDuplicateUsesFeature" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintEllipsizeMaxLines" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintEnforceUTF8" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintExifInterface" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintExportedContentProvider" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintExportedPreferenceActivity" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintExportedReceiver" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintExportedService" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintExtraText" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintExtraTranslation" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintFindViewByIdCast" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintFloatMath" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintFontValidationError" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintFontValidationWarning" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintFullBackupContent" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGetContentDescriptionOverride" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGetInstance" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGetLocales" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGifUsage" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGoogleAppIndexingWarning" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGradleCompatible" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGradleDependency" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGradleDeprecated" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGradleDynamicVersion" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGradleGetter" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGradleIdeError" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGradleOverrides" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGradlePath" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGradlePluginVersion" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGrantAllUris" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintGridLayout" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintHandlerLeak" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintHardcodedDebugMode" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintHardcodedText" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintHardwareIds" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintHighAppVersionCode" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIconColors" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIconDensities" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIconDipSize" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIconDuplicates" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIconDuplicatesConfig" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIconExtension" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIconLauncherShape" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIconLocation" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIconMissingDensityFolder" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIconMixedNinePatch" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIconNoDpi" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIconXmlAndPng" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIllegalResourceRef" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintImpliedQuantity" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintImpliedTouchscreenHardware" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInOrMmUsage" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIncludeLayoutParam" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintIncompatibleMediaBrowserServiceCompatVersion" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInconsistentArrays" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInconsistentLayout" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInefficientWeight" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInflateParams" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInlinedApi" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInnerclassSeparator" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInstantApps" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInvalidAnalyticsName" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInvalidId" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInvalidImeActionId" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInvalidPermission" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInvalidResourceFolder" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInvalidUsesTagAttribute" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInvalidVectorPath" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintInvalidWearFeatureAttribute" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintJavascriptInterface" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintJobSchedulerService" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintKeyboardInaccessibleWidget" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintLabelFor" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintLibraryCustomView" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintLintBaseline" enabled="false" level="INFO"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintLocalSuppress" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintLocaleFolder" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintLogTagMismatch" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintLongLogTag" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintManifestOrder" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintManifestResource" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMenuTitle" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMergeMarker" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMergeRootFrame" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMinSdkTooLow" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMipmapIcons" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingApplicationIcon" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingBackupPin" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingConstraints" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingFirebaseInstanceTokenRefresh" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingId" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingIntentFilterForMediaSearch" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingLeanbackLauncher" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingLeanbackSupport" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingMediaBrowserServiceIntentFilter" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingOnPlayFromSearch" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingPermission" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingPrefix" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingQuantity" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingSuperCall" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingTranslation" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingTvBanner" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMissingVersion" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMockLocation" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintMultipleUsesSdk" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintNamespaceTypo" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintNestedScrolling" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintNestedWeights" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintNetworkSecurityConfig" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintNewApi" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintNfcTechWhitespace" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintNotInterpolated" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintNotSibling" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintObjectAnimatorBinding" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintObsoleteLayoutParam" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintObsoleteSdkInt" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintOldTargetApi" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintOnClick" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintOrientation" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintOverdraw" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintOverride" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintOverrideAbstract" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintPackageManagerGetSignatures" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintPackagedPrivateKey" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintParcelClassLoader" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintParcelCreator" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintPendingBindings" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintPermissionImpliesUnsupportedHardware" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintPinSetExpiry" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintPluralsCandidate" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintPrivateApi" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintPrivateResource" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintProguard" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintProguardSplit" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintPropertyEscape" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintProtectedPermissions" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintPxUsage" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintRange" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintRecycle" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintRecyclerView" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintReferenceType" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintRegistered" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintRelativeOverlap" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintRequiredSize" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintResAuto" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintResourceAsColor" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintResourceCycle" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintResourceName" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintResourceType" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintRestrictedApi" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintRtlCompat" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintRtlEnabled" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintRtlHardcoded" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintRtlSymmetry" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSQLiteString" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSSLCertificateSocketFactoryCreateSocket" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSSLCertificateSocketFactoryGetInsecure" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintScrollViewCount" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintScrollViewSize" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSdCardPath" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSecureRandom" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintServiceCast" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSetJavaScriptEnabled" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSetTextI18n" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSetWorldReadable" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSetWorldWritable" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintShiftFlags" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintShortAlarm" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintShowToast" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSignatureOrSystemPermissions" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSimpleDateFormat" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSmallSp" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSpUsage" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintStateListReachable" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintStaticFieldLeak" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintStringEscaping" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintStringFormatCount" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintStringFormatInvalid" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintStringFormatMatches" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintStringShouldBeInt" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSupportAnnotationUsage" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSuspicious0dp" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSuspiciousImport" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintSwitchIntDef" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintTestAppLink" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintTextFields" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintTextViewEdits" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintTooDeepLayout" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintTooManyViews" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintTrustAllX509TrustManager" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintTypographyDashes" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintTypographyEllipsis" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintTypographyFractions" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintTypographyOther" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintTypos" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUniqueConstants" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUniquePermission" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUnknownId" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUnknownIdInLayout" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUnlocalizedSms" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUnpackedNativeCode" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUnprotectedSMSBroadcastReceiver" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUnsafeDynamicallyLoadedCode" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUnsafeNativeCodeLocation" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUnsafeProtectedBroadcastReceiver" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUnsupportedTvHardware" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUnusedAttribute" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUnusedQuantity" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUnusedResources" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUseAlpha2" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUseCheckPermission" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUseCompoundDrawables" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUseOfBundledGooglePlayServices" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUseSparseArrays" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUseValueOf" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUselessLeaf" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUselessParent" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUsesMinSdkAttributes" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintUsingHttp" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintValidFragment" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintValidRestrictions" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintVectorDrawableCompat" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintVectorPath" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintVectorRaster" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintViewConstructor" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintViewHolder" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintViewTag" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintVisibleForTests" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWakelockTimeout" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWearStandaloneAppFlag" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWearableBindListener" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWebViewLayout" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWebpUnsupported" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWifiManagerLeak" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWifiManagerPotentialLeak" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWorldReadableFiles" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWorldWriteableFiles" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWrongCall" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWrongCase" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWrongConstant" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWrongFolder" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWrongRegion" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWrongThread" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidLintWrongViewCast" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidMissingOnClickHandler" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidNonConstantResIdsInSwitch" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="AndroidUnknownAttribute" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <!-- this rule is inspection is only for old java, we are ok to use annotations -->
     <inspection_tool class="Annotation" enabled="false" level="ERROR" enabled_by_default="false"/>
     <inspection_tool class="AnnotationClass" enabled="true" level="ERROR"
@@ -83,6 +665,8 @@
     <!-- maven and ant are used in the same build, no options in inspection to adjust -->
     <inspection_tool class="AntResolveInspection" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
+    <inspection_tool class="AppEngineForbiddenCode" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="ArgNamesErrorsInspection" enabled="true" level="TYPO"
                      enabled_by_default="true"/>
     <inspection_tool class="ArgNamesWarningsInspection" enabled="true" level="ERROR"
@@ -103,6 +687,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="ArrayEquals" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="ArrayHashCode" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="ArrayInDataClass" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <!-- we see no harm for us for such usages -->
     <inspection_tool class="ArrayLengthInLoopCondition" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
@@ -128,6 +714,8 @@
     <inspection_tool class="AssertsWithoutMessages" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="AssertsWithoutMessagesTestNG" enabled="true" level="ERROR"
+                     enabled_by_default="true"/>
+    <inspection_tool class="AssignmentOrReturnOfFieldWithMutableType" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="AssignmentResultUsedJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
@@ -167,6 +755,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="AssignmentUsedAsCondition" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="AsyncMethodInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <!-- we are ok to use auto-boxing as we use modern java -->
     <inspection_tool class="AutoBoxing" enabled="false" level="ERROR" enabled_by_default="false"/>
     <inspection_tool class="AutoCloseableResource" enabled="true" level="ERROR"
@@ -280,10 +870,10 @@
     <inspection_tool class="BashWrapFunction" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="BashWrapWord" enabled="true" level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="BatchJobDomInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="BatchXmlDomInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="BatchJobDomInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="BatchXmlDomInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="BeforeClassOrAfterClassIsPublicStaticVoidNoArg" enabled="true"
                      level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="BeforeOrAfterIsPublicVoidNoArg" enabled="true" level="ERROR"
@@ -294,8 +884,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="BigDecimalMethodWithoutRoundingCalled" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="BindingAnnotationWithoutInject" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="BindingAnnotationWithoutInject" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="BlockMarkerComments" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="BlockStatementJS" enabled="true" level="ERROR"
@@ -331,6 +921,8 @@
                      enabled_by_default="false"/>
     <inspection_tool class="BoxingBoxedValue" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="BpmnConfigDomInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <!-- we like breaks to be in code -->
     <inspection_tool class="BreakStatement" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
@@ -343,10 +935,10 @@
     <inspection_tool class="BusyWait" enabled="true" level="WARNING" enabled_by_default="true">
         <scope name="Tests" level="WARNING" enabled="false"/>
     </inspection_tool>
-    <inspection_tool class="BvConfigDomInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="BvConstraintMappingsInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="BvConfigDomInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="BvConstraintMappingsInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="CStyleArrayDeclaration" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="CachedNumberConstructorCall" enabled="true" level="ERROR"
@@ -371,11 +963,18 @@
         <option name="REPORT_METHODS" value="false"/>
         <option name="REPORT_FIELDS" value="true"/>
     </inspection_tool>
+    <inspection_tool class="CanBeParameter" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CanBePrimaryConstructorProperty" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CanBeVal" enabled="false" level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="CascadeIf" enabled="false" level="INFO" enabled_by_default="false"/>
     <inspection_tool class="CastConflictsWithInstanceof" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="CastThatLosesPrecision" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="ignoreIntegerCharCasts" value="false"/>
+        <option name="ignoreOverflowingByteCasts" value="false"/>
     </inspection_tool>
     <!-- this is valid but there are many false-positives as we use reflection to load modules
      after recheck by instanceof and we restricted in by existing api types, but some cases
@@ -384,39 +983,46 @@
                      enabled_by_default="false"/>
     <inspection_tool class="CastToIncompatibleInterface" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
+    <inspection_tool class="CatchMayIgnoreException" enabled="true" level="ERROR"
+                     enabled_by_default="true">
+        <scope name="Tests" level="WARNING" enabled="true"/>
+        <option name="m_ignoreCatchBlocksWithComments" value="false"/>
+    </inspection_tool>
     <inspection_tool class="CaughtExceptionImmediatelyRethrown" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="CdiAlternativeInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CdiDecoratorInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CdiDisposerMethodInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CdiDomBeans" enabled="true" level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="CdiInjectInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CdiInjectionPointsInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CdiInterceptorInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CdiManagedBeanInconsistencyInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CdiNormalScopeInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CdiObservesInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CdiScopeInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CdiSpecializesInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CdiStereotypeInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CdiStereotypeRestrictionsInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CdiTypedAnnotationInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CdiUnproxyableBeanTypesInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="CdiAlternativeInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CdiDecoratorInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CdiDisposerMethodInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CdiDomBeans" enabled="false" level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="CdiInjectInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CdiInjectionPointsInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CdiInterceptorInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CdiManagedBeanInconsistencyInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CdiNormalScopeInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CdiObservesInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CdiScopeInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CdiSpecializesInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CdiStereotypeInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CdiStereotypeRestrictionsInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CdiTypedAnnotationInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CdiUnknownProducersForDisposerMethodInspection" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="CdiUnproxyableBeanTypesInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="CfmlFileReference" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="CfmlReferenceInspection" enabled="true" level="ERROR"
@@ -429,6 +1035,10 @@
                      enabled_by_default="true"/>
     <!-- it is too demanding, with no choice limits of chain size etc -->
     <inspection_tool class="ChainedMethodCall" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ChangeToMethod" enabled="false" level="INFORMATION"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ChangeToOperator" enabled="false" level="WEAK WARNING"
                      enabled_by_default="false"/>
     <inspection_tool class="ChannelResource" enabled="true" level="WARNING"
                      enabled_by_default="true">
@@ -456,10 +1066,10 @@
                      enabled_by_default="true"/>
     <inspection_tool class="CheckedExceptionClass" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="ClashingGetters" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="ClashingTraitMethods" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="ClashingGetters" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ClashingTraitMethods" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <!-- we use design model to keep all logic for class in one file.
     So, we have a lot of completely isolated classes and we cannot put them to
     separate package as it will affect users configs -->
@@ -473,8 +1083,6 @@
         <option name="m_includeLibraryClasses" value="false"/>
         <option name="m_limit" value="15"/>
     </inspection_tool>
-    <inspection_tool class="ClassEscapesItsScope" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
     <!-- we do not need that -->
     <inspection_tool class="ClassHasNoToStringMethod" enabled="false" level="ERROR"
                      enabled_by_default="false">
@@ -486,6 +1094,8 @@
         <option name="excludeTestCode" value="false"/>
         <option name="excludeInnerClasses" value="false"/>
     </inspection_tool>
+    <inspection_tool class="ClassInDefaultPackage" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="ClassIndependentOfModule" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ClassInheritanceDepth" enabled="true" level="ERROR"
@@ -500,6 +1110,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="ClassMayBeInterface" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="ClassName" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="ClassNameDiffersFromFileName" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <!-- names of Checks are public to users, we do care about clear name for user
@@ -597,22 +1209,22 @@
          with extra curly braces, we might change our mind in future. -->
     <inspection_tool class="CodeBlock2Expr" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
-    <inspection_tool class="CoffeeScriptArgumentsOutsideFunction" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CoffeeScriptFunctionSignatures" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CoffeeScriptInfiniteLoop" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CoffeeScriptLiteralNotFunction" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CoffeeScriptSillyAssignment" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CoffeeScriptSwitchStatementWithNoDefaultBranch" enabled="true"
-                     level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="CoffeeScriptArgumentsOutsideFunction" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CoffeeScriptFunctionSignatures" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CoffeeScriptInfiniteLoop" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CoffeeScriptLiteralNotFunction" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CoffeeScriptSillyAssignment" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CoffeeScriptSwitchStatementWithNoDefaultBranch" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
     <inspection_tool class="CoffeeScriptUnnecessaryReturn" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="CoffeeScriptUnusedLocalSymbols" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="CoffeeScriptUnusedLocalSymbols" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="CollectionAddAllCanBeReplacedWithConstructor" enabled="true"
                      level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="CollectionAddedToSelf" enabled="true" level="ERROR"
@@ -621,10 +1233,6 @@
                      enabled_by_default="true"/>
     <inspection_tool class="CollectionsFieldAccessReplaceableByMethodCall" enabled="true"
                      level="ERROR" enabled_by_default="true"/>
-    <!-- we do not know initial size in most cases, it could make uncovered mutation problems
-         for pitest that value more -->
-    <inspection_tool class="CollectionsMustHaveInitialCapacity" enabled="false" level="WARNING"
-                     enabled_by_default="false"/>
     <inspection_tool class="CommaExpressionJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ComparableImplementedButEqualsNotOverridden" enabled="true"
@@ -639,20 +1247,27 @@
                      enabled_by_default="true"/>
     <inspection_tool class="ComparisonToNaN" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="ComponentNotRegistered" enabled="false" level="WARNING"
+                     enabled_by_default="false">
+        <option name="CHECK_ACTIONS" value="true"/>
+        <option name="IGNORE_NON_PUBLIC" value="true"/>
+    </inspection_tool>
+    <inspection_tool class="ComponentRegistrationProblems" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="ConditionSignal" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="ConditionalExpression" enabled="true" level="ERROR"
-                     enabled_by_default="true">
-        <option name="ignoreSimpleAssignmentsAndReturns" value="false"/>
-    </inspection_tool>
+                     enabled_by_default="true"/>
     <inspection_tool class="ConditionalExpressionJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ConditionalExpressionWithIdenticalBranches" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ConditionalExpressionWithIdenticalBranchesJS" enabled="true"
                      level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="ConflictingAnnotations" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="ConflictingAnnotations" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ConflictingExtensionProperty" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="ConfusingElse" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="reportWhenNoStatementFollow" value="false"/>
     </inspection_tool>
@@ -668,8 +1283,12 @@
                      enabled_by_default="true"/>
     <inspection_tool class="ConnectionResource" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="ConstPropertyName" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="ConstantAssertCondition" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
+    <inspection_tool class="ConstantConditionIf" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="ConstantConditionalExpression" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ConstantConditionalExpressionJS" enabled="true" level="ERROR"
@@ -679,7 +1298,7 @@
          creation of non-real test case is against our policy of testing. -->
     <inspection_tool class="ConstantConditions" enabled="false" level="WARNING"
                      enabled_by_default="true">
-        <scope name="Tests" enabled="false"/>
+        <scope name="Tests" level="WARNING" enabled="false"/>
         <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="false"/>
         <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false"/>
     </inspection_tool>
@@ -717,17 +1336,17 @@
                      enabled_by_default="true"/>
     <inspection_tool class="ConstantValueVariableUse" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="ConstraintValidatorCreator" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="ConstraintValidatorCreator" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="ConstructorCount" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="ignoreDeprecatedConstructors" value="false"/>
         <option name="m_limit" value="5"/>
     </inspection_tool>
-    <inspection_tool class="ContextComponentScanInconsistencyInspection" enabled="true"
-                     level="WARNING" enabled_by_default="true"/>
-    <inspection_tool class="ContextJavaBeanUnresolvedMethodsInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="ContextComponentScanInconsistencyInspection" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="ContextJavaBeanUnresolvedMethodsInspection" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
     <inspection_tool class="ContinueOrBreakFromFinallyBlock" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ContinueOrBreakFromFinallyBlockJS" enabled="true" level="ERROR"
@@ -757,13 +1376,25 @@
     <inspection_tool class="ConvertAnnotations" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ConvertJavadoc" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="ConvertLambdaToReference" enabled="false" level="INFORMATION"
+                     enabled_by_default="false"/>
     <inspection_tool class="ConvertOldAnnotations" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="ConvertReferenceToLambda" enabled="false" level="INFORMATION"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ConvertSecondaryConstructorToPrimary" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ConvertToStringTemplate" enabled="false" level="INFO"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ConvertTryFinallyToUseCall" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ConvertTwoComparisonsToRangeCheck" enabled="false" level="INFO"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CopyWithoutNamedArguments" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="CovariantCompareTo" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="CovariantEquals" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CriteriaApiResolveInspection" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="CssConvertColorToHexInspection" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
@@ -821,18 +1452,18 @@
     <!-- most found cases are used in xml files that are source for html pages -->
     <inspection_tool class="CssUnusedSymbol" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
-    <inspection_tool class="CucumberExamplesColon" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CucumberJavaStepDefClassInDefaultPackage" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CucumberJavaStepDefClassIsPublic" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CucumberMissedExamples" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CucumberTableInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="CucumberUndefinedStep" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="CucumberExamplesColon" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CucumberJavaStepDefClassInDefaultPackage" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CucumberJavaStepDefClassIsPublic" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CucumberMissedExamples" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CucumberTableInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="CucumberUndefinedStep" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="CustomClassloader" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="CustomSecurityManager" enabled="true" level="ERROR"
@@ -856,6 +1487,8 @@
     </inspection_tool>
     <inspection_tool class="DanglingJavadoc" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="DataClassPrivateConstructor" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="DataProviderReturnType" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="DateToString" enabled="true" level="ERROR" enabled_by_default="true"/>
@@ -878,22 +1511,24 @@
                      enabled_by_default="true"/>
     <inspection_tool class="DefaultNotLastCaseInSwitchJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="DelegatesTo" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="DelegatesTo" enabled="false" level="ERROR" enabled_by_default="false"/>
     <inspection_tool class="Dependency" enabled="true" level="WARNING" enabled_by_default="true"/>
-    <inspection_tool class="DeprecatedCallableAddReplaceWith" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="DeprecatedCallableAddReplaceWith" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="DeprecatedClassUsageInspection" enabled="true" level="WARNING"
                      enabled_by_default="false">
         <scope name="Production" level="WARNING" enabled="true"/>
     </inspection_tool>
+    <inspection_tool class="DeprecatedGradleDependency" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="DeprecatedIsStillUsed" enabled="true" level="WARNING"
                      enabled_by_default="false">
         <scope name="Production" level="WARNING" enabled="true"/>
     </inspection_tool>
+    <inspection_tool class="DeprecatedMavenDependency" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="Deprecation" enabled="true" level="ERROR" enabled_by_default="false">
-        <scope name="Production" level="ERROR" enabled="true">
-            <option name="IGNORE_INSIDE_DEPRECATED" value="true"/>
-        </scope>
+        <scope name="Production" level="ERROR" enabled="true"/>
     </inspection_tool>
     <!-- this inspection is not for us -->
     <inspection_tool class="DeserializableClassInSecureContext" enabled="false" level="ERROR"
@@ -903,8 +1538,18 @@
      to do any breaking compatibility fixes in favor to avoid violations from this inspection -->
     <inspection_tool class="DesignForExtension" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
+    <inspection_tool class="DestructuringWrongName" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="DialogTitleCapitalization" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="DifferentKotlinGradleVersion" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="DifferentKotlinMavenVersion" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="DifferentMavenStdlibVersion" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="DifferentStdlibGradleVersion" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <!-- we against of over decomposition -->
     <inspection_tool class="DisjointPackage" enabled="false" level="ERROR"
                      enabled_by_default="false">
@@ -916,6 +1561,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="DollarSignInName" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
+    <inspection_tool class="DontUsePairConstructor" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="DoubleBraceInitialization" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="DoubleCheckedLocking" enabled="true" level="WARNING"
@@ -936,7 +1583,7 @@
                      enabled_by_default="true"/>
     <inspection_tool class="DuplicateCondition" enabled="true" level="ERROR"
                      enabled_by_default="true">
-        <option name="ignoreMethodCalls" value="false"/>
+        <option name="ignoreSideEffectConditions" value="true"/>
     </inspection_tool>
     <inspection_tool class="DuplicateConditionJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
@@ -955,8 +1602,8 @@
                      enabled_by_default="false"/>
     <inspection_tool class="DuplicateThrows" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="DuplicatedBeanNamesInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="DuplicatedBeanNamesInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="DuplicatedDataProviderNames" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="Duplicates" enabled="true" level="ERROR" enabled_by_default="true">
@@ -968,14 +1615,14 @@
     </inspection_tool>
     <inspection_tool class="DynamicallyGeneratedCodeJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="ELDeferredExpressionsInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="ELMethodSignatureInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="ELSpecValidationInJSP" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="ELValidationInJSP" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="ELDeferredExpressionsInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ELMethodSignatureInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ELSpecValidationInJSP" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ELValidationInJSP" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="ES6Validation" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="EjbClassBasicInspection" enabled="true" level="WARNING"
@@ -1028,6 +1675,8 @@
         <option name="commentsAreContent" value="true"/>
     </inspection_tool>
     <inspection_tool class="EmptyDirectory" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="EmptyEventHandler" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="EmptyFinallyBlock" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="EmptyFinallyBlockJS" enabled="true" level="ERROR"
@@ -1035,8 +1684,14 @@
     <inspection_tool class="EmptyInitializer" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="EmptyMethod" enabled="true" level="WARNING" enabled_by_default="true">
+        <option name="EXCLUDE_ANNOS">
+            <value>
+                <list size="0"/>
+            </value>
+        </option>
         <option name="commentsAreContent" value="true"/>
     </inspection_tool>
+    <inspection_tool class="EmptyRange" enabled="false" level="WARNING" enabled_by_default="false"/>
     <inspection_tool class="EmptyStatementBody" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="m_reportEmptyBlocks" value="true"/>
@@ -1050,11 +1705,13 @@
     <inspection_tool class="EmptyTryBlock" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="EmptyTryBlockJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="EmptyWebServiceClass" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="EmptyWebServiceClass" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="EnumAsName" enabled="true" level="ERROR" enabled_by_default="true"/>
     <!-- we are ok to use enumeration as we use modern java -->
     <inspection_tool class="EnumClass" enabled="false" level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="EnumEntryName" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="ignoreSwitchStatementsWithDefault" value="false"/>
@@ -1083,6 +1740,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="EqualsHashCodeCalledOnUrl" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
+    <inspection_tool class="EqualsOrHashCode" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="EqualsReplaceableByObjectsCall" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="checkNotNull" value="true"/>
@@ -1114,6 +1773,8 @@
     <inspection_tool class="ExpectedExceptionNeverThrownTestNG" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ExplicitGet" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="ExplicitThis" enabled="false" level="INFORMATION"
+                     enabled_by_default="false"/>
     <inspection_tool class="ExtendsAnnotation" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ExtendsConcreteCollection" enabled="true" level="ERROR"
@@ -1129,8 +1790,10 @@
                      enabled_by_default="true"/>
     <inspection_tool class="ExternalizableWithoutPublicNoArgConstructor" enabled="true"
                      level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="FacesModelInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="FacesModelInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FakeJvmFieldConstant" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="FallThroughInSwitchStatementJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="FallthruInSwitchStatement" enabled="true" level="ERROR"
@@ -1172,6 +1835,8 @@
                      enabled_by_default="true">
         <option name="m_ignoreFinalFields" value="false"/>
     </inspection_tool>
+    <inspection_tool class="FileEqualsUsage" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <!-- we are library - we do this on purpose as clear signal to users -->
     <inspection_tool class="FinalClass" enabled="false" level="ERROR" enabled_by_default="false"/>
     <!-- we are library - we do this on purpose as clear signal to users -->
@@ -1194,10 +1859,36 @@
                      enabled_by_default="true"/>
     <inspection_tool class="FinallyBlockCannotCompleteNormally" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="FlexUnitClassInProductSourceInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FlexUnitClassVisibilityInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FlexUnitClassWithNoTestsInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FlexUnitEmptySuiteInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FlexUnitMethodHasParametersInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FlexUnitMethodInSuiteInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FlexUnitMethodIsPropertyInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FlexUnitMethodIsStaticInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FlexUnitMethodReturnTypeInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FlexUnitMethodVisibilityInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FlexUnitMixedAPIInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FlexUnitSuiteWithNoRunnerInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="FloatingPointEquality" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="FlowRequiredBeanTypeInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="FlowRequiredBeanTypeInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FoldInitializerAndIfToElvis" enabled="false" level="INFO"
+                     enabled_by_default="false"/>
     <inspection_tool class="ForCanBeForeach" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="REPORT_INDEXED_LOOP" value="true"/>
         <option name="ignoreUntypedCollections" value="false"/>
@@ -1221,20 +1912,22 @@
     <!-- we are ok to use for-each as we use modern java -->
     <inspection_tool class="ForeachStatement" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
-    <inspection_tool class="FtlCallsInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="FtlDeprecatedBuiltInsInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="FtlFileReferencesInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="FtlImportCallInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="FtlReferencesInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="FtlTypesInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="FtlWellformednessInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="FtlCallsInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FtlDeprecatedBuiltInsInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FtlFileReferencesInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FtlImportCallInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FtlReferencesInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FtlTypesInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FtlWellformednessInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="FunctionName" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="FunctionNamingConventionJS" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="m_regex" value="[a-z][A-Za-z]*"/>
@@ -1248,129 +1941,146 @@
                      enabled_by_default="false"/>
     <inspection_tool class="FunctionWithMultipleReturnPointsJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="GherkinBrokenTableInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GherkinMisplacedBackground" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <!--we do not use this tool-->
+    <inspection_tool class="GWTRemoteServiceAsyncCheck" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GWTStyleCheck" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="Geronimo" enabled="false" level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="GherkinBrokenTableInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GherkinMisplacedBackground" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="GjsLint" enabled="false" level="ERROR" enabled_by_default="false"/>
-    <inspection_tool class="GrDeprecatedAPIUsage" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GrEqualsBetweenInconvertibleTypes" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="Glassfish" enabled="false" level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="GrDeprecatedAPIUsage" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GrEqualsBetweenInconvertibleTypes" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="GrFieldAlreadyDefined" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="GrFinalVariableAccess" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GrMethodMayBeStatic" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GrPackage" enabled="true" level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="GrReassignedInClosureLocalVar" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GrUnresolvedAccess" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyAccessToStaticFieldLockedOnInstance" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyAccessibility" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="GrFinalVariableAccess" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GrMethodMayBeStatic" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GrPackage" enabled="false" level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="GrReassignedInClosureLocalVar" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GrUnnecessaryAlias" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GrUnnecessaryDefModifier" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GrUnnecessaryPublicModifier" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GrUnnecessarySemicolon" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GrUnresolvedAccess" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyAccessToStaticFieldLockedOnInstance" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyAccessibility" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="GroovyAnnotationNamingConvention" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="m_regex" value="[A-Z][A-Za-z\d]*"/>
         <option name="m_minLength" value="8"/>
         <option name="m_maxLength" value="64"/>
     </inspection_tool>
-    <inspection_tool class="GroovyAssignabilityCheck" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyAssignmentCanBeOperatorAssignment" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyAssignabilityCheck" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyAssignmentCanBeOperatorAssignment" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="ignoreLazyOperators" value="true"/>
         <option name="ignoreObscureOperators" value="false"/>
     </inspection_tool>
-    <inspection_tool class="GroovyAssignmentToForLoopParameter" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyAssignmentToMethodParameter" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyBreak" enabled="true" level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="GroovyBusyWait" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="GroovyAssignmentToForLoopParameter" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyAssignmentToMethodParameter" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyBreak" enabled="false" level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="GroovyBusyWait" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="GroovyClassNamingConvention" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="m_regex" value="[A-Z][A-Za-z\d]*"/>
         <option name="m_minLength" value="8"/>
         <option name="m_maxLength" value="64"/>
     </inspection_tool>
-    <inspection_tool class="GroovyConditional" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyConditionalCanBeConditionalCall" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyConditionalCanBeElvis" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyConditionalWithIdenticalBranches" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyConstantConditional" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyConstantIfStatement" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyConstantNamingConvention" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyConditional" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyConditionalCanBeConditionalCall" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyConditionalCanBeElvis" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyConditionalWithIdenticalBranches" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyConstantConditional" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyConstantIfStatement" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyConstantNamingConvention" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_regex" value="[A-Z\d]*"/>
         <option name="m_minLength" value="4"/>
         <option name="m_maxLength" value="32"/>
     </inspection_tool>
-    <inspection_tool class="GroovyConstructorNamedArguments" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyContinue" enabled="true" level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="GroovyContinueOrBreakFromFinallyBlock" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyDivideByZero" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyDocCheck" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyDoubleCheckedLocking" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyConstructorNamedArguments" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyContinue" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyContinueOrBreakFromFinallyBlock" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyDivideByZero" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyDocCheck" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyDoubleCheckedLocking" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="ignoreOnVolatileVariables" value="false"/>
     </inspection_tool>
-    <inspection_tool class="GroovyDoubleNegation" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyDuplicateSwitchBranch" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyEmptyCatchBlock" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyEmptyFinallyBlock" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyEmptyStatementBody" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyEmptySyncBlock" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyEmptyTryBlock" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="GroovyDoubleNegation" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyDuplicateSwitchBranch" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyEmptyCatchBlock" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyEmptyFinallyBlock" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyEmptyStatementBody" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyEmptySyncBlock" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyEmptyTryBlock" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="GroovyEnumerationNamingConvention" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="m_regex" value="[A-Z][A-Za-z\d]*"/>
         <option name="m_minLength" value="8"/>
         <option name="m_maxLength" value="64"/>
     </inspection_tool>
-    <inspection_tool class="GroovyFallthrough" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyIfStatementWithIdenticalBranches" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyIfStatementWithTooManyBranches" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyFallthrough" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyGStringKey" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyIfStatementWithIdenticalBranches" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyIfStatementWithTooManyBranches" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_limit" value="3"/>
     </inspection_tool>
-    <inspection_tool class="GroovyInArgumentCheck" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyInfiniteLoopStatement" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyInfiniteRecursion" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyInstanceMethodNamingConvention" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyInArgumentCheck" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyInfiniteLoopStatement" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyInfiniteRecursion" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyInstanceMethodNamingConvention" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_regex" value="[a-z][A-Za-z\d]*"/>
         <option name="m_minLength" value="4"/>
         <option name="m_maxLength" value="32"/>
     </inspection_tool>
-    <inspection_tool class="GroovyInstanceVariableNamingConvention" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyInstanceVariableNamingConvention" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_regex" value="m_[a-z][A-Za-z\d]*"/>
         <option name="m_minLength" value="1"/>
         <option name="m_maxLength" value="32"/>
@@ -1381,173 +2091,222 @@
         <option name="m_minLength" value="8"/>
         <option name="m_maxLength" value="64"/>
     </inspection_tool>
-    <inspection_tool class="GroovyLabeledStatement" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyListGetCanBeKeyedAccess" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyListSetCanBeKeyedAccess" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyLocalVariableNamingConvention" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyLabeledStatement" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyListGetCanBeKeyedAccess" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyListSetCanBeKeyedAccess" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyLocalVariableNamingConvention" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_regex" value="[a-z][A-Za-z\d]*"/>
         <option name="m_minLength" value="4"/>
         <option name="m_maxLength" value="32"/>
     </inspection_tool>
-    <inspection_tool class="GroovyLoopStatementThatDoesntLoop" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyMapGetCanBeKeyedAccess" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyMapPutCanBeKeyedAccess" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyMethodParameterCount" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyLoopStatementThatDoesntLoop" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyMapGetCanBeKeyedAccess" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyMapPutCanBeKeyedAccess" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyMethodParameterCount" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_limit" value="5"/>
     </inspection_tool>
-    <inspection_tool class="GroovyMethodWithMoreThanThreeNegations" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyMissingReturnStatement" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyMultipleReturnPointsPerMethod" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyMethodWithMoreThanThreeNegations" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyMissingReturnStatement" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyMultipleReturnPointsPerMethod" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_limit" value="1"/>
     </inspection_tool>
-    <inspection_tool class="GroovyNegatedConditional" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyNegatedIf" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyNestedAssignment" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyNestedConditional" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyNestedSwitch" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyNestedSynchronizedStatement" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyNonShortCircuitBoolean" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyNotifyWhileNotSynchronized" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyOctalInteger" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyOverlyComplexArithmeticExpression" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyNegatedConditional" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyNegatedIf" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyNestedAssignment" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyNestedConditional" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyNestedSwitch" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyNestedSynchronizedStatement" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyNonShortCircuitBoolean" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyNotifyWhileNotSynchronized" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyOctalInteger" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyOverlyComplexArithmeticExpression" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_limit" value="3"/>
     </inspection_tool>
-    <inspection_tool class="GroovyOverlyComplexBooleanExpression" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyOverlyComplexBooleanExpression" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_limit" value="3"/>
     </inspection_tool>
-    <inspection_tool class="GroovyOverlyComplexMethod" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyOverlyComplexMethod" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_limit" value="10"/>
     </inspection_tool>
-    <inspection_tool class="GroovyOverlyLongMethod" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyOverlyLongMethod" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_limit" value="30"/>
     </inspection_tool>
-    <inspection_tool class="GroovyOverlyNestedMethod" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyOverlyNestedMethod" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_limit" value="5"/>
     </inspection_tool>
-    <inspection_tool class="GroovyParameterNamingConvention" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyParameterNamingConvention" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_regex" value="[a-z][A-Za-z\d]*"/>
         <option name="m_minLength" value="4"/>
         <option name="m_maxLength" value="32"/>
     </inspection_tool>
-    <inspection_tool class="GroovyPointlessArithmetic" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyPointlessBoolean" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyPublicFieldAccessedInSynchronizedContext" enabled="true"
-                     level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="GroovyRangeTypeCheck" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyResultOfAssignmentUsed" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyResultOfIncrementOrDecrementUsed" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyResultOfObjectAllocationIgnored" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyReturnFromClosureCanBeImplicit" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyReturnFromFinallyBlock" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovySillyAssignment" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="GroovyPointlessArithmetic" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyPointlessBoolean" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyPublicFieldAccessedInSynchronizedContext" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="GroovyRangeTypeCheck" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyResultOfAssignmentUsed" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyResultOfIncrementOrDecrementUsed" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyResultOfObjectAllocationIgnored" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyReturnFromClosureCanBeImplicit" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyReturnFromFinallyBlock" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovySillyAssignment" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="GroovySingletonAnnotation" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="GroovyStaticMethodNamingConvention" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyStaticMethodNamingConvention" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_regex" value="[a-z][A-Za-z\d]*"/>
         <option name="m_minLength" value="4"/>
         <option name="m_maxLength" value="32"/>
     </inspection_tool>
-    <inspection_tool class="GroovyStaticVariableNamingConvention" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovyStaticVariableNamingConvention" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="m_regex" value="s_[a-z][A-Za-z\d]*"/>
         <option name="m_minLength" value="4"/>
         <option name="m_maxLength" value="32"/>
     </inspection_tool>
-    <inspection_tool class="GroovySwitchStatementWithNoDefault" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovySynchronizationOnNonFinalField" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovySynchronizationOnThis" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovySynchronizationOnVariableInitializedWithLiteral" enabled="true"
-                     level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="GroovySynchronizedMethod" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovySystemRunFinalizersOnExit" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyThreadStopSuspendResume" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyThrowFromFinallyBlock" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyTrivialConditional" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyTrivialIf" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyUncheckedAssignmentOfMemberOfRawType" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyUnconditionalWait" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyUnnecessaryContinue" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyUnnecessaryReturn" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyUnreachableStatement" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyUnsynchronizedMethodOverridesSynchronizedMethod" enabled="true"
-                     level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="GroovyUntypedAccess" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyUnusedAssignment" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyUnusedCatchParameter" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyUnusedDeclaration" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyUnusedIncOrDec" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyVariableCanBeFinal" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyVariableNotAssigned" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyWaitCallNotInLoop" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyWaitWhileNotSynchronized" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="GroovyWhileLoopSpinsOnField" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="GroovySwitchStatementWithNoDefault" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovySynchronizationOnNonFinalField" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovySynchronizationOnThis" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovySynchronizationOnVariableInitializedWithLiteral" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="GroovySynchronizedMethod" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovySystemRunFinalizersOnExit" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyThreadStopSuspendResume" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyThrowFromFinallyBlock" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyTrivialConditional" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyTrivialIf" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyUncheckedAssignmentOfMemberOfRawType" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="GroovyUnconditionalWait" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyUnnecessaryContinue" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyUnnecessaryReturn" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyUnreachableStatement" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyUnsynchronizedMethodOverridesSynchronizedMethod" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="GroovyUntypedAccess" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyUnusedAssignment" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyUnusedCatchParameter" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyUnusedDeclaration" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyUnusedIncOrDec" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyVariableCanBeFinal" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyVariableNotAssigned" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyWaitCallNotInLoop" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyWaitWhileNotSynchronized" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GroovyWhileLoopSpinsOnField" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="ignoreNonEmtpyLoops" value="false"/>
     </inspection_tool>
-    <inspection_tool class="Guava" enabled="true" level="WARNING" enabled_by_default="true"/>
+    <inspection_tool class="GspInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GtkPreferredJComboBoxRenderer" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="GuavaFluentIterable" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="GwtClientClassFromNonInheritedModule" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtCssResourceErrors" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtDefaultPackageNotRegistered" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtDeprecatedEventListeners" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtDeprecatedPropertyKeyJavadocTag" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtInconsistentI18nInterface" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtInconsistentSerializableClass" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtIncorrectArgumentOfGwtCreateMethod" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtJavaFromJSMethodCalls" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtJavaScriptReferences" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtMethodWithParametersInConstantsInterface" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="GwtObsoleteTypeArgsJavadocTag" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtOverlayTypeRestrictionsViolated" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtServiceNotRegistered" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtSetServiceEntryPointCalls" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtToHtmlReferences" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtUiBinderErrors" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtUiFieldAssignment" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtUiFieldErrors" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtUiHandlerErrors" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="GwtUiXmlReferences" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="HamlNestedTagContent" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <!-- we like it, it is not performance issue for us -->
     <inspection_tool class="HardCodedStringLiteral" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="HardcodedActionUrl" enabled="false" level="WARNING"
                      enabled_by_default="false"/>
     <!-- there are too much false positives in RegExps
          and javadoc start/end symbols in paths from classpath etc. -->
@@ -1559,23 +2318,23 @@
                      enabled_by_default="false"/>
     <inspection_tool class="HardwiredNamespacePrefix" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="HasPlatformType" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="HashCodeUsesNonFinalVariable" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="HibernateConfigDomFacetInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="HibernateConfigDomInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="HibernateMappingDatasourceDomInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="HibernateMappingDomInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="HibernateConfigDomFacetInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="HibernateConfigDomInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="HibernateMappingDatasourceDomInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="HibernateMappingDomInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="HibernateResource" enabled="true" level="WARNING"
                      enabled_by_default="true">
         <option name="insideTryAllowed" value="false"/>
     </inspection_tool>
     <inspection_tool class="HtmlDeprecatedTag" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="HtmlExtraClosingTag" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="HtmlFormInputWithoutLabel" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
@@ -1657,9 +2416,10 @@
                      enabled_by_default="true">
         <option name="m_limit" value="3"/>
     </inspection_tool>
-    <inspection_tool class="IfThenToElvis" enabled="true" level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="IfThenToSafeAccess" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="IfThenToElvis" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="IfThenToSafeAccess" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="IgnoreCoverEntry" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="IgnoreDuplicateEntry" enabled="true" level="WARNING"
@@ -1697,6 +2457,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="IgnoredJUnitTest" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="IllegalIdentifier" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="ImplicitArrayToString" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <!-- we do not like this style, but we could change our mind in future -->
@@ -1704,20 +2466,24 @@
                      enabled_by_default="false"/>
     <inspection_tool class="ImplicitDefaultCharsetUsage" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="ImplicitNullableNothingType" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="ImplicitNumericConversion" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="ignoreWideningConversions" value="true"/>
         <option name="ignoreCharConversions" value="false"/>
         <option name="ignoreConstantConversions" value="true"/>
     </inspection_tool>
+    <inspection_tool class="ImplicitThis" enabled="false" level="INFORMATION"
+                     enabled_by_default="false"/>
     <inspection_tool class="ImplicitTypeConversion" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="BITS" value="1720"/>
         <option name="FLAG_EXPLICIT_CONVERSION" value="true"/>
         <option name="IGNORE_NODESET_TO_BOOLEAN_VIA_STRING" value="true"/>
     </inspection_tool>
-    <inspection_tool class="ImplicitlyExposedWebServiceMethods" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="ImplicitlyExposedWebServiceMethods" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="IncompatibleMask" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="IncompatibleMaskJS" enabled="true" level="ERROR"
@@ -1728,10 +2494,8 @@
          that have to contain different line separators -->
     <inspection_tool class="InconsistentLineSeparators" enabled="false" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="InconsistentResourceBundle" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="IncorrectOnMessageMethodsInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="IncorrectOnMessageMethodsInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="IncrementDecrementResultUsedJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="IncrementDecrementUsedAsExpression" enabled="true" level="ERROR"
@@ -1748,10 +2512,10 @@
                      enabled_by_default="true"/>
     <inspection_tool class="InjectedReferences" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="InjectionNotApplicable" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="InjectionValueTypeInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="InjectionNotApplicable" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="InjectionValueTypeInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="InnerClassMayBeStatic" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="InnerClassOnInterface" enabled="true" level="WARNING"
@@ -1765,6 +2529,14 @@
         <option name="m_ignoreInvisibleFields" value="true"/>
     </inspection_tool>
     <inspection_tool class="InnerHTMLJS" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="InspectionDescriptionNotFoundInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="InspectionMappingConsistency" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="InspectionUniqueToolbarId" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="InspectionUsingGrayColors" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="InstanceGuardedByStatic" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="InstanceMethodNamingConvention" enabled="true" level="WARNING"
@@ -1799,7 +2571,9 @@
                      enabled_by_default="true"/>
     <!-- we do reflection for testing -->
     <inspection_tool class="InstanceofChain" enabled="true" level="ERROR" enabled_by_default="true">
-        <scope name="Tests" level="ERROR" enabled="false"/>
+        <scope name="Tests" level="ERROR" enabled="false">
+            <option name="ignoreInstanceofOnLibraryClasses" value="false"/>
+        </scope>
         <option name="ignoreInstanceofOnLibraryClasses" value="true"/>
     </inspection_tool>
     <inspection_tool class="InstanceofIncompatibleInterface" enabled="true" level="WARNING"
@@ -1821,8 +2595,10 @@
                      enabled_by_default="true">
         <option name="ignoreNonOverflowingCompileTimeConstants" value="true"/>
     </inspection_tool>
-    <inspection_tool class="InterceptionAnnotationWithoutRuntimeRetention" enabled="true"
-                     level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="IntentionDescriptionNotFoundInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="InterceptionAnnotationWithoutRuntimeRetention" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
     <inspection_tool class="InterfaceMayBeAnnotatedFunctional" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="InterfaceNamingConvention" enabled="true" level="WARNING"
@@ -1838,18 +2614,21 @@
     <!-- we are a library, we do not know all third-party implementations -->
     <inspection_tool class="InterfaceWithOnlyOneDirectInheritor" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
-    <inspection_tool class="IntroduceWhenSubject" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="InvalidImplementedBy" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="InvalidProvidedBy" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="InvalidRequestParameters" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="IntroduceWhenSubject" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="InvalidI18nProperty" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="InvalidImplementedBy" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="InvalidProvidedBy" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="InvalidRequestParameters" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="IteratorHasNextCallsIteratorNext" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="IteratorNextDoesNotThrowNoSuchElementException" enabled="true"
                      level="WARNING" enabled_by_default="true"/>
+    <inspection_tool class="JBoss" enabled="false" level="ERROR" enabled_by_default="false"/>
     <inspection_tool class="JDBCExecuteWithNonConstantString" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="JDBCPrepareStatementWithNonConstantString" enabled="true" level="ERROR"
@@ -1976,8 +2755,8 @@
          When this problem is resolved we could reconsider disablement. -->
     <inspection_tool class="Java8MapApi" enabled="false" level="WARNING"
                      enabled_by_default="false"/>
-    <inspection_tool class="Java8MapForEach" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="JavaCollectionsStaticMethod" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="JavaDoc" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="TOP_LEVEL_CLASS_OPTIONS">
             <value>
@@ -2009,80 +2788,110 @@
         <option name="IGNORE_POINT_TO_ITSELF" value="false"/>
         <option name="myAdditionalJavadocTags" value=""/>
     </inspection_tool>
-    <inspection_tool class="JavaFxDefaultTag" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JavaFxUnresolvedFxIdReference" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JavaFxUnresolvedStyleClassReference" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JavaFxUnusedImports" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="JavaFxColorRgb" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JavaFxDefaultTag" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JavaFxEventHandler" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JavaFxRedundantPropertyValue" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JavaFxResourcePropertyValue" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JavaFxUnresolvedFxIdReference" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JavaFxUnresolvedStyleClassReference" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JavaFxUnusedImports" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="JavaLangImport" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="JavaLangReflect" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="JavaStylePropertiesInvocation" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="JavaStylePropertiesInvocation" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="JavacQuirks" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="JavadocReference" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="JavaeeApplicationDomInspection" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="JdkProxiedBeanTypeInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JpaAttributeMemberSignatureInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JpaAttributeTypeInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JpaConfigDomFacetInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JpaDataSourceORMDomInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JpaDataSourceORMInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JpaDomInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JpaEntityListenerInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JpaEntityListenerWarningsInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JpaMissingIdInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JpaModelReferenceInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JpaORMDomInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JpaObjectClassSignatureInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JpaQlInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JpaQueryApiInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <!--we do not use this tool-->
+    <inspection_tool class="JdkProxiedBeanTypeInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JoinDeclarationAndAssignment" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpaAttributeMemberSignatureInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpaAttributeTypeInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpaConfigDomFacetInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpaDataSourceORMDomInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpaDataSourceORMInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpaDomInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpaEntityListenerInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpaEntityListenerWarningsInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpaMissingIdInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpaModelReferenceInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpaORMDomInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpaObjectClassSignatureInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpaQlInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpaQueryApiInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JpdlModelInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="Jscs" enabled="false" level="WARNING" enabled_by_default="false"/>
-    <inspection_tool class="JsfJamExtendsClassInconsistencyInspection" enabled="true"
-                     level="WARNING" enabled_by_default="true"/>
-    <inspection_tool class="JsfManagedBeansInconsistencyInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="JsfJamExtendsClassInconsistencyInspection" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="JsfManagedBeansInconsistencyInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="JsonDuplicatePropertyKeys" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="JsonStandardCompliance" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="JspAbsolutePathInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JspDirectiveInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JspPropertiesInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JspTagBodyContent" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="JspUnescapedEl" enabled="true" level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="KDocUnresolvedReference" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="JspAbsolutePathInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JspDirectiveInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JspPropertiesInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JspTagBodyContent" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="JspUnescapedEl" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="KDocUnresolvedReference" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="KeySetIterationMayUseEntrySet" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="KotlinDeprecation" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="KotlinDeprecation" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="KotlinDoubleNegation" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="KotlinInternalInJava" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="KotlinInvalidBundleOrProperty" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="KotlinMavenPluginPhase" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="KotlinRedundantOverride" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="KotlinSpringComponentScan" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="KotlinSpringFacetCode" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="KotlinTestJUnit" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="KotlinUnusedImport" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="LabeledStatement" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="LabeledStatementJS" enabled="true" level="ERROR"
@@ -2093,14 +2902,16 @@
                      enabled_by_default="true">
         <option name="m_maxLength" value="25"/>
     </inspection_tool>
-    <inspection_tool class="LanguageMismatch" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="LanguageMismatch" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="CHECK_NON_ANNOTATED_REFERENCES" value="true"/>
     </inspection_tool>
     <!-- it is impossible to follow this Law for us as most violation are caused by fact
          that we do logic not only on token that come to visitToken,
          but by extra traversing over subtree -->
     <inspection_tool class="LawOfDemeter" enabled="false" level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="LeakingThis" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="LengthOneStringInIndexOf" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <!-- it is not critical parts of our application and benefit is minimal
@@ -2115,6 +2926,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="LessUnresolvedVariable" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="LiftReturnOrAssignment" enabled="false" level="INFO"
+                     enabled_by_default="false"/>
     <inspection_tool class="LimitedScopeInnerClass" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="ListIndexOfReplaceableByContains" enabled="true" level="ERROR"
@@ -2136,6 +2949,8 @@
         <option name="m_ignoreInvisibleFields" value="true"/>
         <option name="m_ignoreStaticMethods" value="true"/>
     </inspection_tool>
+    <inspection_tool class="LocalVariableName" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="LocalVariableNamingConvention" enabled="true" level="WARNING"
                      enabled_by_default="true">
         <option name="m_ignoreForLoopParameters" value="false"/>
@@ -2158,9 +2973,6 @@
                      enabled_by_default="true"/>
     <inspection_tool class="LoggerInitializedWithForeignClass" enabled="true" level="ERROR"
                      enabled_by_default="true">
-        <option name="loggerClassName"
-                value="org.apache.log4j.Logger,org.slf4j.LoggerFactory,
-                      ,org.apache.commons.logging.LogFactory,java.util.logging.Logger"/>
         <option name="loggerFactoryMethodName" value="getLogger,getLogger,getLog,getLogger"/>
     </inspection_tool>
     <inspection_tool class="LoggingConditionDisagreesWithLogStatement" enabled="true" level="ERROR"
@@ -2177,11 +2989,13 @@
                      enabled_by_default="true"/>
     <inspection_tool class="LoopStatementsThatDontLoop" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="LoopToCallChain" enabled="false" level="INFORMATION"
+                     enabled_by_default="false"/>
     <inspection_tool class="LoopWithImplicitTerminationCondition" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="LossyEncoding" enabled="true" level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="MVCPathVariableInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="MVCPathVariableInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <!-- we do a lot of String processing : we have lexer and parser,
          we do not have java class that contains
          all lexer tokens with their text values(RPAREN vs ')') -->
@@ -2219,6 +3033,10 @@
                      enabled_by_default="false"/>
     <inspection_tool class="MavenRedundantGroupId" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="MayBeConstant" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="MemberVisibilityCanBePrivate" enabled="false" level="INFO"
+                     enabled_by_default="false"/>
     <!-- this rule is too severe, it requires some options to
          skip well known simple methods like string.length() etc. -->
     <inspection_tool class="MethodCallInLoopCondition" enabled="false" level="ERROR"
@@ -2276,9 +3094,11 @@
     <!-- nonsense in our context -->
     <inspection_tool class="MethodWithMultipleLoops" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
+    <inspection_tool class="MigrateDiagnosticSuppression" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="MimeType" enabled="true" level="WARNING" enabled_by_default="true"/>
-    <inspection_tool class="MinMaxValuesInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="MinMaxValuesInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="MismatchedArrayReadWrite" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="MismatchedCollectionQueryUpdate" enabled="true" level="WARNING"
@@ -2290,11 +3110,17 @@
             <option name="updateNames">
                 <value/>
             </option>
+            <option name="ignoredClasses">
+                <value/>
+            </option>
         </scope>
         <option name="queryNames">
             <value/>
         </option>
         <option name="updateNames">
+            <value/>
+        </option>
+        <option name="ignoredClasses">
             <value/>
         </option>
     </inspection_tool>
@@ -2306,8 +3132,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="MissedExecutable" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="MissingAspectjAutoproxyInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="MissingAspectjAutoproxyInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="MissingDeprecatedAnnotation" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="MissingFinalNewline" enabled="true" level="WARNING"
@@ -2317,10 +3143,6 @@
         <option name="ignoreObjectMethods" value="true"/>
         <option name="ignoreAnonymousClassMethods" value="false"/>
     </inspection_tool>
-    <!-- behavior is non stable between TC and local IDEA,
-         disablement in test scope does not work -->
-    <inspection_tool class="MissingPackageInfo" enabled="false" level="WARNING"
-                     enabled_by_default="false"/>
     <inspection_tool class="MissortedModifiers" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="m_requireAnnotationsFirst" value="true"/>
@@ -2348,22 +3170,25 @@
                      enabled_by_default="false">
         <option name="limit" value="100"/>
     </inspection_tool>
-    <inspection_tool class="MultipleBindingAnnotations" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="MoveSuspiciousCallableReferenceIntoParentheses" enabled="false"
+                     level="WEAK WARNING" enabled_by_default="false"/>
+    <inspection_tool class="MultipleBindingAnnotations" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="MultipleDeclaration" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="ignoreForLoopDeclarations" value="true"/>
     </inspection_tool>
     <inspection_tool class="MultipleExceptionsDeclaredOnTestMethod" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="MultipleInjectedConstructorsForClass" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="MultipleMethodDesignatorsInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="MultipleRepositoryUrls" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="MultipleInjectedConstructorsForClass" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="MultipleMethodDesignatorsInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="MultipleRepositoryUrls" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="MultipleReturnPointsPerMethod" enabled="true" level="ERROR"
                      enabled_by_default="true">
+        <option name="ignoreGuardClauses" value="false"/>
         <option name="ignoreEqualsMethod" value="true"/>
         <option name="m_limit" value="1"/>
     </inspection_tool>
@@ -2375,6 +3200,8 @@
                      enabled_by_default="true">
         <option name="checkDivision" value="false"/>
     </inspection_tool>
+    <inspection_tool class="MysqlParsingInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="NakedNotify" enabled="true" level="WARNING" enabled_by_default="true"/>
     <inspection_tool class="NativeMethodNamingConvention" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
@@ -2432,13 +3259,19 @@
     </inspection_tool>
     <inspection_tool class="NewExceptionWithoutArguments" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="NewInstanceOfSingleton" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="NewGroovyClassNamingConvention" enabled="false" level="ERROR"
+                     enabled_by_default="false">
+        <extension name="GroovyAnnotationNamingConvention" enabled="true"/>
+        <extension name="GroovyClassNamingConvention" enabled="true"/>
+        <extension name="GroovyEnumerationNamingConvention" enabled="true"/>
+        <extension name="GroovyInterfaceNamingConvention" enabled="true"/>
+        <extension name="JUnitAbstractTestClassNamingConvention" enabled="true"/>
+    </inspection_tool>
+    <inspection_tool class="NewInstanceOfSingleton" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="NewStringBufferWithCharArgument" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="NoExplicitFinalizeCalls" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="NonAtomicOperationOnVolatileField" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="NonBlockStatementBodyJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
@@ -2468,8 +3301,12 @@
                      level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="NonFinalUtilityClass" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="NonJaxWsWebServices" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="NonJREEmulationClassesInClientCode" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="NonJaxWsWebServices" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="NonOsgiMavenDependency" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="NonProtectedConstructorInAbstractClass" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="m_ignoreNonPublicClasses" value="false"/>
@@ -2489,6 +3326,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="NonSerializableObjectPassedToObjectStream" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="NonSerializableServiceParameters" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="NonSerializableWithSerialVersionUIDField" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="NonSerializableWithSerializationMethods" enabled="true" level="ERROR"
@@ -2518,7 +3357,11 @@
                      enabled_by_default="true"/>
     <inspection_tool class="NullArgumentToVariableArgMethod" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="NullChecksToSafeCall" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="NullThrown" enabled="true" level="WARNING" enabled_by_default="true"/>
+    <inspection_tool class="NullableBooleanElvis" enabled="false" level="INFO"
+                     enabled_by_default="false"/>
     <!-- we are not ready to use extra dependency com.google.code.findbugs:jsr305 in our API -->
     <inspection_tool class="NullableProblems" enabled="false" level="WARNING"
                      enabled_by_default="false">
@@ -2546,7 +3389,11 @@
                      enabled_by_default="false"/>
     <inspection_tool class="ObjectEqualsNull" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="ObjectLiteralToLambda" enabled="false" level="INFO"
+                     enabled_by_default="false"/>
     <inspection_tool class="ObjectNotify" enabled="true" level="WARNING" enabled_by_default="true"/>
+    <inspection_tool class="ObjectPropertyName" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="ObjectToString" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="ObsoleteCollection" enabled="true" level="ERROR"
@@ -2558,8 +3405,8 @@
     <inspection_tool class="OctalIntegerJS" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="OctalLiteral" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="OnDemandImport" enabled="true" level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="OneWayWebMethod" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="OneWayWebMethod" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <!-- on the moment of review we were not a big fans of functional style,
          none of code coverage tools can distinguish that body of lambda is executed.
          When this problem is resolved we could reconsider disablement. -->
@@ -2602,14 +3449,20 @@
                      level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="OverriddenMethodCallDuringObjectConstruction" enabled="true"
                      level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="PackageDirectoryMismatch" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="OverridingDeprecatedMember" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="PackageAccessibility" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="PackageDirectoryMismatch" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="PackageDotHtmlMayBePackageInfo" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="PackageInMultipleModules" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="PackageInfoWithoutPackage" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="PackageName" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="PackageNamingConvention" enabled="true" level="WARNING"
                      enabled_by_default="true">
         <option name="m_regex" value="[a-z0-9\.]*"/>
@@ -2635,6 +3488,12 @@
                      enabled_by_default="false">
         <option name="limit" value="10"/>
     </inspection_tool>
+    <inspection_tool class="PageflowModelInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="PagesFileModelInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="PagesModelInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="ParameterCanBeLocal" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ParameterHidingMemberVariable" enabled="true" level="ERROR"
@@ -2685,7 +3544,8 @@
                      enabled_by_default="true">
         <option name="m_limit" value="5"/>
     </inspection_tool>
-    <inspection_tool class="PathAnnotation" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="PathAnnotation" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="PatternNotApplicable" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="PatternOverriddenByNonAnnotatedMethod" enabled="true" level="ERROR"
@@ -2698,10 +3558,14 @@
                      enabled_by_default="true"/>
     <inspection_tool class="PlatformDetectionJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="PlatformExtensionReceiverOfInline" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="PlayCustomTagNameInspection" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="PlayPropertyInspection" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="PluginXmlValidity" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="PointcutMethodStyleInspection" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="PointlessArithmeticExpression" enabled="true" level="ERROR"
@@ -2710,8 +3574,8 @@
     </inspection_tool>
     <inspection_tool class="PointlessArithmeticExpressionJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="PointlessBinding" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="PointlessBinding" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="PointlessBitwiseExpression" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="m_ignoreExpressionsContainingConstants" value="false"/>
@@ -2730,18 +3594,28 @@
                      enabled_by_default="true"/>
     <inspection_tool class="PointlessNullCheck" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="PostfixTemplateDescriptionNotFound" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="PresentationAnnotation" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="PrimitiveArrayArgumentToVariableArgMethod" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <!-- we do not like suggested style, but we could change out mind in future -->
     <inspection_tool class="PrivateMemberAccessBetweenOuterAndInnerClass" enabled="false"
                      level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="PrivatePropertyName" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="ProblematicVarargsMethodOverride" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ProblematicWhitespace" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="PropertyName" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="PropertyValueSetToItself" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ProtectedField" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="ProtectedInFinal" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="ProtectedInnerClass" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="ignoreEnums" value="false"/>
@@ -2749,6 +3623,8 @@
     </inspection_tool>
     <inspection_tool class="ProtectedMemberInFinalClass" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
+    <inspection_tool class="PsiElementConcatenation" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <!-- we do not need to force all to have static factory methods -->
     <inspection_tool class="PublicConstructor" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
@@ -2765,10 +3641,6 @@
     </inspection_tool>
     <inspection_tool class="PublicFieldAccessedInSynchronizedContext" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <!-- we like to use them as we not always ready to make class top level, for Checks
-     it is better to keep all in one class. -->
-    <inspection_tool class="PublicInnerClass" enabled="false" level="WARNING"
-                     enabled_by_default="false"/>
     <!-- we are not fanatics of interfaces, we use concept 'the less abstractions the better -->
     <inspection_tool class="PublicMethodNotExposedInInterface" enabled="false" level="ERROR"
                      enabled_by_default="false">
@@ -2794,8 +3666,10 @@
                         ,fred1,fred2,gg,hh,hello,hello1,hello2,hello3,ii,nu11,one,silly,silly2,
                         ,string,two,that,then,three,whi1e,var"/>
     </inspection_tool>
-    <inspection_tool class="RSReferenceInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="QuickFixGetFamilyNameViolation" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RSReferenceInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="RandomDoubleForRandomInteger" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="RawUseOfParameterizedType" enabled="true" level="ERROR"
@@ -2808,40 +3682,70 @@
                      enabled_by_default="true"/>
     <inspection_tool class="RecordStoreResource" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="RecursiveEqualsCall" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RecursivePropertyAccessor" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="RedundantArrayCreation" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="RedundantCast" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="RedundantExplicitType" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="RedundantFieldInitialization" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="RedundantGetter" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RedundantIf" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="RedundantImplements" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="ignoreSerializable" value="false"/>
         <option name="ignoreCloneable" value="false"/>
     </inspection_tool>
+    <inspection_tool class="RedundantLambdaArrow" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="RedundantMethodOverride" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="RedundantScopeBinding" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="RedundantModalityModifier" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RedundantObjectTypeCheck" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RedundantSamConstructor" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RedundantScopeBinding" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RedundantSemicolon" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RedundantSetter" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="RedundantStringFormatCall" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="RedundantSuppression" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="RedundantSuspendModifier" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="RedundantThrows" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="RedundantThrowsDeclaration" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="RedundantToBinding" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="RedundantToProviderBinding" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="RedundantToBinding" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RedundantToProviderBinding" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="RedundantTypeArguments" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="RedundantTypeConversion" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="CHECK_ANY" value="false"/>
     </inspection_tool>
-    <inspection_tool class="ReferencesToClassesFromDefaultPackagesInJSPFile" enabled="true"
-                     level="WARNING" enabled_by_default="true"/>
+    <inspection_tool class="RedundantUnitExpression" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RedundantUnitReturnType" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RedundantVisibilityModifier" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ReferencesToClassesFromDefaultPackagesInJSPFile" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
     <inspection_tool class="ReflectionForUnavailableAnnotation" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ReflectionNotFound" enabled="true" level="ERROR"
@@ -2850,9 +3754,39 @@
         <option name="ignoreEmptySuperMethods" value="false"/>
         <option name="onlyReportWhenAnnotated" value="true"/>
     </inspection_tool>
-    <inspection_tool class="RemoveExplicitTypeArguments" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="RemoveCurlyBracesFromTemplate" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RemoveEmptyClassBody" enabled="false" level="INFO"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RemoveEmptyParenthesesFromLambdaCall" enabled="false" level="INFO"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RemoveEmptyPrimaryConstructor" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RemoveEmptySecondaryConstructorBody" enabled="false"
+                     level="WEAK WARNING" enabled_by_default="false"/>
+    <inspection_tool class="RemoveExplicitSuperQualifier" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RemoveExplicitTypeArguments" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RemoveForLoopIndices" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RemoveRedundantBackticks" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RemoveRedundantCallsOfConversionMethods" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RemoveRedundantSpreadOperator" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RemoveSetterParameterType" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RemoveSingleExpressionStringTemplate" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RemoveToStringInStringTemplate" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="ReplaceAllDot" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="ReplaceArrayEqualityOpWithArraysEquals" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ReplaceArrayOfWithLiteral" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="ReplaceAssignmentWithOperatorAssignment" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="ignoreLazyOperators" value="true"/>
@@ -2860,22 +3794,42 @@
     </inspection_tool>
     <inspection_tool class="ReplaceAssignmentWithOperatorAssignmentJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="ReplaceCallWithBinaryOperator" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="ReplaceDeprecatedFunctionClassUsages" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="ReplaceWithOperatorAssignment" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="RequiredArtifactTypeInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="ReplaceGetOrSet" enabled="false" level="INFO"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ReplacePutWithAssignment" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ReplaceRangeToWithUntil" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ReplaceSingleLineLet" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ReplaceSizeCheckWithIsNotEmpty" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ReplaceSizeZeroCheckWithIsEmpty" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ReplaceToWithInfixForm" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ReplaceWithOperatorAssignment" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RequiredArtifactTypeInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="RequiredAttributes" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="myAdditionalRequiredHtmlAttributes" value=""/>
     </inspection_tool>
-    <inspection_tool class="RequiredBeanTypeInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="RequiredBeanTypeInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="ReservedWordUsedAsNameJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="RestWrongDefaultValueInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="RestParamTypeInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RestResourceMethodInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="RestWrongDefaultValueInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING"
                      enabled_by_default="true">
         <scope name="Tests" level="WARNING" enabled="false"/>
@@ -2923,10 +3877,42 @@
     <!-- it is ok as some methods are in role of configuration 'isEditable{ return false;} -->
     <inspection_tool class="SameReturnValue" enabled="false" level="WARNING"
                      enabled_by_default="false"/>
-    <inspection_tool class="SecondUnsafeCall" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SelfIncludingJspFiles" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="SassScssResolvedByNameOnly" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SassScssUnresolvedMixin" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SassScssUnresolvedPlaceholderSelector" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SassScssUnresolvedVariable" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ScheduledMethodInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ScopeFunctionConversion" enabled="false" level="INFORMATION"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SeamAnnotationIncorrectSignatureInspection" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="SeamAnnotationsInconsistencyInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SeamBijectionIllegalScopeParameterInspection" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="SeamBijectionTypeMismatchInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SeamBijectionUndefinedContextVariableInspection" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="SeamDomModelInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SeamDuplicateComponentsInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SeamIllegalComponentScopeInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SeamJamComponentInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SecondUnsafeCall" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SelfAssignment" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SelfIncludingJspFiles" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="SerialPersistentFieldsWithWrongSignature" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="SerialVersionUIDNotStaticFinal" enabled="true" level="ERROR"
@@ -2971,12 +3957,12 @@
                      enabled_by_default="true"/>
     <inspection_tool class="SerializableWithUnconstructableAncestor" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="ServerEndpointInconsistencyInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="ServerEndpointInconsistencyInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="ServletWithoutMappingInspection" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="SessionScopedInjectsRequestScoped" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="SessionScopedInjectsRequestScoped" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="SetReplaceableByEnumSet" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="SetupCallsSuperSetup" enabled="true" level="ERROR"
@@ -2999,6 +3985,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="SimplifiableAnnotation" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="SimplifiableCallChain" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="SimplifiableConditionalExpression" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="SimplifiableEqualsExpression" enabled="true" level="ERROR"
@@ -3007,10 +3995,14 @@
                      enabled_by_default="true"/>
     <inspection_tool class="SimplifiableJUnitAssertion" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="SimplifyNegatedBinaryExpression" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SimplifyStreamApiCallChains" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="SimplifyAssertNotNull" enabled="false" level="INFO"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SimplifyBooleanWithConstants" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SimplifyNegatedBinaryExpression" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SimplifyWhenWithBooleanConstantCondition" enabled="false"
+                     level="WEAK WARNING" enabled_by_default="false"/>
     <!-- the only violation found is false-positive at AvoidEscapedUnicodeCharactersCheck -->
     <inspection_tool class="SingleCharAlternation" enabled="false" level="WARNING"
                      enabled_by_default="false"/>
@@ -3020,8 +4012,10 @@
     <inspection_tool class="SingleClassImport" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
     <inspection_tool class="Singleton" enabled="true" level="WARNING" enabled_by_default="true"/>
-    <inspection_tool class="SingletonInjectsScoped" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="SingletonConstructor" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SingletonInjectsScoped" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="SizeReplaceableByIsEmpty" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="SleepWhileHoldingLock" enabled="true" level="WARNING"
@@ -3030,6 +4024,8 @@
                      enabled_by_default="true">
         <option name="insideTryAllowed" value="false"/>
     </inspection_tool>
+    <inspection_tool class="SortModifiers" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <!-- even we limit validation comments only, there are still a lot of violations on javadoc
      parameters naming , it also violates names of inspections in noinspection tags etc. -->
     <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO"
@@ -3038,152 +4034,205 @@
         <option name="processLiterals" value="true"/>
         <option name="processComments" value="true"/>
     </inspection_tool>
-    <inspection_tool class="SpringAopErrorsInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringAopWarningsInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringBatchModel" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringBeanAttributesInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="SpringAopErrorsInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringAopWarningsInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringBatchModel" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringBeanAttributesInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="SpringBeanAutowiringInspection" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="SpringBeanConstructorArgInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringBeanDepedencyCheckInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringBeanInstantiationInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringBeanLookupMethodInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringBeanNameConventionInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringBootAdditionalConfig" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringBootApplicationProperties" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringBootApplicationYaml" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringComponentScan" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringContextConfigurationInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="SpringBeanConstructorArgInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringBeanDepedencyCheckInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringBeanInstantiationInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringBeanLookupMethodInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringBeanNameConventionInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringBootAdditionalConfig" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringBootApplicationProperties" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringBootApplicationYaml" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringBootBootstrapConfigurationInspection" enabled="false"
+                     level="WEAK WARNING" enabled_by_default="false"/>
+    <inspection_tool class="SpringCacheAnnotationsOnInterfaceInspection" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="SpringCacheNamesInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringCacheableAndCachePutInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringCacheableComponentsInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringComponentScan" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringContextConfigurationInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="SpringDataJpaMethodInconsistencyInspection" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="SpringElInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringElStaticFieldInjectionInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringFacetCodeInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringFacetInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true">
+    <inspection_tool class="SpringDataMethodInconsistencyInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringDataRepositoryMethodParametersInspection" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="SpringDataRepositoryMethodReturnTypeInspection" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="SpringElInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringElStaticFieldInjectionInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringEventListenerInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringFacetCodeInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringFacetInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false">
         <option name="checkTestFiles" value="false"/>
     </inspection_tool>
-    <inspection_tool class="SpringFacetProgrammaticInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringFactoryMethodInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringHandlersSchemasHighlighting" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringInactiveProfileHighlightingInspection" enabled="true"
-                     level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="SpringIncorrectResourceTypeInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringInjectionValueConsistencyInspection" enabled="true"
-                     level="WARNING" enabled_by_default="true"/>
-    <inspection_tool class="SpringInjectionValueStyleInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringIntegrationDeprecations21" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringIntegrationModel" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringJavaAutowiredMembersInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="SpringFacetProgrammaticInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringFactoryMethodInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringHandlersSchemasHighlighting" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringInactiveProfileHighlightingInspection" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="SpringIncorrectResourceTypeInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringInjectionValueConsistencyInspection" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="SpringInjectionValueStyleInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringIntegrationDeprecations21" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringIntegrationModel" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringJavaAutowiredFieldsWarningInspection" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="SpringJavaAutowiredMembersInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="SpringJavaAutowiringInspection" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="SpringJavaConfigExternalBeansErrorInspection" enabled="true"
-                     level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="SpringJavaConfigInconsistencyInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringMVCInitBinder" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringMVCViewInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringMessageDispatcherWebXmlInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="SpringJavaConfigExternalBeansErrorInspection" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="SpringJavaConfigInconsistencyInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringJavaConstructorAutowiringInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringJavaInjectionPointsAutowiringInspection" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="SpringJavaStaticMembersAutowiringInspection" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="SpringKotlinAutowiredMembers" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringKotlinAutowiring" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringLookupInjectionInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringMVCInitBinder" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringMVCViewInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringMessageDispatcherWebXmlInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="SpringModelInspection" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="SpringOsgiElementsInconsistencyInspection" enabled="true"
-                     level="WARNING" enabled_by_default="true"/>
-    <inspection_tool class="SpringOsgiListenerInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringOsgiServiceCommonInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringPlaceholdersInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringPublicFactoryMethodInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringRequiredAnnotationInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringRequiredPropertyInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringScopesInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringSecurityDebugActivatedInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringSecurityFiltersConfiguredInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringSecurityModelInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="SpringOsgiElementsInconsistencyInspection" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="SpringOsgiListenerInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringOsgiServiceCommonInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringPlaceholdersInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringPublicFactoryMethodInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringRequiredAnnotationInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringRequiredPropertyInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringScopesInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringSecurityAnnotationBeanPointersResolveInspection" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="SpringSecurityDebugActivatedInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringSecurityFiltersConfiguredInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringSecurityModelInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="SpringStaticMembersAutowiringInspection" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="SpringTransactionalComponentInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SpringWebServiceAnnotationsInconsistencyInspection" enabled="true"
-                     level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="SpringWebServicesConfigurationsInspection" enabled="true"
-                     level="WARNING" enabled_by_default="true"/>
-    <inspection_tool class="SpringWebSocketConfigurationInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlAddNotNullColumnInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlAmbiguousColumnInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlAutoIncrementDuplicateInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlCheckUsingColumnsInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlConstantConditionInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlDeprecateTypeInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlDerivedTableAliasInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlDialectInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlDropIndexedColumnInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlIdentifierInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlInsertValuesInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlNoDataSourceInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlNullComparisonInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlPostgresqlSelectFromProcedureInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlResolveInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlShouldBeInGroupByInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="SqlTypeInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="SpringTestingDirtiesContextInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringTestingTransactionalInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringTransactionalComponentInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringWebServiceAnnotationsInconsistencyInspection" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="SpringWebServicesConfigurationsInspection" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="SpringWebSocketConfigurationInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringXmlAutowireExplicitlyInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringXmlAutowiringInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SpringXmlModelInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlAddNotNullColumnInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlAmbiguousColumnInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlAutoIncrementDuplicateInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlCheckUsingColumnsInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlConstantConditionInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlDeprecateTypeInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlDerivedTableAliasInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlDialectInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlDropIndexedColumnInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlIdentifierInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlInsertValuesInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlNoDataSourceInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlNullComparisonInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlPostgresqlSelectFromProcedureInspection" enabled="false"
+                     level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="SqlResolveInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlShouldBeInGroupByInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlSideEffectsInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlSignatureInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlStorageInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlTypeInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="SqlUnusedVariableInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="StandardVariableNames" enabled="true" level="WARNING"
                      enabled_by_default="true">
         <option name="ignoreParameterNameSameAsSuper" value="true"/>
     </inspection_tool>
+    <inspection_tool class="StatefulEp" enabled="false" level="WARNING" enabled_by_default="false"/>
     <inspection_tool class="StatementsPerFunctionJS" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="m_limit" value="30"/>
@@ -3263,10 +4312,6 @@
                      enabled_by_default="true"/>
     <inspection_tool class="StringConcatenationInFormatCall" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="StringConcatenationInLoops" enabled="true" level="WARNING"
-                     enabled_by_default="true">
-        <option name="m_ignoreUnlessAssigned" value="true"/>
-    </inspection_tool>
     <inspection_tool class="StringConcatenationInMessageFormatCall" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="StringConcatenationInsideStringBufferAppend" enabled="true"
@@ -3301,6 +4346,16 @@
                      enabled_by_default="false"/>
     <inspection_tool class="StringTokenizerDelimiter" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="Struts2ModelInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="StrutsInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="StrutsTilesInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="StrutsValidatorFormInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="StrutsValidatorInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="SubstringZero" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
@@ -3398,12 +4453,16 @@
                      enabled_by_default="true">
         <scope name="Production" level="WARNING" enabled="true"/>
     </inspection_tool>
+    <inspection_tool class="SuspiciousEqualsCombination" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="SuspiciousGetterSetter" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="onlyWarnWhenFieldPresent" value="true"/>
     </inspection_tool>
     <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
+    <inspection_tool class="SuspiciousInstanceOfGuard" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="SuspiciousLiteralUnderscore" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="SuspiciousLocalesLanguages" enabled="true" level="ERROR"
@@ -3416,11 +4475,30 @@
                      enabled_by_default="true">
         <group names="x,width,left,right"/>
         <group names="y,height,top,bottom"/>
+        <ignored>
+            <option name="METHOD_MATCHER_CONFIG"
+                    value="java.io.PrintStream,println, ,
+    ,java.io.PrintWriter,println, ,
+    ,java.lang.System,identityHashCode, ,
+    ,java.sql.PreparedStatement,set.*, ,
+    ,java.sql.ResultSet,update.*, ,
+    ,java.sql.SQLOutput,write.*, ,
+    ,java.lang.Integer,compare.*, ,
+    ,java.lang.Long,compare.*, ,
+    ,java.lang.Short,compare, ,
+    ,java.lang.Byte,compare, ,
+    ,java.lang.Character,compare, ,
+    ,java.lang.Boolean,compare, ,
+    ,java.lang.Math,.*, ,
+    ,java.lang.StrictMath,.*"/>
+        </ignored>
     </inspection_tool>
     <inspection_tool class="SuspiciousSystemArraycopy" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="SuspiciousToArrayCall" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="SuspiciousTypeOfGuard" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <!-- we like switch statements, we can not avoid usage of them -->
     <inspection_tool class="SwitchStatement" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
@@ -3464,7 +4542,6 @@
     </inspection_tool>
     <inspection_tool class="SynchronizedOnLiteralObject" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="SyntaxError" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="SystemExit" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="SystemGC" enabled="true" level="WARNING" enabled_by_default="true"/>
     <inspection_tool class="SystemGetenv" enabled="true" level="ERROR" enabled_by_default="true"/>
@@ -3477,8 +4554,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="SystemSetSecurityManager" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="TaglibDomModelInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="TaglibDomModelInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="TailRecursion" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="TailRecursionJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
@@ -3486,6 +4563,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="TeardownIsPublicVoidNoArg" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="TelReferencesInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="TestCaseInProductCode" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="TestCaseWithConstructor" enabled="true" level="ERROR"
@@ -3494,6 +4573,8 @@
                      enabled_by_default="true">
         <option name="ignoreSupers" value="false"/>
     </inspection_tool>
+    <inspection_tool class="TestFunctionName" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="TestMethodInProductCode" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="TestMethodIsPublicVoidNoArg" enabled="true" level="ERROR"
@@ -3578,10 +4659,12 @@
     </inspection_tool>
     <inspection_tool class="ThrowsRuntimeException" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="ThymeleafMessagesResolveInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="ThymeleafVariablesResolveInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="ThymeleafDialectDomInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ThymeleafMessagesResolveInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ThymeleafVariablesResolveInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="TimeToString" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="ToArrayCallWithZeroLengthArrayArgument" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
@@ -3621,8 +4704,9 @@
                      enabled_by_default="false"/>
     <inspection_tool class="TryWithIdenticalCatches" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="TsLint" enabled="true" level="WARNING" enabled_by_default="true"/>
-    <inspection_tool class="TypeCustomizer" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="TsLint" enabled="false" level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="TypeCustomizer" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <!-- we like implementation to be concrete, we do not like a lot of abstractions -->
     <inspection_tool class="TypeMayBeWeakened" enabled="false" level="ERROR"
                      enabled_by_default="false">
@@ -3635,6 +4719,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="TypeParameterExtendsObject" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="TypeParameterFindViewById" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="TypeParameterHidesVisibleType" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="TypeParameterNamingConvention" enabled="true" level="WARNING"
@@ -3643,14 +4729,36 @@
         <option name="m_minLength" value="1"/>
         <option name="m_maxLength" value="1"/>
     </inspection_tool>
-    <inspection_tool class="TypeScriptAccessibilityCheck" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="TypeScriptAbstractClassConstructorCanBeMadeProtected" enabled="false"
+                     level="WEAK WARNING" enabled_by_default="false"/>
+    <inspection_tool class="TypeScriptAccessibilityCheck" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="TypeScriptCheckFunctionSignatures" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="TypeScriptUnresolvedFunction" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="TypeScriptUnresolvedVariable" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="TypeScriptCheckImport" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="TypeScriptFieldCanBeMadeReadonly" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="TypeScriptMissingAugmentationImport" enabled="false" level="INFORMATION"
+                     enabled_by_default="false"/>
+    <inspection_tool class="TypeScriptPreferShortImport" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="TypeScriptSuspiciousConstructorParameterAssignment" enabled="false"
+                     level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="TypeScriptUMDGlobal" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="TypeScriptUnresolvedFunction" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="TypeScriptUnresolvedVariable" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="TypeScriptValidateJSTypes" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="TypeScriptValidateTypes" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="TypescriptExplicitMemberType" enabled="false" level="INFORMATION"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UElementAsPsi" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="UNCHECKED_WARNING" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="UNUSED_IMPORT" enabled="true" level="ERROR" enabled_by_default="true"/>
@@ -3668,17 +4776,19 @@
                      enabled_by_default="true"/>
     <inspection_tool class="UndeclaredTests" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="UnhandledExceptionInJSP" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="UninstantiableBinding" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="UninstantiableImplementedByClass" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="UninstantiableProvidedByClass" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="UndesirableClassUsage" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UnhandledExceptionInJSP" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UninstantiableBinding" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UninstantiableImplementedByClass" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UninstantiableProvidedByClass" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="UnknownGuard" enabled="true" level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="UnknownLanguage" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="UnknownLanguage" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="UnnecessarilyQualifiedInnerClassAccess" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="ignoreReferencesNeedingImport" value="true"/>
@@ -3724,6 +4834,7 @@
     <inspection_tool class="UnnecessaryFullyQualifiedName" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="m_ignoreJavadoc" value="false"/>
+        <option name="ignoreInModuleStatements" value="true"/>
     </inspection_tool>
     <inspection_tool class="UnnecessaryInheritDoc" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
@@ -3759,8 +4870,8 @@
         <option name="ignoreParenthesesOnConditionals" value="false"/>
         <option name="ignoreParenthesesOnLambdaParameter" value="false"/>
     </inspection_tool>
-    <inspection_tool class="UnnecessaryQualifiedReference" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="UnnecessaryQualifiedReference" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="UnnecessaryQualifierForThis" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="UnnecessaryReturn" enabled="true" level="ERROR"
@@ -3769,8 +4880,8 @@
                      enabled_by_default="true"/>
     <inspection_tool class="UnnecessarySemicolon" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="UnnecessaryStaticInjection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="UnnecessaryStaticInjection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="UnnecessarySuperConstructor" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="UnnecessarySuperQualifier" enabled="true" level="ERROR"
@@ -3789,8 +4900,10 @@
                      enabled_by_default="true"/>
     <inspection_tool class="UnnecessaryUnicodeEscape" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="UnparsedCustomBeanInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="UnnecessaryVariable" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UnparsedCustomBeanInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="UnpredictableBigDecimalConstructorCall" enabled="true" level="ERROR"
                      enabled_by_default="true">
         <option name="ignoreReferences" value="true"/>
@@ -3815,12 +4928,20 @@
                      enabled_by_default="false"/>
     <inspection_tool class="UnreachableCodeJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="UnresolvedMessageChannel" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="UnregisteredActivator" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UnresolvedMessageChannel" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="UnresolvedPropertyKey" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
-    <inspection_tool class="UnresolvedReference" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="UnresolvedReference" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UnsafeCastFromDynamic" enabled="false" level="INFO"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UnsafeReturnStatementVisitor" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UnsafeVfsRecursion" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="UnterminatedStatementJS" enabled="true" level="ERROR"
@@ -3847,9 +4968,13 @@
                      enabled_by_default="true">
         <option name="m_ignoreCatchBlocksWithComments" value="false"/>
     </inspection_tool>
-    <inspection_tool class="UnusedDefine" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="UnusedDefine" enabled="false" level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="UnusedEquals" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="UnusedImport" enabled="true" level="WARNING" enabled_by_default="true"/>
     <inspection_tool class="UnusedLabel" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="UnusedLambdaExpressionBody" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="UnusedMessageFormatParameter" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="UnusedParameters" enabled="true" level="WARNING"
@@ -3857,13 +4982,18 @@
         <scope name="Production" level="WARNING" enabled="true"/>
     </inspection_tool>
     <inspection_tool class="UnusedProperty" enabled="true" level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="UnusedReceiverParameter" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
-    <inspection_tool class="UnusedReturnValue" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="UnusedSymbol" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="UnusedReceiverParameter" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UnusedSymbol" enabled="false" level="ERROR" enabled_by_default="false"/>
     <inspection_tool class="UpperCaseFieldNameNotConstant" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
+    <inspection_tool class="UseDPIAwareBorders" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UseDPIAwareInsets" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UseExpressionBody" enabled="false" level="INFORMATION"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UseJBColor" enabled="false" level="WARNING" enabled_by_default="false"/>
     <inspection_tool class="UseOfAWTPeerClass" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <!-- we like this style of accessing of content of inner classes,
@@ -3886,8 +5016,19 @@
                      enabled_by_default="true"/>
     <inspection_tool class="UseOfSunClasses" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="UtilSchemaInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="UsePrimitiveTypes" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UsePropertyAccessSyntax" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UseVirtualFileEquals" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UseWithIndex" enabled="false" level="INFO" enabled_by_default="false"/>
+    <inspection_tool class="UselessCallOnCollection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UselessCallOnNotNull" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="UtilSchemaInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <!-- we are not pure object-oriented library, we like reasonable mix of styles,
          especially state-less and context-less -->
     <inspection_tool class="UtilityClass" enabled="false" level="ERROR" enabled_by_default="false">
@@ -3907,8 +5048,12 @@
         </option>
         <option name="ignoreClassesWithOnlyMain" value="false"/>
     </inspection_tool>
-    <inspection_tool class="ValidExternallyBoundObject" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="ValidExternallyBoundObject" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ValidatorConfigModelInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="ValidatorModelInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <!-- we like varargs methods, we use modern jdk -->
     <inspection_tool class="VarargParameter" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
@@ -3918,21 +5063,31 @@
                      enabled_by_default="false"/>
     <inspection_tool class="VoidExpressionJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="VoidMethodAnnotatedWithGET" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="VoidMethodAnnotatedWithGET" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="VolatileArrayField" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="VolatileLongOrDoubleField" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
+    <inspection_tool class="VtlDirectiveArgsInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="VtlFileReferencesInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="VtlInterpolationsInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <!-- VtlReferencesInspection produce a lot false-positives on ${projectVersion} -->
     <inspection_tool class="VtlReferencesInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="VtlTypesInspection" enabled="false" level="WARNING"
                      enabled_by_default="false"/>
     <inspection_tool class="W3CssValidation" enabled="true" level="ERROR" enabled_by_default="true">
         <option name="myCssVersion" value="css3"/>
         <option name="myIgnoreVendorSpecificProperties" value="true"/>
     </inspection_tool>
-    <inspection_tool class="WSReferenceInspection" enabled="true" level="ERROR"
-                     enabled_by_default="true"/>
+    <inspection_tool class="WSReferenceInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
+    <inspection_tool class="WadlDomInspection" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="WaitCalledOnCondition" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="WaitNotInLoop" enabled="true" level="WARNING"
@@ -3961,12 +5116,15 @@
     <inspection_tool class="WebProperties" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="WebWarnings" enabled="true" level="ERROR" enabled_by_default="true"/>
-    <inspection_tool class="WebflowConfigModelInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="WebflowModelInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
-    <inspection_tool class="WebflowSetupInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="WebflowConfigModelInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="WebflowModelInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="WebflowSetupInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="Weblogic" enabled="false" level="ERROR" enabled_by_default="false"/>
+    <inspection_tool class="WhenWithOnlyElse" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="WhileCanBeForeach" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="WhileLoopSpinsOnField" enabled="true" level="WARNING"
@@ -3975,12 +5133,16 @@
     </inspection_tool>
     <inspection_tool class="WithStatementJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="WrapUnaryOperator" enabled="false" level="WEAK WARNING"
+                     enabled_by_default="false"/>
+    <inspection_tool class="WrongImportPackage" enabled="false" level="ERROR"
+                     enabled_by_default="false"/>
     <inspection_tool class="WrongPackageStatement" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="WrongPropertyKeyValueDelimiter" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
-    <inspection_tool class="WsdlHighlightingInspection" enabled="true" level="WARNING"
-                     enabled_by_default="true"/>
+    <inspection_tool class="WsdlHighlightingInspection" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="XHTMLIncompatabilitiesJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="XmlDuplicatedId" enabled="true" level="WARNING"
@@ -4000,6 +5162,8 @@
                      enabled_by_default="false"/>
     <inspection_tool class="XmlUnusedNamespaceDeclaration" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
+    <inspection_tool class="XmlWrongFileType" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="XmlWrongRootElement" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <inspection_tool class="XsltDeclarations" enabled="true" level="WARNING"
@@ -4021,6 +5185,8 @@
             </value>
         </option>
     </inspection_tool>
+    <inspection_tool class="gwtRawAsyncCallback" enabled="false" level="WARNING"
+                     enabled_by_default="false"/>
     <inspection_tool class="unused" enabled="true" level="WARNING" enabled_by_default="true"
                      field="protected" ignoreAccessors="true">
         <option name="LOCAL_VARIABLE" value="true"/>
@@ -4034,4 +5200,4 @@
         <option name="ADD_SERVLET_TO_ENTRIES" value="true"/>
         <option name="ADD_NONJAVA_TO_ENTRIES" value="true"/>
     </inspection_tool>
-</inspections>
+</profile>


### PR DESCRIPTION
also update file format as it is exported by IDEA 2018.1.4

Issue #5949

all missed comments are only because inspections disappeared.
Bunch of inspections are disabled without comment, as they are unrelated, comment is missed as too much of them are disabled.
diff is here -  https://github.com/checkstyle/checkstyle/issues/5949#issuecomment-399801933 