### PR TITLE
Issue #4845: remove usage of DetailAST from input files

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
@@ -1,7 +1,7 @@
 package com.google.checkstyle.test.chapter4formatting.rule4861blockcommentstyle;
 
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
+
+
 
 /**
  * Contains examples of using comments at the end of the block.
@@ -59,61 +59,61 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     //    }
 
     public void foo11() {
-        CheckUtil
-            .getFirstNode(new DetailAST())
-            .getFirstChild()
-            .getNextSibling();
+        String
+            .valueOf(new Integer(0))
+            .trim()
+            .length();
         // comment
     }
 
     public void foo12() {
-        CheckUtil
-            .getFirstNode(new DetailAST())
-            .getFirstChild()
-            .getNextSibling();
+        String
+            .valueOf(new Integer(0))
+            .trim()
+            .length();
                   // warn
     }
 
     public void foo13() {
-        CheckUtil.getFirstNode(new DetailAST())
-                .getFirstChild()
-                .getNextSibling();
+        String.valueOf(new Integer(0))
+                .trim()
+                .length();
         // comment
     }
 
     public void foo14() {
-        CheckUtil.getFirstNode(new DetailAST())
-            .getFirstChild()
-            .getNextSibling();
+        String.valueOf(new Integer(0))
+            .trim()
+            .length();
                                // warn
     }
 
     public void foo15() {
-        CheckUtil
-              .getFirstNode(new DetailAST());
+        String
+              .valueOf(new Integer(0));
         // comment
     }
 
     public void foo16() {
-        CheckUtil
-            .getFirstNode(new DetailAST());
+        String
+            .valueOf(new Integer(0));
                      // warn
     }
 
     public void foo17() {
-        CheckUtil
-            .getFirstNode(new DetailAST())
-            .getFirstChild()
+        String
+            .valueOf(new Integer(0))
+            .trim()
             // comment
-            .getNextSibling();
+            .length();
     }
 
     public void foo18() {
-        CheckUtil
-            .getFirstNode(new DetailAST())
-            .getFirstChild()
+        String
+            .valueOf(new Integer(0))
+            .trim()
                              // warn
-            .getNextSibling();
+            .length();
     }
 
     public void foo19() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
@@ -85,7 +85,7 @@ public class MethodLengthCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("max", "7");
         checkConfig.addAttribute("countEmpty", "false");
         final String[] expected = {
-            "18:5: " + getCheckMessage(MSG_KEY, 8, 7),
+            "25:5: " + getCheckMessage(MSG_KEY, 8, 7),
         };
         verify(checkConfig, getPath("InputMethodLengthComments.java"), expected);
     }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrder_EclipseDefaultNegative.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrder_EclipseDefaultNegative.java
@@ -1,6 +1,6 @@
 //non-compiled with javac: contains specially crafted set of imports for testing
 package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
-import static com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck.MSG_ORDERING;
+import static com.some.Class.MESSAGE_ORDERING;
 import static java.awt.Button.ABORT;
 import static java.io.File.createTempFile;
 import static javax.swing.WindowConstants.*;
@@ -17,7 +17,7 @@ import sun.tools.java.ArrayType;
 import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
 
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.some.api.DetailClass;
 
 public class InputImportOrder_EclipseDefaultNegative {
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrder_EclipseDefaultPositive.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrder_EclipseDefaultPositive.java
@@ -1,6 +1,6 @@
 //non-compiled with javac: contains specially crafted set of imports for testing
 package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
-import static com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck.MSG_ORDERING;
+import static com.some.Class.MESSAGE_ORDERING;
 import static java.awt.Button.ABORT;
 import static java.io.File.createTempFile;
 import static javax.swing.WindowConstants.*;
@@ -16,7 +16,7 @@ import javax.swing.JTable;
 import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
 
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.some.api.DetailClass;
 
 import sun.tools.java.ArrayType;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeStaticImports.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeStaticImports.java
@@ -3,12 +3,12 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 import static com.puppycrawl.tools.checkstyle.utils.CheckUtil.isElseIf;
 import static com.puppycrawl.tools.checkstyle.utils.CheckUtil.*;
 import static com.puppycrawl.tools.checkstyle.checks.coding.illegaltype.InputIllegalType.SomeStaticClass;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import java.lang.String;
 //configuration: "illegalClassNames": SomeStaticClass
 public class InputIllegalTypeStaticImports
 {
-     private boolean foo(DetailAST ast) {
-         return isElseIf(ast);
+     private boolean foo(String s) {
+         return isElseIf(null);
      }
      SomeStaticClass staticClass; //WARNING
      private static SomeStaticClass foo1() { return null;}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
@@ -1,7 +1,7 @@
 package com.puppycrawl.tools.checkstyle.checks.indentation.commentsindentation;
 
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
+
+
 
 /**
  * Contains examples of using comments at the end of the block.
@@ -59,61 +59,61 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     //    }
 
     public void foo11() {
-        CheckUtil
-            .getFirstNode(new DetailAST())
-            .getFirstChild()
-            .getNextSibling();
+        String
+            .valueOf(new Integer(0))
+            .trim()
+            .length();
         // comment
     }
 
     public void foo12() {
-        CheckUtil
-            .getFirstNode(new DetailAST())
-            .getFirstChild()
-            .getNextSibling();
+        String
+            .valueOf(new Integer(0))
+            .trim()
+            .length();
                   // violation
     }
 
     public void foo13() {
-        CheckUtil.getFirstNode(new DetailAST())
-                .getFirstChild()
-                .getNextSibling();
+        String.valueOf(new Integer(0))
+                .trim()
+                .length();
         // comment
     }
 
     public void foo14() {
-        CheckUtil.getFirstNode(new DetailAST())
-            .getFirstChild()
-            .getNextSibling();
+        String.valueOf(new Integer(0))
+            .trim()
+            .length();
                                // violation
     }
 
     public void foo15() {
-        CheckUtil
-              .getFirstNode(new DetailAST());
+        String
+              .valueOf(new Integer(0));
         // comment
     }
 
     public void foo16() {
-        CheckUtil
-            .getFirstNode(new DetailAST());
+        String
+            .valueOf(new Integer(0));
                      // violation
     }
 
     public void foo17() {
-        CheckUtil
-            .getFirstNode(new DetailAST())
-            .getFirstChild()
+        String
+            .valueOf(new Integer(0))
+            .trim()
             // comment
-            .getNextSibling();
+            .length();
     }
 
     public void foo18() {
-        CheckUtil
-            .getFirstNode(new DetailAST())
-            .getFirstChild()
+        String
+            .valueOf(new Integer(0))
+            .trim()
                              // violation
-            .getNextSibling();
+            .length();
     }
 
     public void foo19() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthComments.java
@@ -1,26 +1,33 @@
 package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
 
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-
 public class InputMethodLengthComments {
-    public void visitToken(DetailAST ast) {
+    static class DetailClass {
+        public DetailClass find(int type) {
+            return null;
+        }
+    }
+    static class Tokens {
+        public static int ZERO = 0;
+        public static int ONE = 1;
+    }
 
-        final DetailAST openingBrace = ast.findFirstToken(TokenTypes.SLIST);
+    public void visitToken(DetailClass ast) {
+
+        final DetailClass openingBrace = ast.find(Tokens.ZERO);
 
         if (openingBrace != null) {
-            final DetailAST closingBrace =
-                    openingBrace.findFirstToken(TokenTypes.RCURLY);
+            final DetailClass closingBrace =
+                    openingBrace.find(Tokens.ONE);
         }
 
     }
 
-    public DetailAST visit(DetailAST ast) {
-        final DetailAST openingBrace = ast.findFirstToken(TokenTypes.SLIST);
-        DetailAST closingBrace = null;
+    public DetailClass visit(DetailClass ast) {
+        final DetailClass openingBrace = ast.find(Tokens.ZERO);
+        DetailClass closingBrace = null;
 
         if (openingBrace != null) {
-            closingBrace = openingBrace.findFirstToken(TokenTypes.RCURLY);
+            closingBrace = openingBrace.find(Tokens.ONE);
         }
         return closingBrace;
     }


### PR DESCRIPTION
Issue #4845

This removes uses of DetailAST from all our inputs.
This is in support of issue #3817 .
No changes to production code, so no regression required.