### PR TITLE
minor: rewrite cpio handling to support bsd

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -368,6 +368,7 @@ elementdef
 elif
 elist
 Ellipsize
+elsif
 emacs
 emptyblock
 emptycatchblock

--- a/.ci/test-spelling-unknown-words.sh
+++ b/.ci/test-spelling-unknown-words.sh
@@ -20,7 +20,9 @@ if [ ! -e $dict ]; then
   file_name=$(curl -s "${mirror}${file_path}" | grep -o "words-.*.noarch.rpm")
   curl "${mirror}${file_path}${file_name}" -o $words_rpm
   $spellchecker/rpm2cpio.sh $words_rpm |\
-    cpio -i --to-stdout ./usr/share/dict/linux.words > $dict
+    perl -e '$/="\0"; while (<>) {if (/^0707/) { $state = (m!\./usr/share/dict/linux.words!) }
+      elsif ($state == 1) { print }} '\
+    > $dict
   rm $words_rpm
 fi
 


### PR DESCRIPTION
`cpio ... --to-stdout` is a gnu-ism which of course doesn't work on *bsd (esp macOS).

This doesn't matter much when one uses Travis on Linux, but I develop on macOS... so it's helpful for the script to work there.

I've looked at `pax` and `cpio` and `tar`, and none of them seem to support pipe-to-pipe extraction (which is really disappointing).

This approach seems to work "well enough" for this one rpm, and I suspect it's fairly close to correct based on https://www.mkssoftware.com/docs/man4/cpio.4.asp
namely, each row has a `0707` magic field at the start, and there's a `\0` delimiter.

(mks is wrong about the magic field, it's only 0707...)