### PR TITLE
minor: explain that PR-workflow with Travis CI doesn't work

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,10 @@ Rules:
 To avoid multiple iterations of fixes and CIs failures, please read
 https://checkstyle.org/contributing.html
 
-ATTENTION: We are not merging Pull Requests that are not passing our CIs,
-but we will help to resolve issues.
+ATTENTION: We are not merging Pull Requests that are not passing our CIs.
+The CIs are not redundant, but each perform individual tasks. The requirement
+for PRs is to pass them all. Travis CI on your GitHub fork is limited to master
+you need to patch the configuration if you insist on using Travis CI to check
+your PRs. Of course, we will help you to resolve issues.
 
 Thanks for reading, remove whole this message and type what you need.


### PR DESCRIPTION
The current restrictions in the use of Travis CI (see #6119 for details) contradicts the usual PR-based workflow (including forks and the ability to work on your forks) almost any FLOSS project uses. This information should be passed on to the user somehow.

Since that is not what users expect (as opposed to what the devs claim in #6119) and contradicts the design of PR-based workflow (which users are much likely expecting when contributing on a PR-workflow based platform) the information should be passed on at other important location such as https://checkstyle.org/contributing.html.