### PR TITLE
config: expanded pitest mutators to defaults

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -846,6 +846,7 @@ nbsp
 ncss
 ndex
 needbraces
+NEGS
 Nejmeh
 NEQ
 nestedfordepth

--- a/pom.xml
+++ b/pom.xml
@@ -1784,6 +1784,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck*</param>
                 <param>
@@ -1844,6 +1853,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.annotation.*</param>
               </targetClasses>
@@ -1876,6 +1894,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.blocks.*</param>
               </targetClasses>
@@ -1908,6 +1935,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.coding.*</param>
               </targetClasses>
@@ -1940,6 +1976,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.design.*</param>
               </targetClasses>
@@ -1972,6 +2017,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.header.*</param>
               </targetClasses>
@@ -2004,6 +2058,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.imports.*</param>
               </targetClasses>
@@ -2036,6 +2099,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.indentation.*</param>
               </targetClasses>
@@ -2068,6 +2140,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.javadoc.*</param>
               </targetClasses>
@@ -2100,6 +2181,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.metrics.*</param>
               </targetClasses>
@@ -2132,6 +2222,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.modifier.*</param>
               </targetClasses>
@@ -2164,6 +2263,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.naming.*</param>
               </targetClasses>
@@ -2202,6 +2310,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.regexp.*</param>
               </targetClasses>
@@ -2234,6 +2351,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.sizes.*</param>
               </targetClasses>
@@ -2266,6 +2392,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.whitespace.*</param>
               </targetClasses>
@@ -2299,6 +2434,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.ant.*</param>
               </targetClasses>
@@ -2331,6 +2475,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.PackageNamesLoader*</param>
               </targetClasses>
@@ -2360,6 +2513,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatter*</param>
                 <param>com.puppycrawl.tools.checkstyle.ConfigurationLoader*</param>
@@ -2419,6 +2581,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.JavadocPropertiesGenerator*</param>
                 <param>com.puppycrawl.tools.checkstyle.XmlLoader*</param>
@@ -2465,6 +2636,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.Main*</param>
               </targetClasses>
@@ -2494,6 +2674,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser*</param>
                 <param>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter*</param>
@@ -2572,6 +2761,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.api.*</param>
               </targetClasses>
@@ -2617,6 +2815,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.filefilters.*</param>
                 <param>com.puppycrawl.tools.checkstyle.filters.*</param>
@@ -2651,6 +2858,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.utils.*</param>
               </targetClasses>
@@ -2701,6 +2917,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.gui.*</param>
               </targetClasses>
@@ -2758,6 +2983,15 @@
             <artifactId>pitest-maven</artifactId>
             <version>${pitest.plugin.version}</version>
             <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.xpath.*</param>
                 <param>com.puppycrawl.tools.checkstyle.XpathFileGeneratorAuditListener*</param>


### PR DESCRIPTION
This is in support of https://github.com/checkstyle/checkstyle/issues/6264 .

Defaults are not added by default when you start adding new mutators. Just adding the new one without the defaults results in only the new mutator running. This is what I used to generate the report in the first post of the issue.