### PR TITLE
minor: Remove restriction to build master only from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ addons:
       - xmlstarlet
       - oracle-java8-installer
 
-branches:
-  only:
-    - master
-
 install:
   -
 


### PR DESCRIPTION
Checkstyle doesn't use a large number of branches besides master and the
complications for pull request authors to get their PR branches to build
on Travis CI is not worth saving a few builds.

Some Travis CI build task seem to need adjustment, though: https://travis-ci.org/krichter722/checkstyle/builds/428993850