### PR TITLE
Issue #6115: Add attribute "value" to all AST nodes

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java
@@ -19,6 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.xpath;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
@@ -40,6 +44,9 @@ public class ElementNode extends AbstractNode {
     /** String literal for text attribute. */
     private static final String TEXT_ATTRIBUTE_NAME = "text";
 
+    /** String literal for value attribute. */
+    private static final String VALUE_ATTRIBUTE_NAME = "value";
+
     /** Constant for optimization. */
     private static final AbstractNode[] EMPTY_ABSTRACT_NODE_ARRAY = new AbstractNode[0];
 
@@ -55,11 +62,8 @@ public class ElementNode extends AbstractNode {
     /** Represents text of the DetailAST. */
     private final String text;
 
-    /** The attributes. */
-    private AbstractNode[] attributes;
-
-    /** Represents value of TokenTypes#IDENT. */
-    private String ident;
+    /** The attributes by attribute name. */
+    private final Map<String, AttributeNode> attributes;
 
     /**
      * Creates a new {@code ElementNode} instance.
@@ -73,7 +77,7 @@ public class ElementNode extends AbstractNode {
         this.parent = parent;
         this.root = root;
         this.detailAst = detailAst;
-        setIdent();
+        attributes = Collections.unmodifiableMap(createAttributesMap());
         createChildren();
         text = TokenUtil.getTokenName(detailAst.getType());
     }
@@ -92,20 +96,22 @@ public class ElementNode extends AbstractNode {
     }
 
     /**
-     * Returns attribute value. Throws {@code UnsupportedOperationException} in case,
-     * when name of the attribute is not equal to 'text'.
+     * Returns attribute value.
      * @param namespace namespace
      * @param localPart actual name of the attribute
      * @return attribute value
      */
     @Override
     public String getAttributeValue(String namespace, String localPart) {
-        if (TEXT_ATTRIBUTE_NAME.equals(localPart)) {
-            return ident;
+        final AttributeNode attribute = attributes.get(localPart);
+        final String value;
+        if (attribute == null) {
+            value = null;
         }
         else {
-            throw throwUnsupportedOperationException();
+            value = attribute.getStringValue();
         }
+        return value;
     }
 
     /**
@@ -175,12 +181,8 @@ public class ElementNode extends AbstractNode {
                 result = new Navigator.AncestorEnumeration(this, true);
                 break;
             case AxisInfo.ATTRIBUTE:
-                if (attributes == null) {
-                    result = EmptyIterator.OfNodes.THE_INSTANCE;
-                }
-                else {
-                    result = new ArrayIterator.OfNodes(attributes);
-                }
+                result = new ArrayIterator.OfNodes(attributes.values()
+                        .toArray(new AttributeNode[0]));
                 break;
             case AxisInfo.CHILD:
                 if (hasChildNodes()) {
@@ -253,17 +255,24 @@ public class ElementNode extends AbstractNode {
     }
 
     /**
-     * Finds child element with {@link TokenTypes#IDENT}, extracts its value and stores it.
-     * Value can be accessed using {@code @text} attribute. Now {@code @text} attribute is only
-     * supported attribute.
+     * Creates a map of attribute name to attribute node.
+     * @return map of attribute name to attribute node
      */
-    private void setIdent() {
-        final DetailAST identAst = detailAst.findFirstToken(TokenTypes.IDENT);
-        if (identAst != null) {
-            ident = identAst.getText();
-            attributes = new AbstractNode[1];
-            attributes[0] = new AttributeNode(TEXT_ATTRIBUTE_NAME, ident);
+    private Map<String, AttributeNode> createAttributesMap() {
+        final Map<String, AttributeNode> attributesMap = new LinkedHashMap<>();
+
+        // Attribute "text"
+        final DetailAST firstIdentChild = detailAst.findFirstToken(TokenTypes.IDENT);
+        if (firstIdentChild != null) {
+            attributesMap.put(TEXT_ATTRIBUTE_NAME,
+                    new AttributeNode(TEXT_ATTRIBUTE_NAME, firstIdentChild.getText()));
         }
+
+        // Attribute "value"
+        attributesMap.put(VALUE_ATTRIBUTE_NAME,
+                new AttributeNode(VALUE_ATTRIBUTE_NAME, detailAst.getText()));
+
+        return attributesMap;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/ElementNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/ElementNodeTest.java
@@ -53,6 +53,24 @@ public class ElementNodeTest extends AbstractPathTestSupport {
     }
 
     @Test
+    public void testGetAttributeNumInt() throws Exception {
+        final String xPath = "//NUM_INT[@value = 123]";
+        final List<Item> nodes = getXpathItems(xPath, rootNode);
+        assertEquals("Invalid number of nodes", 1, nodes.size());
+        assertEquals("Invalid token type", TokenTypes.NUM_INT,
+                ((AbstractNode) nodes.get(0)).getTokenType());
+    }
+
+    @Test
+    public void testGetAttributeStringLiteral() throws Exception {
+        final String xPath = "//STRING_LITERAL[@value = '\"HelloWorld\"']";
+        final List<Item> nodes = getXpathItems(xPath, rootNode);
+        assertEquals("Invalid number of nodes", 2, nodes.size());
+        assertEquals("Invalid token type", TokenTypes.STRING_LITERAL,
+                ((AbstractNode) nodes.get(0)).getTokenType());
+    }
+
+    @Test
     public void testGetParent() throws Exception {
         final String xpath = "//OBJBLOCK";
         final List<Item> nodes = getXpathItems(xpath, rootNode);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
@@ -23,6 +23,7 @@ import static com.puppycrawl.tools.checkstyle.internal.utils.XpathUtil.getXpathI
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -462,13 +463,8 @@ public class XpathMapperTest extends AbstractPathTestSupport {
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<Item> nodes = getXpathItems(xpath, rootNode);
         final ElementNode classDefNode = (ElementNode) nodes.get(0);
-        try {
-            classDefNode.getAttributeValue("", "noneExistingAttribute");
-            fail("Exception is excepted");
-        }
-        catch (UnsupportedOperationException ex) {
-            assertEquals("Invalid number of nodes", "Operation is not supported", ex.getMessage());
-        }
+        assertNull("Not existing attribute should have null value",
+                classDefNode.getAttributeValue("", "notExistingAttribute"));
     }
 
     @Test


### PR DESCRIPTION
These changes add a "value" attribute to all ElementNode objects (used for XPath expressions on the AST) in a generic way. They handle issues #6115 and #6117.

Find two new unit tests for the changes below.