### PR TITLE
Issue #6375: FinalLocalVariable: NPE

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -31,6 +31,7 @@ import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
 
 /**
@@ -205,7 +206,8 @@ public class FinalLocalVariableCheck extends AbstractCheck {
                             .findFirstToken(TokenTypes.FINAL) == null
                         && !isInAbstractOrNativeMethod(ast)
                         && !ScopeUtil.isInInterfaceBlock(ast)
-                        && !isMultipleTypeCatch(ast)) {
+                        && !isMultipleTypeCatch(ast)
+                        && !CheckUtil.isReceiverParameter(ast)) {
                     insertParameter(ast);
                 }
                 break;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -265,4 +265,12 @@ public class FinalLocalVariableCheckTest
         verify(checkConfig, getPath("InputFinalLocalVariableAnonymousClass.java"), expected);
     }
 
+    @Test
+    public void testReceiverParameter() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(FinalLocalVariableCheck.class);
+        checkConfig.addAttribute("tokens", "PARAMETER_DEF,VARIABLE_DEF");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputFinalLocalVariableReceiverParameter.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableReceiverParameter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableReceiverParameter.java
@@ -1,0 +1,15 @@
+package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;
+
+public class InputFinalLocalVariableReceiverParameter {
+    public void foo4(InputFinalLocalVariableReceiverParameter this)
+    {
+    }
+
+    private class Inner
+    {
+        public Inner(InputFinalLocalVariableReceiverParameter
+                InputFinalLocalVariableReceiverParameter.this)
+        {
+        }
+    }
+}


### PR DESCRIPTION
The goal of this PR is to fix Issue #6375, where the FinalLocalVariable check throws a NullPointerException when it encounters "receiver" parameters.

Proposed fix is to exclude these from the check via `CheckUtil.isReceiverParameter` (these parameters are implicitly `final` and the compiler will not let them be modified).

Regression report: http://esilkensen.github.io/checkstyle-tester/6375