### PR TITLE
minor: reorganized it test support classes

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/AbstractModuleTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/AbstractModuleTestSupport.java
@@ -108,7 +108,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * Returns test logger.
      * @return logger test logger
      */
-    public final BriefUtLogger getBriefUtLogger() {
+    protected final BriefUtLogger getBriefUtLogger() {
         return new BriefUtLogger(stream);
     }
 
@@ -118,7 +118,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @return {@link DefaultConfiguration} instance.
      */
     protected static DefaultConfiguration createModuleConfig(Class<?> clazz) {
-        return new DefaultConfiguration(clazz.getName());
+        return new DefaultConfiguration(clazz.getSimpleName());
     }
 
     /**
@@ -127,7 +127,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @return {@link Checker} instance based on the given {@link Configuration} instance.
      * @throws Exception if an exception occurs during checker configuration.
      */
-    public final Checker createChecker(Configuration moduleConfig)
+    protected final Checker createChecker(Configuration moduleConfig)
             throws Exception {
         final String name = moduleConfig.getName();
         ModuleCreationOption moduleCreationOption = ModuleCreationOption.IN_CHECKER;

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/GenericWhitespaceTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/GenericWhitespaceTest.java
@@ -19,6 +19,8 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
+import java.util.Map;
+
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.AbstractModuleTestSupport;
@@ -37,24 +39,25 @@ public class GenericWhitespaceTest extends AbstractModuleTestSupport {
         final String msgPreceded = "ws.preceded";
         final String msgFollowed = "ws.followed";
         final Configuration checkConfig = getModuleConfig("GenericWhitespace");
+        final Map<String, String> messages = checkConfig.getMessages();
 
         final String[] expected = {
-            "12:16: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "12:18: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "12:36: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "12:38: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "12:47: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "12:49: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
-            "12:49: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "14:32: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "14:34: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "14:45: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "15:32: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "15:34: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "15:45: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "20:38: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "20:40: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "20:61: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
+            "12:16: " + getCheckMessage(messages, msgPreceded, "<"),
+            "12:18: " + getCheckMessage(messages, msgFollowed, "<"),
+            "12:36: " + getCheckMessage(messages, msgPreceded, "<"),
+            "12:38: " + getCheckMessage(messages, msgFollowed, "<"),
+            "12:47: " + getCheckMessage(messages, msgPreceded, ">"),
+            "12:49: " + getCheckMessage(messages, msgFollowed, ">"),
+            "12:49: " + getCheckMessage(messages, msgPreceded, ">"),
+            "14:32: " + getCheckMessage(messages, msgPreceded, "<"),
+            "14:34: " + getCheckMessage(messages, msgFollowed, "<"),
+            "14:45: " + getCheckMessage(messages, msgPreceded, ">"),
+            "15:32: " + getCheckMessage(messages, msgPreceded, "<"),
+            "15:34: " + getCheckMessage(messages, msgFollowed, "<"),
+            "15:45: " + getCheckMessage(messages, msgPreceded, ">"),
+            "20:38: " + getCheckMessage(messages, msgPreceded, "<"),
+            "20:40: " + getCheckMessage(messages, msgFollowed, "<"),
+            "20:61: " + getCheckMessage(messages, msgPreceded, ">"),
         };
 
         final String filePath = getPath("InputWhitespaceAroundGenerics.java");
@@ -70,34 +73,35 @@ public class GenericWhitespaceTest extends AbstractModuleTestSupport {
         final String msgNotPreceded = "ws.notPreceded";
         final String msgIllegalFollow = "ws.illegalFollow";
         final Configuration checkConfig = getModuleConfig("GenericWhitespace");
+        final Map<String, String> messages = checkConfig.getMessages();
 
         final String[] expected = {
-            "16:13: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "16:15: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "16:23: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "16:43: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "16:45: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "16:53: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "17:13: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "17:15: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "17:20: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "17:22: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "17:30: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "17:32: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
-            "17:32: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "17:52: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "17:54: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "17:59: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "17:61: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "<"),
-            "17:69: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "17:71: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
-            "17:71: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ">"),
-            "30:17: " + getCheckMessage(checkConfig.getMessages(), msgNotPreceded, "<"),
-            "30:21: " + getCheckMessage(checkConfig.getMessages(), msgIllegalFollow, ">"),
-            "42:21: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "<"),
-            "42:30: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
-            "60:60: " + getCheckMessage(checkConfig.getMessages(), msgNotPreceded, "&"),
-            "63:60: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, ">"),
+            "16:13: " + getCheckMessage(messages, msgPreceded, "<"),
+            "16:15: " + getCheckMessage(messages, msgFollowed, "<"),
+            "16:23: " + getCheckMessage(messages, msgPreceded, ">"),
+            "16:43: " + getCheckMessage(messages, msgPreceded, "<"),
+            "16:45: " + getCheckMessage(messages, msgFollowed, "<"),
+            "16:53: " + getCheckMessage(messages, msgPreceded, ">"),
+            "17:13: " + getCheckMessage(messages, msgPreceded, "<"),
+            "17:15: " + getCheckMessage(messages, msgFollowed, "<"),
+            "17:20: " + getCheckMessage(messages, msgPreceded, "<"),
+            "17:22: " + getCheckMessage(messages, msgFollowed, "<"),
+            "17:30: " + getCheckMessage(messages, msgPreceded, ">"),
+            "17:32: " + getCheckMessage(messages, msgFollowed, ">"),
+            "17:32: " + getCheckMessage(messages, msgPreceded, ">"),
+            "17:52: " + getCheckMessage(messages, msgPreceded, "<"),
+            "17:54: " + getCheckMessage(messages, msgFollowed, "<"),
+            "17:59: " + getCheckMessage(messages, msgPreceded, "<"),
+            "17:61: " + getCheckMessage(messages, msgFollowed, "<"),
+            "17:69: " + getCheckMessage(messages, msgPreceded, ">"),
+            "17:71: " + getCheckMessage(messages, msgFollowed, ">"),
+            "17:71: " + getCheckMessage(messages, msgPreceded, ">"),
+            "30:17: " + getCheckMessage(messages, msgNotPreceded, "<"),
+            "30:21: " + getCheckMessage(messages, msgIllegalFollow, ">"),
+            "42:21: " + getCheckMessage(messages, msgPreceded, "<"),
+            "42:30: " + getCheckMessage(messages, msgFollowed, ">"),
+            "60:60: " + getCheckMessage(messages, msgNotPreceded, "&"),
+            "63:60: " + getCheckMessage(messages, msgFollowed, ">"),
         };
 
         final String filePath = getPath("InputGenericWhitespace.java");

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
@@ -19,6 +19,8 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
+import java.util.Map;
+
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.AbstractModuleTestSupport;
@@ -37,31 +39,32 @@ public class WhitespaceAroundTest extends AbstractModuleTestSupport {
         final Configuration checkConfig = getModuleConfig("WhitespaceAround");
         final String msgPreceded = "ws.notPreceded";
         final String msgFollowed = "ws.notFollowed";
+        final Map<String, String> messages = checkConfig.getMessages();
 
         final String[] expected = {
-            "10:22: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "="),
-            "12:24: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "="),
-            "20:14: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "="),
-            "21:10: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "="),
-            "22:13: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "+="),
-            "23:13: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "-="),
-            "31:21: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "synchronized"),
-            "33:14: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "{"),
-            "35:37: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "{"),
-            "52:11: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "if"),
-            "70:19: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "return"),
-            "92:26: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "=="),
-            "98:22: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "*"),
-            "113:18: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "%"),
-            "114:20: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "%"),
-            "115:18: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "%"),
-            "117:18: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "/"),
-            "118:20: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "/"),
-            "147:15: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "assert"),
-            "150:20: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, ":"),
-            "249:14: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "->"),
-            "250:17: " + getCheckMessage(checkConfig.getMessages(), msgFollowed, "->"),
-            "250:17: " + getCheckMessage(checkConfig.getMessages(), msgPreceded, "{"),
+            "10:22: " + getCheckMessage(messages, msgPreceded, "="),
+            "12:24: " + getCheckMessage(messages, msgFollowed, "="),
+            "20:14: " + getCheckMessage(messages, msgPreceded, "="),
+            "21:10: " + getCheckMessage(messages, msgPreceded, "="),
+            "22:13: " + getCheckMessage(messages, msgFollowed, "+="),
+            "23:13: " + getCheckMessage(messages, msgFollowed, "-="),
+            "31:21: " + getCheckMessage(messages, msgFollowed, "synchronized"),
+            "33:14: " + getCheckMessage(messages, msgFollowed, "{"),
+            "35:37: " + getCheckMessage(messages, msgFollowed, "{"),
+            "52:11: " + getCheckMessage(messages, msgFollowed, "if"),
+            "70:19: " + getCheckMessage(messages, msgFollowed, "return"),
+            "92:26: " + getCheckMessage(messages, msgFollowed, "=="),
+            "98:22: " + getCheckMessage(messages, msgPreceded, "*"),
+            "113:18: " + getCheckMessage(messages, msgPreceded, "%"),
+            "114:20: " + getCheckMessage(messages, msgFollowed, "%"),
+            "115:18: " + getCheckMessage(messages, msgPreceded, "%"),
+            "117:18: " + getCheckMessage(messages, msgPreceded, "/"),
+            "118:20: " + getCheckMessage(messages, msgFollowed, "/"),
+            "147:15: " + getCheckMessage(messages, msgFollowed, "assert"),
+            "150:20: " + getCheckMessage(messages, msgPreceded, ":"),
+            "249:14: " + getCheckMessage(messages, msgPreceded, "->"),
+            "250:17: " + getCheckMessage(messages, msgFollowed, "->"),
+            "250:17: " + getCheckMessage(messages, msgPreceded, "{"),
         };
 
         final String filePath = getPath("InputWhitespaceAroundBasic.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule51identifiernames/CatchParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule51identifiernames/CatchParameterNameTest.java
@@ -19,6 +19,8 @@
 
 package com.google.checkstyle.test.chapter5naming.rule51identifiernames;
 
+import java.util.Map;
+
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.AbstractModuleTestSupport;
@@ -36,14 +38,15 @@ public class CatchParameterNameTest extends AbstractModuleTestSupport {
         final String msgKey = "name.invalidPattern";
         final Configuration checkConfig = getModuleConfig("CatchParameterName");
         final String format = checkConfig.getAttribute("format");
+        final Map<String, String> messages = checkConfig.getMessages();
 
         final String[] expected = {
-            "47:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "iException", format),
-            "50:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "ex_1", format),
-            "53:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "eX", format),
-            "56:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "eXX", format),
-            "59:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "x_y_z", format),
-            "62:28: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Ex", format),
+            "47:28: " + getCheckMessage(messages, msgKey, "iException", format),
+            "50:28: " + getCheckMessage(messages, msgKey, "ex_1", format),
+            "53:28: " + getCheckMessage(messages, msgKey, "eX", format),
+            "56:28: " + getCheckMessage(messages, msgKey, "eXX", format),
+            "59:28: " + getCheckMessage(messages, msgKey, "x_y_z", format),
+            "62:28: " + getCheckMessage(messages, msgKey, "Ex", format),
         };
 
         final String filePath = getPath("InputCatchParameterName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule522typenames/TypeNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule522typenames/TypeNameTest.java
@@ -19,6 +19,8 @@
 
 package com.google.checkstyle.test.chapter5naming.rule522typenames;
 
+import java.util.Map;
+
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.AbstractModuleTestSupport;
@@ -36,44 +38,39 @@ public class TypeNameTest extends AbstractModuleTestSupport {
         final Configuration checkConfig = getModuleConfig("TypeName");
         final String msgKey = "name.invalidPattern";
         final String format = "^[A-Z][a-zA-Z0-9]*$";
+        final Map<String, String> messages = checkConfig.getMessages();
 
         final String[] expected = {
-            "3:7: " + getCheckMessage(checkConfig.getMessages(), msgKey, "inputHeaderClass",
-                format),
-            "5:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "InputHeader___Interface",
-                format),
-            "7:17: " + getCheckMessage(checkConfig.getMessages(), msgKey, "inputHeaderEnum",
-                format),
-            "9:11: " + getCheckMessage(checkConfig.getMessages(), msgKey, "NoValid$Name",
-                format),
-            "11:11: " + getCheckMessage(checkConfig.getMessages(), msgKey, "$NoValidName",
-                format),
-            "13:11: " + getCheckMessage(checkConfig.getMessages(), msgKey, "NoValidName$",
-                format),
-            "19:7: " + getCheckMessage(checkConfig.getMessages(), msgKey, "_ValidName", format),
-            "21:7: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Valid_Name", format),
-            "23:7: " + getCheckMessage(checkConfig.getMessages(), msgKey, "ValidName_", format),
-            "27:11: " + getCheckMessage(checkConfig.getMessages(), msgKey, "_Foo", format),
-            "29:11: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Fo_o", format),
-            "31:11: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Foo_", format),
-            "33:11: " + getCheckMessage(checkConfig.getMessages(), msgKey, "$Foo", format),
-            "35:11: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Fo$o", format),
-            "37:11: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Foo$", format),
-            "41:6: " + getCheckMessage(checkConfig.getMessages(), msgKey, "_FooEnum", format),
-            "43:6: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Foo_Enum", format),
-            "45:6: " + getCheckMessage(checkConfig.getMessages(), msgKey, "FooEnum_", format),
-            "47:6: " + getCheckMessage(checkConfig.getMessages(), msgKey, "$FooEnum", format),
-            "49:6: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Foo$Enum", format),
-            "51:6: " + getCheckMessage(checkConfig.getMessages(), msgKey, "FooEnum$", format),
-            "53:7: " + getCheckMessage(checkConfig.getMessages(), msgKey, "aaa", format),
-            "55:11: " + getCheckMessage(checkConfig.getMessages(), msgKey, "bbb", format),
-            "57:6: " + getCheckMessage(checkConfig.getMessages(), msgKey, "ccc", format),
-            "61:12: " + getCheckMessage(checkConfig.getMessages(), msgKey, "_Annotation", format),
-            "63:12: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Annot_ation", format),
-            "65:12: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Annotation_", format),
-            "67:12: " + getCheckMessage(checkConfig.getMessages(), msgKey, "$Annotation", format),
-            "69:12: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Annot$ation", format),
-            "71:12: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Annotation$", format),
+            "3:7: " + getCheckMessage(messages, msgKey, "inputHeaderClass", format),
+            "5:22: " + getCheckMessage(messages, msgKey, "InputHeader___Interface", format),
+            "7:17: " + getCheckMessage(messages, msgKey, "inputHeaderEnum", format),
+            "9:11: " + getCheckMessage(messages, msgKey, "NoValid$Name", format),
+            "11:11: " + getCheckMessage(messages, msgKey, "$NoValidName", format),
+            "13:11: " + getCheckMessage(messages, msgKey, "NoValidName$", format),
+            "19:7: " + getCheckMessage(messages, msgKey, "_ValidName", format),
+            "21:7: " + getCheckMessage(messages, msgKey, "Valid_Name", format),
+            "23:7: " + getCheckMessage(messages, msgKey, "ValidName_", format),
+            "27:11: " + getCheckMessage(messages, msgKey, "_Foo", format),
+            "29:11: " + getCheckMessage(messages, msgKey, "Fo_o", format),
+            "31:11: " + getCheckMessage(messages, msgKey, "Foo_", format),
+            "33:11: " + getCheckMessage(messages, msgKey, "$Foo", format),
+            "35:11: " + getCheckMessage(messages, msgKey, "Fo$o", format),
+            "37:11: " + getCheckMessage(messages, msgKey, "Foo$", format),
+            "41:6: " + getCheckMessage(messages, msgKey, "_FooEnum", format),
+            "43:6: " + getCheckMessage(messages, msgKey, "Foo_Enum", format),
+            "45:6: " + getCheckMessage(messages, msgKey, "FooEnum_", format),
+            "47:6: " + getCheckMessage(messages, msgKey, "$FooEnum", format),
+            "49:6: " + getCheckMessage(messages, msgKey, "Foo$Enum", format),
+            "51:6: " + getCheckMessage(messages, msgKey, "FooEnum$", format),
+            "53:7: " + getCheckMessage(messages, msgKey, "aaa", format),
+            "55:11: " + getCheckMessage(messages, msgKey, "bbb", format),
+            "57:6: " + getCheckMessage(messages, msgKey, "ccc", format),
+            "61:12: " + getCheckMessage(messages, msgKey, "_Annotation", format),
+            "63:12: " + getCheckMessage(messages, msgKey, "Annot_ation", format),
+            "65:12: " + getCheckMessage(messages, msgKey, "Annotation_", format),
+            "67:12: " + getCheckMessage(messages, msgKey, "$Annotation", format),
+            "69:12: " + getCheckMessage(messages, msgKey, "Annot$ation", format),
+            "71:12: " + getCheckMessage(messages, msgKey, "Annotation$", format),
         };
 
         final String filePath = getPath("InputTypeName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule523methodnames/MethodNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule523methodnames/MethodNameTest.java
@@ -19,6 +19,8 @@
 
 package com.google.checkstyle.test.chapter5naming.rule523methodnames;
 
+import java.util.Map;
+
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.AbstractModuleTestSupport;
@@ -36,32 +38,33 @@ public class MethodNameTest extends AbstractModuleTestSupport {
         final Configuration checkConfig = getModuleConfig("MethodName");
         final String msgKey = "name.invalidPattern";
         final String format = "^[a-z][a-z0-9][a-zA-Z0-9_]*$";
+        final Map<String, String> messages = checkConfig.getMessages();
 
         final String[] expected = {
-            "11:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Foo", format),
-            "12:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "fOo", format),
-            "14:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "f$o", format),
-            "15:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "f_oo", format),
-            "16:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "f", format),
-            "17:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "fO", format),
-            "21:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Foo", format),
-            "22:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "fOo", format),
-            "24:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "f$o", format),
-            "25:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "f_oo", format),
-            "26:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "f", format),
-            "27:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "fO", format),
-            "32:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Foo", format),
-            "33:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "fOo", format),
-            "35:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "f$o", format),
-            "36:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "f_oo", format),
-            "37:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "f", format),
-            "38:22: " + getCheckMessage(checkConfig.getMessages(), msgKey, "fO", format),
-            "44:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "Foo", format),
-            "45:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "fOo", format),
-            "47:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "f$o", format),
-            "48:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "f_oo", format),
-            "49:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "f", format),
-            "50:14: " + getCheckMessage(checkConfig.getMessages(), msgKey, "fO", format),
+            "11:14: " + getCheckMessage(messages, msgKey, "Foo", format),
+            "12:14: " + getCheckMessage(messages, msgKey, "fOo", format),
+            "14:14: " + getCheckMessage(messages, msgKey, "f$o", format),
+            "15:14: " + getCheckMessage(messages, msgKey, "f_oo", format),
+            "16:14: " + getCheckMessage(messages, msgKey, "f", format),
+            "17:14: " + getCheckMessage(messages, msgKey, "fO", format),
+            "21:22: " + getCheckMessage(messages, msgKey, "Foo", format),
+            "22:22: " + getCheckMessage(messages, msgKey, "fOo", format),
+            "24:22: " + getCheckMessage(messages, msgKey, "f$o", format),
+            "25:22: " + getCheckMessage(messages, msgKey, "f_oo", format),
+            "26:22: " + getCheckMessage(messages, msgKey, "f", format),
+            "27:22: " + getCheckMessage(messages, msgKey, "fO", format),
+            "32:22: " + getCheckMessage(messages, msgKey, "Foo", format),
+            "33:22: " + getCheckMessage(messages, msgKey, "fOo", format),
+            "35:22: " + getCheckMessage(messages, msgKey, "f$o", format),
+            "36:22: " + getCheckMessage(messages, msgKey, "f_oo", format),
+            "37:22: " + getCheckMessage(messages, msgKey, "f", format),
+            "38:22: " + getCheckMessage(messages, msgKey, "fO", format),
+            "44:14: " + getCheckMessage(messages, msgKey, "Foo", format),
+            "45:14: " + getCheckMessage(messages, msgKey, "fOo", format),
+            "47:14: " + getCheckMessage(messages, msgKey, "f$o", format),
+            "48:14: " + getCheckMessage(messages, msgKey, "f_oo", format),
+            "49:14: " + getCheckMessage(messages, msgKey, "f", format),
+            "50:14: " + getCheckMessage(messages, msgKey, "fO", format),
         };
 
         final String filePath = getPath("InputMethodName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java
@@ -19,6 +19,8 @@
 
 package com.google.checkstyle.test.chapter5naming.rule525nonconstantfieldnames;
 
+import java.util.Map;
+
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.AbstractModuleTestSupport;
@@ -37,20 +39,21 @@ public class MemberNameTest extends AbstractModuleTestSupport {
     public void testMemberName() throws Exception {
         final Configuration checkConfig = getModuleConfig("MemberName");
         final String format = checkConfig.getAttribute("format");
+        final Map<String, String> messages = checkConfig.getMessages();
         final String[] expected = {
-            "5:16: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mPublic", format),
-            "6:19: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mProtected", format),
-            "7:9: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mPackage", format),
-            "8:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mPrivate", format),
-            "10:16: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_public", format),
-            "11:19: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "prot_ected", format),
-            "12:9: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "package_", format),
-            "13:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "priva$te", format),
-            "20:9: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "ABC", format),
-            "21:15: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "C_D_E", format),
-            "23:16: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$mPublic", format),
-            "24:19: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mPro$tected", format),
-            "25:9: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mPackage$", format),
+            "5:16: " + getCheckMessage(messages, MSG_KEY, "mPublic", format),
+            "6:19: " + getCheckMessage(messages, MSG_KEY, "mProtected", format),
+            "7:9: " + getCheckMessage(messages, MSG_KEY, "mPackage", format),
+            "8:17: " + getCheckMessage(messages, MSG_KEY, "mPrivate", format),
+            "10:16: " + getCheckMessage(messages, MSG_KEY, "_public", format),
+            "11:19: " + getCheckMessage(messages, MSG_KEY, "prot_ected", format),
+            "12:9: " + getCheckMessage(messages, MSG_KEY, "package_", format),
+            "13:17: " + getCheckMessage(messages, MSG_KEY, "priva$te", format),
+            "20:9: " + getCheckMessage(messages, MSG_KEY, "ABC", format),
+            "21:15: " + getCheckMessage(messages, MSG_KEY, "C_D_E", format),
+            "23:16: " + getCheckMessage(messages, MSG_KEY, "$mPublic", format),
+            "24:19: " + getCheckMessage(messages, MSG_KEY, "mPro$tected", format),
+            "25:9: " + getCheckMessage(messages, MSG_KEY, "mPackage$", format),
         };
 
         final String filePath = getPath("InputMemberNameBasic.java");
@@ -63,39 +66,40 @@ public class MemberNameTest extends AbstractModuleTestSupport {
     public void testSimple() throws Exception {
         final Configuration checkConfig = getModuleConfig("MemberName");
         final String format = checkConfig.getAttribute("format");
+        final Map<String, String> messages = checkConfig.getMessages();
         final String[] expected = {
-            "12:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bad$Static", format),
-            "17:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bad_Member", format),
-            "19:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m", format),
-            "21:19: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m_M", format),
-            "24:19: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m$nts", format),
-            "35:9: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest1", format),
-            "37:16: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest2", format),
-            "39:16: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$mTest2", format),
-            "41:16: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTes$t2", format),
-            "43:16: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest2$", format),
-            "77:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bad$Static", format),
-            "79:22: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "sum_Created", format),
-            "82:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bad_Member", format),
-            "84:21: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m", format),
-            "86:23: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m_M", format),
-            "89:23: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m$nts", format),
-            "93:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest1", format),
-            "95:20: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest2", format),
-            "97:20: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$mTest2", format),
-            "99:20: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTes$t2", format),
-            "101:20: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest2$", format),
-            "107:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bad$Static", format),
-            "109:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "sum_Created", format),
-            "112:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "bad_Member", format),
-            "114:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m", format),
-            "116:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m_M", format),
-            "119:27: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "m$nts", format),
-            "123:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest1", format),
-            "125:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest2", format),
-            "127:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$mTest2", format),
-            "129:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTes$t2", format),
-            "131:25: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "mTest2$", format),
+            "12:17: " + getCheckMessage(messages, MSG_KEY, "bad$Static", format),
+            "17:17: " + getCheckMessage(messages, MSG_KEY, "bad_Member", format),
+            "19:17: " + getCheckMessage(messages, MSG_KEY, "m", format),
+            "21:19: " + getCheckMessage(messages, MSG_KEY, "m_M", format),
+            "24:19: " + getCheckMessage(messages, MSG_KEY, "m$nts", format),
+            "35:9: " + getCheckMessage(messages, MSG_KEY, "mTest1", format),
+            "37:16: " + getCheckMessage(messages, MSG_KEY, "mTest2", format),
+            "39:16: " + getCheckMessage(messages, MSG_KEY, "$mTest2", format),
+            "41:16: " + getCheckMessage(messages, MSG_KEY, "mTes$t2", format),
+            "43:16: " + getCheckMessage(messages, MSG_KEY, "mTest2$", format),
+            "77:21: " + getCheckMessage(messages, MSG_KEY, "bad$Static", format),
+            "79:22: " + getCheckMessage(messages, MSG_KEY, "sum_Created", format),
+            "82:21: " + getCheckMessage(messages, MSG_KEY, "bad_Member", format),
+            "84:21: " + getCheckMessage(messages, MSG_KEY, "m", format),
+            "86:23: " + getCheckMessage(messages, MSG_KEY, "m_M", format),
+            "89:23: " + getCheckMessage(messages, MSG_KEY, "m$nts", format),
+            "93:13: " + getCheckMessage(messages, MSG_KEY, "mTest1", format),
+            "95:20: " + getCheckMessage(messages, MSG_KEY, "mTest2", format),
+            "97:20: " + getCheckMessage(messages, MSG_KEY, "$mTest2", format),
+            "99:20: " + getCheckMessage(messages, MSG_KEY, "mTes$t2", format),
+            "101:20: " + getCheckMessage(messages, MSG_KEY, "mTest2$", format),
+            "107:25: " + getCheckMessage(messages, MSG_KEY, "bad$Static", format),
+            "109:25: " + getCheckMessage(messages, MSG_KEY, "sum_Created", format),
+            "112:25: " + getCheckMessage(messages, MSG_KEY, "bad_Member", format),
+            "114:25: " + getCheckMessage(messages, MSG_KEY, "m", format),
+            "116:25: " + getCheckMessage(messages, MSG_KEY, "m_M", format),
+            "119:27: " + getCheckMessage(messages, MSG_KEY, "m$nts", format),
+            "123:25: " + getCheckMessage(messages, MSG_KEY, "mTest1", format),
+            "125:25: " + getCheckMessage(messages, MSG_KEY, "mTest2", format),
+            "127:25: " + getCheckMessage(messages, MSG_KEY, "$mTest2", format),
+            "129:25: " + getCheckMessage(messages, MSG_KEY, "mTes$t2", format),
+            "131:25: " + getCheckMessage(messages, MSG_KEY, "mTest2$", format),
         };
 
         final String filePath = getPath("InputMemberNameSimple.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/LambdaParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/LambdaParameterNameTest.java
@@ -19,6 +19,8 @@
 
 package com.google.checkstyle.test.chapter5naming.rule526parameternames;
 
+import java.util.Map;
+
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.AbstractModuleTestSupport;
@@ -37,13 +39,14 @@ public class LambdaParameterNameTest extends AbstractModuleTestSupport {
     public void testLambdaParameterName() throws Exception {
         final Configuration config = getModuleConfig("LambdaParameterName");
         final String format = config.getAttribute("format");
+        final Map<String, String> messages = config.getMessages();
 
         final String[] expected = {
-            "9:13: " + getCheckMessage(config.getMessages(), MSG_INVALID_PATTERN, "S", format),
-            "12:14: " + getCheckMessage(config.getMessages(), MSG_INVALID_PATTERN, "sT", format),
-            "14:65: " + getCheckMessage(config.getMessages(), MSG_INVALID_PATTERN, "sT1", format),
-            "14:70: " + getCheckMessage(config.getMessages(), MSG_INVALID_PATTERN, "sT2", format),
-            "17:21: " + getCheckMessage(config.getMessages(), MSG_INVALID_PATTERN, "_s", format),
+            "9:13: " + getCheckMessage(messages, MSG_INVALID_PATTERN, "S", format),
+            "12:14: " + getCheckMessage(messages, MSG_INVALID_PATTERN, "sT", format),
+            "14:65: " + getCheckMessage(messages, MSG_INVALID_PATTERN, "sT1", format),
+            "14:70: " + getCheckMessage(messages, MSG_INVALID_PATTERN, "sT2", format),
+            "17:21: " + getCheckMessage(messages, MSG_INVALID_PATTERN, "_s", format),
         };
 
         final String filePath = getPath("InputLambdaParameterName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java
@@ -19,6 +19,8 @@
 
 package com.google.checkstyle.test.chapter5naming.rule526parameternames;
 
+import java.util.Map;
+
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.AbstractModuleTestSupport;
@@ -37,19 +39,20 @@ public class ParameterNameTest extends AbstractModuleTestSupport {
     public void testGeneralParameterName() throws Exception {
         final Configuration config = getModuleConfig("ParameterName");
         final String format = config.getAttribute("format");
+        final Map<String, String> messages = config.getMessages();
         final String[] expected = {
-            "10:21: " + getCheckMessage(config.getMessages(), MSG_KEY, "bB", format),
-            "33:22: " + getCheckMessage(config.getMessages(), MSG_KEY, "llll_llll", format),
-            "34:21: " + getCheckMessage(config.getMessages(), MSG_KEY, "bB", format),
-            "64:13: " + getCheckMessage(config.getMessages(), MSG_KEY, "$arg1", format),
-            "65:13: " + getCheckMessage(config.getMessages(), MSG_KEY, "ar$g2", format),
-            "66:13: " + getCheckMessage(config.getMessages(), MSG_KEY, "arg3$", format),
-            "67:13: " + getCheckMessage(config.getMessages(), MSG_KEY, "a_rg4", format),
-            "68:13: " + getCheckMessage(config.getMessages(), MSG_KEY, "_arg5", format),
-            "69:13: " + getCheckMessage(config.getMessages(), MSG_KEY, "arg6_", format),
-            "70:13: " + getCheckMessage(config.getMessages(), MSG_KEY, "aArg7", format),
-            "71:13: " + getCheckMessage(config.getMessages(), MSG_KEY, "aArg8", format),
-            "72:13: " + getCheckMessage(config.getMessages(), MSG_KEY, "aar_g", format),
+            "10:21: " + getCheckMessage(messages, MSG_KEY, "bB", format),
+            "33:22: " + getCheckMessage(messages, MSG_KEY, "llll_llll", format),
+            "34:21: " + getCheckMessage(messages, MSG_KEY, "bB", format),
+            "64:13: " + getCheckMessage(messages, MSG_KEY, "$arg1", format),
+            "65:13: " + getCheckMessage(messages, MSG_KEY, "ar$g2", format),
+            "66:13: " + getCheckMessage(messages, MSG_KEY, "arg3$", format),
+            "67:13: " + getCheckMessage(messages, MSG_KEY, "a_rg4", format),
+            "68:13: " + getCheckMessage(messages, MSG_KEY, "_arg5", format),
+            "69:13: " + getCheckMessage(messages, MSG_KEY, "arg6_", format),
+            "70:13: " + getCheckMessage(messages, MSG_KEY, "aArg7", format),
+            "71:13: " + getCheckMessage(messages, MSG_KEY, "aArg8", format),
+            "72:13: " + getCheckMessage(messages, MSG_KEY, "aar_g", format),
         };
 
         final String filePath = getPath("InputParameterName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
@@ -19,6 +19,8 @@
 
 package com.google.checkstyle.test.chapter5naming.rule527localvariablenames;
 
+import java.util.Map;
+
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.AbstractModuleTestSupport;
@@ -37,17 +39,18 @@ public class LocalVariableNameTest extends AbstractModuleTestSupport {
     public void testLocalVariableName() throws Exception {
         final Configuration checkConfig = getModuleConfig("LocalVariableName");
         final String format = checkConfig.getAttribute("format");
+        final Map<String, String> messages = checkConfig.getMessages();
         final String[] expected = {
-            "27:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aA", format),
-            "28:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "a1_a", format),
-            "29:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "A_A", format),
-            "30:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aa2_a", format),
-            "31:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_a", format),
-            "32:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_aa", format),
-            "33:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aa_", format),
-            "34:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aaa$aaa", format),
-            "35:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$aaaaaa", format),
-            "36:13: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "aaaaaa$", format),
+            "27:13: " + getCheckMessage(messages, MSG_KEY, "aA", format),
+            "28:13: " + getCheckMessage(messages, MSG_KEY, "a1_a", format),
+            "29:13: " + getCheckMessage(messages, MSG_KEY, "A_A", format),
+            "30:13: " + getCheckMessage(messages, MSG_KEY, "aa2_a", format),
+            "31:13: " + getCheckMessage(messages, MSG_KEY, "_a", format),
+            "32:13: " + getCheckMessage(messages, MSG_KEY, "_aa", format),
+            "33:13: " + getCheckMessage(messages, MSG_KEY, "aa_", format),
+            "34:13: " + getCheckMessage(messages, MSG_KEY, "aaa$aaa", format),
+            "35:13: " + getCheckMessage(messages, MSG_KEY, "$aaaaaa", format),
+            "36:13: " + getCheckMessage(messages, MSG_KEY, "aaaaaa$", format),
         };
 
         final String filePath = getPath("InputLocalVariableNameSimple.java");
@@ -60,13 +63,14 @@ public class LocalVariableNameTest extends AbstractModuleTestSupport {
     public void testOneChar() throws Exception {
         final Configuration checkConfig = getModuleConfig("LocalVariableName");
         final String format = checkConfig.getAttribute("format");
+        final Map<String, String> messages = checkConfig.getMessages();
         final String[] expected = {
-            "21:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "I_ndex", format),
-            "45:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "i_ndex", format),
-            "49:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "ii_i1", format),
-            "53:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "$index", format),
-            "57:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "in$dex", format),
-            "61:17: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "index$", format),
+            "21:17: " + getCheckMessage(messages, MSG_KEY, "I_ndex", format),
+            "45:17: " + getCheckMessage(messages, MSG_KEY, "i_ndex", format),
+            "49:17: " + getCheckMessage(messages, MSG_KEY, "ii_i1", format),
+            "53:17: " + getCheckMessage(messages, MSG_KEY, "$index", format),
+            "57:17: " + getCheckMessage(messages, MSG_KEY, "in$dex", format),
+            "61:17: " + getCheckMessage(messages, MSG_KEY, "index$", format),
         };
 
         final String filePath = getPath("InputLocalVariableNameOneCharVarName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassTypeParameterNameTest.java
@@ -19,6 +19,8 @@
 
 package com.google.checkstyle.test.chapter5naming.rule528typevariablenames;
 
+import java.util.Map;
+
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.AbstractModuleTestSupport;
@@ -37,11 +39,12 @@ public class ClassTypeParameterNameTest extends AbstractModuleTestSupport {
     public void testClassDefault() throws Exception {
         final Configuration configuration = getModuleConfig("ClassTypeParameterName");
         final String format = configuration.getAttribute("format");
+        final Map<String, String> messages = configuration.getMessages();
 
         final String[] expected = {
-            "5:31: " + getCheckMessage(configuration.getMessages(), MSG_KEY, "t", format),
-            "13:14: " + getCheckMessage(configuration.getMessages(), MSG_KEY, "foo", format),
-            "27:24: " + getCheckMessage(configuration.getMessages(), MSG_KEY, "$foo", format),
+            "5:31: " + getCheckMessage(messages, MSG_KEY, "t", format),
+            "13:14: " + getCheckMessage(messages, MSG_KEY, "foo", format),
+            "27:24: " + getCheckMessage(messages, MSG_KEY, "$foo", format),
         };
 
         final String filePath = getPath("InputClassTypeParameterName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InterfaceTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InterfaceTypeParameterNameTest.java
@@ -19,6 +19,8 @@
 
 package com.google.checkstyle.test.chapter5naming.rule528typevariablenames;
 
+import java.util.Map;
+
 import org.junit.Test;
 
 import com.google.checkstyle.test.base.AbstractModuleTestSupport;
@@ -37,11 +39,12 @@ public class InterfaceTypeParameterNameTest extends AbstractModuleTestSupport {
     public void testInterfaceDefault() throws Exception {
         final Configuration configuration = getModuleConfig("InterfaceTypeParameterName");
         final String format = configuration.getAttribute("format");
+        final Map<String, String> messages = configuration.getMessages();
 
         final String[] expected = {
-            "48:15: " + getCheckMessage(configuration.getMessages(), MSG_KEY, "Input", format),
-            "76:25: " + getCheckMessage(configuration.getMessages(), MSG_KEY, "Request", format),
-            "80:25: " + getCheckMessage(configuration.getMessages(), MSG_KEY, "TRequest", format),
+            "48:15: " + getCheckMessage(messages, MSG_KEY, "Input", format),
+            "76:25: " + getCheckMessage(messages, MSG_KEY, "Request", format),
+            "80:25: " + getCheckMessage(messages, MSG_KEY, "TRequest", format),
         };
 
         final String filePath = getPath("InputInterfaceTypeParameterName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/MethodTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/MethodTypeParameterNameTest.java
@@ -19,6 +19,8 @@
 
 package com.google.checkstyle.test.chapter5naming.rule528typevariablenames;
 
+import java.util.Map;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -44,14 +46,15 @@ public class MethodTypeParameterNameTest extends AbstractModuleTestSupport {
     @Test
     public void testMethodDefault() throws Exception {
         final Configuration checkConfig = getModuleConfig("MethodTypeParameterName");
+        final Map<String, String> messages = checkConfig.getMessages();
 
         final String[] expected = {
-            "9:6: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "e_e", format),
-            "19:6: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "Tfo$o2T", format),
-            "23:6: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "foo_", format),
-            "28:10: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "_abc", format),
-            "37:14: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "T$", format),
-            "42:14: " + getCheckMessage(checkConfig.getMessages(), MSG_KEY, "EE", format),
+            "9:6: " + getCheckMessage(messages, MSG_KEY, "e_e", format),
+            "19:6: " + getCheckMessage(messages, MSG_KEY, "Tfo$o2T", format),
+            "23:6: " + getCheckMessage(messages, MSG_KEY, "foo_", format),
+            "28:10: " + getCheckMessage(messages, MSG_KEY, "_abc", format),
+            "37:14: " + getCheckMessage(messages, MSG_KEY, "T$", format),
+            "42:14: " + getCheckMessage(messages, MSG_KEY, "EE", format),
         };
 
         final String filePath = getPath("InputMethodTypeParameterName.java");

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCyclomaticComplexityTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCyclomaticComplexityTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.metrics.CyclomaticComplexityCheck;
 
-public class XpathRegressionCyclomaticComplexityTest extends AbstractXpathRegressionTest {
+public class XpathRegressionCyclomaticComplexityTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -55,7 +55,7 @@ public class XpathRegressionCyclomaticComplexityTest extends AbstractXpathRegres
                 + "/METHOD_DEF[@text='test']/MODIFIERS/LITERAL_PUBLIC"
                 );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -84,7 +84,7 @@ public class XpathRegressionCyclomaticComplexityTest extends AbstractXpathRegres
                     + "/METHOD_DEF[@text='foo2']/MODIFIERS/LITERAL_PUBLIC"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionDeclarationOrderTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionDeclarationOrderTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck;
 
-public class XpathRegressionDeclarationOrderTest extends AbstractXpathRegressionTest {
+public class XpathRegressionDeclarationOrderTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -54,7 +54,7 @@ public class XpathRegressionDeclarationOrderTest extends AbstractXpathRegression
                         + "/OBJBLOCK/VARIABLE_DEF[@text='name']/MODIFIERS/LITERAL_PUBLIC"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -82,7 +82,7 @@ public class XpathRegressionDeclarationOrderTest extends AbstractXpathRegression
                         + "/OBJBLOCK/VARIABLE_DEF[@text='MAX']/MODIFIERS/LITERAL_PUBLIC"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionDefaultComesLastTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionDefaultComesLastTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.coding.DefaultComesLastCheck;
 
-public class XpathRegressionDefaultComesLastTest extends AbstractXpathRegressionTest {
+public class XpathRegressionDefaultComesLastTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -54,7 +54,7 @@ public class XpathRegressionDefaultComesLastTest extends AbstractXpathRegression
                 + "/LITERAL_DEFAULT"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -79,7 +79,7 @@ public class XpathRegressionDefaultComesLastTest extends AbstractXpathRegression
                 + "/METHOD_DEF[@text='test']/SLIST/LITERAL_SWITCH/CASE_GROUP/LITERAL_DEFAULT"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionExplicitInitializationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionExplicitInitializationTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheck;
 
-public class XpathRegressionExplicitInitializationTest extends AbstractXpathRegressionTest {
+public class XpathRegressionExplicitInitializationTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -50,7 +50,7 @@ public class XpathRegressionExplicitInitializationTest extends AbstractXpathRegr
                         + "/OBJBLOCK/VARIABLE_DEF[@text='a']/IDENT"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -74,7 +74,7 @@ public class XpathRegressionExplicitInitializationTest extends AbstractXpathRegr
                         + "/VARIABLE_DEF[@text='bar']/IDENT"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionFallThroughTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionFallThroughTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck;
 
-public class XpathRegressionFallThroughTest extends AbstractXpathRegressionTest {
+public class XpathRegressionFallThroughTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -52,7 +52,7 @@ public class XpathRegressionFallThroughTest extends AbstractXpathRegressionTest 
                 + "/METHOD_DEF[@text='test']/SLIST/LITERAL_SWITCH/CASE_GROUP/LITERAL_CASE"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -81,7 +81,7 @@ public class XpathRegressionFallThroughTest extends AbstractXpathRegressionTest 
                 + "/LITERAL_SWITCH/CASE_GROUP/LITERAL_DEFAULT"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionHiddenFieldTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionHiddenFieldTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck;
 
-public class XpathRegressionHiddenFieldTest extends AbstractXpathRegressionTest {
+public class XpathRegressionHiddenFieldTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -51,7 +51,7 @@ public class XpathRegressionHiddenFieldTest extends AbstractXpathRegressionTest 
                 + "/PARAMETER_DEF[@text='value']/IDENT"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -75,7 +75,7 @@ public class XpathRegressionHiddenFieldTest extends AbstractXpathRegressionTest 
                 + "/METHOD_DEF[@text='method']/PARAMETERS/PARAMETER_DEF[@text='other']/IDENT"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalThrowsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalThrowsTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheck;
 
-public class XpathRegressionIllegalThrowsTest extends AbstractXpathRegressionTest {
+public class XpathRegressionIllegalThrowsTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -50,7 +50,7 @@ public class XpathRegressionIllegalThrowsTest extends AbstractXpathRegressionTes
                 + "/METHOD_DEF[@text='sayHello']/LITERAL_THROWS[@text='RuntimeException']/IDENT"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -74,7 +74,7 @@ public class XpathRegressionIllegalThrowsTest extends AbstractXpathRegressionTes
                 + "/METHOD_DEF[@text='methodTwo']/LITERAL_THROWS/DOT[@text='Error']"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionImportControlTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionImportControlTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck;
 
-public class XpathRegressionImportControlTest extends AbstractXpathRegressionTest {
+public class XpathRegressionImportControlTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -51,7 +51,7 @@ public class XpathRegressionImportControlTest extends AbstractXpathRegressionTes
             "/IMPORT"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -76,7 +76,7 @@ public class XpathRegressionImportControlTest extends AbstractXpathRegressionTes
             "/PACKAGE_DEF"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -99,7 +99,7 @@ public class XpathRegressionImportControlTest extends AbstractXpathRegressionTes
             "/PACKAGE_DEF"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -124,7 +124,7 @@ public class XpathRegressionImportControlTest extends AbstractXpathRegressionTes
             "/IMPORT[./DOT[@text='Scanner']]"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocVariableTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocVariableTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck;
 
-public class XpathRegressionJavadocVariableTest extends AbstractXpathRegressionTest {
+public class XpathRegressionJavadocVariableTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -54,7 +54,7 @@ public class XpathRegressionJavadocVariableTest extends AbstractXpathRegressionT
                 + "/VARIABLE_DEF[@text='age']/MODIFIERS/LITERAL_PRIVATE"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -83,7 +83,7 @@ public class XpathRegressionJavadocVariableTest extends AbstractXpathRegressionT
                 + "/LITERAL_PUBLIC"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionLeftCurlyTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionLeftCurlyTest.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck;
 import com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyOption;
 
-public class XpathRegressionLeftCurlyTest extends AbstractXpathRegressionTest {
+public class XpathRegressionLeftCurlyTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -52,7 +52,7 @@ public class XpathRegressionLeftCurlyTest extends AbstractXpathRegressionTest {
             "/CLASS_DEF[@text='SuppressionXpathRegressionLeftCurlyOne']/OBJBLOCK/LCURLY"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -77,7 +77,7 @@ public class XpathRegressionLeftCurlyTest extends AbstractXpathRegressionTest {
             "/CLASS_DEF[@text='SuppressionXpathRegressionLeftCurlyTwo']/OBJBLOCK/LCURLY"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -101,7 +101,7 @@ public class XpathRegressionLeftCurlyTest extends AbstractXpathRegressionTest {
                 + "/METHOD_DEF[@text='sample']/SLIST/LITERAL_IF/SLIST"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMethodParamPadTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMethodParamPadTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck;
 
-public class XpathRegressionMethodParamPadTest extends AbstractXpathRegressionTest {
+public class XpathRegressionMethodParamPadTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -50,7 +50,7 @@ public class XpathRegressionMethodParamPadTest extends AbstractXpathRegressionTe
                 + "/METHOD_DEF[@text='InputMethodParamPad']/LPAREN"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -74,7 +74,7 @@ public class XpathRegressionMethodParamPadTest extends AbstractXpathRegressionTe
                 + "/METHOD_DEF[@text='sayHello']/LPAREN"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -99,7 +99,7 @@ public class XpathRegressionMethodParamPadTest extends AbstractXpathRegressionTe
                 + "/METHOD_DEF[@text='sayHello']/LPAREN"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMultipleVariableDeclarationsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMultipleVariableDeclarationsTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck;
 
-public class XpathRegressionMultipleVariableDeclarationsTest extends AbstractXpathRegressionTest {
+public class XpathRegressionMultipleVariableDeclarationsTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -64,7 +64,7 @@ public class XpathRegressionMultipleVariableDeclarationsTest extends AbstractXpa
                     + "/VARIABLE_DEF[@text='j']/TYPE/LITERAL_INT"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -94,7 +94,7 @@ public class XpathRegressionMultipleVariableDeclarationsTest extends AbstractXpa
                     + "/VARIABLE_DEF[@text='i1']/TYPE/LITERAL_INT"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNPathComplexityTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNPathComplexityTest.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck;
 
 // -@cs[AbbreviationAsWordInName] Test should be named as its main class.
-public class XpathRegressionNPathComplexityTest extends AbstractXpathRegressionTest {
+public class XpathRegressionNPathComplexityTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -57,7 +57,7 @@ public class XpathRegressionNPathComplexityTest extends AbstractXpathRegressionT
                 + "/METHOD_DEF[@text='test']/MODIFIERS/LITERAL_PUBLIC"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -81,7 +81,7 @@ public class XpathRegressionNPathComplexityTest extends AbstractXpathRegressionT
             "/CLASS_DEF[@text='SuppressionXpathRegressionNPathComplexityTwo']/OBJBLOCK/STATIC_INIT"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNestedForDepthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNestedForDepthTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck;
 
-public class XpathRegressionNestedForDepthTest extends AbstractXpathRegressionTest {
+public class XpathRegressionNestedForDepthTest extends AbstractXpathTestSupport {
 
     @Test
     public void testCorrect() throws Exception {
@@ -50,7 +50,7 @@ public class XpathRegressionNestedForDepthTest extends AbstractXpathRegressionTe
                 + "/METHOD_DEF[@text='test']/SLIST/LITERAL_FOR/SLIST/LITERAL_FOR/SLIST/LITERAL_FOR"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNestedIfDepthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNestedIfDepthTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.coding.NestedIfDepthCheck;
 
-public class XpathRegressionNestedIfDepthTest extends AbstractXpathRegressionTest {
+public class XpathRegressionNestedIfDepthTest extends AbstractXpathTestSupport {
 
     @Test
     public void testCorrect() throws Exception {
@@ -50,7 +50,7 @@ public class XpathRegressionNestedIfDepthTest extends AbstractXpathRegressionTes
                 + "/METHOD_DEF[@text='test']/SLIST/LITERAL_IF/SLIST/LITERAL_IF/SLIST/LITERAL_IF"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNestedTryDepthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNestedTryDepthTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheck;
 
-public class XpathRegressionNestedTryDepthTest extends AbstractXpathRegressionTest {
+public class XpathRegressionNestedTryDepthTest extends AbstractXpathTestSupport {
 
     @Test
     public void testCorrect() throws Exception {
@@ -50,7 +50,7 @@ public class XpathRegressionNestedTryDepthTest extends AbstractXpathRegressionTe
                 + "/METHOD_DEF[@text='test']/SLIST/LITERAL_TRY/SLIST/LITERAL_TRY/SLIST/LITERAL_TRY"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOneStatementPerLineTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOneStatementPerLineTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck;
 
-public class XpathRegressionOneStatementPerLineTest extends AbstractXpathRegressionTest {
+public class XpathRegressionOneStatementPerLineTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -50,7 +50,7 @@ public class XpathRegressionOneStatementPerLineTest extends AbstractXpathRegress
                 + "/VARIABLE_DEF[@text='j']/SEMI"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -74,7 +74,7 @@ public class XpathRegressionOneStatementPerLineTest extends AbstractXpathRegress
                 + "/METHOD_DEF[@text='foo5']/SLIST/LITERAL_FOR/SLIST/SEMI"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOuterTypeNumberTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOuterTypeNumberTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck;
 
-public class XpathRegressionOuterTypeNumberTest extends AbstractXpathRegressionTest {
+public class XpathRegressionOuterTypeNumberTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -50,7 +50,7 @@ public class XpathRegressionOuterTypeNumberTest extends AbstractXpathRegressionT
             "/PACKAGE_DEF"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRequireThisTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRequireThisTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck;
 
-public class XpathRegressionRequireThisTest extends AbstractXpathRegressionTest {
+public class XpathRegressionRequireThisTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -51,7 +51,7 @@ public class XpathRegressionRequireThisTest extends AbstractXpathRegressionTest 
                 + "/METHOD_DEF[@text='changeAge']/SLIST/EXPR/ASSIGN[@text='age']/IDENT"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -76,7 +76,7 @@ public class XpathRegressionRequireThisTest extends AbstractXpathRegressionTest 
                 + "/METHOD_DEF[@text='method2']/SLIST/EXPR/METHOD_CALL[@text='method1']/IDENT"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRightCurlyTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRightCurlyTest.java
@@ -29,7 +29,7 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck;
 import com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyOption;
 
-public class XpathRegressionRightCurlyTest extends AbstractXpathRegressionTest {
+public class XpathRegressionRightCurlyTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
@@ -51,7 +51,7 @@ public class XpathRegressionRightCurlyTest extends AbstractXpathRegressionTest {
                 + "/METHOD_DEF[@text='test']/SLIST/LITERAL_IF/SLIST/RCURLY"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -76,7 +76,7 @@ public class XpathRegressionRightCurlyTest extends AbstractXpathRegressionTest {
                 + "/METHOD_DEF[@text='fooMethod']/SLIST/LITERAL_TRY/SLIST/RCURLY"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -101,7 +101,7 @@ public class XpathRegressionRightCurlyTest extends AbstractXpathRegressionTest {
                 + "/METHOD_DEF[@text='sample']/SLIST/LITERAL_IF/SLIST/RCURLY"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 
@@ -126,7 +126,7 @@ public class XpathRegressionRightCurlyTest extends AbstractXpathRegressionTest {
                 + "/METHOD_DEF[@text='sample']/SLIST/LITERAL_IF/SLIST/RCURLY"
         );
 
-        runVerifications(moduleConfig, checkName, fileToProcess, expectedViolation,
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
 }


### PR DESCRIPTION
Placed tougher restrictions on modifiers.
IT area uses simple class names, so `createModuleConfig` had to change to reflect that.
`getCheckMessage` was changed from a map to make lines smaller.
`AbstractXpathRegressionTest` was renamed to follow pattern of other abstract classes.
Removed check name from `runVerifications` because it wasn't needed since we give the module config.
`ViolationPosition` was never declared static, so it was always connected to the instance of the abstract class.