### PR TITLE
Issue #6462 and #6463

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -147,6 +147,7 @@
       <property name="tokens" value="ANNOTATION_FIELD_DEF"/>
       <property name="tokens" value="PACKAGE_DEF"/>
       <property name="tokens" value="ENUM_CONSTANT_DEF"/>
+      <property name="tokens" value="VARIABLE_DEF"/>
       <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
     </module>
     <module name="AnnotationOnSameLine">

--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -149,10 +149,6 @@
       <property name="tokens" value="ENUM_CONSTANT_DEF"/>
       <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
     </module>
-    <module name="AnnotationLocation">
-      <property name="tokens" value="PARAMETER_DEF"/>
-      <property name="allowSamelineMultipleAnnotations" value="true"/>
-    </module>
     <module name="AnnotationOnSameLine">
       <!-- we can not use it as it conflicts with AnnotationLocation -->
       <property name="severity" value="ignore"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -141,7 +141,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * &lt;/module&gt;
  * </pre>
  * <p>
- * The following example demonstrates how the check validates annotations of method parameters,
+ * The following example demonstrates how the check validates annotations of
  * catch parameters, foreach, for-loop variable definitions.
  * </p>
  * <p>
@@ -153,14 +153,14 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
  *     value=&quot;false&quot;/&gt;
  *   &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
- *   &lt;property name=&quot;tokens&quot; value=&quot;VARIABLE_DEF, PARAMETER_DEF&quot;/&gt;
+ *   &lt;property name=&quot;tokens&quot; value=&quot;VARIABLE_DEF&quot;/&gt;
  *  &lt;/module&gt;
  * </pre>
  * <p>
  * Code example:
  * </p>
  * <pre>
- * public void test(&#64;MyAnnotation String s) { // OK
+ * public void test(String s) {
  *   ...
  *   for (&#64;MyAnnotation char c : s.toCharArray()) { ... }  // OK
  *   ...
@@ -193,7 +193,6 @@ public class AnnotationLocationCheck extends AbstractCheck {
 
     /** Array of single line annotation parents. */
     private static final int[] SINGLELINE_ANNOTATION_PARENTS = {TokenTypes.FOR_EACH_CLAUSE,
-                                                                TokenTypes.PARAMETER_DEF,
                                                                 TokenTypes.FOR_INIT, };
 
     /**
@@ -266,7 +265,6 @@ public class AnnotationLocationCheck extends AbstractCheck {
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
             TokenTypes.VARIABLE_DEF,
-            TokenTypes.PARAMETER_DEF,
             TokenTypes.ANNOTATION_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,
         };

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -31,13 +31,18 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Check location of annotation on language elements.
  * By default, Check enforce to locate annotations immediately after
  * documentation block and before target element, annotation should be located
- * on separate line from target element.
+ * on separate line from target element. Elements that cannot have JavaDoc comments
+ * like local variables are not in the scope of this check even though a token type like
+ * {@code VARIABLE_DEF} would match them. This check also verifies that the annotations
+ * are on the same indenting level as the annotated element if they are not on the same line.
  * </p>
  * <p>
  * Attention: Annotations among modifiers are ignored (looks like false-negative)
  * as there might be a problem with annotations for return types:
  * </p>
- * <pre>public @Nullable Long getStartTimeOrNull() { ... }</pre>
+ * <pre>
+ * public @Nullable Long getStartTimeOrNull() { ... }
+ * </pre>
  * <p>
  * Such annotations are better to keep close to type.
  * Due to limitations, Checkstyle can not examine the target of an annotation.
@@ -140,39 +145,6 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
- * <p>
- * The following example demonstrates how the check validates annotations of
- * catch parameters, foreach, for-loop variable definitions.
- * </p>
- * <p>
- * Configuration:
- * </p>
- * <pre>
- * &lt;module name=&quot;AnnotationLocation&quot;&gt;
- *   &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;false&quot;/&gt;
- *   &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
- *     value=&quot;false&quot;/&gt;
- *   &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
- *   &lt;property name=&quot;tokens&quot; value=&quot;VARIABLE_DEF&quot;/&gt;
- *  &lt;/module&gt;
- * </pre>
- * <p>
- * Code example:
- * </p>
- * <pre>
- * public void test(String s) {
- *   ...
- *   for (&#64;MyAnnotation char c : s.toCharArray()) { ... }  // OK
- *   ...
- *   try { ... }
- *   catch (&#64;MyAnnotation Exception ex) { ... } // OK
- *   ...
- *   for (&#64;MyAnnotation int i = 0; i &lt; 10; i++) { ... } // OK
- *   ...
- *   MathOperation c = (&#64;MyAnnotation int a, &#64;MyAnnotation int b) -&gt; a + b; // OK
- *   ...
- * }
- * </pre>
  *
  * @since 6.0
  */
@@ -190,10 +162,6 @@ public class AnnotationLocationCheck extends AbstractCheck {
      * file.
      */
     public static final String MSG_KEY_ANNOTATION_LOCATION = "annotation.location";
-
-    /** Array of single line annotation parents. */
-    private static final int[] SINGLELINE_ANNOTATION_PARENTS = {TokenTypes.FOR_EACH_CLAUSE,
-                                                                TokenTypes.FOR_INIT, };
 
     /**
      * Allow single parameterless annotation to be located on the same line as
@@ -277,11 +245,15 @@ public class AnnotationLocationCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        DetailAST node = ast.findFirstToken(TokenTypes.MODIFIERS);
-        if (node == null) {
-            node = ast.findFirstToken(TokenTypes.ANNOTATIONS);
+        // ignore variable def tokens that are not field definitions
+        if (ast.getType() != TokenTypes.VARIABLE_DEF
+                || ast.getParent().getType() == TokenTypes.OBJBLOCK) {
+            DetailAST node = ast.findFirstToken(TokenTypes.MODIFIERS);
+            if (node == null) {
+                node = ast.findFirstToken(TokenTypes.ANNOTATIONS);
+            }
+            checkAnnotations(node, getExpectedAnnotationIndentation(node));
         }
-        checkAnnotations(node, getExpectedAnnotationIndentation(node));
     }
 
     /**
@@ -353,8 +325,7 @@ public class AnnotationLocationCheck extends AbstractCheck {
      * the value of {@link AnnotationLocationCheck#allowSamelineParameterizedAnnotation};
      * 2) checks parameterless annotation location considering
      * the value of {@link AnnotationLocationCheck#allowSamelineSingleParameterlessAnnotation};
-     * 3) checks annotation location considering the elements
-     * of {@link AnnotationLocationCheck#SINGLELINE_ANNOTATION_PARENTS};
+     * 3) checks annotation location;
      * @param annotation annotation node.
      * @param hasParams whether an annotation has parameters.
      * @return true if the annotation has a correct location.
@@ -370,8 +341,7 @@ public class AnnotationLocationCheck extends AbstractCheck {
         }
         return allowSamelineMultipleAnnotations
             || allowingCondition && !hasNodeBefore(annotation)
-            || !allowingCondition && (!hasNodeBeside(annotation)
-            || isAllowedPosition(annotation, SINGLELINE_ANNOTATION_PARENTS));
+            || !hasNodeBeside(annotation);
     }
 
     /**
@@ -409,41 +379,6 @@ public class AnnotationLocationCheck extends AbstractCheck {
         }
 
         return annotationLineNo == nextNode.getLineNo();
-    }
-
-    /**
-     * Checks whether position of annotation is allowed.
-     * @param annotation annotation token.
-     * @param allowedPositions an array of allowed annotation positions.
-     * @return true if position of annotation is allowed.
-     */
-    private static boolean isAllowedPosition(DetailAST annotation, int... allowedPositions) {
-        boolean allowed = false;
-        for (int position : allowedPositions) {
-            if (isInSpecificCodeBlock(annotation, position)) {
-                allowed = true;
-                break;
-            }
-        }
-        return allowed;
-    }
-
-    /**
-     * Checks whether the scope of a node is restricted to a specific code block.
-     * @param node node.
-     * @param blockType block type.
-     * @return true if the scope of a node is restricted to a specific code block.
-     */
-    private static boolean isInSpecificCodeBlock(DetailAST node, int blockType) {
-        boolean returnValue = false;
-        for (DetailAST token = node.getParent(); token != null; token = token.getParent()) {
-            final int type = token.getType();
-            if (type == blockType) {
-                returnValue = true;
-                break;
-            }
-        }
-        return returnValue;
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
@@ -89,7 +89,7 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     public void testIncorrectAllTokens() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(AnnotationLocationCheck.class);
         checkConfig.addAttribute("tokens", "CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, "
-                + "CTOR_DEF, VARIABLE_DEF, PARAMETER_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, "
+                + "CTOR_DEF, VARIABLE_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, "
                 + "ENUM_CONSTANT_DEF, PACKAGE_DEF");
         final String[] expected = {
             "6: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnn"),
@@ -116,7 +116,6 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
             "88: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation2", 10, 8),
             "91: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
             "98: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation2", 0, 3),
-            "100: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation2"),
         };
         verify(checkConfig, getPath("InputAnnotationLocationIncorrect.java"), expected);
     }
@@ -134,7 +133,6 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
             TokenTypes.VARIABLE_DEF,
-            TokenTypes.PARAMETER_DEF,
             TokenTypes.ANNOTATION_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,
             };
@@ -189,7 +187,7 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     public void testAllTokens() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(AnnotationLocationCheck.class);
         checkConfig.addAttribute("tokens", "CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, "
-                + "CTOR_DEF, VARIABLE_DEF, PARAMETER_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF");
+                + "CTOR_DEF, VARIABLE_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputAnnotationLocationWithoutAnnotations.java"), expected);
     }
@@ -238,13 +236,12 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testInterface() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(AnnotationLocationCheck.class);
-        checkConfig.addAttribute("tokens", "INTERFACE_DEF, METHOD_DEF, PARAMETER_DEF");
+        checkConfig.addAttribute("tokens", "INTERFACE_DEF, METHOD_DEF");
         final String[] expected = {
             "17: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "InterfaceAnnotation", 2, 0),
             "18: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "InterfaceAnnotation"),
             "21: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "InterfaceAnnotation", 6, 4),
             "22: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "InterfaceAnnotation"),
-            "25: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "InterfaceAnnotation", 10, 8),
         };
         verify(checkConfig, getPath("InputAnnotationLocationInterface.java"), expected);
     }
@@ -264,7 +261,7 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     public void testAnnotationInForEachLoopParameterAndVariableDef() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(AnnotationLocationCheck.class);
         checkConfig.addAttribute("tokens", "CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF,"
-            + " CTOR_DEF, VARIABLE_DEF, PARAMETER_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF");
+            + " CTOR_DEF, VARIABLE_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF");
         checkConfig.addAttribute("allowSamelineMultipleAnnotations", "false");
         checkConfig.addAttribute("allowSamelineSingleParameterlessAnnotation", "false");
         checkConfig.addAttribute("allowSamelineParameterizedAnnotation", "false");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -173,8 +173,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("AnnotationLocation", Stream.of(
                 // state of the configuration when test was made until reason found in
                 // https://github.com/checkstyle/checkstyle/issues/3730
-                "ANNOTATION_DEF", "ANNOTATION_FIELD_DEF", "ENUM_CONSTANT_DEF", "PACKAGE_DEF",
-                "PARAMETER_DEF")
+                "ANNOTATION_DEF", "ANNOTATION_FIELD_DEF", "ENUM_CONSTANT_DEF", "PACKAGE_DEF")
                 .collect(Collectors.toSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("AbbreviationAsWordInName", Stream.of(
                 // enum values should be uppercase

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationInterface.java
@@ -22,7 +22,7 @@ import java.lang.annotation.Target;
     @InterfaceAnnotation("bar") void method( //warn
         int param1,
         @InterfaceAnnotation(value = "foo")
-          @InterfaceAnnotation //warn
+          @InterfaceAnnotation
         @InterfaceAnnotation("bar") int param2,
         int param3);
 

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -103,8 +103,6 @@ public String getNameIfPresent() { ... }
                   CTOR_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
                   VARIABLE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
-                  PARAMETER_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
                   ANNOTATION_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
@@ -189,8 +187,8 @@ public String getNameIfPresent() { ... }
 &lt;/module&gt;
         </source>
        <p>
-         The following example demonstrates how the check validates annotations of method
-         parameters, catch parameters, foreach, for-loop variable definitions.
+         The following example demonstrates how the check validates annotations of
+         catch parameters, foreach, for-loop variable definitions.
        </p>
        <p>Configuration:</p>
        <source>
@@ -199,12 +197,12 @@ public String getNameIfPresent() { ... }
   &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
     value=&quot;false&quot;/&gt;
   &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
-  &lt;property name=&quot;tokens&quot; value=&quot;VARIABLE_DEF, PARAMETER_DEF&quot;/&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;VARIABLE_DEF&quot;/&gt;
  &lt;/module&gt;
        </source>
        <p>Code example:</p>
        <source>
-public void test(&#64;MyAnnotation String s) { // OK
+public void test(String s) {
   ...
   for (&#64;MyAnnotation char c : s.toCharArray()) { ... }  // OK
   ...

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -29,7 +29,10 @@
           Check location of annotation on language elements.
           By default, Check enforce to locate annotations immediately after documentation block
           and before target element, annotation should be located on separate line from target
-          element.
+          element. Elements that cannot have JavaDoc comments like local variables are not in the
+          scope of this check even though a token type like <code>VARIABLE_DEF</code> would match
+          them. This check also verifies that the annotations are on the same indenting level as
+          the annotated element if they are not on the same line.
         </p>
         <p>
           Attention: Annotations among modifiers are ignored (looks like false-negative)
@@ -142,14 +145,14 @@ public String getNameIfPresent() { ... }
         <p>
           Use the following configuration:
         </p>
-        <source>
-&lt;module name=&quot;AnnotationLocation&quot;&gt;
-  &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;true&quot;/&gt;
-  &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
-    value=&quot;false&quot;/&gt;
-  &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
-&lt;/module&gt;
-        </source>
+        <source><![CDATA[
+<module name="AnnotationLocation">
+  <property name="allowSamelineMultipleAnnotations" value="true"/>
+  <property name="allowSamelineSingleParameterlessAnnotation"
+    value="false"/>
+  <property name="allowSamelineParameterizedAnnotation" value="false"/>
+</module>
+        ]]></source>
         <p>
           Example to allow one single parameterless annotation on the same line
         </p>
@@ -160,14 +163,14 @@ public String getNameIfPresent() { ... }
         <p>
           Use the following configuration:
         </p>
-        <source>
-&lt;module name=&quot;AnnotationLocation&quot;&gt;
-  &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;false&quot;/&gt;
-  &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
-    value=&quot;true&quot;/&gt;
-  &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
-&lt;/module&gt;
-        </source>
+        <source><![CDATA[
+<module name="AnnotationLocation">
+  <property name="allowSamelineMultipleAnnotations" value="false"/>
+  <property name="allowSamelineSingleParameterlessAnnotation"
+    value="true"/>
+  <property name="allowSamelineParameterizedAnnotation" value="false"/>
+</module>
+        ]]></source>
         <p>
           Example to allow only one and only parameterized annotation on the same line
         </p>
@@ -178,43 +181,14 @@ public String getNameIfPresent() { ... }
         <p>
           Use the following configuration:
         </p>
-        <source>
-&lt;module name=&quot;AnnotationLocation&quot;&gt;
-  &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;false&quot;/&gt;
-  &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
-    value=&quot;false&quot;/&gt;
-  &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;true&quot;/&gt;
-&lt;/module&gt;
-        </source>
-       <p>
-         The following example demonstrates how the check validates annotations of
-         catch parameters, foreach, for-loop variable definitions.
-       </p>
-       <p>Configuration:</p>
-       <source>
-&lt;module name=&quot;AnnotationLocation&quot;&gt;
-  &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;false&quot;/&gt;
-  &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
-    value=&quot;false&quot;/&gt;
-  &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
-  &lt;property name=&quot;tokens&quot; value=&quot;VARIABLE_DEF&quot;/&gt;
- &lt;/module&gt;
-       </source>
-       <p>Code example:</p>
-       <source>
-public void test(String s) {
-  ...
-  for (&#64;MyAnnotation char c : s.toCharArray()) { ... }  // OK
-  ...
-  try { ... }
-  catch (&#64;MyAnnotation Exception ex) { ... } // OK
-  ...
-  for (&#64;MyAnnotation int i = 0; i &lt; 10; i++) { ... } // OK
-  ...
-  MathOperation c = (&#64;MyAnnotation int a, &#64;MyAnnotation int b) -&gt; a + b; // OK
-  ...
-}
-       </source>
+        <source><![CDATA[
+<module name="AnnotationLocation">
+  <property name="allowSamelineMultipleAnnotations" value="false"/>
+  <property name="allowSamelineSingleParameterlessAnnotation"
+    value="false"/>
+  <property name="allowSamelineParameterizedAnnotation" value="true"/>
+</module>
+        ]]></source>
       </subsection>
 
       <subsection name="Example of Usage" id="AnnotationLocation_Example_of_Usage">


### PR DESCRIPTION
Fixes #6462: Remove PARAMETER_DEF from AnnotationLocation
Fixes #6463: Only handle fields for VARIABLE_DEF in AnnotationLocation check, not local variables