### PR TITLE
minor: disable external dtd load by default

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -96,13 +96,13 @@
   </rule>
   <rule ref="category/java/codestyle.xml/ClassNamingConventions">
     <properties>
-     <!-- Definitions and XmlLoader.FeaturesForVerySecureJavaInstallations aren't utility classes.
+     <!-- Definitions and XmlLoader.LoadExternalDtdFeatureProvider aren't utility classes.
           JavadocTokenTypes and TokenTypes aren't utility classes.
             They are token definition classes. Also, they are part of the API. -->
      <property name="violationSuppressXPath"
                value="//ClassOrInterfaceDeclaration[@Image='Definitions'
                    or @Image='JavadocTokenTypes' or @Image='TokenTypes'
-                   or @Image='FeaturesForVerySecureJavaInstallations']"/>
+                   or @Image='LoadExternalDtdFeatureProvider']"/>
     </properties>
   </rule>
   <rule ref="category/java/codestyle.xml/ConfusingTernary">

--- a/pom.xml
+++ b/pom.xml
@@ -2678,12 +2678,12 @@
               </targetTests>
               <excludedMethods>
                 <!--cause of https://github.com/checkstyle/checkstyle/issues/3605-->
-                <param>addFeaturesForVerySecureJavaInstallations</param>
+                <param>setFeaturesBySystemProperty</param>
               </excludedMethods>
               <avoidCallsTo>
                 <!--cause of https://github.com/checkstyle/checkstyle/issues/3605-->
                 <avoidCallsTo>
-                  com.puppycrawl.tools.checkstyle.XmlLoader$FeaturesForVerySecureJavaInstallations
+                  com.puppycrawl.tools.checkstyle.XmlLoader$LoadExternalDtdFeatureProvider
                 </avoidCallsTo>
               </avoidCallsTo>
               <coverageThreshold>100</coverageThreshold>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java
@@ -65,7 +65,7 @@ public class XmlLoader
             throws SAXException, ParserConfigurationException {
         this.publicIdToResourceNameMap = new HashMap<>(publicIdToResourceNameMap);
         final SAXParserFactory factory = SAXParserFactory.newInstance();
-        FeaturesForVerySecureJavaInstallations.addFeaturesForVerySecureJavaInstallations(factory);
+        LoadExternalDtdFeatureProvider.setFeaturesBySystemProperty(factory);
         factory.setValidating(true);
         parser = factory.newSAXParser().getXMLReader();
         parser.setContentHandler(this);
@@ -113,7 +113,7 @@ public class XmlLoader
      * Used for setting specific for secure java installations features to SAXParserFactory.
      * Pulled out as a separate class in order to suppress Pitest mutations.
      */
-    public static final class FeaturesForVerySecureJavaInstallations {
+    public static final class LoadExternalDtdFeatureProvider {
 
         /** Feature that enables loading external DTD when loading XML files. */
         private static final String LOAD_EXTERNAL_DTD =
@@ -123,20 +123,26 @@ public class XmlLoader
                 "http://xml.org/sax/features/external-general-entities";
 
         /** Stop instances being created. **/
-        private FeaturesForVerySecureJavaInstallations() {
+        private LoadExternalDtdFeatureProvider() {
         }
 
         /**
          * Configures SAXParserFactory with features required
-         * for execution on very secured environments.
+         * to use extrnal DTD file loading, this is not activated by default to no allow
+         * usage of schema files that checkstyle do not know
+         * it is even security problem to allow files from outside.
          * @param factory factory to be configured with special features
          * @throws SAXException if an error occurs
          * @throws ParserConfigurationException if an error occurs
          */
-        public static void addFeaturesForVerySecureJavaInstallations(SAXParserFactory factory)
+        public static void setFeaturesBySystemProperty(SAXParserFactory factory)
                 throws SAXException, ParserConfigurationException {
-            factory.setFeature(LOAD_EXTERNAL_DTD, true);
-            factory.setFeature(EXTERNAL_GENERAL_ENTITIES, true);
+
+            final boolean allowExternalDtdLoad = Boolean.valueOf(
+                System.getProperty("org.checkstyle.allowExternalDtdLoad", "false"));
+
+            factory.setFeature(LOAD_EXTERNAL_DTD, allowExternalDtdLoad);
+            factory.setFeature(EXTERNAL_GENERAL_ENTITIES, allowExternalDtdLoad);
         }
 
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -406,6 +406,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         final Properties props = new Properties();
         props.setProperty("checkstyle.basedir", "basedir");
 
+        System.setProperty("org.checkstyle.allowExternalDtdLoad", "true");
+
         final DefaultConfiguration config =
             (DefaultConfiguration) loadConfiguration(
                 "InputConfigurationLoaderExternalEntity.xml", props);
@@ -421,6 +423,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         final Properties props = new Properties();
         props.setProperty("checkstyle.basedir", "basedir");
 
+        System.setProperty("org.checkstyle.allowExternalDtdLoad", "true");
+
         final DefaultConfiguration config =
             (DefaultConfiguration) loadConfiguration(
                 "subdir/InputConfigurationLoaderExternalEntitySubDir.xml", props);
@@ -435,6 +439,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
     public void testExternalEntityFromUri() throws Exception {
         final Properties props = new Properties();
         props.setProperty("checkstyle.basedir", "basedir");
+
+        System.setProperty("org.checkstyle.allowExternalDtdLoad", "true");
 
         final File file = new File(
                 getPath("subdir/InputConfigurationLoaderExternalEntitySubDir.xml"));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XmlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XmlLoaderTest.java
@@ -47,7 +47,7 @@ public class XmlLoaderTest {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertTrue("Constructor is not private", isUtilsClassHasPrivateConstructor(
-                XmlLoader.FeaturesForVerySecureJavaInstallations.class, true));
+                XmlLoader.LoadExternalDtdFeatureProvider.class, true));
     }
 
     @Test


### PR DESCRIPTION
no system property result in:
```
java.lang.NullPointerException
    at com.sun.org.apache.xerces.internal.impl.dtd.XMLDTDProcessor.endDTD(XMLDTDProcessor.java:1349)
    at com.sun.org.apache.xerces.internal.impl.XMLDTDScannerImpl.endEntity(XMLDTDScannerImpl.java:652)
    at com.sun.org.apache.xerces.internal.impl.XMLEntityManager.endEntity(XMLEntityManager.java:1401)
    at com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.load(XMLEntityScanner.java:1917)
    at com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.skipSpaces(XMLEntityScanner.java:1655)
    at com.sun.org.apache.xerces.internal.impl.XMLDTDScannerImpl.skipSeparator(XMLDTDScannerImpl.java:2082)
    at com.sun.org.apache.xerces.internal.impl.XMLDTDScannerImpl.scanDecls(XMLDTDScannerImpl.java:2058)
    at com.sun.org.apache.xerces.internal.impl.XMLDTDScannerImpl.scanDTDExternalSubset(XMLDTDScannerImpl.java:301)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl$DTDDriver.dispatch(XMLDocumentScannerImpl.java:1175)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl$DTDDriver.next(XMLDocumentScannerImpl.java:1045)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl$PrologDriver.next(XMLDocumentScannerImpl.java:933)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:602)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:505)
    at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:841)
    at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:770)
    at com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
    at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1213)
    at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:643)
    at com.puppycrawl.tools.checkstyle.XmlLoader.parseInputSource(XmlLoader.java:84)
    at com.puppycrawl.tools.checkstyle.ConfigurationLoader.parseInputSource(ConfigurationLoader.java:197)
    at com.puppycrawl.tools.checkstyle.ConfigurationLoader.loadConfiguration(ConfigurationLoader.java:443)
    at com.puppycrawl.tools.checkstyle.ConfigurationLoader.loadConfiguration(ConfigurationLoader.java:395)
    at com.puppycrawl.tools.checkstyle.ConfigurationLoader.loadConfiguration(ConfigurationLoader.java:372)
    at com.puppycrawl.tools.checkstyle.ConfigurationLoader.loadConfiguration(ConfigurationLoader.java:209)
    at com.puppycrawl.tools.checkstyle.ConfigurationLoaderTest.loadConfiguration(ConfigurationLoaderTest.java:62)
    at com.puppycrawl.tools.checkstyle.ConfigurationLoaderTest.testExternalEntity(ConfigurationLoaderTest.java:410)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
    at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
    at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
    at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
    at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
    at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
```