### PR TITLE
Issue #5608: Javadoc type allowed annotations

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -36,6 +36,7 @@ import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.utils.AllowedAnnotationsUtil;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
@@ -357,27 +358,13 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     }
 
     /**
-     * Some javadoc.
-     * @param methodDef Some javadoc.
-     * @return Some javadoc.
+     * Checks if the method is marked with an annotation which allows it
+     * to omit javadoc documentation.
+     * @param methodDef The method definition.
+     * @return true if the method is exempt from comments, false otherwise.
      */
     private boolean hasAllowedAnnotations(DetailAST methodDef) {
-        boolean result = false;
-        final DetailAST modifiersNode = methodDef.findFirstToken(TokenTypes.MODIFIERS);
-        DetailAST annotationNode = modifiersNode.findFirstToken(TokenTypes.ANNOTATION);
-        while (annotationNode != null && annotationNode.getType() == TokenTypes.ANNOTATION) {
-            DetailAST identNode = annotationNode.findFirstToken(TokenTypes.IDENT);
-            if (identNode == null) {
-                identNode = annotationNode.findFirstToken(TokenTypes.DOT)
-                    .findFirstToken(TokenTypes.IDENT);
-            }
-            if (allowedAnnotations.contains(identNode.getText())) {
-                result = true;
-                break;
-            }
-            annotationNode = annotationNode.getNextSibling();
-        }
-        return result;
+        return AllowedAnnotationsUtil.hasAllowedAnnotations(methodDef, allowedAnnotations);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -30,6 +32,7 @@ import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.utils.AllowedAnnotationsUtil;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
@@ -112,6 +115,9 @@ public class JavadocTypeCheck
     /** Controls whether to flag errors for unknown tags. Defaults to false. */
     private boolean allowUnknownTags;
 
+    /** List of annotations that could allow missed documentation. */
+    private List<String> allowedAnnotations = new ArrayList<>();
+
     /**
      * Sets the scope to check.
      * @param scope a scope.
@@ -160,6 +166,14 @@ public class JavadocTypeCheck
      */
     public void setAllowUnknownTags(boolean flag) {
         allowUnknownTags = flag;
+    }
+
+    /**
+     * Sets list of annotations.
+     * @param userAnnotations user's value.
+     */
+    public void setAllowedAnnotations(String... userAnnotations) {
+        allowedAnnotations = Arrays.asList(userAnnotations);
     }
 
     @Override
@@ -239,7 +253,8 @@ public class JavadocTypeCheck
             && (excludeScope == null
                 || !customScope.isIn(excludeScope)
                 || surroundingScope != null
-                && !surroundingScope.isIn(excludeScope));
+                && !surroundingScope.isIn(excludeScope))
+            && !AllowedAnnotationsUtil.hasAllowedAnnotations(ast, allowedAnnotations);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/AllowedAnnotationsUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/AllowedAnnotationsUtil.java
@@ -1,0 +1,64 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2018 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.utils;
+
+import java.util.List;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * Utility class that is used by JavadocTypeCheck and JavadocMethodCheck to
+ * permit certain types and methods to omit documentation.
+ */
+public final class AllowedAnnotationsUtil {
+    /**
+     * Private constructor to indicate the class is a static utility class.
+     */
+    private AllowedAnnotationsUtil() {
+    }
+
+    /**
+     * Checks if the given AST element is marked with an annotation that allows
+     * it to omit javadoc documentation.
+     * @param ast The type or method definition.
+     * @param allowedAnnotations A collection of annotations that allow omitting documentation.
+     * @return true if the type or method is exempt from comments, false otherwise.
+     */
+    public static boolean hasAllowedAnnotations(DetailAST ast, List<String> allowedAnnotations) {
+        boolean result = false;
+        final DetailAST modifiersNode = ast.findFirstToken(TokenTypes.MODIFIERS);
+        DetailAST annotationNode = modifiersNode.findFirstToken(TokenTypes.ANNOTATION);
+        while (annotationNode != null && annotationNode.getType() == TokenTypes.ANNOTATION) {
+            DetailAST identNode = annotationNode.findFirstToken(TokenTypes.IDENT);
+            if (identNode == null) {
+                identNode = annotationNode.findFirstToken(TokenTypes.DOT)
+                        .findFirstToken(TokenTypes.IDENT);
+            }
+            if (allowedAnnotations.contains(identNode.getText())) {
+                result = true;
+                break;
+            }
+            annotationNode = annotationNode.getNextSibling();
+        }
+
+        return result;
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -392,8 +392,32 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("allowUnknownTags", "true");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig,
-                getPath("InputJavadocTypeBadTag.java"),
-                expected);
+            getPath("InputJavadocTypeBadTag.java"),
+            expected);
     }
 
+    @Test
+    public void testAllowedAnnotationsDefault() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(JavadocTypeCheck.class);
+
+        final String[] expected = {
+            "3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig,
+            getPath("InputJavadocTypeAllowedAnnotations.java"),
+            expected);
+    }
+
+    @Test
+    public void testAllowedAnnotationsAllowed() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(JavadocTypeCheck.class);
+        checkConfig.addAttribute("allowedAnnotations", "ThisIsOk");
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+            getPath("InputJavadocTypeAllowedAnnotations.java"),
+            expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeAllowedAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeAllowedAnnotations.java
@@ -1,0 +1,10 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
+
+@ThisIsOk
+public class InputJavadocTypeAllowedAnnotations {
+}
+
+/**
+ * Annotation for unit tests.
+ */
+@interface ThisIsOk {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeUnusedParamInJavadocForClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeUnusedParamInJavadocForClass.java
@@ -9,3 +9,4 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
  */
 public class InputJavadocTypeUnusedParamInJavadocForClass {
 }
+

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1210,6 +1210,13 @@ public boolean isSomething()
             <td>5.1</td>
           </tr>
           <tr>
+            <td>allowedAnnotations</td>
+            <td>List of annotations that could allow missed documentation.</td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
+            <td><code>{}</code></td>
+            <td>8.13</td>
+          </tr>
+          <tr>
             <td>tokens</td>
             <td>tokens to check</td>
             <td>
@@ -1235,6 +1242,7 @@ public boolean isSomething()
             </td>
             <td>3.0</td>
           </tr>
+
         </table>
       </subsection>
 


### PR DESCRIPTION
I followed the example from allowedAnnotations in javadocMethod and implemented it in javadocType. As the functionality is identical, I made a utility class AllowedAnnotationsUtil to avoid code duplication. There is also a unit test added that proves the feature works.

I only don't know what to put in the "since" version. I added "8.13" because that's what I found in the pom.

Please let me know what else I might be missing! :-) 