### PR TITLE
minor: skip temp file english.words from checkstyle validation

### DIFF
--- a/.ci/test-spelling-unknown-words.sh
+++ b/.ci/test-spelling-unknown-words.sh
@@ -7,12 +7,13 @@ set -e
 
 spellchecker=.ci/jsoref-spellchecker
 whitelist_path=.ci/jsoref-spellchecker/whitelist.words
-dict=$spellchecker/english.words
+dict=.ci-temp/english.words
 word_splitter=$spellchecker/spelling-unknown-word-splitter.pl
 run_output=$spellchecker/unknown.words
 if [ ! -e $dict ]; then
+  mkdir -p .ci-temp
   echo "Retrieve ./usr/share/dict/linux.words"
-  words_rpm=$spellchecker/words.rpm
+  words_rpm=.ci-temp/words.rpm
   mirror="https://rpmfind.net"
   file_path="/linux/fedora/linux/development/rawhide/Everything/aarch64/os/Packages/w/"
   file_name=$(curl -s "${mirror}${file_path}" | grep -o "words-.*.noarch.rpm")

--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -108,6 +108,11 @@
 
           <!-- NonDex files -->
           <exclude name=".nondex/**/*" />
+
+          <!-- temp file of jsoref-spellchecker tool,
+               some time happens to be left in repository after problematic execution -->
+          <exclude name=".ci/jsoref-spellchecker/english.words"/>
+
         </fileset>
       </path>
       <formatter type="plain"/>

--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -109,9 +109,8 @@
           <!-- NonDex files -->
           <exclude name=".nondex/**/*" />
 
-          <!-- temp file of jsoref-spellchecker tool,
-               some time happens to be left in repository after problematic execution -->
-          <exclude name=".ci/jsoref-spellchecker/english.words"/>
+          <!-- Do not validate possible source code remnants after regression testing -->
+          <exclude name=".ci-temp/**/*"/>
 
         </fileset>
       </path>

--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -68,6 +68,7 @@
           <exclude name="src/main/**/*"/>
           <exclude name="src/test/java/**/*"/>
           <exclude name="src/site/resources/images/**/*"/>
+          <exclude name="src/site/resources/styleguides/google-java-style-.*/**/*"/>
 
           <!-- Eclipse project files -->
           <exclude name=".settings/**/*"/>

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -6,9 +6,6 @@
 
 <suppressions>
 
-    <!-- Do not validate possible source code remnants after regression testing -->
-    <suppress checks=".*" files=".ci-temp[\\/]"/>
-
     <!-- styleguides are copied/cached from origin place we should not change them  -->
     <suppress checks=".*"
       files="[\\/]site[\\/]resources[\\/]styleguides[\\/]google\-java\-style-.*"/>


### PR DESCRIPTION
it is not first time I have:
`[checkstyle] [ERROR] ....checkstyle/checkstyle/.ci/jsoref-spellchecker/english.words:1: File does not end with a newline. [NewlineAtEndOfFile]`

```
main:

execute:
     [echo] Checkstyle started (checkstyle_checks.xml): 23/11/2018 06:55:40 AM
[checkstyle] Running Checkstyle  on 1012 files
     [echo] Checkstyle finished (checkstyle_checks.xml) : 23/11/2018 06:55:41 AM
     [echo] Checkstyle started (checkstyle_non_main_files_checks.xml): 23/11/2018 06:55:40 AM
[checkstyle] Running Checkstyle  on 1641 files
[checkstyle] [ERROR] ....checkstyle/checkstyle/.ci/jsoref-spellchecker/english.words:1: File does not end with a newline. [NewlineAtEndOfFile]


```