### PR TITLE
Issue #6578: Enable PMD rule LinguisticNaming

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -71,8 +71,6 @@
     <!-- Calling super() is completely pointless, no matter if class inherits anything or not;
          it is meaningful only if you do not call implicit constructor of the base class. -->
     <exclude name="CallSuperInConstructor"/>
-    <!-- Till https://github.com/checkstyle/checkstyle/issues/6578 -->
-    <exclude name="LinguisticNaming"/>
     <!-- Pollutes code with modifiers. -->
     <exclude name="LocalVariableCouldBeFinal"/>
     <!-- Pollutes the code with modifiers. We use the ParameterAssignmentCheck to protect the

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
@@ -61,7 +61,7 @@ public final class NPathComplexityCheck extends AbstractCheck {
     private final Deque<Integer> expressionValues = new ArrayDeque<>();
 
     /** Stack of belongs to range values for question operator. */
-    private final Deque<Boolean> isAfterValues = new ArrayDeque<>();
+    private final Deque<Boolean> afterValues = new ArrayDeque<>();
 
     /**
      * Range of the last processed expression. Used for checking that ternary operation
@@ -122,7 +122,7 @@ public final class NPathComplexityCheck extends AbstractCheck {
     public void beginTree(DetailAST rootAST) {
         rangeValues.clear();
         expressionValues.clear();
-        isAfterValues.clear();
+        afterValues.clear();
         processingTokenEnd.reset();
         currentRangeValue = INITIAL_VALUE;
         branchVisited = false;
@@ -237,7 +237,7 @@ public final class NPathComplexityCheck extends AbstractCheck {
      */
     private void visitUnitaryOperator(DetailAST ast, int basicBranchingFactor) {
         final boolean isAfter = processingTokenEnd.isAfter(ast);
-        isAfterValues.push(isAfter);
+        afterValues.push(isAfter);
         if (!isAfter) {
             processingTokenEnd.setToken(getLastToken(ast));
             final int expressionValue = basicBranchingFactor + countConditionalOperators(ast);
@@ -249,7 +249,7 @@ public final class NPathComplexityCheck extends AbstractCheck {
      * Leaves ternary operator (?:) and return tokens.
      */
     private void leaveUnitaryOperator() {
-        if (!isAfterValues.pop()) {
+        if (!afterValues.pop()) {
             final Values valuePair = popValue();
             BigInteger basicRangeValue = valuePair.getRangeValue();
             BigInteger expressionValue = valuePair.getExpressionValue();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -490,11 +490,11 @@ public class VisibilityModifierCheckTest
             new File(getPath("InputVisibilityModifierIsStarImport.java")),
             JavaParser.Options.WITHOUT_COMMENTS).getNextSibling();
         final VisibilityModifierCheck check = new VisibilityModifierCheck();
-        final Method isStarImport = Whitebox.getMethod(VisibilityModifierCheck.class,
+        final Method method = Whitebox.getMethod(VisibilityModifierCheck.class,
             "isStarImport", DetailAST.class);
 
         assertTrue("Should return true when star import is passed",
-            (boolean) isStarImport.invoke(check, importAst));
+            (boolean) method.invoke(check, importAst));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractTypeAwareCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractTypeAwareCheckTest.java
@@ -47,11 +47,11 @@ public class AbstractTypeAwareCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testIsSubclassWithNulls() throws Exception {
         final JavadocMethodCheck check = new JavadocMethodCheck();
-        final Method isSubclass = check.getClass().getSuperclass()
+        final Method method = check.getClass().getSuperclass()
                 .getDeclaredMethod("isSubclass", Class.class, Class.class);
-        isSubclass.setAccessible(true);
+        method.setAccessible(true);
         assertFalse("Should return false if at least one of the params is null",
-            (boolean) isSubclass.invoke(check, null, null));
+            (boolean) method.invoke(check, null, null));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -156,7 +156,7 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
 
         final NPathComplexityCheck check = new NPathComplexityCheck();
         Assert.assertTrue("Stateful field is not cleared after beginTree",
-            TestUtil.isStatefulFieldClearedDuringBeginTree(check, ast, "isAfterValues",
+            TestUtil.isStatefulFieldClearedDuringBeginTree(check, ast, "afterValues",
                 isAfterValues -> ((Collection<Context>) isAfterValues).isEmpty()));
     }
 


### PR DESCRIPTION
Issue #6578

`Deque<Boolean> isAfterValues` ->  `Deque<Boolean> afterValues`
`Method isSubclass` -> `Method method`
`Method isStarImport` -> `Method method`