### PR TITLE
Issue #6458: Correct typo in Lcruly property type description

### DIFF
--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -290,7 +290,7 @@
           <td><code>nlow</code></td>
           <td>
             If the statement/expression/declaration connected to the brace spans multiple lines,
-            than apply <code>nl</code> rule. Otherwise apply the <code>eol</code> rule.
+            then apply <code>nl</code> rule. Otherwise apply the <code>eol</code> rule.
             <code>nlow</code> is a mnemonic for "new line on wrap".
             For the example above Checkstyle will enforce:
             <pre>


### PR DESCRIPTION
Fixes #6458