### PR TITLE
config: forced more travis CI to run for all file changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ matrix:
       env:
         - DESC="checkstyle and sevntu-checkstyle"
         - CMD="./.ci/travis/travis.sh checkstyle-and-sevntu"
+        - SKIP_CI="false"
 
     # jacoco and codecov (oraclejdk8)
     - jdk: oraclejdk8
@@ -66,6 +67,7 @@ matrix:
       env:
         - DESC="Releasenotes generation"
         - CMD="./.ci/travis/travis.sh releasenotes-gen"
+        - SKIP_CI="false"
 
     # NonDex (oraclejdk8)
     - jdk: oraclejdk8


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/6215#issuecomment-439577599 ,

Violation in `.github` file was missed because the files are part of the list that we skip validation if the commit only contains those files.
This changes the travis job for `checkstyle and sevntu-checkstyle` and `Releasenotes generation` to always run.