### PR TITLE
minor: make ConfigurationLoaderTest#testNonExistentPropertyName jdk11…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -42,6 +43,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
@@ -496,9 +498,13 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         catch (CheckstyleException ex) {
             assertEquals("Invalid exception message",
                 "unable to parse configuration stream", ex.getMessage());
+            assertSame("Expected cause of type SAXException",
+                SAXException.class, ex.getCause().getClass());
+            assertSame("Expected cause of type CheckstyleException",
+                CheckstyleException.class, ex.getCause().getCause().getClass());
             assertEquals("Invalid exception cause message",
                 "Property ${nonexistent} has not been set",
-                    ex.getCause().getMessage());
+                ex.getCause().getCause().getMessage());
         }
     }
 


### PR DESCRIPTION
… compatible

Issue: #6228 

`SAXException` was "fixed" in JDK11.
Formerly, there was a "pseudo cause" exception in the `SAXException`:

http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/jdk/internal/org/xml/sax/SAXException.java#l95
```
    public SAXException (Exception e)
    {
        super();
        this.exception = e;
    }
```

Now it is a regular exception as it should be:
http://hg.openjdk.java.net/jdk/jdk11/file/1ddf9a99e4ad/src/java.xml/share/classes/org/xml/sax/SAXException.java#l99
```
    public SAXException (Exception e)
    {
        super(e);
    }
```
As the result, the exception message is slightly different:
before jdk11: `Property ${nonexistent} has not been set`
after jdk11: `com.puppycrawl.tools.checkstyle.api.CheckstyleException: Property ${nonexistent} has not been set`

The exception itself is not changed. It still a `CheckstyleException` wrapped in `SAXException`wrapped in another `CheckstyleException`.

So, the idea is to check the message of the original exception. We don't have to test the jdk. It has already been tested. Instead, we need to make sure that the correct exception is nested inside and check it. 