### PR TITLE
config: upgraded sevntu-checkstyle-maven-plugin to 1.30.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
     <powermock.version>2.0.0-beta.5</powermock.version>
     <saxon.version>9.8.0-12</saxon.version>
     <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
-    <maven.sevntu.checkstyle.plugin.version>1.29.0</maven.sevntu.checkstyle.plugin.version>
+    <maven.sevntu.checkstyle.plugin.version>1.30.0</maven.sevntu.checkstyle.plugin.version>
     <maven.sevntu-checkstyle-check.checkstyle.version>
       8.10.1
     </maven.sevntu-checkstyle-check.checkstyle.version>


### PR DESCRIPTION
Identified at https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/709#issuecomment-408118508

Caused:
> checkstyle-regression
Unable to instantiate 'com.github.sevntu.checkstyle.checks.coding.EnumTrailingCommaAndSemicolonCheck' class