### PR TITLE
Issue #6452: Use default value false for javaFiveCompatibility property of MissingOverride check in checkstyle_checks.xml

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -174,9 +174,7 @@
     </module>
     <module name="AnnotationUseStyle"/>
     <module name="MissingDeprecated"/>
-    <module name="MissingOverride">
-      <property name="javaFiveCompatibility" value="true"/>
-    </module>
+    <module name="MissingOverride"/>
     <module name="PackageAnnotation"/>
     <module name="SuppressWarnings">
         <property name="format" value="^((?!unchecked|deprecation|rawtypes|resource).)*$"/>


### PR DESCRIPTION
Fixes #6452