### PR TITLE
Issue #4625: Unite type/static import for EmptyLineSeparatorCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -38,6 +38,7 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * <p> By default the check will check the following statements:
  *  {@link TokenTypes#PACKAGE_DEF PACKAGE_DEF},
  *  {@link TokenTypes#IMPORT IMPORT},
+ *  {@link TokenTypes#STATIC_IMPORT STATIC_IMPORT},
  *  {@link TokenTypes#CLASS_DEF CLASS_DEF},
  *  {@link TokenTypes#INTERFACE_DEF INTERFACE_DEF},
  *  {@link TokenTypes#STATIC_INIT STATIC_INIT},
@@ -266,6 +267,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
         return new int[] {
             TokenTypes.PACKAGE_DEF,
             TokenTypes.IMPORT,
+            TokenTypes.STATIC_IMPORT,
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
@@ -302,7 +304,8 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
                     processVariableDef(ast, nextToken);
                     break;
                 case TokenTypes.IMPORT:
-                    processImport(ast, nextToken, astType);
+                case TokenTypes.STATIC_IMPORT:
+                    processImport(ast, nextToken);
                     break;
                 case TokenTypes.PACKAGE_DEF:
                     processPackage(ast, nextToken);
@@ -434,10 +437,10 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
      * Process Import.
      * @param ast token
      * @param nextToken next token
-     * @param astType token Type
      */
-    private void processImport(DetailAST ast, DetailAST nextToken, int astType) {
-        if (astType != nextToken.getType() && !hasEmptyLineAfter(ast)) {
+    private void processImport(DetailAST ast, DetailAST nextToken) {
+        if (nextToken.getType() != TokenTypes.IMPORT
+                && nextToken.getType() != TokenTypes.STATIC_IMPORT && !hasEmptyLineAfter(ast)) {
             log(nextToken.getLineNo(), MSG_SHOULD_BE_SEPARATED, nextToken.getText());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -144,6 +144,7 @@ public class EmptyLineSeparatorCheckTest
         final int[] expected = {
             TokenTypes.PACKAGE_DEF,
             TokenTypes.IMPORT,
+            TokenTypes.STATIC_IMPORT,
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
@@ -214,6 +215,13 @@ public class EmptyLineSeparatorCheckTest
         verify(checkConfig,
                 getPath("InputEmptyLineSeparatorMultipleEmptyLinesInside.java"),
                 expected);
+    }
+
+    @Test
+    public void testImportsAndStaticImports() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(EmptyLineSeparatorCheck.class);
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputEmptyLineSeparatorImports.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorImports.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorImports.java
@@ -1,0 +1,26 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2018 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+import java.math.BigDecimal;
+import static java.lang.Math.abs;
+
+public class InputEmptyLineSeparatorImports {
+}

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -268,6 +268,8 @@ for (Iterator foo = very.long.line.iterator();
                 PACKAGE_DEF</a>,
             <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">
                 IMPORT</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
+                STATIC_IMPORT</a>,
             <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
                 CLASS_DEF</a>,
             <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
@@ -290,6 +292,8 @@ for (Iterator foo = very.long.line.iterator();
                 PACKAGE_DEF</a>,
             <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">
                 IMPORT</a>,
+            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
+                STATIC_IMPORT</a>,
             <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
                 CLASS_DEF</a>,
             <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">


### PR DESCRIPTION
Issue #4625 

Do not distinguish between type import and static import for `EmptyLineSeparatorCheck`,
to properly support `ImportOrderCheck` with `option` = `inflow`