### PR TITLE
Issue #6130: AbbreviationAsWordInName false positive at end of the word

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java
@@ -42,13 +42,10 @@ public class AbbreviationAsWordInNameTest extends AbstractModuleTestSupport {
         final int maxCapitalCount = 2;
 
         final String[] expected = {
-            "50: " + getWarningMessage("newCustomerID", maxCapitalCount),
             "52: " + getWarningMessage("supportsIPv6OnIOS", maxCapitalCount),
             "54: " + getWarningMessage("XMLHTTPRequest", maxCapitalCount),
-            "58: " + getWarningMessage("newCustomerID", maxCapitalCount),
             "60: " + getWarningMessage("supportsIPv6OnIOS", maxCapitalCount),
             "62: " + getWarningMessage("XMLHTTPRequest", maxCapitalCount),
-            "67: " + getWarningMessage("newCustomerID", maxCapitalCount),
             "69: " + getWarningMessage("supportsIPv6OnIOS", maxCapitalCount),
             "71: " + getWarningMessage("XMLHTTPRequest", maxCapitalCount),
         };

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule53camelcase/InputAbbreviationAsWordInTypeNameCheck.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule53camelcase/InputAbbreviationAsWordInTypeNameCheck.java
@@ -47,7 +47,7 @@ class AbbreviationsCorrect {
 
 class AbbreviationsIncorrect {
     
-    int newCustomerID; //warn
+    int newCustomerID;
     
     boolean supportsIPv6OnIOS; //warn
     
@@ -55,7 +55,7 @@ class AbbreviationsIncorrect {
     
     class InnerBad {
         
-        int newCustomerID; //warn
+        int newCustomerID;
         
         boolean supportsIPv6OnIOS; //warn
         
@@ -64,7 +64,7 @@ class AbbreviationsIncorrect {
     
         AbbreviationsCorrect anonymousBad = new AbbreviationsCorrect() {
         
-            int newCustomerID; //warn
+            int newCustomerID;
             
             boolean supportsIPv6OnIOS; //warn
             

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -344,7 +344,6 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
                 abbrStarted = false;
 
                 final int endIndex = index - 1;
-                // -1 as a first capital is usually beginning of next word
                 result = getAbbreviationIfIllegal(str, beginIndex, endIndex);
                 if (result != null) {
                     break;
@@ -352,29 +351,59 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
                 beginIndex = -1;
             }
         }
-        // if abbreviation at the end of name and it is not single character (example: scaleX)
-        if (abbrStarted && beginIndex != str.length() - 1) {
-            final int endIndex = str.length();
+        // if abbreviation at the end of name (example: scaleX)
+        if (abbrStarted) {
+            final int endIndex = str.length() - 1;
             result = getAbbreviationIfIllegal(str, beginIndex, endIndex);
         }
         return result;
     }
 
     /**
-     * Get Abbreviation if it is illegal.
+     * Get Abbreviation if it is illegal, where {@code beginIndex} and {@code endIndex} are
+     * inclusive indexes of a sequence of consecutive upper-case characters.
      * @param str name
      * @param beginIndex begin index
      * @param endIndex end index
-     * @return true is abbreviation is bigger that required and not in ignore list
+     * @return the abbreviation if it is bigger than required and not in the
+     *         ignore list, otherwise {@code null}
      */
     private String getAbbreviationIfIllegal(String str, int beginIndex, int endIndex) {
         String result = null;
         final int abbrLength = endIndex - beginIndex;
         if (abbrLength > allowedAbbreviationLength) {
-            final String abbr = str.substring(beginIndex, endIndex);
+            final String abbr = getAbbreviation(str, beginIndex, endIndex);
             if (!allowedAbbreviations.contains(abbr)) {
                 result = abbr;
             }
+        }
+        return result;
+    }
+
+    /**
+     * Gets the abbreviation, where {@code beginIndex} and {@code endIndex} are
+     * inclusive indexes of a sequence of consecutive upper-case characters.
+     * <p>
+     * The character at {@code endIndex} is only included in the abbreviation if
+     * it is the last character in the string; otherwise it is usually the first
+     * capital in the next word.
+     * </p>
+     * <p>
+     * For example, {@code getAbbreviation("getXMLParser", 3, 6)} returns "XML"
+     * (not "XMLP"), and so does {@code getAbbreviation("parseXML", 5, 7)}.
+     * </p>
+     * @param str name
+     * @param beginIndex begin index
+     * @param endIndex end index
+     * @return the specified abbreviation
+     */
+    private static String getAbbreviation(String str, int beginIndex, int endIndex) {
+        final String result;
+        if (endIndex == str.length() - 1) {
+            result = str.substring(beginIndex);
+        }
+        else {
+            result = str.substring(beginIndex, endIndex);
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
@@ -107,7 +107,6 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
             "38: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
             "39: " + getWarningMessage("marazmaticVARIABLEName", expectedCapitalCount),
             "40: " + getWarningMessage("MARAZMATICVariableName", expectedCapitalCount),
-            "58: " + getWarningMessage("serialNUMBER", expectedCapitalCount),
         };
 
         verify(checkConfig, getPath("InputAbbreviationAsWordInNameType.java"), expected);
@@ -212,9 +211,6 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
             "32: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
             "37: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
             "38: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
-            "58: " + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
-            "59: "
-                + getWarningMessage("s1erialNUMBER", expectedCapitalCount), // no ignore for final
         };
 
         verify(checkConfig, getPath("InputAbbreviationAsWordInNameType.java"), expected);


### PR DESCRIPTION
The goal of this PR is to fix Issue #6130: 
- Calls to `getAbbreviationIfIllegal(String str, int beginIndex, int endIndex)` are now with inclusive indexes, regardless of whether the abbreviation is at the end of the string.
- When checking if an abbreviation is allowed, the final character is not stripped when the abbreviation is at the end of the string.

Regression results: http://esilkensen.github.io/checkstyle-tester/6130