### PR TITLE
Issue #5970: udpate documentation for rcurly property

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java
@@ -27,6 +27,21 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 public enum RightCurlyOption {
 
     /**
+     * Represents the policy that the brace must be alone on the line.
+     * For example:
+     *
+     * <pre>
+     * try {
+     *     ...
+     * <b>}</b>
+     * finally {
+     *     ...
+     * <b>}</b>
+     * </pre>
+     **/
+    ALONE,
+
+    /**
      * Represents the policy that the brace must be alone on the line,
      * yet allows single-line format of block.
      * For example:
@@ -47,29 +62,18 @@ public enum RightCurlyOption {
     ALONE_OR_SINGLELINE,
 
     /**
-     * Represents the policy that the brace must be alone on the line.
-     * For example:
-     *
-     * <pre>
-     * try {
-     *     ...
-     * <b>}</b>
-     * finally {
-     *     ...
-     * <b>}</b>
-     * </pre>
-     **/
-    ALONE,
-
-    /**
-     * Represents the policy that the brace should be on the same line as the
-     * the next part of a multi-block statement (one that directly contains
+     * Represents the policy that the brace should folllow
+     * {@link RightCurlyOption#ALONE_OR_SINGLELINE} policy
+     * but the brace should be on the same line as the next part of a multi-block statement
+     * (one that directly contains
      * multiple blocks: if/else-if/else or try/catch/finally). It also allows
      * single-line format of multi-block statements.
      *
      * <p>Examples:</p>
      *
      * <pre>
+     * public long getId() {return id;<b>}</b> // this is OK, it is single line
+     *
      * // try-catch-finally blocks
      * try {
      *     ...
@@ -105,19 +109,14 @@ public enum RightCurlyOption {
      *
      * if (a &#62; 0) {
      *     ...
-     * <b>}</b> int i = 5; // this is NOT OK, next part of a multi-block statement is absent
-     *
-     * // Single line blocks will rise violations, because right curly
-     * // brace is not on the same line as the next part of a multi-block
-     * // statement, it just ends the line.
-     * public long getId() {return id;<b>}</b> // this is NOT OK
+     * <b>}</b> int i = 5; // NOT OK, no next part of a multi-block statement, so should be alone
      *
      * Thread t = new Thread(new Runnable() {
      *  &#64;Override
      *  public void run() {
      *                ...
-     *  <b>}</b> // this is NOT OK, not on the same line as the next part of a multi-block statement
-     * <b>}</b>); // this is OK, allowed for better code readability
+     *  <b>}</b> // this is OK, should be alone as next part of a multi-block statement is absent
+     * <b>}</b>); // this is OK, this case is out of scope of RightCurly Check (see issue #5945)
      *
      * if (a &#62; 0) { ... <b>}</b> // OK, single-line multi-block statement
      * if (a &#62; 0) { ... } else { ... <b>}</b> // OK, single-line multi-block statement

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java
@@ -62,12 +62,13 @@ public enum RightCurlyOption {
     ALONE_OR_SINGLELINE,
 
     /**
-     * Represents the policy that the brace should folllow
+     * Represents the policy that the brace should follow
      * {@link RightCurlyOption#ALONE_OR_SINGLELINE} policy
      * but the brace should be on the same line as the next part of a multi-block statement
      * (one that directly contains
-     * multiple blocks: if/else-if/else or try/catch/finally). It also allows
-     * single-line format of multi-block statements.
+     * multiple blocks: if/else-if/else or try/catch/finally).
+     * If no next part of a multi-block statement present, brace must be alone on line.
+     * It also allows single-line format of multi-block statements.
      *
      * <p>Examples:</p>
      *
@@ -116,7 +117,7 @@ public enum RightCurlyOption {
      *  public void run() {
      *                ...
      *  <b>}</b> // this is OK, should be alone as next part of a multi-block statement is absent
-     * <b>}</b>); // this is OK, this case is out of scope of RightCurly Check (see issue #5945)
+     * <b>}</b>); // this case is out of scope of RightCurly Check (see issue #5945)
      *
      * if (a &#62; 0) { ... <b>}</b> // OK, single-line multi-block statement
      * if (a &#62; 0) { ... } else { ... <b>}</b> // OK, single-line multi-block statement

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -326,15 +326,54 @@
         </tr>
 
         <tr>
+          <td><code>alone</code></td>
+          <td>
+            The brace must be alone on the line. For example:
+            <pre>
+    try {
+        ...
+    <b>}</b>
+    finally {
+        ...
+    <b>}</b>
+            </pre>
+          </td>
+        </tr>
+
+        <tr>
+          <td><code>alone_or_singleline</code></td>
+          <td>
+                  The brace must be alone on the line, yet
+                  single-line format of block is allowed.
+                  For example:
+            <pre>
+    // Brace is alone on the line
+    try {
+        ...
+    <b>}</b>
+    finally {
+        ...
+    <b>}</b>
+
+    // Single-line format of block
+    public long getId() { return id; <b>}</b>
+            </pre>
+          </td>
+        </tr>
+
+        <tr>
           <td><code>same</code></td>
           <td>
-            The brace should be on the same line as the next part of a multi-block statement
+            Work as alone_or_singleline but the brace should be on the same line
+            as the next part of a multi-block statement
             (one that directly contains multiple blocks: if/else-if/else or try/catch/finally).
             It also allows single-line format of multi-block statements.
 
             <p>Examples:</p>
 
               <pre>
+    public long getId() {return id;<b>}</b> // this is OK, it is single line
+
     // try-catch-finally blocks
     try {
         ...
@@ -368,21 +407,15 @@
        ...
     }
 
-    if (a > 0) {
+    if (a &#62; 0) {
        ...
-    <b>}</b> int i = 5; // this is NOT OK, next part of a multi-block statement is absent
-
-    // Single line blocks will rise violations, because right curly
-    // brace is not on the same line as the next part of a multi-block
-    // statement, it just ends the line.
-    public long getId() {return id;<b>}</b> // this is NOT OK
+    <b>}</b> int i = 5; // NOT OK, should be alone as next part of a multi-block statement is absent
 
     Thread t = new Thread(new Runnable() {
        @Override
        public void run() {
                   ...
-       <b>}</b> // this is NOT OK, brace is not on the same line as the next part
-         // of a multi-block statement
+       <b>}</b> // this is OK, should be alone as next part of a multi-block statement is absent
     <b>}</b>); // this is OK, allowed for better code readability
 
     if (a &#62; 0) { ... <b>}</b> // OK, single-line multi-block statement
@@ -394,41 +427,6 @@
           </td>
         </tr>
 
-        <tr>
-          <td><code>alone</code></td>
-          <td>
-            The brace must be alone on the line. For example:
-            <pre>
-    try {
-        ...
-    <b>}</b>
-    finally {
-        ...
-    <b>}</b>
-            </pre>
-          </td>
-        </tr>
-
-          <tr>
-              <td><code>alone_or_singleline</code></td>
-              <td>
-                  The brace must be alone on the line, yet
-                  single-line format of block is allowed.
-                  For example:
-                  <pre>
-    // Brace is alone on the line
-    try {
-        ...
-    <b>}</b>
-    finally {
-        ...
-    <b>}</b>
-
-    // Single-line format of block
-    public long getId() { return id; <b>}</b>
-                  </pre>
-              </td>
-          </tr>
       </table>
     </section>
 

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -364,7 +364,7 @@
         <tr>
           <td><code>same</code></td>
           <td>
-            Work as alone_or_singleline but the brace should be on the same line
+            Works like <code>alone_or_singleline</code> but the brace should be on the same line
             as the next part of a multi-block statement
             (one that directly contains multiple blocks: if/else-if/else or try/catch/finally).
             It also allows single-line format of multi-block statements.
@@ -409,14 +409,14 @@
 
     if (a &#62; 0) {
        ...
-    <b>}</b> int i = 5; // NOT OK, should be alone as next part of a multi-block statement is absent
+    <b>}</b> int i = 5;// NOT OK, next part of a multi-block statement is absent, so should be alone
 
     Thread t = new Thread(new Runnable() {
        @Override
        public void run() {
                   ...
        <b>}</b> // this is OK, should be alone as next part of a multi-block statement is absent
-    <b>}</b>); // this is OK, allowed for better code readability
+    <b>}</b>); // this is OK, this case is out of scope of RightCurly Check (see issue #5945)
 
     if (a &#62; 0) { ... <b>}</b> // OK, single-line multi-block statement
     if (a &#62; 0) { ... } else { ... <b>}</b> // OK, single-line multi-block statement

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -409,7 +409,7 @@
 
     if (a &#62; 0) {
        ...
-    <b>}</b> int i = 5;// NOT OK, next part of a multi-block statement is absent, so should be alone
+    <b>}</b> int i = 5; // NOT OK, no next part of a multi-block statement, so should be alone
 
     Thread t = new Thread(new Runnable() {
        @Override

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -367,6 +367,7 @@
             Works like <code>alone_or_singleline</code> but the brace should be on the same line
             as the next part of a multi-block statement
             (one that directly contains multiple blocks: if/else-if/else or try/catch/finally).
+            If no next part of a multi-block statement present, brace must be alone on line.
             It also allows single-line format of multi-block statements.
 
             <p>Examples:</p>
@@ -416,7 +417,7 @@
        public void run() {
                   ...
        <b>}</b> // this is OK, should be alone as next part of a multi-block statement is absent
-    <b>}</b>); // this is OK, this case is out of scope of RightCurly Check (see issue #5945)
+    <b>}</b>); // this case is out of scope of RightCurly Check (see issue #5945)
 
     if (a &#62; 0) { ... <b>}</b> // OK, single-line multi-block statement
     if (a &#62; 0) { ... } else { ... <b>}</b> // OK, single-line multi-block statement


### PR DESCRIPTION
Issue #5970 

alone and alone_or_singleline were moved on top without changes (just minor HTML tags indentation change).

![image](https://user-images.githubusercontent.com/812984/42131729-da6271e6-7cbd-11e8-8a30-e28b642d1fe4.png)

![image](https://user-images.githubusercontent.com/812984/42131732-e9e9db0e-7cbd-11e8-9768-0521b3f14463.png)
