### PR TITLE
config: fixed exclude for .checkstyle from eclipse-cs

### DIFF
--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -79,7 +79,7 @@
 
           <!-- m2e-code-quality Eclipse IDE plugin temporary configuration files
                for Eclipse CS Checkstyle / PMD / SpotBugs Plug-Ins -->
-          <exclude name=".checkstyle/**/*"/>
+          <exclude name=".checkstyle"/>
           <exclude name=".pmd/**/*"/>
           <exclude name=".pmdruleset.xml"/>
           <exclude name=".fbExcludeFilterFile/**/*"/>


### PR DESCRIPTION
The exclude makes it look like it is excluding a folder but it is actually just a file.

There are some other around the same area that look like they might be files and not folders, but I am not sure. This is the only one that is affecting me right now.