### PR TITLE
spelling: add xcode

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1334,6 +1334,7 @@ Wsdl
 www
 Xandy
 xargs
+xcode
 xcommons
 xdoc
 xdocspagetitle


### PR DESCRIPTION
Issue #6055 

missed patch for spelling whitelist