### PR TITLE
Issue #5750: aligned javadoc/xdoc for (Custom)ImportOrder 

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -38,62 +38,49 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * by the user. If there is an import but its group is not specified in the
  * configuration such an import should be placed at the end of the import list.
  * </p>
+ * <p>
  * The rule consists of:
- *
- * <p>
- * 1. STATIC group. This group sets the ordering of static imports.
  * </p>
- *
- * <p>
- * 2. SAME_PACKAGE(n) group. This group sets the ordering of the same package imports.
- * Imports are considered on SAME_PACKAGE group if <b>n</b> first domains in package name
- * and import name are identical.
- * </p>
- *
+ * <ol>
+ * <li>
+ * STATIC group. This group sets the ordering of static imports.
+ * </li>
+ * <li>
+ * SAME_PACKAGE(n) group. This group sets the ordering of the same package imports.
+ * Imports are considered on SAME_PACKAGE group if <b>n</b> first domains in package
+ * name and import name are identical:
  * <pre>
- *{@code
- *package java.util.concurrent.locks;
+ * package java.util.concurrent.locks;
  *
- *import java.io.File;
- *import java.util.*; //#1
- *import java.util.List; //#2
- *import java.util.StringTokenizer; //#3
- *import java.util.concurrent.*; //#4
- *import java.util.concurrent.AbstractExecutorService; //#5
- *import java.util.concurrent.locks.LockSupport; //#6
- *import java.util.regex.Pattern; //#7
- *import java.util.regex.Matcher; //#8
- *}
+ * import java.io.File;
+ * import java.util.*; //#1
+ * import java.util.List; //#2
+ * import java.util.StringTokenizer; //#3
+ * import java.util.concurrent.*; //#4
+ * import java.util.concurrent.AbstractExecutorService; //#5
+ * import java.util.concurrent.locks.LockSupport; //#6
+ * import java.util.regex.Pattern; //#7
+ * import java.util.regex.Matcher; //#8
  * </pre>
- *
- * <p>
- * If we have SAME_PACKAGE(3) on configuration file,
- * imports #4-6 will be considered as a SAME_PACKAGE group (java.util.concurrent.*,
- * java.util.concurrent.AbstractExecutorService, java.util.concurrent.locks.LockSupport).
- * SAME_PACKAGE(2) will include #1-8. SAME_PACKAGE(4) will include only #6.
- * SAME_PACKAGE(5) will result in no imports assigned to SAME_PACKAGE group because
- * actual package java.util.concurrent.locks has only 4 domains.
- * </p>
- *
- * <p>
- * 3. THIRD_PARTY_PACKAGE group. This group sets ordering of third party imports.
- * Third party imports are all imports except STATIC,
- * SAME_PACKAGE(n), STANDARD_JAVA_PACKAGE and SPECIAL_IMPORTS.
- * </p>
- *
- * <p>
- * 4. STANDARD_JAVA_PACKAGE group. By default this group sets ordering of standard java/javax
- * imports.
- * </p>
- *
- * <p>
- * 5. SPECIAL_IMPORTS group. This group may contains some imports
- * that have particular meaning for the user.
- * </p>
- *
- * <p>
- * NOTE!
- * </p>
+ * If we have SAME_PACKAGE(3) on configuration file, imports #4-6 will be considered as
+ * a SAME_PACKAGE group (java.util.concurrent.*, java.util.concurrent.AbstractExecutorService,
+ * java.util.concurrent.locks.LockSupport). SAME_PACKAGE(2) will include #1-8.
+ * SAME_PACKAGE(4) will include only #6. SAME_PACKAGE(5) will result in no imports assigned
+ * to SAME_PACKAGE group because actual package java.util.concurrent.locks has only 4 domains.
+ * </li>
+ * <li>
+ * THIRD_PARTY_PACKAGE group. This group sets ordering of third party imports.
+ * Third party imports are all imports except STATIC, SAME_PACKAGE(n), STANDARD_JAVA_PACKAGE and
+ * SPECIAL_IMPORTS.
+ * </li>
+ * <li>
+ * STANDARD_JAVA_PACKAGE group. By default this group sets ordering of standard java/javax imports.
+ * </li>
+ * <li>
+ * SPECIAL_IMPORTS group. This group may contains some imports that have particular meaning for the
+ * user.
+ * </li>
+ * </ol>
  * <p>
  * Use the separator '###' between rules.
  * </p>
@@ -108,146 +95,208 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </p>
  * <ol>
  * <li>
- *    STATIC has top priority
+ * STATIC has top priority
  * </li>
  * <li>
- *    SAME_PACKAGE has second priority
+ * SAME_PACKAGE has second priority
  * </li>
  * <li>
- *    STANDARD_JAVA_PACKAGE and SPECIAL_IMPORTS will compete using "best match" rule: longer
- *    matching substring wins; in case of the same length, lower position of matching substring
- *    wins; if position is the same, order of rules in configuration solves the puzzle.
+ * STANDARD_JAVA_PACKAGE and SPECIAL_IMPORTS will compete using "best match" rule: longer
+ * matching substring wins; in case of the same length, lower position of matching substring
+ * wins; if position is the same, order of rules in configuration solves the puzzle.
  * </li>
  * <li>
- *    THIRD_PARTY has the least priority
+ * THIRD_PARTY has the least priority
  * </li>
  * </ol>
  * <p>
- *    Few examples to illustrate "best match":
+ * Few examples to illustrate "best match":
  * </p>
  * <p>
- *    1. patterns STANDARD_JAVA_PACKAGE = "Check", SPECIAL_IMPORTS="ImportOrderCheck" and input
- *    file:
+ * 1. patterns STANDARD_JAVA_PACKAGE = "Check", SPECIAL_IMPORTS="ImportOrderCheck" and input file:
  * </p>
  * <pre>
- *{@code
- *import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
- *import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;}
+ * import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+ * import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
  * </pre>
  * <p>
- *    Result: imports will be assigned to SPECIAL_IMPORTS, because matching substring length is 16.
- *    Matching substring for STANDARD_JAVA_PACKAGE is 5.
+ * Result: imports will be assigned to SPECIAL_IMPORTS, because matching substring length is 16.
+ * Matching substring for STANDARD_JAVA_PACKAGE is 5.
  * </p>
  * <p>
- *    2. patterns STANDARD_JAVA_PACKAGE = "Check", SPECIAL_IMPORTS="Avoid" and file:
+ * 2. patterns STANDARD_JAVA_PACKAGE = "Check", SPECIAL_IMPORTS="Avoid" and file:
  * </p>
  * <pre>
- *{@code
- *import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;}
+ * import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
  * </pre>
  * <p>
- *   Result: import will be assigned to SPECIAL_IMPORTS. Matching substring length is 5 for both
- *   patterns. However, "Avoid" position is lower then "Check" position.
+ * Result: import will be assigned to SPECIAL_IMPORTS. Matching substring length is 5 for both
+ * patterns. However, "Avoid" position is lower then "Check" position.
  * </p>
- *
- * <pre>
- *    Properties:
- * </pre>
- * <table summary="Properties" border="1">
- *     <tr><th>name</th><th>Description</th><th>type</th><th>default value</th></tr>
- *      <tr><td>customImportOrderRules</td><td>List of order declaration customizing by user.</td>
- *          <td>string</td><td>null</td></tr>
- *      <tr><td>standardPackageRegExp</td><td>RegExp for STANDARD_JAVA_PACKAGE group imports.</td>
- *          <td>regular expression</td><td>^(java|javax)\.</td></tr>
- *      <tr><td>thirdPartyPackageRegExp</td><td>RegExp for THIRD_PARTY_PACKAGE group imports.</td>
- *          <td>regular expression</td><td>.*</td></tr>
- *      <tr><td>specialImportsRegExp</td><td>RegExp for SPECIAL_IMPORTS group imports.</td>
- *          <td>regular expression</td><td>^$</td></tr>
- *      <tr><td>separateLineBetweenGroups</td><td>Force empty line separator between import groups.
- *          </td><td>boolean</td><td>true</td></tr>
- *      <tr><td>sortImportsInGroupAlphabetically</td><td>Force grouping alphabetically,
- *          in ASCII sort order.</td><td>boolean</td><td>false</td></tr>
- * </table>
- *
+ * <ul>
+ * <li>
+ * Property {@code customImportOrderRules} - Specify list of order declaration customizing by user.
+ * Default value is {@code {}}.
+ * </li>
+ * <li>
+ * Property {@code standardPackageRegExp} - Specify RegExp for STANDARD_JAVA_PACKAGE group imports.
+ * Default value is {@code "^(java|javax)\."}.
+ * </li>
+ * <li>
+ * Property {@code thirdPartyPackageRegExp} - Specify RegExp for THIRD_PARTY_PACKAGE group imports.
+ * Default value is {@code ".*"}.
+ * </li>
+ * <li>
+ * Property {@code specialImportsRegExp} - Specify RegExp for SPECIAL_IMPORTS group imports.
+ * Default value is {@code "^$" (empty)}.
+ * </li>
+ * <li>
+ * Property {@code separateLineBetweenGroups} - Force empty line separator between
+ * import groups.
+ * Default value is {@code true}.
+ * </li>
+ * <li>
+ * Property {@code sortImportsInGroupAlphabetically} - Force grouping alphabetically,
+ * in <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>.
+ * Default value is {@code false}.
+ * </li>
+ * </ul>
  * <p>
- * For example:
+ * To configure the check so that it matches default Eclipse formatter configuration
+ * (tested on Kepler and Luna releases):
  * </p>
- *        <p>To configure the check so that it matches default Eclipse formatter configuration
- *        (tested on Kepler, Luna and Mars):</p>
- *        <ul>
- *          <li>group of static imports is on the top</li>
- *          <li>groups of non-static imports: &quot;java&quot; and &quot;javax&quot; packages
- *          first, then &quot;org&quot; and then all other imports</li>
- *          <li>imports will be sorted in the groups</li>
- *          <li>groups are separated by, at least, one blank line</li>
- *        </ul>
+ * <ul>
+ * <li>
+ * group of static imports is on the top
+ * </li>
+ * <li>
+ * groups of non-static imports: "java" and "javax" packages first, then "org" and then all other
+ * imports
+ * </li>
+ * <li>
+ * imports will be sorted in the groups
+ * </li>
+ * <li>
+ * groups are separated by single blank line
+ * </li>
+ * </ul>
+ * <p>
+ * Notes:
+ * </p>
+ * <ul>
+ * <li>
+ * "com" package is not mentioned on configuration, because it is ignored by Eclipse Kepler and Luna
+ * (looks like Eclipse defect)
+ * </li>
+ * <li>
+ * configuration below doesn't work in all 100% cases due to inconsistent behavior prior to Mars
+ * release, but covers most scenarios
+ * </li>
+ * </ul>
  * <pre>
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
- *    &lt;property name=&quot;customImportOrderRules&quot;
- *        value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS&quot;/&gt;
- *    &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;org&quot;/&gt;
- *    &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
- *    &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;customImportOrderRules&quot;
+ *     value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS&quot;/&gt;
+ *   &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^org\.&quot;/&gt;
+ *   &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
- *
- *        <p>To configure the check so that it matches default IntelliJ IDEA formatter
- *        configuration (tested on v14):</p>
- *        <ul>
- *          <li>group of static imports is on the bottom</li>
- *          <li>groups of non-static imports: all imports except of &quot;javax&quot;
- *          and &quot;java&quot;, then &quot;javax&quot; and &quot;java&quot;</li>
- *          <li>imports will be sorted in the groups</li>
- *          <li>groups are separated by, at least, one blank line</li>
- *        </ul>
- *
- *        <p>
- *        Note: &quot;separated&quot; option is disabled because IDEA default has blank line
- *        between &quot;java&quot; and static imports, and no blank line between
- *        &quot;javax&quot; and &quot;java&quot;
- *        </p>
- *
- * <pre>
- * &lt;module name=&quot;CustomImportOrder&quot;&gt;
- *    &lt;property name=&quot;customImportOrderRules&quot;
- *        value=&quot;THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE
- *        ###STATIC&quot;/&gt;
- *    &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^javax\.&quot;/&gt;
- *    &lt;property name=&quot;standardPackageRegExp&quot; value=&quot;^java\.&quot;/&gt;
- *    &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
- *    &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;false&quot;/&gt;
- *&lt;/module&gt;
- * </pre>
- *
- * <p>To configure the check so that it matches default NetBeans formatter
- *    configuration (tested on v8):</p>
+ * <p>
+ * To configure the check so that it matches default Eclipse formatter configuration
+ * (tested on Mars release):
+ * </p>
  * <ul>
- *     <li>groups of non-static imports are not defined, all imports will be sorted as a one
- *         group</li>
- *     <li>static imports are not separated, they will be sorted along with other imports</li>
+ * <li>
+ * group of static imports is on the top
+ * </li>
+ * <li>
+ * groups of non-static imports: "java" and "javax" packages first, then "org" and "com",
+ * then all other imports as one group
+ * </li>
+ * <li>
+ * imports will be sorted in the groups
+ * </li>
+ * <li>
+ * groups are separated by, at least, one blank line
+ * </li>
  * </ul>
- *
- * <pre>
- *&lt;module name=&quot;CustomImportOrder&quot;/&gt;
- * </pre>
- * <p>To set RegExps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
- *         thirdPartyPackageRegExp and standardPackageRegExp options.</p>
  * <pre>
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
- *    &lt;property name=&quot;customImportOrderRules&quot;
- *    value=&quot;STATIC###SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE&quot;/&gt;
- *    &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;com|org&quot;/&gt;
- *    &lt;property name=&quot;standardPackageRegExp&quot; value=&quot;^(java|javax)\.&quot;/&gt;
+ *   &lt;property name=&quot;customImportOrderRules&quot;
+ *     value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE&quot;/&gt;
+ *   &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^org\.&quot;/&gt;
+ *   &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^com\.&quot;/&gt;
+ *   &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * To configure the check so that it matches default IntelliJ IDEA formatter configuration
+ * (tested on v14):
+ * </p>
+ * <ul>
+ * <li>
+ * group of static imports is on the bottom
+ * </li>
+ * <li>
+ * groups of non-static imports: all imports except of "javax" and "java", then "javax" and "java"
+ * </li>
+ * <li>
+ * imports will be sorted in the groups
+ * </li>
+ * <li>
+ * groups are separated by, at least, one blank line
+ * </li>
+ * </ul>
+ * <p>
+ * Note: "separated" option is disabled because IDEA default has blank line between "java" and
+ * static imports, and no blank line between "javax" and "java"
+ * </p>
+ * <pre>
+ * &lt;module name="CustomImportOrder"&gt;
+ *   &lt;property name="customImportOrderRules"
+ *     value="THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE###STATIC"/&gt;
+ *   &lt;property name="specialImportsRegExp" value="^javax\."/&gt;
+ *   &lt;property name="standardPackageRegExp" value="^java\."/&gt;
+ *   &lt;property name="sortImportsInGroupAlphabetically" value="true"/&gt;
+ *   &lt;property name="separateLineBetweenGroups" value="false"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * To configure the check so that it matches default NetBeans formatter configuration
+ * (tested on v8):
+ * </p>
+ * <ul>
+ * <li>
+ * groups of non-static imports are not defined, all imports will be sorted as a one group
+ * </li>
+ * <li>
+ * static imports are not separated, they will be sorted along with other imports
+ * </li>
+ * </ul>
+ * <pre>
+ * &lt;module name=&quot;CustomImportOrder&quot;/&gt;
+ * </pre>
+ * <p>
+ * To set RegExps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
+ * thirdPartyPackageRegExp and standardPackageRegExp options.
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;CustomImportOrder&quot;&gt;
+ *   &lt;property name=&quot;customImportOrderRules&quot;
+ *     value=&quot;STATIC###SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE&quot;/&gt;
+ *   &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^(com|org)\.&quot;/&gt;
+ *   &lt;property name=&quot;standardPackageRegExp&quot; value=&quot;^(java|javax)\.&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>
  * Also, this check can be configured to force empty line separator between
- * import groups. For example
+ * import groups. For example.
  * </p>
- *
  * <pre>
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
- *    &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>
@@ -257,26 +306,23 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </p>
  * <pre>
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
- *    &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>
  * Example of ASCII order:
  * </p>
  * <pre>
- * {@code
- *import java.awt.Dialog;
- *import java.awt.Window;
- *import java.awt.color.ColorSpace;
- *import java.awt.Frame; // violation here - in ASCII order 'F' should go before 'c',
- *                       // as all uppercase come before lowercase letters}
+ * import java.awt.Dialog;
+ * import java.awt.Window;
+ * import java.awt.color.ColorSpace;
+ * import java.awt.Frame; // violation here - in ASCII order 'F' should go before 'c',
+ *                        // as all uppercase come before lowercase letters
  * </pre>
  * <p>
  * To force checking imports sequence such as:
  * </p>
- *
  * <pre>
- * {@code
  * package com.puppycrawl.tools.checkstyle.imports;
  *
  * import com.google.common.annotations.GwtCompatible;
@@ -289,17 +335,20 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *
  * import com.google.common.annotations.GwtCompatible; // violation here - should be in the
  *                                                     // THIRD_PARTY_PACKAGE group
- * import android.*;}
+ * import android.*;
  * </pre>
+ * <p>
  * configure as follows:
+ * </p>
  * <pre>
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
- *    &lt;property name=&quot;customImportOrderRules&quot;
- *    value=&quot;SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STATIC###SPECIAL_IMPORTS&quot;/&gt;
- *    &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;android.*&quot;/&gt;
+ *   &lt;property name=&quot;customImportOrderRules&quot;
+ *     value=&quot;SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STATIC###SPECIAL_IMPORTS&quot;/&gt;
+ *   &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^android\.&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
  *
+ * @since 5.8
  */
 @FileStatefulCheck
 public class CustomImportOrderCheck extends AbstractCheck {
@@ -355,35 +404,38 @@ public class CustomImportOrderCheck extends AbstractCheck {
     /** Pattern used to separate groups of imports. */
     private static final Pattern GROUP_SEPARATOR_PATTERN = Pattern.compile("\\s*###\\s*");
 
-    /** List of order declaration customizing by user. */
+    /** Specify list of order declaration customizing by user. */
     private final List<String> customImportOrderRules = new ArrayList<>();
 
     /** Contains objects with import attributes. */
     private final List<ImportDetails> importToGroupList = new ArrayList<>();
 
-    /** RegExp for SAME_PACKAGE group imports. */
+    /** Specify RegExp for SAME_PACKAGE group imports. */
     private String samePackageDomainsRegExp = "";
 
-    /** RegExp for STANDARD_JAVA_PACKAGE group imports. */
+    /** Specify RegExp for STANDARD_JAVA_PACKAGE group imports. */
     private Pattern standardPackageRegExp = Pattern.compile("^(java|javax)\\.");
 
-    /** RegExp for THIRD_PARTY_PACKAGE group imports. */
+    /** Specify RegExp for THIRD_PARTY_PACKAGE group imports. */
     private Pattern thirdPartyPackageRegExp = Pattern.compile(".*");
 
-    /** RegExp for SPECIAL_IMPORTS group imports. */
+    /** Specify RegExp for SPECIAL_IMPORTS group imports. */
     private Pattern specialImportsRegExp = Pattern.compile("^$");
 
     /** Force empty line separator between import groups. */
     private boolean separateLineBetweenGroups = true;
 
-    /** Force grouping alphabetically, in ASCII order. */
+    /**
+     * Force grouping alphabetically,
+     * in <a href="https://en.wikipedia.org/wiki/ASCII#Order"> ASCII sort order</a>.
+     */
     private boolean sortImportsInGroupAlphabetically;
 
     /** Number of first domains for SAME_PACKAGE group. */
     private int samePackageMatchingDepth = 2;
 
     /**
-     * Sets standardRegExp specified by user.
+     * Setter to specify RegExp for STANDARD_JAVA_PACKAGE group imports.
      * @param regexp
      *        user value.
      */
@@ -392,7 +444,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
     }
 
     /**
-     * Sets thirdPartyRegExp specified by user.
+     * Setter to specify RegExp for THIRD_PARTY_PACKAGE group imports.
      * @param regexp
      *        user value.
      */
@@ -401,7 +453,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
     }
 
     /**
-     * Sets specialImportsRegExp specified by user.
+     * Setter to specify RegExp for SPECIAL_IMPORTS group imports.
      * @param regexp
      *        user value.
      */
@@ -410,7 +462,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
     }
 
     /**
-     * Sets separateLineBetweenGroups specified by user.
+     * Setter to force empty line separator between import groups.
      * @param value
      *        user value.
      */
@@ -419,7 +471,8 @@ public class CustomImportOrderCheck extends AbstractCheck {
     }
 
     /**
-     * Sets sortImportsInGroupAlphabetically specified by user.
+     * Setter to force grouping alphabetically, in
+     * <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>.
      * @param value
      *        user value.
      */
@@ -428,8 +481,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
     }
 
     /**
-     * Sets a custom import order from the rules in the string format specified
-     * by user.
+     * Setter to specify list of order declaration customizing by user.
      * @param inputCustomImportOrder
      *        user value.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -31,163 +31,342 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
+ * <p>
  * Checks the ordering/grouping of imports. Features are:
- * <ul>
- * <li>groups imports: ensures that groups of imports come in a specific order
- * (e.g., java. comes first, javax. comes second, then everything else)</li>
- * <li>adds a separation between groups : ensures that a blank line sit between
- * each group</li>
- * <li>import groups aren't separated internally: ensures that
- * each group aren't separated internally by blank line or comment</li>
- * <li>sorts imports inside each group: ensures that imports within each group
- * are in lexicographic order</li>
- * <li>sorts according to case: ensures that the comparison between import is
- * case sensitive</li>
- * <li>groups static imports: ensures that static imports are at the top (or the
- * bottom) of all the imports, or above (or under) each group, or are treated
- * like non static imports (@see {@link ImportOrderOption}</li>
- * </ul>.
- *
- * <pre>
- * Properties:
- * </pre>
- * <table summary="Properties" border="1">
- *   <tr><th>name</th><th>Description</th><th>type</th><th>default value</th></tr>
- *   <tr><td>option</td><td>policy on the relative order between regular imports and static
- *       imports</td><td>{@link ImportOrderOption}</td><td>under</td></tr>
- *   <tr><td>groups</td><td>list of type import groups (every group identified either by a
- *       common prefix string, or by a regular expression enclosed in forward slashes
- *       (e.g. /regexp/). All type imports, which does not match any group,
- *       falls into an additional group, located at the end. Thus, the empty list of type groups
- *       (the default value) means one group for all type imports</td>
- *       <td>list of strings</td><td>empty list</td></tr>
- *   <tr><td>ordered</td><td>whether type imports within group should be sorted</td>
- *       <td>Boolean</td><td>true</td></tr>
- *   <tr><td>separated</td><td>whether type imports groups should be separated by, at least,
- *       one blank line or comment and aren't separated internally
- *       </td><td>Boolean</td><td>false</td></tr>
- *   <tr><td>separatedStaticGroups</td><td>whether static imports should be separated by, at least,
- *       one blank line or comment and aren't separated internally
- *       </td><td>Boolean</td><td>false</td></tr>
- *   <tr><td>caseSensitive</td><td>whether string comparison should be case sensitive or not.
- *       Case sensitive sorting is in ASCII sort order</td><td>Boolean</td><td>true</td></tr>
- *   <tr><td>staticGroups</td><td>list of static import groups (every group identified either by a
- *       common prefix string, or by a regular expression enclosed in forward slashes
- *       (e.g. /regexp/). All static imports, which does not match any group,
- *       falls into an additional group, located at the end. Thus, the empty list of static groups
- *       (the default value) means one group for all static imports</td>
- *       <td>list of strings</td><td>empty list</td></tr>
- *   <tr><td>sortStaticImportsAlphabetically</td><td>whether static imports located at top or
- *       bottom are sorted within the group.</td><td>Boolean</td><td>false</td></tr>
- *   <tr><td>useContainerOrderingForStatic</td><td>whether to use container ordering
- *       (Eclipse IDE term) for static imports or not</td><td>Boolean</td><td>false</td></tr>
- * </table>
- *
- * <p>
- * Example:
  * </p>
- * <p>To configure the check so that it matches default Eclipse formatter configuration
- *    (tested on Kepler, Luna and Mars):</p>
  * <ul>
- *     <li>group of static imports is on the top</li>
- *     <li>groups of non-static imports: &quot;java&quot; then &quot;javax&quot;
- *         packages first, then &quot;org&quot; and then all other imports</li>
- *     <li>imports will be sorted in the groups</li>
- *     <li>groups are separated by, at least, one blank line and aren't separated internally</li>
+ * <li>
+ * groups type/static imports: ensures that groups of imports come in a specific order
+ * (e.g., java. comes first, javax. comes second, then everything else)
+ * </li>
+ * <li>
+ * adds a separation between type import groups : ensures that a blank line sit between each group
+ * </li>
+ * <li>
+ * type/static import groups aren't separated internally: ensures that each group aren't separated
+ * internally by blank line or comment
+ * </li>
+ * <li>
+ * sorts type/static imports inside each group: ensures that imports within each group are in
+ * lexicographic order
+ * </li>
+ * <li>
+ * sorts according to case: ensures that the comparison between imports is case sensitive, in
+ * <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>
+ * </li>
+ * <li>
+ * arrange static imports: ensures the relative order between type imports and static imports
+ * (see <a href="property_types.html#importOrder">import orders</a>)
+ * </li>
  * </ul>
- *
+ * <ul>
+ * <li>
+ * Property {@code option} - specify policy on the relative order between type imports and static
+ * imports.
+ * Default value is {@code under}.
+ * </li>
+ * <li>
+ * Property {@code groups} - specify list of <b>type import</b> groups (every group identified
+ * either by a common prefix string, or by a regular expression enclosed in forward slashes
+ * (e.g.{@code /regexp/}). All type imports, which does not match any group, falls into an
+ * additional group, located at the end.
+ * Thus, the empty list of type groups (the default value) means one group for all type imports.
+ * Default value is {@code {}}.
+ * </li>
+ * <li>
+ * Property {@code ordered} - control whether type imports within each group should be
+ * sorted.
+ * It doesn't affect sorting for static imports.
+ * Default value is true.
+ * </li>
+ * <li>
+ * Property {@code separated} - control whether type import groups should be separated
+ * by, at least, one blank line or comment and aren't separated internally.
+ * It doesn't affect separations for static imports.
+ * Default value is false.
+ * </li>
+ * <li>
+ * Property {@code separatedStaticGroups} - control whether static import groups should
+ * be separated by, at least, one blank line or comment and aren't separated internally.
+ * This property has effect only when the property {@code option} is is set to {@code top}
+ * or {@code bottom}.
+ * Default value is false.
+ * </li>
+ * <li>
+ * Property {@code caseSensitive} - control whether string comparison should be case
+ * sensitive or not. Case sensitive sorting is in
+ * <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>.
+ * It affects both type imports and static imports.
+ * Default value is true.
+ * </li>
+ * <li>
+ * Property {@code staticGroups} - specify list of <b>static</b> import groups (every group
+ * identified either by a common prefix string, or by a regular expression enclosed in forward
+ * slashes (e.g.{@code /regexp/}). All static imports, which does not match any group, falls into an
+ * additional group, located at the end. Thus, the empty list of static groups (the default value)
+ * means one group for all static imports. This property has effect only when the property
+ * {@code option} is set to {@code top} or {@code bottom}.
+ * Default value is {@code {}}.
+ * </li>
+ * <li>
+ * Property {@code sortStaticImportsAlphabetically} - control whether
+ * <b>static imports</b> located at <b>top</b> or <b>bottom</b> are sorted within the group.
+ * Default value is false.
+ * </li>
+ * <li>
+ * Property {@code useContainerOrderingForStatic} - control whether to use container
+ * ordering (Eclipse IDE term) for static imports or not.
+ * Default value is false.
+ * </li>
+ * <li>
+ * Property {@code tokens} - tokens to check
+ * Default value is:
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
+ * STATIC_IMPORT</a>.
+ * </li>
+ * </ul>
+ * <p>
+ * To configure the check so that it matches default Eclipse formatter configuration
+ * (tested on Kepler and Luna releases):
+ * </p>
+ * <ul>
+ * <li>
+ * group of static imports is on the top
+ * </li>
+ * <li>
+ * groups of type imports: "java" and "javax" packages first, then "org" and then all other imports
+ * </li>
+ * <li>
+ * imports will be sorted in the groups
+ * </li>
+ * <li>
+ * groups are separated by, at least, one blank line and aren't separated internally
+ * </li>
+ * </ul>
+ * <p>
+ * Notes:
+ * </p>
+ * <ul>
+ * <li>
+ * "com" package is not mentioned on configuration, because it is ignored by Eclipse Kepler and Luna
+ * (looks like Eclipse defect)
+ * </li>
+ * <li>
+ * configuration below doesn't work in all 100% cases due to inconsistent behavior prior to
+ * Mars release, but covers most scenarios
+ * </li>
+ * </ul>
  * <pre>
  * &lt;module name=&quot;ImportOrder&quot;&gt;
- *    &lt;property name=&quot;groups&quot; value=&quot;/^javax?\./,org&quot;/&gt;
- *    &lt;property name=&quot;ordered&quot; value=&quot;true&quot;/&gt;
- *    &lt;property name=&quot;separated&quot; value=&quot;true&quot;/&gt;
- *    &lt;property name=&quot;option&quot; value=&quot;above&quot;/&gt;
- *    &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;groups&quot; value=&quot;/^java\./,javax,org&quot;/&gt;
+ *   &lt;property name=&quot;ordered&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;separated&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;option&quot; value=&quot;above&quot;/&gt;
+ *   &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
- *
- * <p>To configure the check so that it matches default IntelliJ IDEA formatter configuration
- *    (tested on v14):</p>
+ * <p>
+ * To configure the check so that it matches default Eclipse formatter configuration
+ * (tested on Mars release):
+ * </p>
  * <ul>
- *     <li>group of static imports is on the bottom</li>
- *     <li>groups of non-static imports: all imports except of &quot;javax&quot; and
- *         &quot;java&quot;, then &quot;javax&quot; and &quot;java&quot;</li>
- *     <li>imports will be sorted in the groups</li>
- *     <li>groups are separated by, at least, one blank line and aren't separated internally</li>
+ * <li>
+ * group of static imports is on the top
+ * </li>
+ * <li>
+ * groups of type imports: "java" and "javax" packages first, then "org" and "com",
+ * then all other imports as one group
+ * </li>
+ * <li>
+ * imports will be sorted in the groups
+ * </li>
+ * <li>
+ * groups are separated by, at least, one blank line and aren't separated internally
+ * </li>
  * </ul>
- *
- *         <p>
- *         Note: &quot;separated&quot; option is disabled because IDEA default has blank line
- *         between &quot;java&quot; and static imports, and no blank line between
- *         &quot;javax&quot; and &quot;java&quot;
- *         </p>
- *
  * <pre>
  * &lt;module name=&quot;ImportOrder&quot;&gt;
- *     &lt;property name=&quot;groups&quot; value=&quot;*,javax,java&quot;/&gt;
- *     &lt;property name=&quot;ordered&quot; value=&quot;true&quot;/&gt;
- *     &lt;property name=&quot;separated&quot; value=&quot;false&quot;/&gt;
- *     &lt;property name=&quot;option&quot; value=&quot;bottom&quot;/&gt;
- *     &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;groups&quot; value=&quot;/^java\./,javax,org,com&quot;/&gt;
+ *   &lt;property name=&quot;ordered&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;separated&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;option&quot; value=&quot;above&quot;/&gt;
+ *   &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
- *
- * <p>To configure the check so that it matches default NetBeans formatter configuration
- *    (tested on v8):</p>
+ * <p>
+ * To configure the check so that it matches default IntelliJ IDEA formatter configuration
+ * (tested on v2018.2):
+ * </p>
  * <ul>
- *     <li>groups of non-static imports are not defined, all imports will be sorted
- *         as a one group</li>
- *     <li>static imports are not separated, they will be sorted along with other imports</li>
+ * <li>
+ * group of static imports is on the bottom
+ * </li>
+ * <li>
+ * groups of type imports: all imports except of "javax" and "java", then "javax" and "java"
+ * </li>
+ * <li>
+ * imports will be sorted in the groups
+ * </li>
+ * <li>
+ * groups are separated by, at least, one blank line and aren't separated internally
+ * </li>
  * </ul>
- *
+ * <p>
+ * Note: a <a href="config_filters.html#SuppressionFilter">suppression filter</a> is needed because
+ * IDEA has no blank line between "javax" and "java".
+ * ImportOrder has a limitation by design to enforce an empty line between groups ("java", "javax").
+ * There is no flexibility to enforce empty lines between some groups and no empty lines between
+ * other groups.
+ * </p>
+ * <p>
+ * Note: "separated" option is disabled because IDEA default has blank line between "java" and
+ * static imports, and no blank line between "javax" and "java".
+ * </p>
  * <pre>
  * &lt;module name=&quot;ImportOrder&quot;&gt;
- *     &lt;property name=&quot;option&quot; value=&quot;inflow&quot;/&gt;
+ *   &lt;property name=&quot;groups&quot; value=&quot;*,javax,java&quot;/&gt;
+ *   &lt;property name=&quot;ordered&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;separated&quot; value=&quot;false&quot;/&gt;
+ *   &lt;property name=&quot;option&quot; value=&quot;bottom&quot;/&gt;
+ *   &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
- *
- * <p>
- * Group descriptions enclosed in slashes are interpreted as regular
- * expressions. If multiple groups match, the one matching a longer
- * substring of the imported name will take precedence, with ties
- * broken first in favor of earlier matches and finally in favor of
- * the first matching group.
- * </p>
- *
- * <p>
- * There is always a wildcard group to which everything not in a named group
- * belongs. If an import does not match a named group, the group belongs to
- * this wildcard group. The wildcard group position can be specified using the
- * {@code *} character.
- * </p>
- *
- * <p>Check also has on option making it more flexible:
- * <b>sortStaticImportsAlphabetically</b> - sets whether static imports grouped by
- * <b>top</b> or <b>bottom</b> option should be sorted alphabetically or
- * not, default value is <b>false</b>. It is applied to static imports grouped
- * with <b>top</b> or <b>bottom</b> options.<br>
- * This option is helping in reconciling of this Check and other tools like
- * Eclipse's Organize Imports feature.
- * </p>
- * <p>
- * To configure the Check allows static imports grouped to the <b>top</b>
- * being sorted alphabetically:
- * </p>
- *
  * <pre>
- * {@code
- * import static java.lang.Math.abs;
+ * &lt;?xml version=&quot;1.0&quot;?&gt;
+ * &lt;!DOCTYPE suppressions PUBLIC
+ *     &quot;-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN&quot;
+ *     &quot;https://checkstyle.org/dtds/suppressions_1_2.dtd&quot;&gt;
+ *
+ * &lt;suppressions&gt;
+ *     &lt;!-- message contains no message text to work well in multi-language environments --&gt;
+ *     &lt;suppress checks=&quot;ImportOrder&quot; message=&quot;^'java\..*'.*&quot;/&gt;
+ * &lt;/suppressions&gt;
+ * </pre>
+ * <p>
+ * To configure the check so that it matches default NetBeans formatter configuration
+ * (tested on v8):
+ * </p>
+ * <ul>
+ * <li>
+ * groups of type imports are not defined, all imports will be sorted as a one group
+ * </li>
+ * <li>
+ * static imports are not separated, they will be sorted along with other imports
+ * </li>
+ * </ul>
+ * <pre>
+ * &lt;module name=&quot;ImportOrder&quot;&gt;
+ *   &lt;property name=&quot;option&quot; value=&quot;inflow&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Group descriptions enclosed in slashes are interpreted as regular expressions.
+ * If multiple groups match, the one matching a longer substring of the imported name
+ * will take precedence, with ties broken first in favor of earlier matches and finally
+ * in favor of the first matching group.
+ * </p>
+ * <p>
+ * There is always a wildcard group to which everything not in a named group belongs.
+ * If an import does not match a named group, the group belongs to this wildcard group.
+ * The wildcard group position can be specified using the {@code *} character.
+ * </p>
+ * <p>
+ * Check also has on option making it more flexible: <b>sortStaticImportsAlphabetically</b>
+ * - sets whether static imports grouped by <b>top</b> or <b>bottom</b> option should be sorted
+ * alphabetically or not, default value is <b>false</b>. It is applied to static imports grouped
+ * with <b>top</b> or <b>bottom</b> options. This option is helping in reconciling of this
+ * Check and other tools like Eclipse's Organize Imports feature.
+ * </p>
+ * <p>
+ * To configure the Check allows static imports grouped to the <b>top</b> being sorted
+ * alphabetically:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;ImportOrder&quot;&gt;
+ *   &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;option&quot; value=&quot;top&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * import static java.lang.Math.PI;
+ * import static java.lang.Math.abs; // OK, alphabetical case sensitive ASCII order, 'P' &lt; 'a'
  * import static org.abego.treelayout.Configuration.AlignmentInLevel; // OK, alphabetical order
  *
  * import org.abego.*;
  *
- * import java.util.Set;
+ * import java.util.Set; //  Wrong order for 'java.util.Set' import.
  *
  * public class SomeClass { ... }
- * }
+ * </pre>
+ * <p>
+ * To configure the Check with groups of static imports:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;ImportOrder&quot;&gt;
+ *   &lt;property name=&quot;staticGroups&quot; value=&quot;org,java&quot;/&gt;
+ *   &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * import static org.abego.treelayout.Configuration.AlignmentInLevel; // Group 1
+ * import static java.lang.Math.abs; // Group 2
+ * import static java.lang.String.format; // Group 2
+ * import static com.google.common.primitives.Doubles.BYTES; // Group "everything else"
+ *
+ * public class SomeClass { ... }
+ * </pre>
+ * <p>
+ * The following example shows the idea of 'useContainerOrderingForStatic' option that is
+ * useful for Eclipse IDE users to match ordering validation.
+ * This is how the import comparison works for static imports: we first compare
+ * the container of the static import, container is the type enclosing the static element
+ * being imported. When the result of the comparison is 0 (containers are equal),
+ * we compare the fully qualified import names.
+ * For e.g. this is what is considered to be container names for the given example:
+ *
+ * import static HttpConstants.COLON     =&gt; HttpConstants
+ * import static HttpHeaders.addHeader   =&gt; HttpHeaders
+ * import static HttpHeaders.setHeader   =&gt; HttpHeaders
+ * import static HttpHeaders.Names.DATE  =&gt; HttpHeaders.Names
+ *
+ * According to this logic, HttpHeaders.Names should come after HttpHeaders.
+ * </p> Example for {@code useContainerOrderingForStatic=true}
+ * <pre>
+ * &lt;module name=&quot;ImportOrder&quot;&gt;
+ *   &lt;property name=&quot;useContainerOrderingForStatic&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;ordered&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;option&quot; value=&quot;top&quot;/&gt;
+ *   &lt;property name=&quot;caseSensitive&quot; value=&quot;false&quot;/&gt;
+ *   &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * import static io.netty.handler.codec.http.HttpConstants.COLON;
+ * import static io.netty.handler.codec.http.HttpHeaders.addHeader;
+ * import static io.netty.handler.codec.http.HttpHeaders.setHeader;
+ * import static io.netty.handler.codec.http.HttpHeaders.Names.DATE;
+ *
+ * public class InputEclipseStaticImportsOrder { }
+ * </pre> Example for {@code useContainerOrderingForStatic=false}
+ * <pre>
+ * &lt;module name=&quot;ImportOrder&quot;&gt;
+ *   &lt;property name=&quot;useContainerOrderingForStatic&quot; value=&quot;false&quot;/&gt;
+ *   &lt;property name=&quot;ordered&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;option&quot; value=&quot;top&quot;/&gt;
+ *   &lt;property name=&quot;caseSensitive&quot; value=&quot;false&quot;/&gt;
+ *   &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * import static io.netty.handler.codec.http.HttpConstants.COLON;
+ * import static io.netty.handler.codec.http.HttpHeaders.addHeader;
+ * import static io.netty.handler.codec.http.HttpHeaders.setHeader;
+ * import static io.netty.handler.codec.http.HttpHeaders.Names.DATE; // violation
+ *
+ * public class InputEclipseStaticImportsOrder { }
  * </pre>
  *
- *
+ * @since 3.2
  */
 @FileStatefulCheck
 public class ImportOrderCheck
@@ -217,17 +396,50 @@ public class ImportOrderCheck
     /** Empty array of pattern type needed to initialize check. */
     private static final Pattern[] EMPTY_PATTERN_ARRAY = new Pattern[0];
 
-    /** List of type import groups specified by the user. */
+    /**
+     * Specify list of <b>type import</b> groups (every group identified either by a common prefix
+     * string, or by a regular expression enclosed in forward slashes (e.g.{@code /regexp/}).
+     * All type imports, which does not match any group, falls into an additional group,
+     * located at the end. Thus, the empty list of type groups (the default value) means one group
+     * for all type imports.
+     */
     private Pattern[] groups = EMPTY_PATTERN_ARRAY;
-    /** List of static import groups specified by the user. */
+
+    /**
+     * Specify list of <b>static</b> import groups (every group identified either by a common prefix
+     * string, or by a regular expression enclosed in forward slashes (e.g.{@code /regexp/}).
+     * All static imports, which does not match any group, falls into an additional group, located
+     * at the end. Thus, the empty list of static groups (the default value) means one group for all
+     * static imports. This property has effect only when the property {@code option} is set to
+     * {@code top} or {@code bottom}.
+     */
     private Pattern[] staticGroups = EMPTY_PATTERN_ARRAY;
-    /** Require imports in group be separated. */
+
+    /**
+     * Control whether type import groups should be separated by, at least, one blank
+     * line or comment and aren't separated internally. It doesn't affect separations for static
+     * imports.
+     */
     private boolean separated;
-    /** Require static imports in group be separated. */
+
+    /**
+     * Control whether static import groups should be separated by, at least, one blank
+     * line or comment and aren't separated internally. This property has effect only when the
+     * property {@code option} is is set to {@code top} or {@code bottom}.
+     */
     private boolean separatedStaticGroups;
-    /** Require imports in group. */
+
+    /**
+     * Control whether type imports within each group should be sorted.
+     * It doesn't affect sorting for static imports.
+     */
     private boolean ordered = true;
-    /** Should comparison be case sensitive. */
+
+    /**
+     * Control whether string comparison should be case sensitive or not. Case sensitive
+     * sorting is in <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>.
+     * It affects both type imports and static imports.
+     */
     private boolean caseSensitive = true;
 
     /** Last imported group. */
@@ -247,16 +459,26 @@ public class ImportOrderCheck
      * uses the properties {@code staticGroups} and {@code separatedStaticGroups}.
      **/
     private boolean staticImportsApart;
-    /** Whether static imports should be sorted alphabetically or not. */
+
+    /**
+     * Control whether <b>static imports</b> located at <b>top</b> or <b>bottom</b> are
+     * sorted within the group.
+     */
     private boolean sortStaticImportsAlphabetically;
-    /** Whether to use container ordering (Eclipse IDE term) for static imports or not. */
+
+    /**
+     * Control whether to use container ordering (Eclipse IDE term) for static imports
+     * or not.
+     */
     private boolean useContainerOrderingForStatic;
 
-    /** The policy to enforce. */
+    /**
+     * Specify policy on the relative order between type imports and static imports.
+     */
     private ImportOrderOption option = ImportOrderOption.UNDER;
 
     /**
-     * Set the option to enforce.
+     * Setter to specify policy on the relative order between type imports and static imports.
      * @param optionStr string to decode option from
      * @throws IllegalArgumentException if unable to decode
      */
@@ -265,8 +487,11 @@ public class ImportOrderCheck
     }
 
     /**
-     * Sets the list of package groups for type imports and the order they should occur in the
-     * file.
+     * Setter to specify list of <b>type import</b> groups (every group identified either by a
+     * common prefix string, or by a regular expression enclosed in forward slashes
+     * (e.g.{@code /regexp/}). All type imports, which does not match any group, falls into an
+     * additional group, located at the end. Thus, the empty list of type groups (the default value)
+     * means one group for all type imports.
      *
      * @param packageGroups a comma-separated list of package names/prefixes.
      */
@@ -275,9 +500,12 @@ public class ImportOrderCheck
     }
 
     /**
-     * Sets the list of package groups for static imports and the order they should occur in the
-     * file. This property has effect only when the property {@code option} is set to {@code top}
-     * or {@code bottom}.)
+     * Setter to specify list of <b>static</b> import groups (every group identified either by a
+     * common prefix string, or by a regular expression enclosed in forward slashes
+     * (e.g.{@code /regexp/}). All static imports, which does not match any group, falls into an
+     * additional group, located at the end. Thus, the empty list of static groups (the default
+     * value) means one group for all static imports. This property has effect only when
+     * the property {@code option} is set to {@code top} or {@code bottom}.
      *
      * @param packageGroups a comma-separated list of package names/prefixes.
      */
@@ -286,8 +514,8 @@ public class ImportOrderCheck
     }
 
     /**
-     * Sets whether or not imports should be ordered within any one group of
-     * imports.
+     * Setter to control whether type imports within each group should be sorted.
+     * It doesn't affect sorting for static imports.
      *
      * @param ordered
      *            whether lexicographic ordering of imports within a group
@@ -298,8 +526,9 @@ public class ImportOrderCheck
     }
 
     /**
-     * Sets whether or not groups of type imports must be separated from one another
-     * by at least one blank line or comment.
+     * Setter to control whether type import groups should be separated by, at least,
+     * one blank line or comment and aren't separated internally.
+     * It doesn't affect separations for static imports.
      *
      * @param separated
      *            whether groups should be separated by one blank line or comment.
@@ -309,9 +538,10 @@ public class ImportOrderCheck
     }
 
     /**
-     * Sets whether or not groups of static imports must be separated from one another
-     * by at least one blank line or comment. This property has effect only when the property
-     * {@code option} is set to {@code top} or {@code bottom}.)
+     * Setter to control whether static import groups should be separated by, at least,
+     * one blank line or comment and aren't separated internally.
+     * This property has effect only when the property
+     * {@code option} is is set to {@code top} or {@code bottom}.
      *
      * @param separatedStaticGroups
      *            whether groups should be separated by one blank line or comment.
@@ -321,8 +551,10 @@ public class ImportOrderCheck
     }
 
     /**
-     * Sets whether string comparison should be case sensitive or not.
-     *
+     * Setter to control whether string comparison should be case sensitive or not.
+     * Case sensitive sorting is in
+     * <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>.
+     * It affects both type imports and static imports.
      * @param caseSensitive
      *            whether string comparison should be case sensitive.
      */
@@ -331,8 +563,8 @@ public class ImportOrderCheck
     }
 
     /**
-     * Sets whether static imports (when grouped using 'top' and 'bottom' option)
-     * are sorted alphabetically or according to the package groupings.
+     * Setter to control whether <b>static imports</b> located at <b>top</b> or
+     * <b>bottom</b> are sorted within the group.
      * @param sortAlphabetically true or false.
      */
     public void setSortStaticImportsAlphabetically(boolean sortAlphabetically) {
@@ -340,7 +572,8 @@ public class ImportOrderCheck
     }
 
     /**
-     * Sets whether to use container ordering (Eclipse IDE term) for static imports or not.
+     * Setter to control whether to use container ordering (Eclipse IDE term) for static
+     * imports or not.
      * @param useContainerOrdering whether to use container ordering for static imports or not.
      */
     public void setUseContainerOrderingForStatic(boolean useContainerOrdering) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -75,6 +75,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         "ClassMemberImpliedModifier",
         "ClassTypeParameterName",
         "ConstantName",
+        "CustomImportOrder",
         "InterfaceMemberImpliedModifier",
         "InterfaceTypeParameterName",
         "LambdaParameterName",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -76,6 +76,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         "ClassTypeParameterName",
         "ConstantName",
         "CustomImportOrder",
+        "ImportOrder",
         "InterfaceMemberImpliedModifier",
         "InterfaceTypeParameterName",
         "LambdaParameterName",

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -1348,8 +1348,8 @@ import java.util.stream.IntStream;
     </section>
 
     <section name="ImportOrder">
+      <p>Since Checkstyle 3.2</p>
       <subsection name="Description" id="ImportOrder_Description">
-        <p>Since Checkstyle 3.2</p>
         <p>Checks the ordering/grouping of imports. Features are:</p>
         <ul>
           <li>groups type/static imports: ensures that groups of imports come in a
@@ -1367,11 +1367,7 @@ import java.util.stream.IntStream;
           <li>arrange static imports: ensures the relative order between
           type imports and static imports (see
           <a href="property_types.html#importOrder">import orders</a>)</li>
-         </ul>
-        <p>
-        <a href="#ImportOrder_Examples">Examples section</a> contains examples that
-          work with default formatter configurations of Eclipse, IntelliJ IDEA and NetBeans
-        </p>
+        </ul>
       </subsection>
 
       <subsection name="Properties" id="ImportOrder_Properties">
@@ -1385,7 +1381,7 @@ import java.util.stream.IntStream;
           </tr>
           <tr>
             <td>option</td>
-            <td>policy on the relative order between type imports and static imports</td>
+            <td>specify policy on the relative order between type imports and static imports.</td>
             <td><a href="property_types.html#importOrder">Import Order Policy</a></td>
             <td><code>under</code></td>
             <td>5.0</td>
@@ -1393,7 +1389,7 @@ import java.util.stream.IntStream;
           <tr>
             <td>groups</td>
             <td>
-              list of <b>type import</b> groups (every group identified either by a
+              specify list of <b>type import</b> groups (every group identified either by a
               common prefix string, or by a regular expression enclosed
               in forward slashes (e.g. <code>/regexp/</code>). All type imports,
               which does not match any group, falls into an additional group, located at the end.
@@ -1406,8 +1402,8 @@ import java.util.stream.IntStream;
           </tr>
           <tr>
             <td>ordered</td>
-            <td>whether type imports within each group should be sorted
-              (It doesn't affect sorting for static imports.)</td>
+            <td>control whether type imports within each group should be sorted.
+              It doesn't affect sorting for static imports.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>true</td>
             <td>3.2</td>
@@ -1415,9 +1411,9 @@ import java.util.stream.IntStream;
           <tr>
             <td>separated</td>
             <td>
-              whether type import groups should be separated by, at least, one
+              control whether type import groups should be separated by, at least, one
               blank line or comment and aren't separated internally.
-              (It doesn't affect separations for static imports.)
+              It doesn't affect separations for static imports.
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
@@ -1426,10 +1422,10 @@ import java.util.stream.IntStream;
           <tr>
           <td>separatedStaticGroups</td>
               <td>
-              whether static import groups should be separated by, at least, one
+              control whether static import groups should be separated by, at least, one
               blank line or comment and aren't separated internally.
-              (This property has effect only when the property <code>option</code>
-              is is set to <code>top</code> or <code>bottom</code>.)
+              This property has effect only when the property <code>option</code>
+              is is set to <code>top</code> or <code>bottom</code>.
               </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
@@ -1437,10 +1433,10 @@ import java.util.stream.IntStream;
           </tr>
           <tr>
             <td>caseSensitive</td>
-            <td>whether string comparison should be case sensitive or not.
+            <td>control whether string comparison should be case sensitive or not.
               Case sensitive sorting is in
               <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>.
-              (It affects both type imports and static imports)
+              It affects both type imports and static imports.
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>true</td>
@@ -1449,13 +1445,13 @@ import java.util.stream.IntStream;
           <tr>
             <td>staticGroups</td>
             <td>
-                list of <b>static</b> import groups (every group identified either by a
+                specify list of <b>static</b> import groups (every group identified either by a
                 common prefix string, or by a regular expression enclosed
                 in forward slashes (e.g. <code>/regexp/</code>). All static imports,
                 which does not match any group, falls into an additional group, located at the end.
                 Thus, the empty list of static groups (the default value) means
-                one group for all static imports. (This property has effect only when
-                the property <code>option</code> is set to <code>top</code> or <code>bottom</code>.)
+                one group for all static imports. This property has effect only when
+                the property <code>option</code> is set to <code>top</code> or <code>bottom</code>.
             </td>
             <td><a href="property_types.html#regexp">Regular Expressions</a></td>
             <td><code>{}</code></td>
@@ -1463,15 +1459,19 @@ import java.util.stream.IntStream;
           </tr>
           <tr>
             <td>sortStaticImportsAlphabetically</td>
-            <td>whether <b>static imports</b> located at <b>top</b> or <b>bottom</b> are sorted
-                within the group.</td>
+            <td>
+                control whether <b>static imports</b> located at <b>top</b> or
+                <b>bottom</b> are sorted within the group.
+            </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
             <td>6.5</td>
           </tr>
           <tr>
             <td>useContainerOrderingForStatic</td>
-            <td>whether to use container ordering (Eclipse IDE term) for static imports or not</td>
+            <td>
+                control whether to use container ordering (Eclipse IDE term) for static
+                imports or not.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td>false</td>
             <td>7.1</td>
@@ -1559,12 +1559,15 @@ import java.util.stream.IntStream;
            ImportOrder has a limitation by design to enforce an empty line between groups
            ("java", "javax"). There is no flexibility to enforce empty lines between some
            groups and no empty lines between other groups.</p>
-
+          <p>
+            Note: "separated" option is disabled because IDEA default has blank line
+            between "java" and static imports, and no blank line between "javax" and "java".
+          </p>
         <source>
 &lt;module name=&quot;ImportOrder&quot;&gt;
   &lt;property name=&quot;groups&quot; value=&quot;*,javax,java&quot;/&gt;
   &lt;property name=&quot;ordered&quot; value=&quot;true&quot;/&gt;
-  &lt;property name=&quot;separated&quot; value=&quot;true&quot;/&gt;
+  &lt;property name=&quot;separated&quot; value=&quot;false&quot;/&gt;
   &lt;property name=&quot;option&quot; value=&quot;bottom&quot;/&gt;
   &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
@@ -1596,6 +1599,27 @@ import java.util.stream.IntStream;
 &lt;/module&gt;
         </source>
 
+        <p>
+          Group descriptions enclosed in slashes are interpreted as regular expressions.
+          If multiple groups match, the one matching a longer
+          substring of the imported name will take precedence, with ties
+          broken first in favor of earlier matches and finally in favor of
+          the first matching group.
+        </p>
+        <p>
+          There is always a wildcard group to which everything not in a named group
+          belongs. If an import does not match a named group, the group belongs to
+          this wildcard group. The wildcard group position can be specified using the
+          {@code *} character.
+        </p>
+        <p>
+          Check also has on option making it more flexible:
+          <b>sortStaticImportsAlphabetically</b> - sets whether static imports grouped by
+          <b>top</b> or <b>bottom</b> option should be sorted alphabetically or
+          not, default value is <b>false</b>. It is applied to static imports grouped
+          with <b>top</b> or <b>bottom</b> options. This option is helping in reconciling
+          of this Check and other tools like Eclipse's Organize Imports feature.
+        </p>
         <p>
           To configure the Check allows static imports grouped to the <b>top</b> being sorted
           alphabetically:
@@ -1649,10 +1673,10 @@ public class SomeClass { ... }
           we compare the fully qualified import names.
           For e.g. this is what is considered to be container names for the given example:
 
-          import static HttpConstants.COLON     => HttpConstants
-          import static HttpHeaders.addHeader   => HttpHeaders
-          import static HttpHeaders.setHeader   => HttpHeaders
-          import static HttpHeaders.Names.DATE  => HttpHeaders.Names
+          import static HttpConstants.COLON     =&gt; HttpConstants
+          import static HttpHeaders.addHeader   =&gt; HttpHeaders
+          import static HttpHeaders.setHeader   =&gt; HttpHeaders
+          import static HttpHeaders.Names.DATE  =&gt; HttpHeaders.Names
 
           According to this logic, HttpHeaders.Names should come after HttpHeaders.
         </p>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -229,16 +229,12 @@
     </section>
 
     <section name="CustomImportOrder">
+      <p>Since Checkstyle 5.8</p>
       <subsection name="Description" id="CustomImportOrder_Description">
-        <p>Since Checkstyle 5.8</p>
         <p>
           Checks that the groups of import declarations appear in the order specified
           by the user. If there is an import but its group is not specified in the
           configuration such an import should be placed at the end of the import list.
-        </p>
-        <p>
-          <a href="#CustomImportOrder_Examples">Examples section</a> contains examples that
-          work with default formatter configurations of Eclipse, IntelliJ IDEA and NetBeans
         </p>
       </subsection>
 
@@ -246,16 +242,17 @@
         <p>
           The rule consists of:
         </p>
-        <p>
-         1) STATIC group. This group sets the ordering of static imports.
-        </p>
-        <p>
-          2) SAME_PACKAGE(n) group. This group sets the ordering of the same package imports.
-          Imports are considered on SAME_PACKAGE group if <b>n</b> first domains in package
-          name and import name are identical. For example:
-        </p>
-        <source>
+        <ol>
+          <li>
+            STATIC group. This group sets the ordering of static imports.
+          </li>
+          <li>
+            SAME_PACKAGE(n) group. This group sets the ordering of the same package imports.
+            Imports are considered on SAME_PACKAGE group if <b>n</b> first domains in package
+            name and import name are identical:
+            <source>
 package java.util.concurrent.locks;
+
 import java.io.File;
 import java.util.*; //#1
 import java.util.List; //#2
@@ -265,27 +262,28 @@ import java.util.concurrent.AbstractExecutorService; //#5
 import java.util.concurrent.locks.LockSupport; //#6
 import java.util.regex.Pattern; //#7
 import java.util.regex.Matcher; //#8
-        </source>
-        <p>
-          If we have SAME_PACKAGE(3) on configuration file, imports #4-6 will be considered as a
-          SAME_PACKAGE group (java.util.concurrent.*, java.util.concurrent.AbstractExecutorService,
-          java.util.concurrent.locks.LockSupport). SAME_PACKAGE(2) will include #1-8.
-          SAME_PACKAGE(4) will include only #6. SAME_PACKAGE(5) will result in no imports assigned
-          to SAME_PACKAGE group because actual package java.util.concurrent.locks has only 4
-          domains.
-        </p>
-        <p>
-          3) THIRD_PARTY_PACKAGE group. This group sets ordering of third party imports.
-          Third party imports are all imports except STATIC,
-          SAME_PACKAGE(n), STANDARD_JAVA_PACKAGE and SPECIAL_IMPORTS.
-        </p>
-        <p>
-          4) STANDARD_JAVA_PACKAGE group. This group sets ordering of standard java/javax imports.
-        </p>
-        <p>
-          5) SPECIAL_IMPORTS group. This group may contains some imports
-          that have particular meaning for the user.
-        </p>
+            </source>
+            If we have SAME_PACKAGE(3) on configuration file,
+            imports #4-6 will be considered as a SAME_PACKAGE group (java.util.concurrent.*,
+            java.util.concurrent.AbstractExecutorService, java.util.concurrent.locks.LockSupport).
+            SAME_PACKAGE(2) will include #1-8. SAME_PACKAGE(4) will include only #6.
+            SAME_PACKAGE(5) will result in no imports assigned to SAME_PACKAGE group because
+            actual package java.util.concurrent.locks has only 4 domains.
+          </li>
+          <li>
+            THIRD_PARTY_PACKAGE group. This group sets ordering of third party imports.
+            Third party imports are all imports except STATIC, SAME_PACKAGE(n),
+            STANDARD_JAVA_PACKAGE and SPECIAL_IMPORTS.
+          </li>
+          <li>
+            STANDARD_JAVA_PACKAGE group. By default this group sets ordering of standard
+            java/javax imports.
+          </li>
+          <li>
+            SPECIAL_IMPORTS group. This group may contains some imports that have particular
+            meaning for the user.
+          </li>
+        </ol>
       </subsection>
 
       <subsection name="Notes" id="CustomImportOrder_Notes">
@@ -334,8 +332,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
           Result: import will be assigned to SPECIAL_IMPORTS. Matching substring length is 5 for
           both patterns. However, "Avoid" position is lower then "Check" position.
         </p>
-
-    </subsection>
+      </subsection>
 
       <subsection name="Properties" id="CustomImportOrder_Properties">
         <table>
@@ -348,28 +345,28 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
           </tr>
           <tr>
             <td>customImportOrderRules</td>
-            <td>List of order declaration customizing by user.</td>
+            <td>Specify list of order declaration customizing by user.</td>
             <td><a href="property_types.html#string">String</a></td>
             <td><code>{}</code></td>
             <td>5.8</td>
           </tr>
           <tr>
             <td>standardPackageRegExp</td>
-            <td>RegExp for STANDARD_JAVA_PACKAGE group imports.</td>
+            <td>Specify RegExp for STANDARD_JAVA_PACKAGE group imports.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^(java|javax)\."</code></td>
             <td>5.8</td>
           </tr>
           <tr>
             <td>thirdPartyPackageRegExp</td>
-            <td>RegExp for THIRD_PARTY_PACKAGE group imports.</td>
+            <td>Specify RegExp for THIRD_PARTY_PACKAGE group imports.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>".*"</code></td>
             <td>5.8</td>
           </tr>
           <tr>
             <td>specialImportsRegExp</td>
-            <td>RegExp for SPECIAL_IMPORTS group imports.</td>
+            <td>Specify RegExp for SPECIAL_IMPORTS group imports.</td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>
             <td><code>"^$" (empty)</code></td>
             <td>5.8</td>


### PR DESCRIPTION
Issue #5750 

First commit to exclude internal classes from validation.
The hack with `depth` counting won't work since this check validates only comment bocks, so the method `leaveToken` will be called right after the first processed comment. Instead of, the inner types now are filtered out by the scope.

Second commit for `CustomImportOrderCheck`, third for `ImportOrderCheck`