### PR TITLE
Issue #6560: run tests with English locale and UTF-8 encoding by default

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -314,6 +314,7 @@ Destructuring
 detailast
 detailnodetreestringprinter
 Dexec
+Dfile
 dfn
 Dfoo
 Dforbiddenapis

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,7 @@
     <pitest.plugin.timeout.constant>50000</pitest.plugin.timeout.constant>
     <pitest.plugin.threads>4</pitest.plugin.threads>
     <sonar.test.exclusions>**/test/resources/**/*,**/it/resources/**/*</sonar.test.exclusions>
+    <argLine>-Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8</argLine>
   </properties>
 
   <!-- that repositories are required for testing plugin's snapshot version -->


### PR DESCRIPTION
Fixes #6560