### PR TITLE
Issue #6241: disable ClassIndependentOfModule till IDEA-203424

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -1099,7 +1099,8 @@
     </inspection_tool>
     <inspection_tool class="ClassInDefaultPackage" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
-    <inspection_tool class="ClassIndependentOfModule" enabled="true" level="ERROR"
+    <!-- disabled till https://youtrack.jetbrains.com/issue/IDEA-203424 -->
+    <inspection_tool class="ClassIndependentOfModule" enabled="false" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ClassInheritanceDepth" enabled="true" level="ERROR"
                      enabled_by_default="true">


### PR DESCRIPTION
Issue #6241

reason - https://teamcity.jetbrains.com/viewLog.html?buildId=1798853&tab=Inspection&buildTypeId=Checkstyle_IdeaInspectionsMaster

on merge: do comment at https://youtrack.jetbrains.com/issue/IDEA-203424 that one more inspection is affected, with link to PR. This PR have link to master (see above), in PR status will be link to PR CI results with disablement in action.