### PR TITLE
Issue #6121: Update FullIdent to store DetailAST instead of line/column

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
@@ -40,10 +40,8 @@ public final class FullIdent {
 
     /** The list holding subsequent elements of identifier. **/
     private final List<String> elements = new ArrayList<>();
-    /** The line number. **/
-    private int lineNo;
-    /** The column number. **/
-    private int columnNo;
+    /** The topmost and leftmost AST of the full identifier. */
+    private DetailAST detailAst;
 
     /** Hide default constructor. */
     private FullIdent() {
@@ -78,11 +76,19 @@ public final class FullIdent {
     }
 
     /**
+     * Gets the topmost leftmost DetailAST for this FullIdent.
+     * @return the topmost leftmost ast
+     */
+    public DetailAST getDetailAst() {
+        return detailAst;
+    }
+
+    /**
      * Gets the line number.
      * @return the line number
      */
     public int getLineNo() {
-        return lineNo;
+        return detailAst.getLineNo();
     }
 
     /**
@@ -90,12 +96,13 @@ public final class FullIdent {
      * @return the column number
      */
     public int getColumnNo() {
-        return columnNo;
+        return detailAst.getColumnNo();
     }
 
     @Override
     public String toString() {
-        return String.join("", elements) + "[" + lineNo + "x" + columnNo + "]";
+        return String.join("", elements)
+            + "[" + detailAst.getLineNo() + "x" + detailAst.getColumnNo() + "]";
     }
 
     /**
@@ -137,17 +144,8 @@ public final class FullIdent {
      */
     private void append(DetailAST ast) {
         elements.add(ast.getText());
-        if (lineNo == 0) {
-            lineNo = ast.getLineNo();
-        }
-        else if (ast.getLineNo() > 0) {
-            lineNo = Math.min(lineNo, ast.getLineNo());
-        }
-        if (columnNo == 0) {
-            columnNo = ast.getColumnNo();
-        }
-        else if (ast.getColumnNo() > 0) {
-            columnNo = Math.min(columnNo, ast.getColumnNo());
+        if (detailAst == null) {
+            detailAst = ast;
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -327,8 +327,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
         final FullIdent ident = FullIdent.createFullIdent(type.getFirstChild());
 
         if (isMatchingClassName(ident.getText())) {
-            log(ident.getLineNo(), ident.getColumnNo(),
-                MSG_KEY, ident.getText());
+            log(ident.getDetailAst(), MSG_KEY, ident.getText());
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -108,8 +108,7 @@ public class UnusedImportsCheck extends AbstractCheck {
         // loop over all the imports to see if referenced.
         imports.stream()
             .filter(imprt -> isUnusedImport(imprt.getText()))
-            .forEach(imprt -> log(imprt.getLineNo(),
-                imprt.getColumnNo(),
+            .forEach(imprt -> log(imprt.getDetailAst(),
                 MSG_KEY, imprt.getText()));
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
@@ -109,8 +109,7 @@ public class PackageNameCheck
         final DetailAST nameAST = ast.getLastChild().getPreviousSibling();
         final FullIdent full = FullIdent.createFullIdent(nameAST);
         if (!format.matcher(full.getText()).find()) {
-            log(full.getLineNo(),
-                full.getColumnNo(),
+            log(full.getDetailAst(),
                 MSG_KEY,
                 full.getText(),
                 format.pattern());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
@@ -48,6 +48,17 @@ public class FullIdentTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testGetDetailAst() throws Exception {
+        final FileText testFileText = new FileText(
+                new File(getPath("InputFullIdentTestArrayType.java")).getAbsoluteFile(),
+                System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
+        final DetailAST packageDefinitionNode = JavaParser.parse(new FileContents(testFileText));
+        final DetailAST packageName = packageDefinitionNode.getFirstChild().getNextSibling();
+        final FullIdent ident = FullIdent.createFullIdent(packageName);
+        Assert.assertEquals("Invalid full indent", "com[1x8]", ident.getDetailAst().toString());
+    }
+
+    @Test
     public void testNonValidCoordinatesWithNegative() {
         final FullIdent fullIdent = prepareFullIdentWithCoordinates(14, 15);
         Assert.assertEquals("Invalid full indent", "MyTest.MyTestik[15x14]", fullIdent.toString());

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImports.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImports.java
@@ -24,8 +24,8 @@ import javax.swing.BorderFactory;
 import static java.io.File.listRoots;
 
 import static javax.swing.WindowConstants.*;
-import static java.io.File.createTempFile;
-
+import static java.io.File.
+    createTempFile;
 
 import java.awt.Graphics2D;
 import java.awt.HeadlessException;


### PR DESCRIPTION
Issue #6121 

Note that the whole FullIdent::append was changed to simple
```
        if (detailAST == null) {
            detailAST = ast;
        }
```

this is because the deepest `IDENT` in the chain as always the top- and leftmost one.