### PR TITLE
minor: fix bug with hashtag in url for anchors

### DIFF
--- a/src/site/resources/js/anchors.js
+++ b/src/site/resources/js/anchors.js
@@ -4,6 +4,12 @@
     "use strict";
     window.addEventListener("load", function () {
         var url = window.location.href;
+        var position = url.indexOf("#");
+
+        if (position !== -1) {
+            url = url.substring(0, position);
+        }
+
         var anchors = document.getElementsByTagName("h2");
         [].forEach.call(anchors, function (anchorItem) {
             var name = anchorItem.childNodes[0].name;


### PR DESCRIPTION
Go to `http://checkstyle.sourceforge.net/config_annotation.html#AnnotationLocation` . Click on any anchor, AnnotationLocation for example, and the new URL becomes `http://checkstyle.sourceforge.net/config_annotation.html#AnnotationLocation#AnnotationLocation`.
This issue always messes me up when switching to other anchor tags as most browsers will take this double hashtag as nonsense and not take you to either anchor on a page refresh.
This fixes this bug so it is always using the page's raw location.