### PR TITLE
doc: add File Filter section in extending.xml

### DIFF
--- a/src/xdocs/extending.xml
+++ b/src/xdocs/extending.xml
@@ -25,6 +25,7 @@
         <li><a href="writingchecks.html">Writing Checks</a>;</li>
         <li><a href="writingjavadocchecks.html">Writing Javadoc Checks</a>;</li>
         <li><a href="writingfilters.html">Writing filters</a>;</li>
+        <li><a href="writingfilefilters.html">Writing file filters</a>;</li>
         <li><a href="writinglisteners.html">Writing listeners</a>.</li>
       </ul>
     </section>


### PR DESCRIPTION
Now, on the sidebar, there are 5 sections under `Extending Checkstyle` . However, in [Extending Checkstyle](https://checkstyle.org/extending.html) page, there are only 4 of them and File filter section is missing.

Let's add the File FIlter section back to extending.xml.