### PR TITLE
Issue #6301: ArrayTypeStyle support for method definitions

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/ArrayTypeStyleTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/ArrayTypeStyleTest.java
@@ -41,8 +41,11 @@ public class ArrayTypeStyleTest extends AbstractModuleTestSupport {
             "15:44: " + getCheckMessage(ArrayTypeStyleCheck.class, MSG_KEY),
             "21:20: " + getCheckMessage(ArrayTypeStyleCheck.class, MSG_KEY),
             "22:23: " + getCheckMessage(ArrayTypeStyleCheck.class, MSG_KEY),
-            "41:16: " + getCheckMessage(ArrayTypeStyleCheck.class, MSG_KEY),
-            "42:19: " + getCheckMessage(ArrayTypeStyleCheck.class, MSG_KEY),
+            "41:33: " + getCheckMessage(ArrayTypeStyleCheck.class, MSG_KEY),
+            "46:36: " + getCheckMessage(ArrayTypeStyleCheck.class, MSG_KEY),
+            "52:27: " + getCheckMessage(ArrayTypeStyleCheck.class, MSG_KEY),
+            "62:16: " + getCheckMessage(ArrayTypeStyleCheck.class, MSG_KEY),
+            "63:19: " + getCheckMessage(ArrayTypeStyleCheck.class, MSG_KEY),
         };
 
         final Configuration checkConfig = getModuleConfig("ArrayTypeStyle");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/InputArrayTypeStyle.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/InputArrayTypeStyle.java
@@ -29,11 +29,32 @@ public class InputArrayTypeStyle
 
         public Test[]
             getTests()
-        { // we shouldn't check methods because there is no alternatives.
+        {
             return null;
         }
 
         public Test[] getNewTest() //ok
+        {
+            return null;
+        }
+
+        public Test getOldTest()[] //warn
+        {
+            return null;
+        }
+
+        public Test getOldTests()[][] //warn
+        {
+            return null;
+        }
+
+        public Test[]
+            getMoreTests()[] //warn
+        {
+            return null;
+        }
+
+        public Test[][] getTests2() //ok
         {
             return null;
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheckTest.java
@@ -54,6 +54,9 @@ public class ArrayTypeStyleCheckTest
             "14:23: " + getCheckMessage(MSG_KEY),
             "15:18: " + getCheckMessage(MSG_KEY),
             "21:44: " + getCheckMessage(MSG_KEY),
+            "45:33: " + getCheckMessage(MSG_KEY),
+            "50:36: " + getCheckMessage(MSG_KEY),
+            "56:29: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputArrayTypeStyle.java"), expected);
     }
@@ -69,6 +72,9 @@ public class ArrayTypeStyleCheckTest
             "17:39: " + getCheckMessage(MSG_KEY),
             "23:18: " + getCheckMessage(MSG_KEY),
             "31:20: " + getCheckMessage(MSG_KEY),
+            "45:33: " + getCheckMessage(MSG_KEY),
+            "50:36: " + getCheckMessage(MSG_KEY),
+            "56:29: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputArrayTypeStyle.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/arraytypestyle/InputArrayTypeStyle.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/arraytypestyle/InputArrayTypeStyle.java
@@ -33,11 +33,32 @@ public class InputArrayTypeStyle
 
         public Test[]
             getTests()
-        { // we shouldn't check methods because there is no alternatives.
+        {
             return null;
         }
 
         public Test[] getNewTest()
+        {
+            return null;
+        }
+
+        public Test getOldTest()[]
+        {
+            return null;
+        }
+
+        public Test getOldTests()[][]
+        {
+            return null;
+        }
+
+        public Test[]
+            getMoreTests()[][]
+        {
+            return null;
+        }
+
+        public Test[][] getTests2()
         {
             return null;
         }

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -28,7 +28,15 @@
         <p>
           Checks the style of array type definitions.  Some like Java style:
           <code>public static void main(String[] args)</code> and some like
-          C style: public static void main(String args[])
+          C style: <code>public static void main(String args[])</code>.
+        </p>
+        <p>
+          By default the Check enforces Java style.
+        </p>
+        <p>
+          This check strictly enforces only Java style for method return types
+          regardless of the value for 'javaStyle'. For example, <code>byte[] getData()</code>.
+          This is because C doesn't compile methods with array declarations on the name.
         </p>
       </subsection>
 
@@ -60,7 +68,23 @@
         <source>
 &lt;module name=&quot;ArrayTypeStyle&quot;/&gt;
         </source>
+        <p>
+          Example:
+        </p>
+        <source>
+public class MyClass {
+  int[] nums; // OK
+  String strings[]; // violation
 
+  char[] toCharArray() { // OK
+    return null;
+  }
+
+  byte getData()[] { // violation
+    return null;
+  }
+}
+        </source>
         <p>
           To configure the check to enforce C style:
         </p>
@@ -68,6 +92,23 @@
 &lt;module name=&quot;ArrayTypeStyle&quot;&gt;
   &lt;property name=&quot;javaStyle&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+public class MyClass {
+  int[] nums; // violation
+  String strings[]; // OK
+
+  char[] toCharArray() { // OK
+    return null;
+  }
+
+  byte getData()[] { // violation
+    return null;
+  }
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
The goal of this PR is to address Issue #6301 by adding support for checking the [ArrayTypeStyle](https://checkstyle.org/config_misc.html#ArrayTypeStyle) of method definitions.

The following is valid Java syntax:
```
Object emptyArray()[] {
    ...
}
```

With this PR, method definitions with array return types like the above would be reported as violations regardless of the value of `javaStyle`. My initial thought was that since functions can't have an array return type in C, it could make sense for this check to always enforce "Java-style" method return types.

That said, I think it'd be an easy enough code change to only report these method return type violations when `javaStyle` is `true` - or similarly to add a new parameter (or `TokenTypes.METHOD_DEF` as an optional token?) to configure whether to check method return types.

What do you think? 

Regression reports: 
* http://esilkensen.github.io/checkstyle-tester/6301/true (`javaStyle="true"` )
* http://esilkensen.github.io/checkstyle-tester/6301/false (`javaStyle="false"`)
