### PR TITLE
minor: remove unnecessary antlr classes from main code

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks;
 import java.util.Arrays;
 import java.util.Set;
 
-import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -314,7 +313,7 @@ public class DescendantTokenCheck extends AbstractCheck {
      * @param ast the root token for descendants.
      * @param depth the maximum depth of the counted descendants.
      */
-    private void countTokens(AST ast, int depth) {
+    private void countTokens(DetailAST ast, int depth) {
         if (depth <= maximumDepth) {
             //update count
             if (depth >= minimumDepth) {
@@ -323,7 +322,7 @@ public class DescendantTokenCheck extends AbstractCheck {
                     counts[type - 1]++;
                 }
             }
-            AST child = ast.getFirstChild();
+            DetailAST child = ast.getFirstChild();
             final int nextDepth = depth + 1;
             while (child != null) {
                 countTokens(child, nextDepth);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import java.util.Deque;
 import java.util.LinkedList;
 
-import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -146,7 +145,7 @@ public abstract class AbstractSuperCheck
      * @return true if method name is the same
      */
     private boolean isSameNameMethod(DetailAST ast) {
-        AST sibling = ast.getNextSibling();
+        DetailAST sibling = ast.getNextSibling();
         // ignore type parameters
         if (sibling != null
             && sibling.getType() == TokenTypes.TYPE_ARGUMENTS) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import java.util.HashMap;
 import java.util.Map;
 
-import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -134,8 +133,8 @@ public class EqualsHashCodeCheck
      */
     private static boolean isHashCodeMethod(DetailAST ast) {
         final DetailAST modifiers = ast.getFirstChild();
-        final AST type = ast.findFirstToken(TokenTypes.TYPE);
-        final AST methodName = ast.findFirstToken(TokenTypes.IDENT);
+        final DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
+        final DetailAST methodName = ast.findFirstToken(TokenTypes.IDENT);
         final DetailAST parameters = ast.findFirstToken(TokenTypes.PARAMETERS);
 
         return type.getFirstChild().getType() == TokenTypes.LITERAL_INT

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -215,7 +214,7 @@ public class IllegalInstantiationCheck
      */
     private void postProcessLiteralNew(DetailAST newTokenAst) {
         final DetailAST typeNameAst = newTokenAst.getFirstChild();
-        final AST nameSibling = typeNameAst.getNextSibling();
+        final DetailAST nameSibling = typeNameAst.getNextSibling();
         if (nameSibling.getType() != TokenTypes.ARRAY_DECLARATOR) {
             // ast != "new Boolean[]"
             final FullIdent typeIdent = FullIdent.createFullIdent(typeNameAst);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.Arrays;
 
-import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -173,7 +172,7 @@ public class InnerAssignmentCheck
         boolean result = false;
         if (isInContext(ast, CONTROL_CONTEXT)) {
             final DetailAST expr = ast.getParent();
-            final AST exprNext = expr.getNextSibling();
+            final DetailAST exprNext = expr.getNextSibling();
             result = exprNext.getType() == TokenTypes.SEMI;
         }
         return result;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -72,14 +71,14 @@ public class SimplifyBooleanReturnCheck
         // [ LITERAL_ELSE (with the elseStatement as a child) ]
 
         // don't bother if this is not if then else
-        final AST elseLiteral =
+        final DetailAST elseLiteral =
             ast.findFirstToken(TokenTypes.LITERAL_ELSE);
         if (elseLiteral != null) {
-            final AST elseStatement = elseLiteral.getFirstChild();
+            final DetailAST elseStatement = elseLiteral.getFirstChild();
 
             // skip '(' and ')'
-            final AST condition = ast.getFirstChild().getNextSibling();
-            final AST thenStatement = condition.getNextSibling().getNextSibling();
+            final DetailAST condition = ast.getFirstChild().getNextSibling();
+            final DetailAST thenStatement = condition.getNextSibling().getNextSibling();
 
             if (canReturnOnlyBooleanLiteral(thenStatement)
                 && canReturnOnlyBooleanLiteral(elseStatement)) {
@@ -108,10 +107,10 @@ public class SimplifyBooleanReturnCheck
      * @param ast the syntax tree to check
      * @return if ast is a return statement with a boolean literal.
      */
-    private static boolean canReturnOnlyBooleanLiteral(AST ast) {
+    private static boolean canReturnOnlyBooleanLiteral(DetailAST ast) {
         boolean result = true;
         if (!isBooleanLiteralReturnStatement(ast)) {
-            final AST firstStatement = ast.getFirstChild();
+            final DetailAST firstStatement = ast.getFirstChild();
             result = isBooleanLiteralReturnStatement(firstStatement);
         }
         return result;
@@ -129,14 +128,14 @@ public class SimplifyBooleanReturnCheck
      * @param ast the syntax tree to check
      * @return if ast is a return statement with a boolean literal.
      */
-    private static boolean isBooleanLiteralReturnStatement(AST ast) {
+    private static boolean isBooleanLiteralReturnStatement(DetailAST ast) {
         boolean booleanReturnStatement = false;
 
         if (ast != null && ast.getType() == TokenTypes.LITERAL_RETURN) {
-            final AST expr = ast.getFirstChild();
+            final DetailAST expr = ast.getFirstChild();
 
             if (expr.getType() != TokenTypes.SEMI) {
-                final AST value = expr.getFirstChild();
+                final DetailAST value = expr.getFirstChild();
                 booleanReturnStatement = isBooleanLiteralType(value.getType());
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -64,8 +63,8 @@ public class StringLiteralEqualityCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         // no need to check for nulls here, == and != always have two children
-        final AST firstChild = ast.getFirstChild();
-        final AST secondChild = firstChild.getNextSibling();
+        final DetailAST firstChild = ast.getFirstChild();
+        final DetailAST secondChild = firstChild.getNextSibling();
 
         if (firstChild.getType() == TokenTypes.STRING_LITERAL
                 || secondChild.getType() == TokenTypes.STRING_LITERAL) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -603,10 +602,10 @@ public class VisibilityModifierCheck
      * @return the set of modifier Strings for defAST.
      */
     private static Set<String> getModifiers(DetailAST defAST) {
-        final AST modifiersAST = defAST.findFirstToken(TokenTypes.MODIFIERS);
+        final DetailAST modifiersAST = defAST.findFirstToken(TokenTypes.MODIFIERS);
         final Set<String> modifiersSet = new HashSet<>();
         if (modifiersAST != null) {
-            AST modifier = modifiersAST.getFirstChild();
+            DetailAST modifier = modifiersAST.getFirstChild();
             while (modifier != null) {
                 modifiersSet.add(modifier.getText());
                 modifier = modifier.getNextSibling();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -423,7 +422,7 @@ public final class CheckUtil {
 
         // default access modifier
         AccessModifier accessModifier = AccessModifier.PACKAGE;
-        for (AST token = modifiersToken.getFirstChild(); token != null;
+        for (DetailAST token = modifiersToken.getFirstChild(); token != null;
              token = token.getNextSibling()) {
             final int tokenType = token.getType();
             if (tokenType == TokenTypes.LITERAL_PUBLIC) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.utils;
 
-import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -43,7 +42,7 @@ public final class ScopeUtil {
     public static Scope getScopeFromMods(DetailAST aMods) {
         // default scope
         Scope returnValue = Scope.PACKAGE;
-        for (AST token = aMods.getFirstChild(); token != null
+        for (DetailAST token = aMods.getFirstChild(); token != null
                 && returnValue == Scope.PACKAGE;
                 token = token.getNextSibling()) {
             if ("public".equals(token.getText())) {


### PR DESCRIPTION
This removes uses of ANTLR classes and uses DetailAST directly instead.
This is in support of issue #3817 .