### PR TITLE
minor: fixed inlined javadoc tag from being split between lines

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -544,7 +544,7 @@
     </module>
     <module name="LineLength">
       <property name="max" value="100"/>
-      <property name="ignorePattern" value="^ *\* *([^ ]+|&lt;a href.*)$"/>
+      <property name="ignorePattern" value="^ *\* *([^ ]+|\{@code .*|&lt;a href.*)$"/>
     </module>
     <module name="MethodCount">
       <property name="maxTotal" value="34"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -59,8 +59,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </li>
  * <li>
  * Property {@code tagOrder} - Specify the order by tags. Default value is
- * {@code @author, @version, @param, @return, @throws, @exception, @see, @since, @serial,
- * @serialField, @serialData, @deprecated}.
+ * {@code @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, @serialField, @serialData, @deprecated}.
  * </li>
  * </ul>
  * <p>


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/6101#issuecomment-418950942