### PR TITLE
config: remove coverage/mutation threshold because pitest rounding issue

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -37,21 +37,26 @@ pitest-annotation|pitest-design|pitest-header|pitest-imports \
 |pitest-api|pitest-common|pitest-filters|pitest-main \
 |pitest-packagenamesloader|pitest-tree-walker|pitest-utils \
 |pitest-xpath|pitest-common-2)
-  mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
+  (mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;)
+  EXIT_CODE=$?
   declare -a ignoredItems=();
   checkPitestReport "${ignoredItems[@]}"
+  exit $EXIT_CODE
   ;;
 
 pitest-misc)
-  mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
+  (mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;)
+  EXIT_CODE=$?
   declare -a ignoredItems=(
   "SuppressWarningsHolder.java.html:<td class='covered'><pre><span  class='survived'>                        lastColumn = nextAST.getColumnNo() - 1;</span></pre></td></tr>"
   );
   checkPitestReport "${ignoredItems[@]}"
+  exit $EXIT_CODE
   ;;
 
 pitest-blocks)
-  mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
+  (mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;)
+  EXIT_CODE=$?
   declare -a ignoredItems=(
   "LeftCurlyCheck.java.html:<td class='covered'><pre><span  class='survived'>               &#38;&#38; annotation.getNextSibling().getType() == TokenTypes.ANNOTATION) {</span></pre></td></tr>"
   "LeftCurlyCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; previousAnnotation.getPreviousSibling().getLineNo()</span></pre></td></tr>"
@@ -60,10 +65,12 @@ pitest-blocks)
   "LeftCurlyCheck.java.html:<td class='covered'><pre><span  class='survived'>        while (previousAnnotation.getPreviousSibling() != null</span></pre></td></tr>"
   );
   checkPitestReport "${ignoredItems[@]}"
+  exit $EXIT_CODE
   ;;
 
 pitest-coding)
-  mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
+  (mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;)
+  EXIT_CODE=$?
   declare -a ignoredItems=(
   "EqualsAvoidNullCheck.java.html:<td class='covered'><pre><span  class='survived'>                    &#38;&#38; field.getColumnNo() + minimumSymbolsBetween &#60;= objCalledOn.getColumnNo()) {</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>            processVariable(ast);</span></pre></td></tr>"
@@ -86,10 +93,12 @@ pitest-coding)
   "VariableDeclarationUsageDistanceCheck.java.html:<td class='covered'><pre><span  class='survived'>        while (currentNode != null</span></pre></td></tr>"
   );
   checkPitestReport "${ignoredItems[@]}"
+  exit $EXIT_CODE
   ;;
 
 pitest-indentation)
-  mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
+  (mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;)
+  EXIT_CODE=$?
   declare -a ignoredItems=(
   "AbstractExpressionHandler.java.html:<td class='covered'><pre><span  class='survived'>            if (colNum == null || thisLineColumn &#60; colNum) {</span></pre></td></tr>"
   "AbstractExpressionHandler.java.html:<td class='covered'><pre><span  class='survived'>        if (currLine &#60; realStart) {</span></pre></td></tr>"
@@ -131,10 +140,12 @@ pitest-indentation)
   "TryHandler.java.html:<td class='covered'><pre><span  class='survived'>            checkTryResParen(getTryResLparen(), &#34;lparen&#34;);</span></pre></td></tr>"
   );
   checkPitestReport "${ignoredItems[@]}"
+  exit $EXIT_CODE
   ;;
 
 pitest-javadoc)
-  mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
+  (mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;)
+  EXIT_CODE=$?
   declare -a ignoredItems=(
   "AbstractJavadocCheck.java.html:<td class='covered'><pre><span  class='survived'>            Arrays.sort(acceptableJavadocTokens);</span></pre></td></tr>"
   "AbstractJavadocCheck.java.html:<td class='covered'><pre><span  class='survived'>            Arrays.sort(defaultJavadocTokens);</span></pre></td></tr>"
@@ -174,6 +185,7 @@ pitest-javadoc)
   "WriteTagCheck.java.html:<td class='covered'><pre><span  class='survived'>                    tagCount += 1;</span></pre></td></tr>"
   );
   checkPitestReport "${ignoredItems[@]}"
+  exit $EXIT_CODE
   ;;
 
 # pitesttyle-gui)


### PR DESCRIPTION
Discussed at https://github.com/checkstyle/checkstyle/issues/4684#issuecomment-445939995 ,

Coverage/Mutation removed.
Default values are 0 for both.
See https://github.com/hcoles/pitest/blob/333c3215643b578c37c5925a3ed9aa75147b0b73/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java#L259 and https://github.com/hcoles/pitest/blob/333c3215643b578c37c5925a3ed9aa75147b0b73/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java#L247 .
When thresholds are 0, no check occurs.
See https://github.com/hcoles/pitest/blob/333c3215643b578c37c5925a3ed9aa75147b0b73/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java#L430-L431 and https://github.com/hcoles/pitest/blob/333c3215643b578c37c5925a3ed9aa75147b0b73/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java#L442 .