### PR TITLE
Issue #6273: removed comment support from JavadocMethodCheck

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -128,7 +128,6 @@ pitest-javadoc)
   "AbstractTypeAwareCheck.java.html:<td class='covered'><pre><span  class='survived'>        typeParams.clear();</span></pre></td></tr>"
   "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>        final int col = noargMultilineStart.start(1) - 1;</span></pre></td></tr>"
   "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>        return (ast.getType() == TokenTypes.METHOD_DEF || ast.getType() == TokenTypes.CTOR_DEF)</span></pre></td></tr>"
-  "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>        return true;</span></pre></td></tr>"
   "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>        while (remIndex &#60; lines.length) {</span></pre></td></tr>"
   "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>        while (remIndex &#60; lines.length) {</span></pre></td></tr>"
   "JavadocPackageCheck.java.html:<td class='covered'><pre><span  class='survived'>        directoriesChecked.clear();</span></pre></td></tr>"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -335,11 +335,6 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
     }
 
     @Override
-    public boolean isCommentNodesRequired() {
-        return true;
-    }
-
-    @Override
     protected final void processAST(DetailAST ast) {
         final Scope theScope = calculateScope(ast);
         if (shouldCheck(ast, theScope)) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -627,4 +627,16 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig, getPath("InputJavadocMethodReceiverParameter.java"), expected);
     }
 
+    @Test
+    public void testJavadocInMethod() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(JavadocMethodCheck.class);
+        final String[] expected = {
+            "4:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "6:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "9:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "13:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig, getPath("InputJavadocMethodJavadocInMethod.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodJavadocInMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodJavadocInMethod.java
@@ -1,0 +1,33 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+public class InputJavadocMethodJavadocInMethod {
+    public void foo1() { }
+
+    @Deprecated
+    public void foo2() { }
+
+    @Deprecated
+    /** */
+    public void foo3() { }
+
+    public void foo4() { /** */ }
+
+    @Deprecated
+    public void foo5() { /** */ }
+
+    @Deprecated
+    /** */
+    public void foo6() { /** */ }
+
+    /** */
+    public void foo7() { /** */ }
+
+    /** */
+    @Deprecated
+    public void foo8() { /** */ }
+
+    /** */
+    @Deprecated
+    /** */
+    public void foo9() { /** */ }
+}


### PR DESCRIPTION
Issue #6273 

Like issue stated, I found this because there was a mutation surviving on it and this is the results I got when I ran regression. I will run a new regression for this PR.

Comments aren't required because the check's implementation actually looks at the Java's source, so it sees everything, including comments.

This issue is needed to finish mutations which is the only reason I bring it up for a check we consider deprecated.