### PR TITLE
minor: reset the test stream for each test

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/AbstractModuleTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/AbstractModuleTestSupport.java
@@ -259,6 +259,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
             Integer... warnsExpected)
             throws Exception {
         stream.flush();
+        stream.reset();
         final List<File> theFiles = new ArrayList<>();
         Collections.addAll(theFiles, processedFiles);
         final List<Integer> theWarnings = new ArrayList<>();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -273,6 +273,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
                           String... expected)
             throws Exception {
         stream.flush();
+        stream.reset();
         final List<File> theFiles = new ArrayList<>();
         Collections.addAll(theFiles, processedFiles);
         final int errs = checker.process(theFiles);
@@ -310,6 +311,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
                           Map<String, List<String>> expectedViolations)
             throws Exception {
         stream.flush();
+        stream.reset();
         final List<File> theFiles = new ArrayList<>();
         Collections.addAll(theFiles, processedFiles);
         final int errs = checker.process(theFiles);


### PR DESCRIPTION
These streams are reused and without the reset call,
you are getting "Audit done." messages in assertion failures when
unexpected violations happen instead of the actual unexpected violation.
Resetting the streams fixes this.

This is a followup of #6511.