### PR TITLE
Issue #6496: made and documented all filter elements are immutable

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElement.java
@@ -27,7 +27,7 @@ import java.util.StringTokenizer;
 
 /**
  * <p>
- * This filter accepts an integer that matches a CSV value, where
+ * This filter element is immutable and accepts an integer that matches a CSV value, where
  * each value is an integer or a range of integers.
  * </p>
  */
@@ -68,7 +68,7 @@ class CsvFilterElement implements IntFilterElement {
      * Adds a IntFilterElement to the set.
      * @param filter the IntFilterElement to add.
      */
-    public final void addFilter(IntFilterElement filter) {
+    private void addFilter(IntFilterElement filter) {
         filters.add(filter);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterElement.java
@@ -20,7 +20,7 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 /**
- * This filter accepts a matching Integer.
+ * This filter element is immutable and accepts a matching Integer.
  */
 class IntMatchFilterElement implements IntFilterElement {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterElement.java
@@ -22,7 +22,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 import java.util.Objects;
 
 /**
- * This filter accepts an Integer in a range.
+ * This filter element is immutable and accepts an Integer in a range.
  */
 class IntRangeFilterElement implements IntFilterElement {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
@@ -36,7 +36,7 @@ import net.sf.saxon.sxpath.XPathExpression;
 import net.sf.saxon.trans.XPathException;
 
 /**
- * This filter processes {@link TreeWalkerAuditEvent}
+ * This filter element is immutable and processes {@link TreeWalkerAuditEvent}
  * objects based on the criteria of file, check, module id, xpathQuery.
  *
  */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElementTest.java
@@ -85,32 +85,6 @@ public class CsvFilterElementTest {
     }
 
     @Test
-    public void testOneFilter() {
-        final CsvFilterElement filter = new CsvFilterElement("");
-        filter.addFilter(new IntMatchFilterElement(0));
-        assertTrue("0", filter.accept(0));
-        assertFalse("1", filter.accept(1));
-    }
-
-    @Test
-    public void testMultipleFilter() {
-        final CsvFilterElement filter = new CsvFilterElement("");
-        filter.addFilter(new IntMatchFilterElement(0));
-        filter.addFilter(new IntRangeFilterElement(0, 2));
-        assertTrue("0", filter.accept(0));
-        assertTrue("1", filter.accept(1));
-        filter.addFilter(new IntRangeFilterElement(3, 4));
-        assertTrue("0 is in [3,4]", filter.accept(0));
-    }
-
-    @Test
-    public void testGetFilters() {
-        final CsvFilterElement filter = new CsvFilterElement("");
-        filter.addFilter(new IntMatchFilterElement(0));
-        assertEquals("size is the same", 1, filter.getFilters().size());
-    }
-
-    @Test
     public void testEqualsAndHashCode() {
         final EqualsVerifierReport ev = EqualsVerifier.forClass(CsvFilterElement.class)
                 .usingGetClass().report();


### PR DESCRIPTION
Issue #6496

All classes already have equals/hashCode. Mostly minor documentation changes except CsvFilterElement where a public method had to be made private as it modifies the field from the constructor. Tests were removed as they were just duplicates of others and pitest/code coverage should show this.