### PR TITLE
minor: GeneratedJava14LexerTest depends on encoding, not on OS, so fix the assumption to represent this

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/GeneratedJava14LexerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/GeneratedJava14LexerTest.java
@@ -21,6 +21,9 @@ package com.puppycrawl.tools.checkstyle.grammar;
 
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import org.junit.Assume;
 import org.junit.Test;
 
@@ -36,11 +39,10 @@ public class GeneratedJava14LexerTest
     extends AbstractModuleTestSupport {
 
     /**
-     * <p>Is {@code true} if this is Windows.</p>
-     *
-     * <p>Adapted from org.apache.commons.lang3.SystemUtils.</p>
+     * Is {@code true} if current default encoding is UTF-8.
      */
-    private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
+    private static final boolean IS_UTF8 = Charset.forName(System.getProperty("file.encoding"))
+            .equals(StandardCharsets.UTF_8);
 
     @Override
     protected String getPackageLocation() {
@@ -49,8 +51,8 @@ public class GeneratedJava14LexerTest
 
     @Test
     public void testUnexpectedChar() throws Exception {
-        // Encoding problems can occur in Windows
-        Assume.assumeFalse("Problems with encoding may occur", IS_WINDOWS);
+        // Encoding problems will occur if default encoding is not UTF-8
+        Assume.assumeTrue("Problems with encoding may occur", IS_UTF8);
 
         final DefaultConfiguration checkConfig =
             createModuleConfig(MemberNameCheck.class);


### PR DESCRIPTION
If you set the encoding when running maven or if you run from IDE or if your
default encoding actually is UTF-8 even on Windows, the test could pretty well
run, so the assumption that is used to determine whether the test should be
skipped should represent this and not check for the OS.