### PR TITLE
Issue #6485: added tabWidth to Checker and populated it to all checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2862,6 +2862,7 @@
               </targetClasses>
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.api.*</param>
+                <param>com.puppycrawl.tools.checkstyle.TreeWalkerTest</param>
                 <param>com.puppycrawl.tools.checkstyle.grammar.comments.CommentsTest</param>
                 <param>com.puppycrawl.tools.checkstyle.filefilters.*</param>
                 <param>com.puppycrawl.tools.checkstyle.filters.*</param>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -131,6 +131,9 @@ public class Checker extends AutomaticBean implements MessageDispatcher, RootMod
     /** Controls whether exceptions should halt execution or not. */
     private boolean haltOnException = true;
 
+    /** The tab width for column reporting. */
+    private int tabWidth = CommonUtil.DEFAULT_TAB_WIDTH;
+
     /**
      * Creates a new {@code Checker} instance.
      * The instance needs to be contextualized and configured.
@@ -446,6 +449,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher, RootMod
         context.add("moduleFactory", moduleFactory);
         context.add("severity", severity.getName());
         context.add("basedir", basedir);
+        context.add("tabWidth", String.valueOf(tabWidth));
         childContext = context;
     }
 
@@ -622,6 +626,14 @@ public class Checker extends AutomaticBean implements MessageDispatcher, RootMod
      */
     public void setHaltOnException(boolean haltOnException) {
         this.haltOnException = haltOnException;
+    }
+
+    /**
+     * Set the tab width to report errors with.
+     * @param tabWidth an {@code int} value
+     */
+    public final void setTabWidth(int tabWidth) {
+        this.tabWidth = tabWidth;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -581,9 +581,6 @@ public final class Main {
         /** The default number of threads to use for checker and the tree walker. */
         private static final int DEFAULT_THREAD_COUNT = 1;
 
-        /** Default distance between tab stops. */
-        private static final int DEFAULT_TAB_WIDTH = 8;
-
         /** Name for the moduleConfig attribute 'tabWidth'. */
         private static final String ATTRIB_TAB_WIDTH_NAME = "tabWidth";
 
@@ -622,7 +619,7 @@ public final class Main {
          */
         @Option(names = "--tabWidth", description = "Sets the length of the tab character. "
                 + "Used only with \"-s\" option. Default value is ${DEFAULT-VALUE}")
-        private int tabWidth = DEFAULT_TAB_WIDTH;
+        private int tabWidth = CommonUtil.DEFAULT_TAB_WIDTH;
 
         /** Switch whether to generate suppressions file or not. */
         @Option(names = {"-g", "--generate-xpath-suppression"},

--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -51,9 +51,6 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 @FileStatefulCheck
 public final class TreeWalker extends AbstractFileSetCheck implements ExternalResourceHolder {
 
-    /** Default distance between tab stops. */
-    private static final int DEFAULT_TAB_WIDTH = 8;
-
     /** Maps from token name to ordinary checks. */
     private final Map<String, Set<AbstractCheck>> tokenToOrdinaryChecks =
         new HashMap<>();
@@ -74,9 +71,6 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
     /** The sorted set of messages. */
     private final SortedSet<LocalizedMessage> messages = new TreeSet<>();
 
-    /** The distance between tab stops. */
-    private int tabWidth = DEFAULT_TAB_WIDTH;
-
     /** Class loader to resolve classes with. **/
     private ClassLoader classLoader;
 
@@ -91,14 +85,6 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
      */
     public TreeWalker() {
         setFileExtensions("java");
-    }
-
-    /**
-     * Sets tab width.
-     * @param tabWidth the distance between tab stops
-     */
-    public void setTabWidth(int tabWidth) {
-        this.tabWidth = tabWidth;
     }
 
     /**
@@ -135,7 +121,7 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
         final DefaultContext checkContext = new DefaultContext();
         checkContext.add("classLoader", classLoader);
         checkContext.add("severity", getSeverity());
-        checkContext.add("tabWidth", String.valueOf(tabWidth));
+        checkContext.add("tabWidth", String.valueOf(getTabWidth()));
 
         childContext = checkContext;
     }
@@ -183,7 +169,7 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
     protected void processFiltered(File file, FileText fileText) throws CheckstyleException {
         // check if already checked and passed the file
         if (!ordinaryChecks.isEmpty() || !commentChecks.isEmpty()) {
-            final FileContents contents = new FileContents(fileText);
+            final FileContents contents = getFileContents();
             final DetailAST rootAST = JavaParser.parse(contents);
             if (!ordinaryChecks.isEmpty()) {
                 walk(rootAST, contents, AstState.ORDINARY);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
@@ -36,9 +36,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  */
 public abstract class AbstractCheck extends AbstractViolationReporter {
 
-    /** Default tab width for column reporting. */
-    private static final int DEFAULT_TAB_WIDTH = 8;
-
     /**
      * The check context.
      * @noinspection ThreadLocalNotStaticFinal
@@ -49,7 +46,7 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
     private final Set<String> tokens = new HashSet<>();
 
     /** The tab width for column reporting. */
-    private int tabWidth = DEFAULT_TAB_WIDTH;
+    private int tabWidth = CommonUtil.DEFAULT_TAB_WIDTH;
 
     /**
      * The class loader to load external classes. Not initialized as this must

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -36,16 +36,19 @@ public abstract class AbstractFileSetCheck
     implements FileSetCheck {
 
     /**
-     * Collects the error messages.
+     * The check context.
+     * @noinspection ThreadLocalNotStaticFinal
      */
-    private static final ThreadLocal<SortedSet<LocalizedMessage>> MESSAGE_COLLECTOR =
-            ThreadLocal.withInitial(TreeSet::new);
+    private final ThreadLocal<FileContext> context = ThreadLocal.withInitial(FileContext::new);
 
     /** The dispatcher errors are fired to. */
     private MessageDispatcher messageDispatcher;
 
     /** The file extensions that are accepted by this filter. */
     private String[] fileExtensions = CommonUtil.EMPTY_STRING_ARRAY;
+
+    /** The tab width for column reporting. */
+    private int tabWidth = CommonUtil.DEFAULT_TAB_WIDTH;
 
     /**
      * Called to process a file that matches the specified file extensions.
@@ -74,7 +77,8 @@ public abstract class AbstractFileSetCheck
     @Override
     public final SortedSet<LocalizedMessage> process(File file, FileText fileText)
             throws CheckstyleException {
-        final SortedSet<LocalizedMessage> messages = MESSAGE_COLLECTOR.get();
+        final SortedSet<LocalizedMessage> messages = context.get().messages;
+        context.get().fileContents = new FileContents(fileText);
         messages.clear();
         // Process only what interested in
         if (CommonUtil.matchesFileExtension(file, fileExtensions)) {
@@ -103,6 +107,30 @@ public abstract class AbstractFileSetCheck
      */
     protected final MessageDispatcher getMessageDispatcher() {
         return messageDispatcher;
+    }
+
+    /**
+     * Returns the sorted set of {@link LocalizedMessage}.
+     * @return the sorted set of {@link LocalizedMessage}.
+     */
+    public SortedSet<LocalizedMessage> getMessages() {
+        return new TreeSet<>(context.get().messages);
+    }
+
+    /**
+     * Set the file contents associated with the tree.
+     * @param contents the manager
+     */
+    public final void setFileContents(FileContents contents) {
+        context.get().fileContents = contents;
+    }
+
+    /**
+     * Returns the file contents associated with the file.
+     * @return the file contents
+     */
+    protected final FileContents getFileContents() {
+        return context.get().fileContents;
     }
 
     /**
@@ -139,24 +167,50 @@ public abstract class AbstractFileSetCheck
     }
 
     /**
+     * Get tab width to report errors with.
+     * @return the tab width to report errors with
+     */
+    protected final int getTabWidth() {
+        return tabWidth;
+    }
+
+    /**
+     * Set the tab width to report errors with.
+     * @param tabWidth an {@code int} value
+     */
+    public final void setTabWidth(int tabWidth) {
+        this.tabWidth = tabWidth;
+    }
+
+    /**
      * Adds the sorted set of {@link LocalizedMessage} to the message collector.
      * @param messages the sorted set of {@link LocalizedMessage}.
      */
-    protected static void addMessages(SortedSet<LocalizedMessage> messages) {
-        MESSAGE_COLLECTOR.get().addAll(messages);
+    protected void addMessages(SortedSet<LocalizedMessage> messages) {
+        context.get().messages.addAll(messages);
     }
 
     @Override
     public final void log(int line, String key, Object... args) {
-        log(line, 0, key, args);
+        context.get().messages.add(
+                new LocalizedMessage(line,
+                        getMessageBundle(),
+                        key,
+                        args,
+                        getSeverityLevel(),
+                        getId(),
+                        getClass(),
+                        getCustomMessages().get(key)));
     }
 
     @Override
     public final void log(int lineNo, int colNo, String key,
             Object... args) {
-        MESSAGE_COLLECTOR.get().add(
+        final int col = 1 + CommonUtil.lengthExpandedTabs(
+                context.get().fileContents.getLine(lineNo - 1), colNo, tabWidth);
+        context.get().messages.add(
                 new LocalizedMessage(lineNo,
-                        colNo,
+                        col,
                         getMessageBundle(),
                         key,
                         args,
@@ -173,9 +227,22 @@ public abstract class AbstractFileSetCheck
      * @param fileName the audited file
      */
     protected final void fireErrors(String fileName) {
-        final SortedSet<LocalizedMessage> errors = new TreeSet<>(MESSAGE_COLLECTOR.get());
-        MESSAGE_COLLECTOR.get().clear();
+        final SortedSet<LocalizedMessage> errors = new TreeSet<>(context.get().messages);
+        context.get().messages.clear();
         messageDispatcher.fireErrors(fileName, errors);
+    }
+
+    /**
+     * The actual context holder.
+     */
+    private static class FileContext {
+
+        /** The sorted set for collecting messages. */
+        private final SortedSet<LocalizedMessage> messages = new TreeSet<>();
+
+        /** The current file contents. */
+        private FileContents fileContents;
+
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheck.java
@@ -55,10 +55,10 @@ public class FileTabCharacterCheck extends AbstractFileSetCheck {
             final int tabPosition = line.indexOf('\t');
             if (tabPosition != -1) {
                 if (eachLine) {
-                    log(lineNum, tabPosition + 1, MSG_CONTAINS_TAB);
+                    log(lineNum, tabPosition, MSG_CONTAINS_TAB);
                 }
                 else {
-                    log(lineNum, tabPosition + 1, MSG_FILE_CONTAINS_TAB);
+                    log(lineNum, tabPosition, MSG_FILE_CONTAINS_TAB);
                     break;
                 }
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -49,6 +49,9 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  */
 public final class CommonUtil {
 
+    /** Default tab width for column reporting. */
+    public static final int DEFAULT_TAB_WIDTH = 8;
+
     /** Copied from org.apache.commons.lang3.ArrayUtils. */
     public static final String[] EMPTY_STRING_ARRAY = new String[0];
     /** Copied from org.apache.commons.lang3.ArrayUtils. */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -1203,6 +1203,32 @@ public class CheckerTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testTabViolationDefault() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(VerifyPositionAfterTabFileSet.class);
+        final String[] expected = {
+            "2:9: violation",
+            "3:17: violation",
+        };
+        verify(checkConfig, getPath("InputCheckerTabCharacter.txt"),
+            expected);
+    }
+
+    @Test
+    public void testTabViolation() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(VerifyPositionAfterTabFileSet.class);
+        final DefaultConfiguration checkerConfig = createRootConfig(checkConfig);
+        checkerConfig.addAttribute("tabWidth", "4");
+        final String[] expected = {
+            "2:5: violation",
+            "3:9: violation",
+        };
+        verify(checkerConfig, getPath("InputCheckerTabCharacter.txt"),
+            expected);
+    }
+
+    @Test
     public void testCheckerProcessCallAllNeededMethodsOfFileSets() throws Exception {
         final DummyFileSet fileSet = new DummyFileSet();
         final Checker checker = new Checker();
@@ -1641,6 +1667,23 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         public MessageDispatcher getInternalMessageDispatcher() {
             return getMessageDispatcher();
+        }
+
+    }
+
+    private static class VerifyPositionAfterTabFileSet extends AbstractFileSetCheck {
+
+        @Override
+        protected void processFiltered(File file, FileText fileText) {
+            int lineNumber = 0;
+            for (String line : getFileContents().getLines()) {
+                final int position = line.lastIndexOf('\t');
+                lineNumber++;
+
+                if (position != -1) {
+                    log(lineNumber, position + 1, "violation");
+                }
+            }
         }
 
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -46,6 +46,7 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.Context;
+import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck;
@@ -215,6 +216,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             new ArrayList<>(Arrays.asList("package com.puppycrawl.tools.checkstyle;", "",
                 "error public class InputTreeWalkerFileWithViolation {}"));
         final FileText fileText = new FileText(file, lines);
+        treeWalker.setFileContents(new FileContents(fileText));
         try {
             treeWalker.processFiltered(file, fileText);
             fail("Exception expected");
@@ -263,6 +265,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final List<String> lines = new ArrayList<>();
         lines.add(" classD a {} ");
         final FileText fileText = new FileText(file, lines);
+        treeWalker.setFileContents(new FileContents(fileText));
         try {
             treeWalker.processFiltered(file, fileText);
             fail("Exception is expected");
@@ -286,6 +289,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final List<String> lines = new ArrayList<>();
         lines.add(" class a%$# {} ");
         final FileText fileText = new FileText(file, lines);
+        treeWalker.setFileContents(new FileContents(fileText));
         try {
             treeWalker.processFiltered(file, fileText);
             fail("Exception is expected");
@@ -356,6 +360,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final List<String> lines = new ArrayList<>();
         lines.add(" class a%$# {} ");
         final FileText fileText = new FileText(file, lines);
+        treeWalker.setFileContents(new FileContents(fileText));
 
         try {
             treeWalker.processFiltered(file, fileText);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -50,11 +49,8 @@ public class AbstractFileSetCheckTest {
         assertEquals("Invalid message", "File should not be empty.",
             firstFileMessages.first().getMessage());
 
-        final Field field = AbstractFileSetCheck.class.getDeclaredField("MESSAGE_COLLECTOR");
-        field.setAccessible(true);
-        @SuppressWarnings("unchecked")
         final SortedSet<LocalizedMessage> internalMessages =
-                ((ThreadLocal<SortedSet<LocalizedMessage>>) field.get(null)).get();
+                check.getMessages();
         assertTrue("Internal message should be empty, but was not", internalMessages.isEmpty());
 
         final File secondFile = new File("inputAbstractFileSetCheck.txt");
@@ -81,11 +77,8 @@ public class AbstractFileSetCheckTest {
             assertEquals("Invalid exception message", "Test", ex.getMessage());
         }
 
-        final Field field = AbstractFileSetCheck.class.getDeclaredField("MESSAGE_COLLECTOR");
-        field.setAccessible(true);
-        @SuppressWarnings("unchecked")
         final SortedSet<LocalizedMessage> internalMessages =
-                ((ThreadLocal<SortedSet<LocalizedMessage>>) field.get(null)).get();
+                check.getMessages();
         assertEquals("Internal message should only have 1", 1, internalMessages.size());
 
         // again to prove only 1 violation exists
@@ -99,9 +92,8 @@ public class AbstractFileSetCheckTest {
             assertEquals("Invalid exception message", "Test", ex.getMessage());
         }
 
-        @SuppressWarnings("unchecked")
         final SortedSet<LocalizedMessage> internalMessages2 =
-            ((ThreadLocal<SortedSet<LocalizedMessage>>) field.get(null)).get();
+            check.getMessages();
         assertEquals("Internal message should only have 1 again", 1, internalMessages2.size());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheckTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.regex.Pattern;
 
 import org.junit.Test;
@@ -32,6 +33,7 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class RegexpOnFilenameCheckTest extends AbstractModuleTestSupport {
@@ -243,7 +245,7 @@ public class RegexpOnFilenameCheckTest extends AbstractModuleTestSupport {
         try {
             final RegexpOnFilenameCheck check = new RegexpOnFilenameCheck();
             check.setFileNamePattern(Pattern.compile("BAD"));
-            check.process(file, null);
+            check.process(file, new FileText(file, Collections.emptyList()));
             fail("CheckstyleException expected");
         }
         catch (CheckstyleException ex) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/TreeWalkerPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/TreeWalkerPowerTest.java
@@ -71,7 +71,9 @@ public class TreeWalkerPowerTest extends AbstractModuleTestSupport {
         final File file = temporaryFolder.newFile("file.java");
         final List<String> lines = new ArrayList<>();
         lines.add("class Test {}");
-        Whitebox.invokeMethod(treeWalkerSpy, "processFiltered", file, new FileText(file, lines));
+        final FileText fileText = new FileText(file, lines);
+        treeWalkerSpy.setFileContents(new FileContents(fileText));
+        Whitebox.invokeMethod(treeWalkerSpy, "processFiltered", file, fileText);
         verifyPrivate(treeWalkerSpy, times(1)).invoke("walk",
                 any(DetailAST.class), any(FileContents.class), any(classAstState));
         verifyPrivate(treeWalkerSpy, times(0)).invoke("getFilteredMessages",
@@ -91,7 +93,9 @@ public class TreeWalkerPowerTest extends AbstractModuleTestSupport {
         final File file = temporaryFolder.newFile("file.java");
         final List<String> lines = new ArrayList<>();
         lines.add("class Test {}");
-        Whitebox.invokeMethod(treeWalkerSpy, "processFiltered", file, new FileText(file, lines));
+        final FileText fileText = new FileText(file, lines);
+        treeWalkerSpy.setFileContents(new FileContents(fileText));
+        Whitebox.invokeMethod(treeWalkerSpy, "processFiltered", file, fileText);
         verifyPrivate(treeWalkerSpy, times(1)).invoke("walk",
                 any(DetailAST.class), any(FileContents.class), any(classAstState));
         verifyPrivate(treeWalkerSpy, times(0)).invoke("getFilteredMessages",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checker/InputCheckerTabCharacter.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checker/InputCheckerTabCharacter.txt
@@ -1,0 +1,3 @@
+//has no tabs
+	//has tab
+		//has 2 tabs

--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -361,6 +361,14 @@
             <td><code>true</code></td>
             <td>7.4</td>
           </tr>
+          <tr>
+            <td>tabWidth</td>
+            <td>number of expanded spaces for a tab character (<code>'\t'</code>); used in
+            messages and Checks that print violations on files with tabs</td>
+            <td><a href="property_types.html#integer">Integer</a></td>
+            <td><code>8</code></td>
+            <td>8.19</td>
+          </tr>
         </table>
       </subsection>
 
@@ -510,15 +518,6 @@
             <th>type</th>
             <th>default value</th>
             <th>since</th>
-          </tr>
-          <tr>
-            <td>tabWidth</td>
-            <td>number of expanded spaces for a tab character (<code>'\t'</code>); used in
-            messages and Checks that require a tab width, such as <a
-            href="config_sizes.html#LineLength"><code>LineLength</code></a></td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>8</code></td>
-            <td>3.0</td>
           </tr>
           <tr>
             <td>fileExtensions</td>


### PR DESCRIPTION
Issue #6485

I moved the standard tab width to `CommonUtil` since everyone is using it now.
To be able to generate the column position in `AbstractFileSetCheck` I had to make a few changes and collect the `FileContents` and used this to pass it to TreeWalker.
`FileTabCharacter` is the only file set that had to be changed to give the correct column position. This is because the changes to the log statement already included the +1 which is an exact mirror of `AbstractCheck`'s log method.