### PR TITLE
minor: make RequireThisCheck.{Catch,For}Frame private

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -1402,7 +1402,7 @@ public class RequireThisCheck extends AbstractCheck {
     /**
      * A frame initiated on entering a catch block; holds local catch variable names.
      */
-    public static class CatchFrame extends AbstractFrame {
+    private static class CatchFrame extends AbstractFrame {
 
         /**
          * Creates catch frame.
@@ -1423,7 +1423,7 @@ public class RequireThisCheck extends AbstractCheck {
     /**
      * A frame initiated on entering a for block; holds local for variable names.
      */
-    public static class ForFrame extends AbstractFrame {
+    private static class ForFrame extends AbstractFrame {
 
         /**
          * Creates for frame.


### PR DESCRIPTION
From https://github.com/checkstyle/checkstyle/pull/6604/files#r268451734
Fixes #6604

`RequireThisCheck.CatchFrame` and `RequireThisCheck.ForFrame` should be private or documented.
The second option is questionable because all other frame classes are private.