### PR TITLE
Issue #6536: upgrade to PMD 6.12

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -15,8 +15,6 @@
     <exclude name="AccessorMethodGeneration"/>
     <!-- The PMD mistakes the AbstractViolationReporter::log() as a debug log. -->
     <exclude name="GuardLogStatement"/>
-    <!-- Till https://github.com/pmd/pmd/issues/1181 -->
-    <exclude name="UnusedPrivateMethod"/>
   </rule>
   <rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace">
     <properties>
@@ -73,6 +71,8 @@
     <!-- Calling super() is completely pointless, no matter if class inherits anything or not;
          it is meaningful only if you do not call implicit constructor of the base class. -->
     <exclude name="CallSuperInConstructor"/>
+    <!-- Till https://github.com/checkstyle/checkstyle/issues/6578 -->
+    <exclude name="LinguisticNaming"/>
     <!-- Pollutes code with modifiers. -->
     <exclude name="LocalVariableCouldBeFinal"/>
     <!-- Pollutes the code with modifiers. We use the ParameterAssignmentCheck to protect the
@@ -83,6 +83,8 @@
     <exclude name="OnlyOneReturn"/>
     <!-- We use CheckstyleCustomShortVariable, to control the length and skip Override methods. -->
     <exclude name="ShortVariable"/>
+    <!-- Till https://github.com/checkstyle/checkstyle/issues/6579 -->
+    <exclude name="UseUnderscoresInNumericLiterals"/>
   </rule>
   <rule ref="category/java/codestyle.xml/ClassNamingConventions">
     <properties>
@@ -272,7 +274,7 @@
   </rule>
   <rule ref="category/java/design.xml/CyclomaticComplexity">
     <properties>
-      <property name="classReportLevel" value="76"/>
+      <property name="classReportLevel" value="75"/>
       <property name="methodReportLevel" value="11"/>
       <!-- RequireThisCheck, VariableDeclarationUsageDistanceCheck, XdocsPagesTest,
              JavadocMethodCheck and CommentsIndentationCheck are big classes and should not
@@ -289,12 +291,13 @@
              validated by checkstyle version of Npath, we think that pmd is wrong here.
            Checker.processFiles is validated by checkstyle version of Npath, we think that pmd is
              wrong here.
+           CommonUtil is clearly designed for a large number of small methods for common use.
            XdocsJavaDocsTest.testAllCheckSectionJavaDocs is needed until all suppressions are
              removed. -->
       <property name="violationSuppressXPath"
                 value="//ClassOrInterfaceDeclaration[@Image='RequireThisCheck'
       or @Image='VariableDeclarationUsageDistanceCheck' or @Image='XdocsPagesTest'
-      or @Image='JavadocMethodCheck' or @Image='CommentsIndentationCheck']
+      or @Image='JavadocMethodCheck' or @Image='CommentsIndentationCheck' or @Image='CommonUtil']
     | //ClassOrInterfaceDeclaration[@Image='Main']//MethodDeclaration[@Name='validateCli']
     | //ClassOrInterfaceDeclaration[@Image='Checker']//MethodDeclaration[@Name='processFiles']
     | //ClassOrInterfaceDeclaration[@Image='FallThroughCheck']

--- a/config/version-number-rules.xml
+++ b/config/version-number-rules.xml
@@ -22,12 +22,6 @@
                 <ignoreVersion type="regex">20030911</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <rule groupId="org.apache.maven.plugins" artifactId="maven-pmd-plugin">
-            <ignoreVersions>
-                <!-- till https://github.com/checkstyle/checkstyle/issues/5790 -->
-                <ignoreVersion type="regex">3.10.0</ignoreVersion>
-            </ignoreVersions>
-        </rule>
         <rule groupId="org.apache.maven.plugins" artifactId="maven-release-plugin">
             <ignoreVersions>
                 <!-- we use 2.1 version that is defined at our parent

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <maven.site.plugin.version>3.7.1</maven.site.plugin.version>
     <maven.spotbugs.plugin.version>3.1.11</maven.spotbugs.plugin.version>
     <maven.pmd.plugin.version>3.11.0</maven.pmd.plugin.version>
-    <pmd.version>6.6.0</pmd.version>
+    <pmd.version>6.12.0</pmd.version>
     <maven.jacoco.plugin.version>0.8.3</maven.jacoco.plugin.version>
     <powermock.version>2.0.0</powermock.version>
     <saxon.version>9.9.1-2</saxon.version>


### PR DESCRIPTION
Issue #6536 

`LinguisticNaming` and `UseUnderscoresInNumericLiterals` are excluded for a while.

`CommonUtil` whitelisted since it is no more fit to `classReportLevel` of `CyclomaticComplexity`.
The level itself is reduced to 75.