### PR TITLE
Issue #6531: aligned javadoc/xdoc for PackageAnnotation

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheck.java
@@ -26,13 +26,13 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
 
 /**
+ * <p>
  * This check makes sure that all package annotations are in the
  * package-info.java file.
- *
+ * </p>
  * <p>
  * According to the Java Language Specification.
  * </p>
- *
  * <p>
  * The JLS does not enforce the placement of package annotations.
  * This placement may vary based on implementation. The JLS
@@ -40,9 +40,17 @@ import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
  * placed in the package-info.java file.
  *
  * See <a
- * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.4.1">
- * Java Language Specification, section 7.4.1</a>.
+ * href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-7.html#jls-7.4.1">
+ * Java Language Specification, &#167;7.4.1</a>.
  * </p>
+ * <p>
+ * To configure the check:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;PackageAnnotation&quot;/&gt;
+ * </pre>
+ *
+ * @since 5.0
  */
 @StatelessCheck
 public class PackageAnnotationCheck extends AbstractCheck {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -95,6 +95,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         "MissingDeprecated",
         "MissingOverride",
         "NeedBraces",
+        "PackageAnnotation",
         "PackageName",
         "ParameterName",
         "RightCurly",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -499,7 +499,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                         CHECK_TEXT.get("Description")
                                 + CHECK_TEXT.computeIfAbsent("Rule Description", unused -> "")
                                 + CHECK_TEXT.computeIfAbsent("Notes", unused -> "")
-                                + CHECK_TEXT.get("Properties")
+                                + CHECK_TEXT.computeIfAbsent("Properties", unused -> "")
                                 + CHECK_TEXT.get("Examples") + " @since "
                                 + CHECK_TEXT.get("since"), getJavaDocText(ast));
             }

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -797,8 +797,8 @@ public static final int COUNTER = 10; // violation as javadoc exists
     </section>
 
     <section name="PackageAnnotation">
+      <p>Since Checkstyle 5.0</p>
       <subsection name="Description" id="PackageAnnotation_Description">
-        <p>Since Checkstyle 5.0</p>
         <p>  This check makes sure that all package annotations are in the
              package-info.java file.
         </p>
@@ -813,8 +813,8 @@ public static final int COUNTER = 10; // violation as javadoc exists
             placed in the package-info.java file.
 
             See <a
-            href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.4.1">
-            Java Language Specification, section 7.4.1</a>.
+            href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-7.html#jls-7.4.1">
+            Java Language Specification, &#167;7.4.1</a>.
         </p>
       </subsection>
 


### PR DESCRIPTION
Issue #6531 (part of #5750)

Second commit to allow checks without any properties.