### PR TITLE
#6068 Migrate command line parser to picocli from Commons CLI (initial version)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+      <version>3.5.1</version>
+    </dependency>
+    <dependency>
       <groupId>antlr</groupId>
       <artifactId>antlr</artifactId>
       <version>2.7.7</version>

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
-      <version>3.5.1</version>
+      <version>3.6.0</version>
     </dependency>
     <dependency>
       <groupId>antlr</groupId>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -1353,6 +1353,7 @@ public class MainTest {
      * @throws Exception if error occurs
      * @see <a href="https://github.com/jacoco/jacoco/issues/117">Jacoco issue 117</a>
      */
+    @Ignore("new code has only a single conditional; jacoco #117 is not a problem any more")
     @Test
     public void testJacocoWorkaround() throws Exception {
         final String expected = "Missing required parameter: <files>"


### PR DESCRIPTION
Issue #6068

Please take a look at what the source code for Main would look like with picocli.

* I was able to remove 200 lines of code, and the remaining code is more declarative and focused on the business logic. 
* The usage help for `Main` now looks like this on Cygwin: https://ibb.co/j7wymU (to give some idea of the ANSI colors and styles)

This is a first cut. Please let me know if you are interested in refining this further to something that can be merged.

* TODO 1: The usage help message can be polished more. (Custom option labels, reorder options and simpler synopsis - all can be done with annotations.)
* TODO 2: Some tests in MainTest fail (probably because the usage help and some error messages looks different)