### PR TITLE
Issue #6241: allow disablement of ClassWithTooManyDependents inspection

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -4431,6 +4431,8 @@
                 <option value="MultipleReturnPointsPerMethod"/>
                 <!-- MT check markers are annotations -->
                 <option value="AnnotationClass"/>
+                <!-- Suppression is only for TokenTypes class -->
+                <option value="ClassWithTooManyDependents"/>
                 <!-- till #4870, used in MT check markers -->
                 <option value="ClassIndependentOfModule"/>
                 <!-- till #4870, used in MT check markers -->


### PR DESCRIPTION
#6241 

it does not work for my local IDEA, if still be an issue on remote, I will open issue on IDEA and disable inspection.

the same problem is with violations like:
```
Modularization issues
Class independent of its module
AllTestsTest.java
Class 'AllTestsTest' has no dependencies or dependents in its module
```