### PR TITLE
Issue #4814: added try/catch to setting up TreeWalker children

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -148,11 +148,19 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
     public void setupChild(Configuration childConf)
             throws CheckstyleException {
         final String name = childConf.getName();
-        final Object module = moduleFactory.createModule(name);
-        if (module instanceof AutomaticBean) {
-            final AutomaticBean bean = (AutomaticBean) module;
-            bean.contextualize(childContext);
-            bean.configure(childConf);
+        final Object module;
+
+        try {
+            module = moduleFactory.createModule(name);
+            if (module instanceof AutomaticBean) {
+                final AutomaticBean bean = (AutomaticBean) module;
+                bean.contextualize(childContext);
+                bean.configure(childConf);
+            }
+        }
+        catch (final CheckstyleException ex) {
+            throw new CheckstyleException("cannot initialize module " + name
+                    + " - " + ex.getMessage(), ex);
         }
         if (module instanceof AbstractCheck) {
             final AbstractCheck check = (AbstractCheck) module;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -188,7 +188,7 @@ public abstract class AutomaticBean
         for (final String key : attributes) {
             final String value = config.getAttribute(key);
 
-            tryCopyProperty(config.getName(), key, value, true);
+            tryCopyProperty(key, value, true);
         }
 
         finishLocalSetup();
@@ -201,13 +201,12 @@ public abstract class AutomaticBean
 
     /**
      * Recheck property and try to copy it.
-     * @param moduleName name of the module/class
      * @param key key of value
      * @param value value
      * @param recheck whether to check for property existence before copy
      * @throws CheckstyleException then property defined incorrectly
      */
-    private void tryCopyProperty(String moduleName, String key, Object value, boolean recheck)
+    private void tryCopyProperty(String key, Object value, boolean recheck)
             throws CheckstyleException {
         final BeanUtilsBean beanUtils = createBeanUtilsBean();
 
@@ -219,8 +218,8 @@ public abstract class AutomaticBean
                 final PropertyDescriptor descriptor =
                         PropertyUtils.getPropertyDescriptor(this, key);
                 if (descriptor == null) {
-                    final String message = String.format(Locale.ROOT, "Property '%s' in module %s "
-                            + "does not exist, please check the documentation", key, moduleName);
+                    final String message = String.format(Locale.ROOT, "Property '%s' "
+                            + "does not exist, please check the documentation", key);
                     throw new CheckstyleException(message);
                 }
             }
@@ -234,12 +233,12 @@ public abstract class AutomaticBean
             // so we have to join these exceptions with InvocationTargetException
             // to satisfy UTs coverage
             final String message = String.format(Locale.ROOT,
-                    "Cannot set property '%s' to '%s' in module %s", key, value, moduleName);
+                    "Cannot set property '%s' to '%s'", key, value);
             throw new CheckstyleException(message, ex);
         }
         catch (final IllegalArgumentException | ConversionException ex) {
             final String message = String.format(Locale.ROOT, "illegal value '%s' for property "
-                    + "'%s' of module %s", value, key, moduleName);
+                    + "'%s'", value, key);
             throw new CheckstyleException(message, ex);
         }
     }
@@ -256,7 +255,7 @@ public abstract class AutomaticBean
         for (final String key : attributes) {
             final Object value = context.get(key);
 
-            tryCopyProperty(getClass().getName(), key, value, false);
+            tryCopyProperty(key, value, false);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -459,7 +459,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
         catch (CheckstyleException ex) {
             assertEquals("Error message is not expected",
                     "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker"
-                        + " - Property '$$No such property' in module " + checkConfig.getName()
+                        + " - cannot initialize module " + checkConfig.getName()
+                        + " - Property '$$No such property'"
                         + " does not exist, please check the documentation", ex.getMessage());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -549,8 +549,9 @@ public class MainTest {
             final String output = errorCounterOneMessage.getMessage() + EOL;
             assertEquals("Unexpected output log", output, systemOut.getLog());
             final String errorOutput = "com.puppycrawl.tools.checkstyle.api."
-                    + "CheckstyleException: cannot initialize module TreeWalker"
-                    + " - JavadocVariable is not allowed as a child in JavadocMethod";
+                    + "CheckstyleException: cannot initialize module TreeWalker - "
+                    + "cannot initialize module JavadocMethod - "
+                    + "JavadocVariable is not allowed as a child in JavadocMethod";
             assertTrue("Unexpected system error log", systemErr.getLog().startsWith(errorOutput));
         });
         Main.main("-c", getPath("InputMainConfig-incorrectChildren2.xml"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -48,10 +48,10 @@ public class AutomaticBeanTest {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            final String expected = "Property 'NonExistent' in module ";
             assertNull("Exceptions cause should be null", ex.getCause());
-            assertTrue("Invalid exception message, should start with: " + expected,
-                    ex.getMessage().startsWith(expected));
+            assertEquals("Invalid exception message",
+                    "Property 'NonExistent' does not exist, please check the documentation",
+                    ex.getMessage());
         }
     }
 
@@ -65,10 +65,10 @@ public class AutomaticBeanTest {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            final String expected = "Property 'privateField' in module ";
             assertNull("Exceptions cause should be null", ex.getCause());
-            assertTrue("Invalid exception message, should start with: " + expected,
-                    ex.getMessage().startsWith(expected));
+            assertEquals("Invalid exception message",
+                    "Property 'privateField' does not exist, please check the documentation",
+                    ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -150,11 +150,11 @@ public class NewlineAtEndOfFileCheckTest
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            assertTrue("Error message is unexpected",
-                    ex.getMessage().startsWith(
+            assertEquals("Error message is unexpected",
                     "cannot initialize module com.puppycrawl.tools.checkstyle."
                             + "checks.NewlineAtEndOfFileCheck - "
-                            + "Cannot set property 'lineSeparator' to 'ct' in module"));
+                            + "Cannot set property 'lineSeparator' to 'ct'",
+                    ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckTest.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 import static com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck.MSG_KEY_BLOCK_EMPTY;
 import static com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck.MSG_KEY_BLOCK_NO_STATEMENT;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
@@ -149,12 +148,12 @@ public class EmptyBlockCheckTest
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart =
-                "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
-                    + "Cannot set property 'option' to 'invalid_option' in module";
-
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+            assertEquals("Invalid exception message",
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                        + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                        + "blocks.EmptyBlockCheck - "
+                        + "Cannot set property 'option' to 'invalid_option'",
+                    ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -24,7 +24,6 @@ import static com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck.MSG_K
 import static com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck.MSG_KEY_LINE_PREVIOUS;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
@@ -434,12 +433,12 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart =
+            assertEquals("Invalid exception message",
                 "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
-                    + "Cannot set property 'option' to 'invalid_option' in module";
-
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                    + "blocks.LeftCurlyCheck - "
+                    + "Cannot set property 'option' to 'invalid_option'",
+                ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -23,7 +23,6 @@ import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_
 import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_BREAK_BEFORE;
 import static com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck.MSG_KEY_LINE_SAME;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
@@ -317,11 +316,12 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart =
+            assertEquals("Invalid exception message",
                 "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
-                    + "Cannot set property 'option' to 'invalid_option' in module";
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                    + "blocks.RightCurlyCheck - "
+                    + "Cannot set property 'option' to 'invalid_option'",
+                ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -122,8 +122,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
         catch (CheckstyleException ex) {
             assertEquals("Invalid exception message", "cannot initialize module"
                     + " com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck"
-                    + " - Cannot set property 'charset' to 'XSO-8859-1' in module"
-                    + " com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck",
+                    + " - Cannot set property 'charset' to 'XSO-8859-1'",
                     ex.getMessage());
             assertEquals("Invalid exception message", "unsupported charset: 'XSO-8859-1'",
                     ex.getCause().getCause().getCause().getMessage());
@@ -141,8 +140,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
         catch (CheckstyleException ex) {
             assertEquals("Invalid exception message", "cannot initialize module"
                     + " com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck"
-                    + " - Cannot set property 'headerFile' to '' in module"
-                    + " com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck",
+                    + " - Cannot set property 'headerFile' to ''",
                     ex.getMessage());
             assertEquals("Invalid exception message",
                     "property 'headerFile' is missing or invalid in module"
@@ -162,8 +160,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
         catch (CheckstyleException ex) {
             assertEquals("Invalid exception message", "cannot initialize module"
                     + " com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck"
-                    + " - Cannot set property 'headerFile' to 'null' in module"
-                    + " com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck",
+                    + " - Cannot set property 'headerFile' to 'null'",
                     ex.getMessage());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
@@ -129,8 +129,7 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
         catch (CheckstyleException ex) {
             assertEquals("Invalid exception message", "cannot initialize module"
                     + " com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck"
-                    + " - Cannot set property 'headerFile' to '' in"
-                    + " module com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck",
+                    + " - Cannot set property 'headerFile' to ''",
                     ex.getMessage());
         }
     }
@@ -180,8 +179,7 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
         catch (CheckstyleException ex) {
             assertEquals("Invalid exception message", "cannot initialize module"
                     + " com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck"
-                    + " - Cannot set property 'header' to '^(.*\\n.*)' in module"
-                    + " com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck",
+                    + " - Cannot set property 'header' to '^(.*\\n.*)'",
                     ex.getMessage());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -26,7 +26,6 @@ import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCh
 import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.MSG_ORDER;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -526,15 +525,16 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart =
+            assertEquals("Invalid exception message",
                 "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
-                    + "Cannot set property 'customImportOrderRules' to "
-                    + "'SAME_PACKAGE(-1)' in module";
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+                        + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
+                        + ".imports.CustomImportOrderCheck - "
+                        + "Cannot set property 'customImportOrderRules' to "
+                        + "'SAME_PACKAGE(-1)'",
+                ex.getMessage());
             assertEquals("Invalid exception message",
                     "SAME_PACKAGE rule parameter should be positive integer: SAME_PACKAGE(-1)",
-                        ex.getCause().getCause().getCause().getMessage());
+                        ex.getCause().getCause().getCause().getCause().getMessage());
         }
     }
 
@@ -554,15 +554,16 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart =
+            assertEquals("Invalid exception message",
                 "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
-                    + "Cannot set property 'customImportOrderRules' to "
-                    + "'SAME_PACKAGE(0)' in module";
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+                        + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
+                        + ".imports.CustomImportOrderCheck - "
+                        + "Cannot set property 'customImportOrderRules' to "
+                        + "'SAME_PACKAGE(0)'",
+                ex.getMessage());
             assertEquals("Invalid exception message",
                     "SAME_PACKAGE rule parameter should be positive integer: SAME_PACKAGE(0)",
-                        ex.getCause().getCause().getCause().getMessage());
+                        ex.getCause().getCause().getCause().getCause().getMessage());
         }
     }
 
@@ -581,14 +582,15 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart =
+            assertEquals("Invalid exception message",
                 "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
-                    + "Cannot set property 'customImportOrderRules' to "
-                    + "'SAME_PACKAGE(3)###UNSUPPORTED_RULE' in module";
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+                        + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
+                        + ".imports.CustomImportOrderCheck - "
+                        + "Cannot set property 'customImportOrderRules' to "
+                        + "'SAME_PACKAGE(3)###UNSUPPORTED_RULE'",
+                ex.getMessage());
             assertEquals("Invalid exception message", "Unexpected rule: UNSUPPORTED_RULE", ex
-                    .getCause().getCause().getCause().getMessage());
+                    .getCause().getCause().getCause().getCause().getMessage());
         }
     }
 
@@ -606,15 +608,16 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart =
+            assertEquals("Invalid exception message",
                 "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
-                    + "Cannot set property 'customImportOrderRules' to "
-                    + "'SAME_PACKAGE(INT_IS_REQUIRED_HERE)' in module";
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+                        + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
+                        + ".imports.CustomImportOrderCheck - "
+                        + "Cannot set property 'customImportOrderRules' to "
+                        + "'SAME_PACKAGE(INT_IS_REQUIRED_HERE)'",
+                ex.getMessage());
             assertEquals("Invalid exception message",
                     "For input string: \"INT_IS_REQUIRED_HERE\"",
-                    ex.getCause().getCause().getCause().getMessage());
+                    ex.getCause().getCause().getCause().getCause().getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -451,7 +451,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
      * @return String message of original exception
      */
     private static String getCheckstyleExceptionMessage(CheckstyleException exception) {
-        return exception.getCause().getCause().getCause().getMessage();
+        return exception.getCause().getCause().getCause().getCause().getMessage();
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -218,12 +218,12 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart = "cannot initialize module "
-                + "com.puppycrawl.tools.checkstyle.TreeWalker - Cannot set property 'option' to "
-                + "'invalid_option' in module";
-
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+            assertEquals("Invalid exception message",
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                        + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
+                        + ".imports.ImportOrderCheck - "
+                        + "Cannot set property 'option' to 'invalid_option'",
+                    ex.getMessage());
         }
     }
 
@@ -613,14 +613,14 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart = "cannot initialize module "
-                + "com.puppycrawl.tools.checkstyle.TreeWalker - Cannot set property"
-                + " 'groups' to '/^javax' in module";
-
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+            assertEquals("Invalid exception message",
+                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                        + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
+                        + ".imports.ImportOrderCheck - "
+                        + "Cannot set property 'groups' to '/^javax'",
+                    ex.getMessage());
             assertEquals("Invalid exception message", "Invalid group: /^javax",
-                    ex.getCause().getCause().getCause().getMessage());
+                    ex.getCause().getCause().getCause().getCause().getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
@@ -23,7 +23,6 @@ import static com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractio
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
@@ -124,19 +123,17 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart =
+            assertEquals("Invalid exception message",
                 "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                    + "metrics.ClassDataAbstractionCouplingCheck - "
                     + "Cannot set property 'excludedPackages' to "
-                    + "'com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.' in module "
-                    + "com.puppycrawl.tools.checkstyle.checks.metrics."
-                    + "ClassDataAbstractionCouplingCheck";
-
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+                    + "'com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.'",
+                ex.getMessage());
             assertEquals("Invalid exception message,",
                     "the following values are not valid identifiers: ["
                             + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.]", ex
-                            .getCause().getCause().getCause().getMessage());
+                            .getCause().getCause().getCause().getCause().getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.checks.metrics;
 
 import static com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck.MSG_KEY;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.Assert;
@@ -105,19 +104,17 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart =
+            assertEquals("Invalid exception message",
                 "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                    + "metrics.ClassFanOutComplexityCheck - "
                     + "Cannot set property 'excludedPackages' to "
-                    + "'com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.' in module "
-                    + "com.puppycrawl.tools.checkstyle.checks.metrics."
-                    + "ClassFanOutComplexityCheck";
-
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+                    + "'com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.'",
+                ex.getMessage());
             assertEquals("Invalid exception message,",
                     "the following values are not valid identifiers: ["
                             + "com.puppycrawl.tools.checkstyle.checks.metrics.inputs.a.]", ex
-                            .getCause().getCause().getCause().getMessage());
+                            .getCause().getCause().getCause().getCause().getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
@@ -60,11 +60,12 @@ public class ConstantNameCheckTest
             fail("CheckstyleException is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message", "cannot initialize module"
-                    + " com.puppycrawl.tools.checkstyle.TreeWalker - illegal value"
-                    + " '\\' for property 'format' of module"
-                    + " com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck",
-                    ex.getMessage());
+            assertEquals("Invalid exception message",
+                "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                    + "naming.ConstantNameCheck - "
+                    + "illegal value '\\' for property 'format'",
+                ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckTest.java
@@ -83,11 +83,10 @@ public class FileLengthCheckTest
             fail("Should indicate illegal args");
         }
         catch (CheckstyleException ex) {
-            // Expected Exception because of illegal argument for "max"
-            assertEquals("Invalid exception message", "cannot initialize module"
-                + " com.puppycrawl.tools.checkstyle.checks.sizes.FileLengthCheck"
-                + " - illegal value 'abc' for property 'max' of module"
-                + " com.puppycrawl.tools.checkstyle.checks.sizes.FileLengthCheck",
+            assertEquals("Invalid exception message",
+                "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                    + "sizes.FileLengthCheck - "
+                    + "illegal value 'abc' for property 'max'",
                 ex.getMessage());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
@@ -23,7 +23,6 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitiali
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck.MSG_PRECEDED;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
@@ -115,11 +114,12 @@ public class EmptyForInitializerPadCheckTest
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart = "cannot initialize module "
-                + "com.puppycrawl.tools.checkstyle.TreeWalker - Cannot set property 'option' to "
-                + "'invalid_option' in module";
-            assertTrue("Invalid exception message, should start with: ",
-                ex.getMessage().startsWith(messageStart));
+            assertEquals("Invalid exception message",
+                "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                    + "whitespace.EmptyForInitializerPadCheck - "
+                    + "Cannot set property 'option' to 'invalid_option'",
+                ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
@@ -22,7 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck.MSG_WS_FOLLOWED;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck.MSG_WS_NOT_FOLLOWED;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
@@ -92,11 +92,12 @@ public class EmptyForIteratorPadCheckTest
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart = "cannot initialize module "
-                + "com.puppycrawl.tools.checkstyle.TreeWalker - Cannot set property 'option' to "
-                + "'invalid_option' in module";
-            assertTrue("Invalid exception message, should start with: ",
-                ex.getMessage().startsWith(messageStart));
+            assertEquals("Invalid exception message",
+                "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                    + "whitespace.EmptyForIteratorPadCheck - "
+                    + "Cannot set property 'option' to 'invalid_option'",
+                ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
@@ -23,7 +23,7 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCh
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck.MSG_WS_NOT_PRECEDED;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck.MSG_WS_PRECEDED;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
@@ -161,11 +161,12 @@ public class MethodParamPadCheckTest
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart = "cannot initialize module "
-                + "com.puppycrawl.tools.checkstyle.TreeWalker - Cannot set property 'option' to "
-                + "'invalid_option' in module";
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+            assertEquals("Invalid exception message",
+                "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                    + "whitespace.MethodParamPadCheck - "
+                    + "Cannot set property 'option' to 'invalid_option'",
+                ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheckTest.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck.MSG_LINE_NEW;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck.MSG_LINE_PREVIOUS;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
@@ -114,11 +114,12 @@ public class OperatorWrapCheckTest
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart = "cannot initialize module "
-                + "com.puppycrawl.tools.checkstyle.TreeWalker - Cannot set property 'option' to "
-                + "'invalid_option' in module";
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+            assertEquals("Invalid exception message",
+                "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                    + "whitespace.OperatorWrapCheck - "
+                    + "Cannot set property 'option' to 'invalid_option'",
+                ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
@@ -23,6 +23,7 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPad
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck.MSG_WS_NOT_FOLLOWED;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck.MSG_WS_NOT_PRECEDED;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck.MSG_WS_PRECEDED;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -337,11 +338,12 @@ public class ParenPadCheckTest
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart = "cannot initialize module "
-                + "com.puppycrawl.tools.checkstyle.TreeWalker - Cannot set property 'option' to "
-                + "'invalid_option' in module";
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+            assertEquals("Invalid exception message",
+                "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                    + "whitespace.ParenPadCheck - "
+                    + "Cannot set property 'option' to 'invalid_option'",
+                ex.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck.MSG_LINE_NEW;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck.MSG_LINE_PREVIOUS;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import org.junit.Assert;
@@ -98,11 +98,12 @@ public class SeparatorWrapCheckTest
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            final String messageStart = "cannot initialize module "
-                + "com.puppycrawl.tools.checkstyle.TreeWalker - Cannot set property 'option' to "
-                + "'invalid_option' in module";
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+            assertEquals("Invalid exception message",
+                "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+                    + "cannot initialize module com.puppycrawl.tools.checkstyle.checks."
+                    + "whitespace.SeparatorWrapCheck - "
+                    + "Cannot set property 'option' to 'invalid_option'",
+                ex.getMessage());
         }
     }
 


### PR DESCRIPTION
Issue #4814

Benefit of this PR is that most `startsWith` was removed and we are doing full `equals` now.