### PR TITLE
Issue #6252: Move test inputs with deprecated packages to resources-noncompilable

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrderValid.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrderValid.java
@@ -6,7 +6,6 @@ import static com.puppycrawl.tools.checkstyle.utils.AnnotationUtil.getAnnotation
 import com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck;
 import com.puppycrawl.tools.checkstyle.checks.design.ThrowsCountCheck;
 import com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck;
-import com.sun.accessibility.internal.resources.*;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Map;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
@@ -54,7 +54,7 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
             "23:1: " + getCheckMessage(MSG_KEY, "java.io.File.listRoots"),
             "27:1: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
         };
-        verify(checkConfig, getPath("InputIllegalImportDefault.java"), expected);
+        verify(checkConfig, getNonCompilablePath("InputIllegalImportDefault.java"), expected);
     }
 
     @Test
@@ -66,7 +66,7 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
             "15:1: " + getCheckMessage(MSG_KEY, "sun.applet.*"),
             "28:1: " + getCheckMessage(MSG_KEY, "sun.*"),
         };
-        verify(checkConfig, getPath("InputIllegalImportDefault.java"), expected);
+        verify(checkConfig, getNonCompilablePath("InputIllegalImportDefault.java"), expected);
     }
 
     @Test
@@ -90,7 +90,7 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
             "15:1: " + getCheckMessage(MSG_KEY, "sun.applet.*"),
             "28:1: " + getCheckMessage(MSG_KEY, "sun.*"),
         };
-        verify(checkConfig, getPath("InputIllegalImportDefault.java"), expected);
+        verify(checkConfig, getNonCompilablePath("InputIllegalImportDefault.java"), expected);
     }
 
     @Test
@@ -109,7 +109,7 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
             "35:1: " + getCheckMessage(MSG_KEY, "java.util.Calendar"),
             "36:1: " + getCheckMessage(MSG_KEY, "java.util.BitSet"),
         };
-        verify(checkConfig, getPath("InputIllegalImportDefault.java"), expected);
+        verify(checkConfig, getNonCompilablePath("InputIllegalImportDefault.java"), expected);
     }
 
     @Test
@@ -125,7 +125,7 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
             "13:1: " + getCheckMessage(MSG_KEY, "java.util.List"),
             "17:1: " + getCheckMessage(MSG_KEY, "java.util.Arrays"),
         };
-        verify(checkConfig, getPath("InputIllegalImportDefault.java"), expected);
+        verify(checkConfig, getNonCompilablePath("InputIllegalImportDefault.java"), expected);
     }
 
     @Test
@@ -135,20 +135,22 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
                 createModuleConfig(IllegalImportCheck.class);
         checkConfig.addAttribute("illegalPkgs", "java\\.util");
         checkConfig.addAttribute("illegalClasses",
-                "^com\\.puppycrawl\\.tools\\.checkstyle\\.Checker.*");
+                "^java\\.awt\\..*");
         checkConfig.addAttribute("regexp", "true");
         final String[] expected = {
             "12:1: " + getCheckMessage(MSG_KEY, "java.util.List"),
             "13:1: " + getCheckMessage(MSG_KEY, "java.util.List"),
             "16:1: " + getCheckMessage(MSG_KEY, "java.util.Enumeration"),
             "17:1: " + getCheckMessage(MSG_KEY, "java.util.Arrays"),
+            "30:1: " + getCheckMessage(MSG_KEY, "java.awt.Component"),
+            "31:1: " + getCheckMessage(MSG_KEY, "java.awt.Graphics2D"),
+            "32:1: " + getCheckMessage(MSG_KEY, "java.awt.HeadlessException"),
+            "33:1: " + getCheckMessage(MSG_KEY, "java.awt.Label"),
             "34:1: " + getCheckMessage(MSG_KEY, "java.util.Date"),
             "35:1: " + getCheckMessage(MSG_KEY, "java.util.Calendar"),
             "36:1: " + getCheckMessage(MSG_KEY, "java.util.BitSet"),
-            "38:1: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.Checker"),
-            "39:1: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.CheckerTest"),
         };
-        verify(checkConfig, getPath("InputIllegalImportDefault.java"), expected);
+        verify(checkConfig, getNonCompilablePath("InputIllegalImportDefault.java"), expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -402,11 +402,11 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
             createModuleConfig(JavadocTypeCheck.class);
 
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "6: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "10: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verify(checkConfig,
-            getPath("InputJavadocTypeAllowedAnnotations.java"),
+            getNonCompilablePath("InputJavadocTypeAllowedAnnotations.java"),
             expected);
     }
 
@@ -419,12 +419,12 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype.ThisIsOk");
 
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "13: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "6: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "10: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verify(checkConfig,
-                getPath("InputJavadocTypeAllowedAnnotations.java"),
+                getNonCompilablePath("InputJavadocTypeAllowedAnnotations.java"),
                 expected);
     }
 
@@ -436,7 +436,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig,
-            getPath("InputJavadocTypeAllowedAnnotations.java"),
+            getNonCompilablePath("InputJavadocTypeAllowedAnnotations.java"),
             expected);
     }
 
@@ -447,12 +447,12 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("allowedAnnotations", "Override");
 
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "13: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "6: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "10: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verify(checkConfig,
-            getPath("InputJavadocTypeAllowedAnnotations.java"),
+            getNonCompilablePath("InputJavadocTypeAllowedAnnotations.java"),
             expected);
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault.java
@@ -1,7 +1,7 @@
-////////////////////////////////////////////////////////////////////////////////
-// Test case file for checkstyle.
-// Created: 2001
-////////////////////////////////////////////////////////////////////////////////
+//non-compiled with jdk10: contains dropped packages
+
+
+
 package com.puppycrawl.tools.checkstyle.checks.imports.illegalimport;
 
 import com.puppycrawl.tools.checkstyle.checks.imports.*;
@@ -34,14 +34,6 @@ import java.awt.Label;
 import java.util.Date;
 import java.util.Calendar;
 import java.util.BitSet;
-
-import com.puppycrawl.tools.checkstyle.Checker;
-import com.puppycrawl.tools.checkstyle.CheckerTest;
-import com.puppycrawl.tools.checkstyle.Definitions;
-import com.puppycrawl.tools.checkstyle.ConfigurationLoaderTest;
-import com.puppycrawl.tools.checkstyle.PackageNamesLoader;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.DefaultLogger;
 
 /**
  * Test case for imports

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeAllowedAnnotations.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeAllowedAnnotations.java
@@ -1,3 +1,4 @@
+//non-compiled with jkd11: contains dropped packages
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
 import javax.annotation.Generated;


### PR DESCRIPTION
Issue #6252 

Part of #6228 

from the test input `/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrderValid.java` one line was removed:
`import com.sun.accessibility.internal.resources.*;`
The line is not important and can be removed without any effect.
