### PR TITLE
config: bump saxon to 9.9.0-1

### DIFF
--- a/config/version-number-rules.xml
+++ b/config/version-number-rules.xml
@@ -28,6 +28,12 @@
                 <ignoreVersion type="regex">3.10.0</ignoreVersion>
             </ignoreVersions>
         </rule>
+        <rule groupId="net.sf.saxon" artifactId="Saxon-HE">
+            <ignoreVersions>
+                <!-- till https://github.com/checkstyle/checkstyle/issues/6149 -->
+                <ignoreVersion type="regex">9.9.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
         <rule groupId="org.apache.maven.plugins" artifactId="maven-release-plugin">
             <ignoreVersions>
                 <!-- we use 2.1 version that is defined at our parent


### PR DESCRIPTION
saxon update is suppressed till #6149

this PR is based on failure of #6144