### PR TITLE
config: ignore whitespace for pitest ignorelist

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -10,7 +10,7 @@ function checkPitestReport() {
   grep -irE "$SEARCH_REGEXP" target/pit-reports \
      | sed -E 's/.*\/([A-Za-z]+.java.html)/\1/' | LC_ALL=C sort > target/actual.txt
   printf "%s\n" "${ignored[@]}" | sed '/^$/d' | LC_ALL=C sort > target/ignored.txt
-  if [ "$(diff --unified target/ignored.txt target/actual.txt)" != "" ] ; then
+  if [ "$(diff --unified -w target/ignored.txt target/actual.txt)" != "" ] ; then
       fail=1
       echo "Actual:" ;
       grep -irE "$SEARCH_REGEXP" target/pit-reports \
@@ -18,7 +18,7 @@ function checkPitestReport() {
       echo "Ignore:" ;
       printf '%s\n' "${ignored[@]}"
       echo "Diff:"
-      diff --unified target/ignored.txt target/actual.txt | cat
+      diff --unified -w target/ignored.txt target/actual.txt | cat
   fi;
   if [ "$fail" -ne "0" ]; then
     echo "Difference between 'Actual' and 'Ignore' lists is detected, lists should be equal."


### PR DESCRIPTION
When running pitest on Windows, the diff shows all lines changed when there are
ignores configured due to difference in line endings. With this change, -w is
used for the diff so whitespaces are ignored.