### PR TITLE
Issue #6377: FinalLocalVariable: IllegalStateException

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -132,7 +132,8 @@ public class FinalLocalVariableCheckTest
             "21:66: " + getCheckMessage(MSG_KEY, "snippets"),
             "22:32: " + getCheckMessage(MSG_KEY, "filteredSnippets"),
             "23:21: " + getCheckMessage(MSG_KEY, "snippet"),
-            "27:20: " + getCheckMessage(MSG_KEY, "snippet"),
+            "38:20: " + getCheckMessage(MSG_KEY, "a"),
+            "41:16: " + getCheckMessage(MSG_KEY, "a"),
         };
         verify(checkConfig, getPath("InputFinalLocalVariableEnhancedForLoopVariable.java"),
             expected);
@@ -147,6 +148,7 @@ public class FinalLocalVariableCheckTest
             "15:13: " + getCheckMessage(MSG_KEY, "x"),
             "21:66: " + getCheckMessage(MSG_KEY, "snippets"),
             "22:32: " + getCheckMessage(MSG_KEY, "filteredSnippets"),
+            "41:16: " + getCheckMessage(MSG_KEY, "a"),
         };
         verify(checkConfig, getPath("InputFinalLocalVariableEnhancedForLoopVariable.java"),
             expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableEnhancedForLoopVariable.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableEnhancedForLoopVariable.java
@@ -30,4 +30,27 @@ public class InputFinalLocalVariableEnhancedForLoopVariable {
         }
         return filteredSnippets;
     }
+
+    public void method4()
+    {
+        final java.util.List<Object> list = new java.util.ArrayList<>();
+
+        for(Object a : list) {
+        }
+
+        Object a;
+        if (list.isEmpty())
+        {
+            a = new String("empty");
+        }
+        else
+        {
+            a = new String("not empty");
+        }
+
+        for(Object b : list) {
+            b = new String("b");
+        }
+    }
+    
 }


### PR DESCRIPTION
The goal of this PR is to fix Issue #6377, where the FinalLocalVariable check can throw an IllegalStateException when checking an enhanced for-loop.

Proposed solution is to push/pop a new `ScopeData` when entering/exiting a `LITERAL_FOR` token, and to mark `FinalVariableCandidate`'s for enhanced for-loop variables as `assigned` upon creation.

Regression report: http://esilkensen.github.io/checkstyle-tester/6377

Elasticsearch example from the Issue description: [#A119](http://esilkensen.github.io/checkstyle-tester/6377/elasticsearch/index.html#A119)

**Example of the exception:** (with my understanding of how it happens)

```
public void method() {
  for (Object o : collection) {
    // do nothing
  }

  Object o;
  if (condition) {
    o = new String("foo");
  } else {
    o = new String("bar");
  }
}
```

With the existing code, the `o` introduced by the `for` loop is added to the top `method` level `ScopeData` and it does not leave that scope after the `for` loop. Then a second `o` is added to the `ScopeData` at line 6.

When the check exits the closing `}` for the `if`, the current scope has one assigned `o` variable (the `o = new String("foo");` and the previous scope has two unassigned `o` variables (`for (Object o` and `Object o;`).

It checks `isSameVariables` between the assigned `o` and each unassigned `o`, which returns `true` in both cases (it only checks that they are contained in the same `method`) and so two calls to `iterator.remove()` are made, throwing an exception.

**Solution:**

With the code in this PR, a `ScopeData` is pushed when the check enters a `for` loop to capture variables introduced by `FOR_INIT`/`FOR_EACH_CLAUSE` -- e.g. the `o` bound by the loop. When the check exits a `for` loop it pops that `ScopeData` because those variables are no longer in scope and can be used again. In the example above, it sees that the `o` bound by the loop was never assigned and logs it as a `final` candidate.

This avoids the IllegalStateException in the example because the `o` bound by the loop is no longer part of the scope when the check is processing the if/else, so there is only a single unassigned `o` to consider.

The other change in this PR is to set `assigned` to `true` when creating a `FinalLocalVariableCandidate` for any variable bound in an enhanced for-loop, because these loops implicitly assign the variable when starting iteration.