### PR TITLE
Issue #6345: RightCurly with option alone false negative for class, method and constructor

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -236,8 +236,7 @@ public class RightCurlyCheck extends AbstractCheck {
      */
     private static boolean shouldBeAloneOnLineWithAloneOption(Details details,
                                                               String targetSrcLine) {
-        return !isAloneOnLine(details, targetSrcLine)
-                && !isEmptyBody(details.lcurly);
+        return !isAloneOnLine(details, targetSrcLine);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
@@ -54,7 +54,8 @@ public final class DetectorOptions {
     private Pattern pattern;
 
     /** Default constructor.*/
-    private DetectorOptions() { }
+    private DetectorOptions() {
+    }
 
     /**
      * Returns new Builder object.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -107,6 +107,9 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "122:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
             "136:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "136:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
+            "144:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
+            "149:45: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 45),
+            "152:20: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 20),
         };
         verify(checkConfig, getPath("InputRightCurlyLeft.java"), expected);
     }
@@ -156,7 +159,9 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
                 + "LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT");
         final String[] expected = {
             "35:43: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 43),
+            "38:17: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 17),
             "41:71: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 71),
+            "43:38: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 38),
             "47:25: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 25),
         };
         verify(checkConfig, getPath("InputRightCurlyLineBreakBefore.java"), expected);
@@ -199,17 +204,22 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "47:88: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 88),
             "50:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
             "53:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
+            "56:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
             "60:38: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 38),
+            "61:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
             "67:62: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 62),
             "76:28: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 28),
             "78:21: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 21),
             "80:20: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 20),
             "82:14: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 14),
             "93:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 26),
+            "94:20: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 20),
             "103:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
+            "103:38: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 38),
             "107:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
-            "111:88: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 88),
+            "107:38: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 38),
             "111:40: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 40),
+            "111:88: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 88),
             "114:18: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 18),
             "118:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
             "121:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
@@ -359,6 +369,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "19:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "24:67: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 67),
             "25:35: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 35),
+            "27:64: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 64),
             "27:92: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 92),
             "33:67: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 67),
             "35:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
@@ -441,6 +452,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "63:43: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 43),
             "67:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "74:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "74:11: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 11),
         };
         verify(checkConfig, getPath("InputRightCurlyAlone.java"),
                 expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLine2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLine2.java
@@ -65,4 +65,8 @@ public class InputRightCurlyAloneOrSingleLine2 {
     class TestClass3 {
         private int field;
     };  //violation
+
+    class TestClass4 { }
+
+    class TestClass5 { } { }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAnnotations.java
@@ -53,12 +53,12 @@ class InputRightCurlyAnnotations
     private void foo10() { ; } //violation
 
     @SuppressWarnings("unused")
-    private void foo11() {  } //it's ok - empty block
+    private void foo11() {  } //empty block - violation
 
     @SuppressWarnings("unused")
     private void foo12() {
         try { int i = 5; int b = 10; } //violation
-        catch (Exception e) { } //it's ok - empty block
+        catch (Exception e) { } //empty block - violation
     }
 
     @Deprecated
@@ -91,7 +91,7 @@ class InputRightCurlyAnnotations
     @Deprecated
     private void foo15() {
         class A { int a; } var1++; //violation
-        class B {  }
+        class B {  } //empty block - violation
         if(true) {
 
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeft.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeft.java
@@ -141,15 +141,15 @@ class FooInner
  */
 class Absent_CustomFieldSerializer3 {
 
-    public static void serialize() {} //Expected nothing but was "'}' should be alone on a line."
+    public static void serialize() {} //empty body - violation
 }
 
 class Absent_CustomFieldSerializer4
 {
-    public Absent_CustomFieldSerializer4() {}
+    public Absent_CustomFieldSerializer4() {} //empty body - violation
 }
 
-class EmptyClass2 {}
+class EmptyClass2 {} //empty body - violation
 
 interface EmptyInterface3 {}
 


### PR DESCRIPTION
Fixes #6345.

When I working with this pr, I found that this may be an intended behavior of checkstyle.
See [here](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java#L225), it allows empty body.

If it is not the intended behavior, I will just delete the line that allows empty body.

