### PR TITLE
Issue #6381: Incorrect warning for empty lambda bodies with google_checks.xml

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -6,7 +6,7 @@
 
 <suppressions>
     <!-- can't split long messages between lines -->
-    <suppress checks="RegexpSingleline" files="google_checks\.xml" lines="37,77"/>
+    <suppress checks="RegexpSingleline" files="google_checks\.xml" lines="37,78"/>
 
     <suppress checks="FileLength"
               files="TokenTypes.java|IndentationCheckTest.java"

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
@@ -64,7 +64,6 @@ public class WhitespaceAroundTest extends AbstractModuleTestSupport {
             "150:20: " + getCheckMessage(messages, msgPreceded, ":"),
             "249:14: " + getCheckMessage(messages, msgPreceded, "->"),
             "250:15: " + getCheckMessage(messages, msgFollowed, "->"),
-            "250:17: " + getCheckMessage(messages, msgPreceded, "{"),
         };
 
         final String filePath = getPath("InputWhitespaceAroundBasic.java");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundBasic.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundBasic.java
@@ -248,7 +248,8 @@ class NewGoogleOperators
 
        l = ()-> { }; //warn
        l = () ->{ }; //warn
-       l = () -> { };
+       l = () -> { }; //ok
+       l = () -> {}; //ok
 
        java.util.Arrays.sort(null, String :: compareToIgnoreCase);
        java.util.Arrays.sort(null, String::compareToIgnoreCase);

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -70,6 +70,7 @@
         </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyLambdas" value="true"/>
             <property name="allowEmptyMethods" value="true"/>
             <property name="allowEmptyTypes" value="true"/>
             <property name="allowEmptyLoops" value="true"/>


### PR DESCRIPTION
Issue #6381

I have tried to removed the `TokenTypes.LAMBDA` from `getDefaultTokens()` method in `WhitespaceAroundCheck` [here](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java#L213). However, it seems that it does not work.

While investigating on the issue, I found that there is already a [test](https://github.com/checkstyle/checkstyle/blob/master/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java#L415) that tests the same issue. See the test with its previous test and the [test file](https://github.com/checkstyle/checkstyle/blob/master/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyLambdaExpressions.java#L7). 

So, let's just add this property to `google_checks.xml` so the problem is solved.