### PR TITLE
Issue #4073: Use lf_cr_crlf as default for NewlineAtEndOfFile check

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
@@ -71,7 +71,7 @@ public class NewlineAtEndOfFileCheck
     public static final String MSG_KEY_NO_NEWLINE_EOF = "noNewlineAtEOF";
 
     /** The line separator to check against. */
-    private LineSeparatorOption lineSeparator = LineSeparatorOption.SYSTEM;
+    private LineSeparatorOption lineSeparator = LineSeparatorOption.LF_CR_CRLF;
 
     @Override
     protected void processFiltered(File file, FileText fileText) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG_KEY_NO_NEWLINE_EOF;
 import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG_KEY_UNABLE_OPEN;
-import static java.util.Locale.ENGLISH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -224,14 +223,8 @@ public class NewlineAtEndOfFileCheckTest
             fail("Exception is expected");
         }
         catch (IOException ex) {
-            if (System.getProperty("os.name").toLowerCase(ENGLISH).startsWith("windows")) {
-                assertEquals("Error message is unexpected",
-                        "Unable to read 2 bytes, got 0", ex.getMessage());
-            }
-            else {
-                assertEquals("Error message is unexpected",
-                        "Unable to read 1 bytes, got 0", ex.getMessage());
-            }
+            assertEquals("Error message is unexpected",
+                    "Unable to read 1 bytes, got 0", ex.getMessage());
         }
     }
 

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -1236,7 +1236,7 @@ void foo(String aFooString,
             <td>lineSeparator</td>
             <td>type of line separator</td>
             <td><a href="property_types.html#lineSeparator">Line Separator Policy</a></td>
-            <td>system</td>
+            <td>lf_cr_crlf</td>
             <td>3.1</td>
           </tr>
           <tr>


### PR DESCRIPTION
This matches more the intention of the check and also works properly
if you for example have files with Linux line ending on
Windows systems as is common for cross-platform projects.

Fixes #4073 
Depends on #6509