### PR TITLE
Issue #5411: split JavadocType for missing javadocs

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -790,6 +790,7 @@ misconfigured
 Misordered
 missingctor
 missingdeprecated
+missingjavadoctype
 missingoverride
 missingswitchdefault
 missingtag

--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -451,6 +451,7 @@
       <property name="allowUnknownTags" value="true"/>
     </module>
     <module name="JavadocVariable"/>
+    <module name="MissingJavadocType"/>
     <module name="NonEmptyAtclauseDescription"/>
     <module name="SingleLineJavadoc"/>
     <module name="WriteTag"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -627,6 +627,8 @@ public class PackageObjectFactory implements ModuleFactory {
                 BASE_PACKAGE + ".checks.javadoc.JavadocTypeCheck");
         NAME_TO_FULL_MODULE_NAME.put("JavadocVariableCheck",
                 BASE_PACKAGE + ".checks.javadoc.JavadocVariableCheck");
+        NAME_TO_FULL_MODULE_NAME.put("MissingJavadocTypeCheck",
+                BASE_PACKAGE + ".checks.javadoc.MissingJavadocTypeCheck");
         NAME_TO_FULL_MODULE_NAME.put("NonEmptyAtclauseDescriptionCheck",
                 BASE_PACKAGE + ".checks.javadoc.NonEmptyAtclauseDescriptionCheck");
         NAME_TO_FULL_MODULE_NAME.put("SingleLineJavadocCheck",

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -53,12 +53,6 @@ public class JavadocTypeCheck
      * A key is pointing to the warning message text in "messages.properties"
      * file.
      */
-    public static final String MSG_JAVADOC_MISSING = "javadoc.missing";
-
-    /**
-     * A key is pointing to the warning message text in "messages.properties"
-     * file.
-     */
     public static final String MSG_UNKNOWN_TAG = "javadoc.unknownTag";
 
     /**
@@ -202,10 +196,7 @@ public class JavadocTypeCheck
             final FileContents contents = getFileContents();
             final int lineNo = ast.getLineNo();
             final TextBlock textBlock = contents.getJavadocBefore(lineNo);
-            if (textBlock == null) {
-                log(lineNo, MSG_JAVADOC_MISSING);
-            }
-            else {
+            if (textBlock != null) {
                 final List<JavadocTag> tags = getJavadocTags(textBlock);
                 if (ScopeUtil.isOuterMostType(ast)) {
                     // don't check author/version for inner classes

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java
@@ -1,0 +1,241 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2019 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.puppycrawl.tools.checkstyle.StatelessCheck;
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.FileContents;
+import com.puppycrawl.tools.checkstyle.api.Scope;
+import com.puppycrawl.tools.checkstyle.api.TextBlock;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
+
+/**
+ * <p>
+ * Checks for missing Javadoc comments for class, enum, interface, and annotation interface
+ * definitions. The scope to verify is specified using the {@code Scope} class and defaults
+ * to {@code Scope.PUBLIC}. To verify another scope, set property scope to one of the
+ * {@code Scope} constants.
+ * </p>
+ * <ul>
+ * <li>
+ * Property {@code scope} - specify the visibility scope where Javadoc comments are checked.
+ * Default value is {@code public}.
+ * </li>
+ * <li>
+ * Property {@code excludeScope} - specify the visibility scope where Javadoc comments are not
+ * checked. Default value is {@code null}.
+ * </li>
+ * <li>
+ * Property {@code skipAnnotations} - specify the list of annotations that allow missed
+ * documentation. Only short names are allowed, e.g.{@code Generated}. Default value is
+ * {@code Generated}.
+ * </li>
+ * <li>
+ * Property {@code tokens} - tokens to check Default value is:
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">INTERFACE_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">ENUM_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">ANNOTATION_DEF</a>.
+ * </li>
+ * </ul>
+ * <p>
+ * To configure the default check to make sure all public class, enum, interface, and annotation
+ * interface, definitions have javadocs:
+ * </p>
+ * <pre>
+ * &lt;module name="MissingJavadocType"/&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * public class PublicClass {} // violation
+ * private class PublicClass {}
+ * protected class PublicClass {}
+ * class PackagePrivateClass {}
+ * </pre>
+ * <p>
+ * To configure the check for {@code private} scope:
+ * </p>
+ * <pre>
+ * &lt;module name="MissingJavadocType"&gt;
+ *   &lt;property name="scope" value="private"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * public class PublicClass {} // violation
+ * private class PublicClass {} // violation
+ * protected class PublicClass {} // violation
+ * class PackagePrivateClass {} // violation
+ * </pre>
+ * <p>
+ * To configure the check for {@code private} classes only:
+ * </p>
+ * <pre>
+ * &lt;module name="MissingJavadocType"&gt;
+ *   &lt;property name="scope" value="private"/&gt;
+ *   &lt;property name="excludeScope" value="package"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * public class PublicClass {}
+ * private class PublicClass {} // violation
+ * protected class PublicClass {}
+ * class PackagePrivateClass {}
+ * </pre>
+ * <p>
+ * Example that allows missing comments for classes annotated with {@code @SpringBootApplication}
+ * and {@code @Configuration}:
+ * </p>
+ * <pre>
+ * &#64;SpringBootApplication // no violations about missing comment on class
+ * public class Application {}
+ *
+ * &#64;Configuration // no violations about missing comment on class
+ * class DatabaseConfiguration {}
+ * </pre>
+ * <p>
+ * Use following configuration:
+ * </p>
+ * <pre>
+ * &lt;module name="MissingJavadocType"&gt;
+ *   &lt;property name="skipAnnotations" value="SpringBootApplication,Configuration"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * @since 8.20
+ */
+@StatelessCheck
+public class MissingJavadocTypeCheck extends AbstractCheck {
+
+    /**
+     * A key is pointing to the warning message text in "messages.properties"
+     * file.
+     */
+    public static final String MSG_JAVADOC_MISSING = "javadoc.missing";
+
+    /** Specify the visibility scope where Javadoc comments are checked. */
+    private Scope scope = Scope.PUBLIC;
+    /** Specify the visibility scope where Javadoc comments are not checked. */
+    private Scope excludeScope;
+
+    /**
+     * Specify the list of annotations that allow missed documentation.
+     * Only short names are allowed, e.g.{@code Generated}.
+     */
+    private List<String> skipAnnotations = Collections.singletonList("Generated");
+
+    /**
+     * Setter to specify the visibility scope where Javadoc comments are checked.
+     * @param scope a scope.
+     */
+    public void setScope(Scope scope) {
+        this.scope = scope;
+    }
+
+    /**
+     * Setter to specify the visibility scope where Javadoc comments are not checked.
+     * @param excludeScope a scope.
+     */
+    public void setExcludeScope(Scope excludeScope) {
+        this.excludeScope = excludeScope;
+    }
+
+    /**
+     * Setter to specify the list of annotations that allow missed documentation.
+     * Only short names are allowed, e.g.{@code Generated}.
+     * @param userAnnotations user's value.
+     */
+    public void setSkipAnnotations(String... userAnnotations) {
+        skipAnnotations = Arrays.asList(userAnnotations);
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return new int[] {
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.ANNOTATION_DEF,
+        };
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return CommonUtil.EMPTY_INT_ARRAY;
+    }
+
+    @Override
+    public void visitToken(DetailAST ast) {
+        if (shouldCheck(ast)) {
+            final FileContents contents = getFileContents();
+            final int lineNo = ast.getLineNo();
+            final TextBlock textBlock = contents.getJavadocBefore(lineNo);
+            if (textBlock == null) {
+                log(lineNo, MSG_JAVADOC_MISSING);
+            }
+        }
+    }
+
+    /**
+     * Whether we should check this node.
+     * @param ast a given node.
+     * @return whether we should check a given node.
+     */
+    private boolean shouldCheck(final DetailAST ast) {
+        final Scope customScope;
+
+        if (ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
+            customScope = Scope.PUBLIC;
+        }
+        else {
+            final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
+            customScope = ScopeUtil.getScopeFromMods(mods);
+        }
+        final Scope surroundingScope = ScopeUtil.getSurroundingScope(ast);
+
+        return customScope.isIn(scope)
+            && (surroundingScope == null || surroundingScope.isIn(scope))
+            && (excludeScope == null
+                || !customScope.isIn(excludeScope)
+                || surroundingScope != null
+                && !surroundingScope.isIn(excludeScope))
+            && !AnnotationUtil.containsAnnotation(ast, skipAnnotations);
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_JAVADOC_MISSING;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_MISSING_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_TAG_FORMAT;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_UNKNOWN_TAG;
@@ -68,11 +67,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testTags() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(JavadocTypeCheck.class);
-        final String[] expected = {
-            "8: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "302: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "327: " + getCheckMessage(MSG_JAVADOC_MISSING),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputJavadocTypeTags.java"), expected);
     }
 
@@ -80,11 +75,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testInner() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(JavadocTypeCheck.class);
-        final String[] expected = {
-            "14: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "21: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "27: " + getCheckMessage(MSG_JAVADOC_MISSING),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputJavadocTypeInner.java"), expected);
     }
 
@@ -92,12 +83,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testStrict() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(JavadocTypeCheck.class);
-        final String[] expected = {
-            "7: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "14: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "34: " + getCheckMessage(MSG_JAVADOC_MISSING),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputJavadocTypePublicOnly.java"), expected);
     }
 
@@ -106,9 +92,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
             createModuleConfig(JavadocTypeCheck.class);
         checkConfig.addAttribute("scope", Scope.PROTECTED.getName());
-        final String[] expected = {
-            "7: " + getCheckMessage(MSG_JAVADOC_MISSING),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputJavadocTypePublicOnly.java"), expected);
     }
 
@@ -117,10 +101,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
             createModuleConfig(JavadocTypeCheck.class);
         checkConfig.addAttribute("scope", Scope.PUBLIC.getName());
-        final String[] expected = {
-            "7: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "38: " + getCheckMessage(MSG_JAVADOC_MISSING),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig,
                getPath("InputJavadocTypeScopeInnerInterfaces.java"),
                expected);
@@ -131,12 +112,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
             createModuleConfig(JavadocTypeCheck.class);
         checkConfig.addAttribute("scope", Scope.PROTECTED.getName());
-        final String[] expected = {
-            "7: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "29: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "38: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "65: " + getCheckMessage(MSG_JAVADOC_MISSING),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig,
                getPath("InputJavadocTypeScopeInnerInterfaces.java"),
                expected);
@@ -150,9 +126,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
             "scope",
             Scope.PACKAGE.getName());
         final String[] expected = {
-            "18: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "20: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "22: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "43: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
         };
         verify(checkConfig, getPath("InputJavadocTypeScopeInnerClasses.java"), expected);
     }
@@ -164,9 +138,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute(
             "scope",
             Scope.PUBLIC.getName());
-        final String[] expected = {
-            "18: " + getCheckMessage(MSG_JAVADOC_MISSING),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputJavadocTypeScopeInnerClasses.java"), expected);
     }
 
@@ -269,16 +241,8 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
             createModuleConfig(JavadocTypeCheck.class);
         final String[] expected = {
-            "3: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "15: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "27: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "39: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "52: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "63: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "75: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "87: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "99: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "111: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "4: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "123: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
         };
         verify(checkConfig,
                getPath("InputJavadocTypeNoJavadoc.java"),
@@ -290,9 +254,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
             createModuleConfig(JavadocTypeCheck.class);
         checkConfig.addAttribute("tokens", "INTERFACE_DEF");
-        final String[] expected = {
-            "4: " + getCheckMessage(MSG_JAVADOC_MISSING),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig,
                getPath("InputJavadocTypeNoJavadocOnInterface.java"),
                expected);
@@ -304,8 +266,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
             createModuleConfig(JavadocTypeCheck.class);
         checkConfig.addAttribute("scope", Scope.PROTECTED.getName());
         final String[] expected = {
-            "3: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "15: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "4: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
         };
         verify(checkConfig,
                getPath("InputJavadocTypeNoJavadoc.java"),
@@ -319,14 +280,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("scope", Scope.PRIVATE.getName());
         checkConfig.addAttribute("excludeScope", Scope.PROTECTED.getName());
         final String[] expected = {
-            "27: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "39: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "52: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "63: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "75: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "87: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "99: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "111: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "123: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
         };
         verify(checkConfig,
                getPath("InputJavadocTypeNoJavadoc.java"),
@@ -401,10 +355,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
             createModuleConfig(JavadocTypeCheck.class);
 
-        final String[] expected = {
-            "6: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "10: " + getCheckMessage(MSG_JAVADOC_MISSING),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig,
             getNonCompilablePath("InputJavadocTypeAllowedAnnotations.java"),
             expected);
@@ -418,11 +369,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
             "allowedAnnotations",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype.ThisIsOk");
 
-        final String[] expected = {
-            "6: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "10: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "14: " + getCheckMessage(MSG_JAVADOC_MISSING),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig,
                 getNonCompilablePath("InputJavadocTypeAllowedAnnotations.java"),
                 expected);
@@ -446,11 +393,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
             createModuleConfig(JavadocTypeCheck.class);
         checkConfig.addAttribute("allowedAnnotations", "Override");
 
-        final String[] expected = {
-            "6: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "10: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "14: " + getCheckMessage(MSG_JAVADOC_MISSING),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig,
             getNonCompilablePath("InputJavadocTypeAllowedAnnotations.java"),
             expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
@@ -1,0 +1,316 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2019 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck.MSG_JAVADOC_MISSING;
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.Scope;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+
+public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype";
+    }
+
+    @Test
+    public void testGetRequiredTokens() {
+        final MissingJavadocTypeCheck missingJavadocTypeCheck = new MissingJavadocTypeCheck();
+        assertArrayEquals(
+            "MissingJavadocTypeCheck#getRequiredTokens should return empty array by default",
+            CommonUtil.EMPTY_INT_ARRAY, missingJavadocTypeCheck.getRequiredTokens());
+    }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        final MissingJavadocTypeCheck missingJavadocTypeCheck = new MissingJavadocTypeCheck();
+
+        final int[] actual = missingJavadocTypeCheck.getAcceptableTokens();
+        final int[] expected = {
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.ANNOTATION_DEF,
+        };
+
+        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+    }
+
+    @Test
+    public void testTags() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", "PRIVATE");
+        final String[] expected = {
+            "4: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "298: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "323: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig, getPath("InputMissingJavadocTypeTags.java"), expected);
+    }
+
+    @Test
+    public void testInner() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", "PRIVATE");
+        final String[] expected = {
+            "9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "22: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig, getPath("InputMissingJavadocTypeInner.java"), expected);
+    }
+
+    @Test
+    public void testStrict() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", "PRIVATE");
+        final String[] expected = {
+            "3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "10: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "30: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig, getPath("InputMissingJavadocTypePublicOnly.java"), expected);
+    }
+
+    @Test
+    public void testProtected() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", Scope.PROTECTED.getName());
+        final String[] expected = {
+            "3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig, getPath("InputMissingJavadocTypePublicOnly.java"), expected);
+    }
+
+    @Test
+    public void testPublic() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", Scope.PUBLIC.getName());
+        final String[] expected = {
+            "3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "34: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig,
+               getPath("InputMissingJavadocTypeScopeInnerInterfaces.java"),
+               expected);
+    }
+
+    @Test
+    public void testProtest() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", Scope.PROTECTED.getName());
+        final String[] expected = {
+            "3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "34: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "61: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig,
+               getPath("InputMissingJavadocTypeScopeInnerInterfaces.java"),
+               expected);
+    }
+
+    @Test
+    public void testPkg() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute(
+            "scope",
+            Scope.PACKAGE.getName());
+        final String[] expected = {
+            "12: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig, getPath("InputMissingJavadocTypeScopeInnerClasses.java"), expected);
+    }
+
+    @Test
+    public void testEclipse() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute(
+            "scope",
+            Scope.PUBLIC.getName());
+        final String[] expected = {
+            "12: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig, getPath("InputMissingJavadocTypeScopeInnerClasses.java"), expected);
+    }
+
+    @Test
+    public void testScopes() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", "PRIVATE");
+        final String[] expected = {
+            "3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "39: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "52: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "63: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "75: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "87: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "99: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "111: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig,
+               getPath("InputMissingJavadocTypeNoJavadoc.java"),
+               expected);
+    }
+
+    @Test
+    public void testLimitViolationsBySpecifyingTokens() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", "PRIVATE");
+        checkConfig.addAttribute("tokens", "INTERFACE_DEF");
+        final String[] expected = {
+            "5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig,
+               getPath("InputMissingJavadocTypeNoJavadocOnInterface.java"),
+               expected);
+    }
+
+    @Test
+    public void testScopes2() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", Scope.PROTECTED.getName());
+        final String[] expected = {
+            "3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig,
+               getPath("InputMissingJavadocTypeNoJavadoc.java"),
+               expected);
+    }
+
+    @Test
+    public void testExcludeScope() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", Scope.PRIVATE.getName());
+        checkConfig.addAttribute("excludeScope", Scope.PROTECTED.getName());
+        final String[] expected = {
+            "27: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "39: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "52: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "63: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "75: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "87: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "99: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "111: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig,
+               getPath("InputMissingJavadocTypeNoJavadoc.java"),
+               expected);
+    }
+
+    @Test
+    public void testDontAllowUnusedParameterTag() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(MissingJavadocTypeCheck.class);
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+                getPath("InputMissingJavadocTypeUnusedParamInJavadocForClass.java"),
+                expected);
+    }
+
+    @Test
+    public void testSkipAnnotationsDefault() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", "PRIVATE");
+
+        final String[] expected = {
+            "5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig,
+            getPath("InputMissingJavadocTypeSkipAnnotations.java"),
+            expected);
+    }
+
+    @Test
+    public void testSkipAnnotationsWithFullyQualifiedName() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", "PRIVATE");
+        checkConfig.addAttribute(
+            "skipAnnotations",
+            "com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype.ThisIsOk");
+
+        final String[] expected = {
+            "5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "13: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig,
+                getPath("InputMissingJavadocTypeSkipAnnotations.java"),
+                expected);
+    }
+
+    @Test
+    public void testSkipAnnotationsAllowed() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("skipAnnotations", "Generated, ThisIsOk");
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+            getPath("InputMissingJavadocTypeSkipAnnotations.java"),
+            expected);
+    }
+
+    @Test
+    public void testSkipAnnotationsNotAllowed() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", "PRIVATE");
+        checkConfig.addAttribute("skipAnnotations", "Override");
+
+        final String[] expected = {
+            "5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "13: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig,
+            getPath("InputMissingJavadocTypeSkipAnnotations.java"),
+            expected);
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -19,7 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_JAVADOC_MISSING;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck.MSG_JAVADOC_MISSING;
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 
 import java.util.Arrays;
@@ -35,7 +35,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder;
 import com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck;
 import com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck;
-import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
@@ -46,9 +46,9 @@ public class SuppressWarningsFilterTest
     extends AbstractModuleTestSupport {
 
     private static final String[] ALL_MESSAGES = {
-        "16: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
-        "17: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
-        "19: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "16: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "17: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "19: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         "22:45: "
             + getCheckMessage(AbstractNameCheck.class,
                 MSG_INVALID_PATTERN, "I", "^[a-z][a-zA-Z0-9]*$"),
@@ -76,15 +76,15 @@ public class SuppressWarningsFilterTest
             + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
         "56:9: "
             + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY, "Exception"),
-        "61: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "61: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         "71: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
-        "76: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "76: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         "77: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
-        "83: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "83: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         "84: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
-        "90: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "90: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         "91: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
-        "97: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        "97: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
     };
 
     @Override
@@ -121,7 +121,6 @@ public class SuppressWarningsFilterTest
             "77: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
             "84: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
             "91: " + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
-            "97: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
         };
         verifySuppressed(filterConfig, suppressed);
     }
@@ -161,7 +160,11 @@ public class SuppressWarningsFilterTest
         treewalkerConfig.addChild(createModuleConfig(ParameterNumberCheck.class));
         treewalkerConfig.addChild(createModuleConfig(IllegalCatchCheck.class));
         treewalkerConfig.addChild(uncommentedMainCheckConfig);
-        treewalkerConfig.addChild(createModuleConfig(JavadocTypeCheck.class));
+
+        final DefaultConfiguration missingJavadocConfig =
+                createModuleConfig(MissingJavadocTypeCheck.class);
+        missingJavadocConfig.addAttribute("scope", "private");
+        treewalkerConfig.addChild(missingJavadocConfig);
 
         final DefaultConfiguration checkerConfig =
                 createRootConfig(treewalkerConfig);
@@ -192,7 +195,7 @@ public class SuppressWarningsFilterTest
                 + getCheckMessage(UncommentedMainCheck.class, UncommentedMainCheck.MSG_KEY),
         };
         final String[] expectedViolationMessages = {
-            "3: " + getCheckMessage(JavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "3: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
             "6:17: "
                 + getCheckMessage(AbstractNameCheck.class,
                     MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -105,6 +105,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         "MethodTypeParameterName",
         "MissingCtor",
         "MissingDeprecated",
+        "MissingJavadocType",
         "MissingOverride",
         "MissingSwitchDefault",
         "NeedBraces",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeInner.java
@@ -1,0 +1,74 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+/**
+ * Tests having inner types
+ **/
+class InputMissingJavadocTypeInner
+{
+    // Ignore - two errors
+    class InnerInner2 // warn
+    {
+        // Ignore
+        public int fData;
+    }
+
+    // Ignore - 2 errors
+    interface InnerInterface2 // warn
+    {
+        // Ignore - should be all upper case
+        String data = "zxzc";
+
+        // Ignore
+        class InnerInterfaceInnerClass // warn
+        {
+            // Ignore - need Javadoc and made private
+            public int rData;
+
+            /** needs to be made private unless allowProtected. */
+            protected int protectedVariable;
+
+            /** needs to be made private unless allowPackage. */
+            int packageVariable;
+        }
+    }
+
+    /** demonstrate bug in handling static final **/
+    protected static Object sWeird = new Object();
+    /** demonstrate bug in handling static final **/
+    static Object sWeird2 = new Object();
+    
+    /** demonstrate bug in local final variable */
+    public interface Inter
+    {
+    }
+    
+     public static void main()
+     {
+        Inter m = new Inter()
+        {
+            private static final int CDS = 1;
+            
+            private int ABC;
+        };
+     }
+
+    /** annotation field incorrectly named. */
+    @interface InnerAnnotation
+    {
+        /** Ignore - should be all upper case. */
+        String data = "zxzc";
+    }
+
+    /** enum with public member variable */
+    enum InnerEnum
+    {
+        /** First constant */
+        A,
+
+        /** Second constant */
+        B;
+
+        /** Should be private */
+        public int someValue;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc.java
@@ -1,7 +1,6 @@
-package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-/** */
-public class InputJavadocTypeNoJavadoc<T> //comment test
+public class InputMissingJavadocTypeNoJavadoc //comment test
 {
     public int i1;
     protected int i2;
@@ -118,8 +117,4 @@ class PackageClass {
 
     /**/
     void methodWithTwoStarComment() {}
-
-    /** */
-    protected class ProtectedInner2<T> {
-    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadocOnInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadocOnInterface.java
@@ -1,0 +1,6 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+class InputMissingJavadocTypeNoJavadocOnInterface { // no violation,
+    // CLASS_DEF not in the list of tokens
+    interface NoJavadoc {} // warn, INTERFACE_DEF in the list of tokens
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly.java
@@ -1,0 +1,113 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+public class InputMissingJavadocTypePublicOnly // ignore - need javadoc
+{
+    private interface InnerInterface // ignore - when not relaxed about Javadoc
+    {
+        String CONST = "InnerInterface"; // ignore - w.n.r.a.j
+        void method(); // ignore - when not relaxed about Javadoc
+
+        class InnerInnerClass // ignore - when not relaxed about Javadoc
+        {
+            private int mData; // ignore - when not relaxed about Javadoc
+
+            private InnerInnerClass()
+            {
+                final Runnable r = new Runnable() {
+                        public void run() {};
+                    };
+            }
+
+            void method2() // ignore - when not relaxed about Javadoc
+            {
+                final Runnable r = new Runnable() {
+                        public void run() {};
+                    };
+            }
+        }
+    }
+
+    private class InnerClass // ignore
+    {
+        private int mDiff; // ignore - when not relaxed about Javadoc
+
+        void method() // ignore - when not relaxed about Javadoc
+        {
+        }
+    }
+
+    private int mSize; // ignore - when not relaxed about Javadoc
+    int mLen; // ignore - when not relaxed about Javadoc
+    protected int mDeer; // ignore
+    public int aFreddo; // ignore
+
+    // ignore - need Javadoc
+    private InputMissingJavadocTypePublicOnly(int aA)
+    {
+    }
+
+    // ignore - need Javadoc when not relaxed
+    InputMissingJavadocTypePublicOnly(String aA)
+    {
+    }
+
+    // ignore - always need javadoc
+    protected InputMissingJavadocTypePublicOnly(Object aA)
+    {
+    }
+
+    // ignore - always need javadoc
+    public InputMissingJavadocTypePublicOnly(Class<Object> aA)
+    {
+    }
+
+    // ignore - when not relaxed about Javadoc
+    private void method(int aA)
+    {
+    }
+
+    // ignore - when not relaxed about Javadoc
+    void method(Long aA)
+    {
+    }
+
+    // ignore - need javadoc
+    protected void method(Class<Object> aA)
+    {
+    }
+
+    // ignore - need javadoc
+    public void method(StringBuffer aA)
+    {
+    }
+
+
+    /**
+       A param tag should not be required here when relaxed about Javadoc.
+       Writing a little documentation should not be worse than not
+       writing any documentation at all.
+     */
+    private void method(String aA)
+    {
+    }
+
+    /**
+       This inner class has no author tag, which is OK.
+     */
+    public class InnerWithoutAuthor
+    {
+
+    }
+
+    /** {@inheritDoc} */
+    public String toString()
+    {
+        return super.toString();
+    }
+
+    @Deprecated @Override
+    public int hashCode()
+    {
+        return super.hashCode();
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerClasses.java
@@ -1,8 +1,4 @@
-////////////////////////////////////////////////////////////////////////////////
-// Test case file for checkstyle.
-// Created: 2001
-////////////////////////////////////////////////////////////////////////////////
-package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 /**
    Checks javadoc scoping for inner classes.
@@ -10,10 +6,8 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
    Once the Javadoc Check Scope has been left,
    all inner elements should not be reported as error,
    even if they belong to the checkscope if isolated.
-
-   @author lkuehne
  */
-public class InputJavadocTypeScopeInnerClasses
+public class InputMissingJavadocTypeScopeInnerClasses
 {
     public class InnerPublic
     {
@@ -38,9 +32,5 @@ public class InputJavadocTypeScopeInnerClasses
                 }
             }
         }
-    }
-    /** */
-    protected class InnerPublic2<T>
-    {
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerInterfaces.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerInterfaces.java
@@ -1,0 +1,70 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+public class InputMissingJavadocTypeScopeInnerInterfaces
+{
+    // inner interfaces with different scopes
+
+    private interface PrivateInterface
+    {
+        public String CA = "CONST A";
+        String CB = "CONST b";
+
+        public void ma();
+        void mb();
+    }
+
+    interface PackageInnerInterface
+    {
+        public String CA = "CONST A";
+        String CB = "CONST b";
+
+        public void ma();
+        void mb();
+    }
+
+    protected interface ProtectedInnerInterface
+    {
+        public String CA = "CONST A";
+        String CB = "CONST b";
+
+        public void ma();
+        void mb();
+    }
+
+    public interface PublicInnerInterface
+    {
+        public String CA = "CONST A";
+        String CB = "CONST b";
+
+        public void ma();
+        void mb();
+    }
+
+    private
+    class 
+    MyClass1 {
+    }
+
+    class 
+    MyClass2 {
+    }
+
+    private
+    interface
+    MyInterface1 {
+    }
+
+    interface
+    MyInterface2 {
+    }
+
+    protected
+    enum
+    MyEnum {
+    }
+    
+    private
+    @interface
+    MyAnnotation {
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations.java
@@ -1,0 +1,26 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+
+
+@ThisIsOk
+class InputMissingJavadocTypeSkipAnnotations {
+}
+
+@com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype.ThisIsOk
+class InputJavadocTypeSkipAnnotationsFQN {
+}
+
+@Generated(value = "some code generator")
+class InputJavadocTypeAllowedAnnotationByDefault {
+}
+
+/**
+ * Annotation for unit tests.
+ */
+@interface ThisIsOk {}
+/**
+ * Annotation for unit tests.
+ */
+@interface Generated {
+    String[] value();
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTags.java
@@ -1,0 +1,364 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+import java.io.IOException;
+// Tests for Javadoc tags.
+class InputMissingJavadocTypeTags1 // warn
+{
+    // Invalid - should be Javadoc
+    private int mMissingJavadoc;
+
+    // Invalid - should be Javadoc
+    void method1()
+    {
+    }
+
+    /** @param unused asd **/
+    void method2()
+    {
+    }
+
+    /** missing return **/
+    int method3()
+    {
+        return 3;
+    }
+
+    /**
+     * <p>missing return
+     * @param aOne ignored
+     **/
+    int method4(int aOne)
+    {
+        return aOne;
+    }
+
+    /** missing throws **/
+    void method5()
+        throws Exception
+    {
+    }
+
+    /**
+     * @see missing throws
+     * @see need to see tags to avoid shortcut logic
+     **/
+    void method6()
+        throws Exception
+    {
+    }
+
+    /** @throws WrongException error **/
+    void method7()
+        throws Exception, NullPointerException
+    {
+    }
+
+    /** missing param **/
+    void method8(int aOne)
+    {
+    }
+
+    /**
+     * @see missing param
+     * @see need to see tags to avoid shortcut logic
+     **/
+    void method9(int aOne)
+    {
+    }
+
+    /** @param WrongParam error **/
+    void method10(int aOne, int aTwo)
+    {
+    }
+
+    /**
+     * @param Unneeded parameter
+     * @return also unneeded
+     **/
+    void method11()
+    {
+    }
+
+    /**
+     * @return first one
+     * @return duplicate
+     **/
+    int method12()
+    {
+        return 0;
+    }
+
+    /**
+     * @param aOne
+     * @param aTwo
+     *
+     *     This is a multiline piece of javadoc
+     *     Unlike the previous one, it actually has content
+     * @param aThree
+     *
+     *
+     *     This also has content
+     * @param aFour
+
+     *
+     * @param aFive
+     **/
+    void method13(int aOne, int aTwo, int aThree, int aFour, int aFive)
+    {
+    }
+
+    /** @param aOne Perfectly legal **/
+    void method14(int aOne)
+    {
+    }
+
+    /** @throws java.io.IOException
+     *               just to see if this is also legal **/
+    void method14()
+       throws java.io.IOException
+    {
+    }
+
+
+
+    // Test static initialiser
+    static
+    {
+        int x = 1; // should not require any javadoc
+    }
+
+    // test initialiser
+    {
+        int z = 2; // should not require any javadoc
+    }
+
+    /** handle where variable declaration over several lines **/
+    private static final int
+        ON_SECOND_LINE = 2;
+
+
+    /**
+     * Documenting different causes for the same exception
+     * in separate tags is OK (bug 540384).
+     *
+     * @throws java.io.IOException if A happens
+     * @throws java.io.IOException if B happens
+     **/
+    void method15()
+       throws java.io.IOException
+    {
+    }
+
+    /** {@inheritDoc} **/
+    public String toString()
+    {
+        return super.toString();
+    }
+
+    /** getting code coverage up **/
+    static final int serialVersionUID = 666;
+
+    //**********************************************************************/
+    // Method Name: method16
+    /**
+     * handle the case of an elaborate header surrounding javadoc comments
+     *
+     * @param aOne valid parameter content
+     */
+    //**********************************************************************/
+    void method16(int aOne)
+    {
+    }
+
+
+    /**
+     * @throws ThreadDeath although bad practice, should be silently ignored
+     * @throws ArrayStoreException another r/t subclass
+     * @throws IllegalMonitorStateException should be told to remove from throws
+     */
+    void method17()
+        throws IllegalMonitorStateException
+    {
+    }
+
+    /**
+     * declaring the imported version of an Exception and documenting
+     * the full class name is OK (bug 658805).
+     * @throws java.io.IOException if bad things happen.
+     */
+    void method18()
+        throws IOException
+    {
+        throw new IOException("to make compiler happy");
+    }
+
+    /**
+     * reverse of bug 658805.
+     * @throws IOException if bad things happen.
+     */
+    void method19()
+        throws java.io.IOException
+    {
+        throw new IOException("to make compiler happy");
+    }
+
+    /**
+     * Bug 579190, "expected return tag when one is there".
+     *
+     * Linebreaks after return tag should be legal.
+     *
+     * @return
+     *   the bug that states that linebreak should be legal
+     */
+    int method20()
+    {
+        return 579190;
+    }
+
+    /**
+     * Bug XXXX, "two tags for the same exception"
+     *
+     * @exception java.io.IOException for some reasons
+     * @exception IOException for another reason
+     */
+    void method21()
+       throws IOException
+    {
+    }
+
+    /**
+     * RFE 540383, "Unused throws tag for exception subclass"
+     *
+     * @exception IOException for some reasons
+     * @exception java.io.FileNotFoundException for another reasons
+     */
+    void method22()
+       throws IOException
+    {
+    }
+
+    /**
+     * @exception WrongException exception w/o class info but matched by name
+     */
+    void method23() throws WrongException
+    {
+    }
+
+    /**
+     * Bug 803577, "allowThrowsTagsForSubclasses/allowMissingThrowsTag interfere"
+     *
+     * no exception tag for IOException, but here is a tag for its subclass.
+     * @exception java.io.FileNotFoundException for another reasons
+     */
+    void method24() throws IOException
+    {
+    }
+
+    /**
+     * Bug 841942, "ArrayIndexOutOfBounds in JavadocStyle".
+     * @param aParam there is no such param in the method.
+     * The problem should be reported with correct line number.
+     */
+
+    void method25()
+    {
+    }
+
+    /** {@inheritDoc} */
+    int method26()
+    { return 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return something very important.
+     */
+    int method27(int aParam)
+    { return 0;
+    }
+
+    /**
+     * @return something very important.
+     * {@inheritDoc}
+     */
+    int method28(int aParam)
+    { return 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return 1
+     */
+    public int foo(Object _arg) {
+
+        return 1;
+    }
+}
+
+enum InputJavadocTypeTagsEnum // warn
+{
+    CONSTANT_A,
+
+    /**
+     *
+     */
+    CONSTANT_B,
+
+    CONSTANT_C
+    {
+        /**
+         *
+         */
+        public void someMethod()
+        {
+        }
+
+        public void someOtherMethod()
+        {
+
+        }
+    }
+}
+
+@interface InputJavadocTypeTagsAnnotation // warn
+{
+    String someField();
+    int A_CONSTANT = 0;
+    /** Some javadoc. */
+    int B_CONSTANT = 1;
+    /** @return This tag is valid here and expected with Java 8 */
+    String someField2();
+}
+
+/**
+ * Some javadoc.
+ */
+public class InputMissingJavadocTypeTags {
+
+    /**
+     * Constructor.
+     */
+    public InputMissingJavadocTypeTags() {
+    }
+
+   /**
+    * Sample method.
+    * @param arg1   first argument
+    * @param arg2   second argument
+    * @return java.lang.String      the result string
+    * @throws java.lang.Exception   in case of problem
+    */
+    public final String myMethod(final String arg1,
+                                 final Object arg2)
+      throws Exception
+    {
+        return null;
+    }
+}
+
+/**
+ *  Added to make this file compilable.
+ */
+class WrongException extends RuntimeException
+{
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeUnusedParamInJavadocForClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeUnusedParamInJavadocForClass.java
@@ -1,0 +1,11 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+/**
+ * InputJavadocTypeUnusedParamInJavadocForClass.
+ *
+ * @param BAD This is bad.
+ * @param <BAD> This doesn't exist.
+ * @param
+ */
+public class InputMissingJavadocTypeUnusedParamInJavadocForClass {
+}

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -479,6 +479,11 @@
         </td>
       </tr>
       <tr>
+        <td><a href="config_javadoc.html#MissingJavadocType">MissingJavadocType</a></td>
+        <td>Checks for missing Javadoc comments for class, enum, interface, and annotation
+        interface definitions.</td>
+      </tr>
+      <tr>
         <td><a href="config_annotation.html#MissingOverride">MissingOverride</a></td>
         <td>
         This class is used to verify that the java.lang.Override annotation is present

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1329,10 +1329,6 @@ class DatabaseConfiguration {}
       <subsection name="Error Messages" id="JavadocType_Error_Messages">
         <ul>
           <li>
-            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missing%22">
-            javadoc.missing</a>
-          </li>
-          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unknownTag%22">
             javadoc.unknownTag</a>
           </li>
@@ -1501,6 +1497,186 @@ class DatabaseConfiguration {}
       </subsection>
 
       <subsection name="Parent Module" id="JavadocVariable_Parent_Module">
+        <p>
+          <a href="config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+
+    <section name="MissingJavadocType">
+      <p>Since Checkstyle 8.20</p>
+      <subsection name="Description" id="MissingJavadocType_Description">
+        <p>
+          Checks for missing Javadoc comments for class, enum, interface, and annotation
+          interface definitions. The scope to verify is specified using the <code>Scope</code>
+          class and defaults to <code>Scope.PUBLIC</code>. To verify
+          another scope, set property scope to one of the
+          <code>Scope</code> constants.
+        </p>
+      </subsection>
+
+      <subsection name="Properties" id="MissingJavadocType_Properties">
+        <table>
+          <tr>
+            <th>name</th>
+            <th>description</th>
+            <th>type</th>
+            <th>default value</th>
+            <th>since</th>
+          </tr>
+          <tr>
+            <td>scope</td>
+            <td>specify the visibility scope where Javadoc comments are checked.</td>
+            <td><a href="property_types.html#scope">Scope</a></td>
+            <td><code>public</code></td>
+            <td>8.20</td>
+          </tr>
+          <tr>
+            <td>excludeScope</td>
+            <td>specify the visibility scope where Javadoc comments are not checked.</td>
+            <td><a href="property_types.html#scope">Scope</a></td>
+            <td><code>null</code></td>
+            <td>8.20</td>
+          </tr>
+          <tr>
+            <td>skipAnnotations</td>
+            <td>
+              specify the list of annotations that allow missed documentation.
+              Only short names are allowed, e.g. <code>Generated</code>.
+            </td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
+            <td><code>Generated</code></td>
+            <td>8.20</td>
+          </tr>
+          <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+            <td>
+              subset of tokens
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                INTERFACE_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                CLASS_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                ENUM_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                ANNOTATION_DEF</a>.
+            </td>
+            <td>
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                INTERFACE_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                CLASS_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                ENUM_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                ANNOTATION_DEF</a>.
+            </td>
+            <td>8.20</td>
+          </tr>
+        </table>
+      </subsection>
+
+      <subsection name="Examples" id="MissingJavadocType_Examples">
+        <p>
+          To configure the default check to make sure all public class, enum, interface, and
+          annotation interface, definitions have javadocs:
+        </p>
+        <source>
+&lt;module name="MissingJavadocType"/&gt;
+        </source>
+
+        <p>Example:</p>
+        <pre>
+public class PublicClass {} // violation
+private class PublicClass {}
+protected class PublicClass {}
+class PackagePrivateClass {}
+        </pre>
+
+        <p>
+          To configure the check for <code>private</code> scope:
+        </p>
+        <source>
+&lt;module name="MissingJavadocType"&gt;
+  &lt;property name="scope" value="private"/&gt;
+&lt;/module&gt;
+        </source>
+
+        <p>Example:</p>
+        <pre>
+public class PublicClass {} // violation
+private class PublicClass {} // violation
+protected class PublicClass {} // violation
+class PackagePrivateClass {} // violation
+        </pre>
+
+        <p>
+          To configure the check for <code>private</code> classes only:
+        </p>
+        <source>
+&lt;module name="MissingJavadocType"&gt;
+  &lt;property name="scope" value="private"/&gt;
+  &lt;property name="excludeScope" value="package"/&gt;
+&lt;/module&gt;
+        </source>
+
+        <p>Example:</p>
+        <pre>
+public class PublicClass {}
+private class PublicClass {} // violation
+protected class PublicClass {}
+class PackagePrivateClass {}
+        </pre>
+
+        <p>
+          Example that allows missing comments for classes annotated with
+          <code>@SpringBootApplication</code> and <code>@Configuration</code>:
+        </p>
+        <source>
+@SpringBootApplication // no violations about missing comment on class
+public class Application {}
+
+@Configuration // no violations about missing comment on class
+class DatabaseConfiguration {}
+        </source>
+        <p>Use following configuration:</p>
+        <source>
+&lt;module name="MissingJavadocType"&gt;
+  &lt;property name="skipAnnotations" value="SpringBootApplication,Configuration"/&gt;
+&lt;/module&gt;
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="MissingJavadocType_Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocType">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Error Messages" id="MissingJavadocType_Error_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missing%22">
+            javadoc.missing</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="config.html#Custom_messages">see the documentation</a> to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="MissingJavadocType_Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.javadoc
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="MissingJavadocType_Parent_Module">
         <p>
           <a href="config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -432,9 +432,8 @@
     </section>
 
     <section name="scope">
-      <p>This property represents a Java scope. The scope is treated
-      inclusively (as javadoc does): 'package' means all 'package', 'protected'
-      and 'public' methods/fields/classes. The valid options are:</p>
+      <p>This property represents a Java scope. Checks use this to determine which
+      methods/fields/classes will be examined by it's logic. The valid options are:</p>
 
       <ul>
         <li><code>nothing</code></li>
@@ -444,6 +443,15 @@
         <li><code>private</code></li>
         <li><code>anoninner</code></li>
       </ul>
+
+      <p>Using a specific scope means not only will that modifier be examined, but also all the
+      modifiers listed above it in the previous list. Specifying <code>public</code> means only
+      items with <code>public</code> modifiers are checked. Specifying <code>protected</code>
+      means only <code>public</code> and <code>protected</code> modifiers are checked.
+      If you wish to only validate items with <code>private</code> modifiers and ignore any
+      others, then you must set the exclude scope property, if available, to the scope above
+      it in the table. In this case you would exclude <code>package</code>.
+      </p>
     </section>
 
       <section name="access_modifiers">


### PR DESCRIPTION
Issue #5411

This is for MissingJavadocType. It was pretty much a copy/paste of the original check.