### PR TITLE
Skip JDepend in no-validations and assembly profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1655,6 +1655,7 @@
         <jacoco.skip>true</jacoco.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <linkcheck.skip>true</linkcheck.skip>
+        <jdepend.skip>true</jdepend.skip>
       </properties>
     </profile>
 
@@ -1673,6 +1674,7 @@
         <jacoco.skip>true</jacoco.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <linkcheck.skip>true</linkcheck.skip>
+        <jdepend.skip>true</jdepend.skip>
         <!-- difference from "no-validations" -->
         <maven.site.skip>true</maven.site.skip>
       </properties>


### PR DESCRIPTION
As far as I understood the `no-validations` and `assembly` Maven profiles, they are intended to skip all validation tasks (and the latter additionally the site generation).
When I executed a build with `no-validations` profile I observed that the JDepend tasks are nevertheless run.
This change correct this and excludes JDepend validation in said profiles.