### PR TITLE
Issue #6236: add build instructions to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Contributors chat: [![][gitter_con img]][gitter_con]
 
 ![](https://raw.githubusercontent.com/checkstyle/resources/master/img/checkstyle-logos/checkstyle-logo-260x99.png)
 
+
 Checkstyle is a tool for checking Java source code for adherence to a Code Standard
 or set of validation rules (best practices).
 
@@ -29,6 +30,21 @@ Each-commit builds of maven artifacts can be found at
 [Maven Snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/com/puppycrawl/tools/checkstyle/) .
 
 Documentation is available in HTML format, see https://checkstyle.org/checks.html.
+
+Build instructions and Contribution
+======================
+
+[Build instructions](https://checkstyle.org/contributing.html#Build)
+
+[Setup IDE for development](https://checkstyle.org/beginning_development.html)
+
+[Explanation on how to create your own module](https://checkstyle.org/extending.html)
+
+[Verification of code quality](https://checkstyle.org/contributing.html#Quality_matters)
+
+[Sending Pull Request](https://checkstyle.org/contributing.html#Submitting_your_contribution)
+
+[Report Issue](https://checkstyle.org/contributing.html#Report_an_issue)
 
 Continuous integration and Quality reports
 ======================
@@ -88,7 +104,7 @@ these packages are in the file named "LICENSE.apache20" in this
 directory.
 
 The software uses the Picocli Library
-(https://github.com/remkop/picocli/). Its license terms 
+(https://github.com/remkop/picocli/). Its license terms
 are in the file named "LICENSE.apache20" in this directory.
 
 [travis]:https://travis-ci.org/checkstyle/checkstyle/builds

--- a/src/xdocs/contributing.xml
+++ b/src/xdocs/contributing.xml
@@ -72,6 +72,24 @@
       </p>
     </section>
 
+    <section name="Build">
+      <p>
+        Project is following general maven layout and phases for build.
+        Generated jars will be in folder <code>target</code>.
+      </p>
+
+      <p>
+        Generate maven standard jar: <code>mvn install</code>
+        <br/>
+        Generate maven standard jar and skip all validations/verifications:
+        <code>mvn -P no-validations install</code>
+        <br/>
+        Generate uber jar (checkstyle-all-X.XX.jar) to use our
+        <a href="/cmdline.html">command line</a>:
+        <code>mvn -P assembly package</code>
+      </p>
+    </section>
+
     <section name="Quality matters">
 
       <p>
@@ -91,10 +109,10 @@
 
         This means it is not sufficient to pass all tests, but the tests
         should ideally execute each line in the code, code coverage should be 100%. To generate the
-        JaCoCo report, run the Maven command
-
+        JaCoCo report, run the Maven command:
+        <br/>
         <code>mvn test jacoco:restore-instrumented-classes jacoco:report@default-report</code>.
-
+        <br/>
         Check results on report target/site/jacoco/index.html in project home folder.
       </p>
 
@@ -117,8 +135,10 @@
       <p>
         The last step of verification that all works fine please do testing of your
         functionality on any open-source project (Spring, Hibernate, ....).
-        Here is how to do it from <a href="https://checkstyle.org/cmdline.html">
-        command line</a>
+        Here is how to do it by
+        <a href=
+          "https://github.com/checkstyle/contribution/tree/master/checkstyle-tester#checkstyle-tester">
+        our testing tool</a>. Generated report is required to be shared in Pull Request.
       </p>
     </section>
 
@@ -155,7 +175,8 @@
       <p>
         After submitting a Pull Request, it will be automatically checked by
         <a href="https://travis-ci.org/checkstyle/checkstyle">Travis</a> and other continuous
-        integration tools. Therefore, please recheck after some minutes that the system didn't
+        integration (CI) services.
+        Therefore, please recheck after some minutes that the CIs didn't
         find any issues with your changes. If there are issues, please fix them by amending
         commit (not by separate commit) and provide an updated version of the same Pull Request.
       </p>


### PR DESCRIPTION
Issue #6236

I will update checkstyle.org to have "Build" section after merge.

![image](https://user-images.githubusercontent.com/812984/52174813-7e375a80-274e-11e9-889c-54b5cebfdac5.png)
