### PR TITLE
config: update distelli execution to run maven in non-interactive mode

### DIFF
--- a/.ci/check-only-javadoc-error.sh
+++ b/.ci/check-only-javadoc-error.sh
@@ -7,7 +7,7 @@ set -e
 
 uname -a
 mvn --version
-mvn -e clean install -Pno-validations
+mvn -B -e clean install -Pno-validations
 git clone https://github.com/checkstyle/contribution && cd contribution/checkstyle-tester
 sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
 sed -i.'' 's/#spring-framework/spring-framework/' projects-to-test-on.properties


### PR DESCRIPTION
 in (batch) mode to reduce amount of download logs

right now it is printing following:
```
Downloaded: https://repo.maven.apache.org/maven2/commons-digester/commons-digester/1.8.1/commons-digester-1.8.1.jar (143 KB at 278.7 KB/sec)
    182/182 KB   308/328 KB   132/145 KB   
182/182 KB   307/328 KB   132/145 KB   
182/182 KB   308/328 KB   136/145 KB   
182/182 KB   308/328 KB   140/145 KB   
182/182 KB   311/328 KB   140/145 KB   
182/182 KB   311/328 KB   144/145 KB   
182/182 KB   311/328 KB   145/145 KB   
182/182 KB   312/328 KB   145/145 KB   
182/182 KB   315/328 KB   145/145 KB   
182/182 KB   316/328 KB   145/145 KB   
182/182 KB   319/328 KB   145/145 KB   
182/182 KB   320/328 KB   145/145 KB   
182/182 KB   323/328 KB   145/145 KB   
182/182 KB   325/328 KB   145/145 KB   
182/182 KB   328/328 KB   145/145 KB  
```

but should do just:
`Downloaded: https://repo.maven.apache.org/maven2/commons-digester/commons-digester/1.8.1/commons-digester-1.8.1.jar (143 KB at 278.7 KB/sec)`