### PR TITLE
Issue #3417: split DetailAST between interface and implementation

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -313,6 +313,7 @@ DEST
 destfile
 Destructuring
 detailast
+detailastimpl
 detailnodetreestringprinter
 Dexec
 dfn

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -14,7 +14,9 @@
   <!-- guava causes issues with other libraries since not everyone is on the same version -->
   <disallow pkg="com\.google.*" regex="true"/>
 
-  <allow pkg="antlr"/>
+  <!-- until https://github.com/checkstyle/checkstyle/issues/6628 -->
+  <allow class="com.puppycrawl.tools.checkstyle.DetailAstImpl"/>
+
   <allow pkg="com.puppycrawl.tools.checkstyle.api"/>
   <allow pkg="com.puppycrawl.tools.checkstyle.checks"/>
   <allow pkg="java.io"/>
@@ -33,7 +35,6 @@
   <allow pkg="com.puppycrawl.tools.checkstyle.utils" local-only="true"/>
   <allow pkg="com.puppycrawl.tools.checkstyle.grammar" local-only="true"/>
   <allow pkg="picocli" local-only="true"/>
-  <allow pkg="org.antlr.v4.runtime" local-only="true"/>
   <allow class="com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.+"
           local-only="true" regex="true"/>
   <allow class="java.lang.annotation.ElementType" local-only="true"/>
@@ -48,11 +49,21 @@
   <allow class="com.puppycrawl.tools.checkstyle.XpathFileGeneratorAuditListener"
          local-only="true"/>
 
+  <file name="DetailAstImpl|JavaParser" regex="true">
+    <allow pkg="antlr"/>
+  </file>
+  <file name="JavadocDetailNodeParser">
+    <allow pkg="org.antlr.v4.runtime"/>
+  </file>
   <file name="PropertyCacheFile">
     <allow class="java.math.BigInteger"/>
   </file>
 
   <subpackage name="utils">
+    <!-- until https://github.com/checkstyle/checkstyle/issues/6628 -->
+    <allow pkg="antlr"/>
+    <allow class="com.puppycrawl.tools.checkstyle.DetailAstImpl"/>
+
     <allow pkg="java.lang.reflect" local-only="true" />
     <allow pkg="java.nio" local-only="true" />
     <allow class="com.puppycrawl.tools.checkstyle.TreeWalkerFilter"/>
@@ -71,6 +82,8 @@
   </subpackage>
 
   <subpackage name="api">
+    <disallow pkg="org.antlr.v4.runtime"/>
+
     <allow pkg="com.puppycrawl.tools.checkstyle.grammar"/>
     <allow pkg="java.lang.reflect" local-only="true"/>
     <allow pkg="java.nio.charset" local-only="true"/>
@@ -83,7 +96,6 @@
     its usage by API clients till https://github.com/checkstyle/checkstyle/issues/3511-->
     <allow class="com.puppycrawl.tools.checkstyle.checks.naming.AccessModifier"
            local-only="true"/>
-    <allow pkg="org.antlr.v4.runtime" local-only="true"/>
 
     <allow class="com.puppycrawl.tools.checkstyle.Checker" local-only="true"/>
     <!-- allowed till https://github.com/checkstyle/checkstyle/issues/3817 -->
@@ -136,7 +148,10 @@
   </subpackage>
 
   <subpackage name="gui" strategyOnMismatch="disallowed">
+    <!-- until https://github.com/checkstyle/checkstyle/issues/3095 -->
     <allow pkg="antlr"/>
+    <allow class="com.puppycrawl.tools.checkstyle.DetailAstImpl"/>
+
     <allow pkg="java.awt"/>
     <allow pkg="java.io"/>
     <allow pkg="javax.swing"/>

--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -4423,7 +4423,8 @@
                 <option value="WeakerAccess"/>
                 <!-- we need to work with AntClassLoader, there is no way to avoid this -->
                 <option value="ClassLoaderInstantiation"/>
-                <!-- There are asserts in DetailASTTest#checkNode, but idea does not see them -->
+                <!-- There are asserts in DetailAstImplTest#checkNode,
+                       but idea does not see them -->
                 <option value="JUnitTestMethodWithNoAssertions"/>
                 <!-- we use it in Main class -->
                 <option value="CallToSystemExit"/>

--- a/config/pmd-test.xml
+++ b/config/pmd-test.xml
@@ -109,7 +109,7 @@
         <!-- PMD cannot find assert if it is located in private method of this class called from
                the test method or method of another class. -->
         <properties>
-            <!-- In AllChecksTest, AstRegressionTest, DetailASTTest and ImportControlCheckTest
+            <!-- In AllChecksTest, AstRegressionTest, DetailAstImplTest and ImportControlCheckTest
                    PMD does not find asserts in private methods of the test class called from the
                    test method.
                  In MainTest PMD does not find asserts in lambdas called in the method
@@ -121,7 +121,7 @@
                  method. -->
             <property name="violationSuppressXPath"
                       value="//ClassOrInterfaceDeclaration[@Image='AllChecksTest'
-              or @Image='AstRegressionTest' or @Image='DetailASTTest'
+              or @Image='AstRegressionTest' or @Image='DetailAstImplTest'
               or @Image='ImportControlCheckTest']//PrimaryPrefix/Name[@Image='verify']
             | //ClassOrInterfaceDeclaration[@Image='MainTest']
                   //PrimaryPrefix//Name[starts-with(@Image, 'assert')]

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -107,7 +107,7 @@
       <property name="violationSuppressXPath"
                 value="//ClassOrInterfaceDeclaration[@Image='XMLLogger']
                            //MethodDeclarator[@Image='isReference']
-      | //ClassOrInterfaceDeclaration[@Image='DetailAST']
+      | //ClassOrInterfaceDeclaration[@Image='DetailAstImpl']
               //MethodDeclarator[@Image='addPreviousSibling']
       | //ClassOrInterfaceDeclaration[@Image='AnnotationLocationCheck']
               //MethodDeclarator[@Image='checkAnnotations']

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -29,7 +29,7 @@
 
     <!-- Tone down the checking for test code -->
     <suppress checks="ForbidCertainImports"
-              files="DetailASTTest\.java"/>
+              files="DetailAstImplTest\.java"/>
     <suppress checks="SingleBreakOrContinue" files="[\\/]XdocsPagesTest\.java"/>
 
     <!-- Main and MainTest are technically not part of the checkstyle library,

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -48,7 +48,7 @@
     <Match>
       <!-- have never been a case for years, Eclipse does not show any other classes
            inherited from CommonASTWithHiddenTokens -->
-      <Class name="com.puppycrawl.tools.checkstyle.api.DetailAST" />
+      <Class name="com.puppycrawl.tools.checkstyle.DetailAstImpl" />
       <Bug pattern="BC_UNCONFIRMED_CAST" />
     </Match>
     <Match>

--- a/pom.xml
+++ b/pom.xml
@@ -2667,11 +2667,13 @@
                 <mutator>VOID_METHOD_CALLS</mutator>
               </mutators>
               <targetClasses>
+                <param>com.puppycrawl.tools.checkstyle.DetailAstImpl*</param>
                 <param>com.puppycrawl.tools.checkstyle.JavadocPropertiesGenerator*</param>
                 <param>com.puppycrawl.tools.checkstyle.XmlLoader*</param>
                 <param>com.puppycrawl.tools.checkstyle.JavaParser*</param>
               </targetClasses>
               <targetTests>
+                <param>com.puppycrawl.tools.checkstyle.DetailAstImplTest</param>
                 <param>com.puppycrawl.tools.checkstyle.JavadocPropertiesGeneratorTest</param>
                 <param>com.puppycrawl.tools.checkstyle.XmlLoaderTest</param>
                 <param>com.puppycrawl.tools.checkstyle.JavaParserTest</param>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
@@ -1,0 +1,383 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2019 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.util.BitSet;
+
+import antlr.CommonASTWithHiddenTokens;
+import antlr.Token;
+import antlr.collections.AST;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
+
+/**
+ * The implementation of {@link DetailAST}. This should only be directly used to
+ * create custom AST nodes.
+ * @noinspection FieldNotUsedInToString, SerializableHasSerializationMethods
+ */
+public final class DetailAstImpl extends CommonASTWithHiddenTokens implements DetailAST {
+
+    private static final long serialVersionUID = -2580884815577559874L;
+
+    /** Constant to indicate if not calculated the child count. */
+    private static final int NOT_INITIALIZED = Integer.MIN_VALUE;
+
+    /** The line number. **/
+    private int lineNo = NOT_INITIALIZED;
+    /** The column number. **/
+    private int columnNo = NOT_INITIALIZED;
+
+    /** Number of children. */
+    private int childCount = NOT_INITIALIZED;
+    /** The parent token. */
+    private DetailAstImpl parent;
+    /** Previous sibling. */
+    private DetailAstImpl previousSibling;
+
+    /**
+     * All token types in this branch.
+     * Token 'x' (where x is an int) is in this branch
+     * if branchTokenTypes.get(x) is true.
+     */
+    private BitSet branchTokenTypes;
+
+    @Override
+    public void initialize(Token tok) {
+        super.initialize(tok);
+        lineNo = tok.getLine();
+
+        // expect columns to start @ 0
+        columnNo = tok.getColumn() - 1;
+    }
+
+    @Override
+    public void initialize(AST ast) {
+        final DetailAstImpl detailAst = (DetailAstImpl) ast;
+        setText(detailAst.getText());
+        setType(detailAst.getType());
+        lineNo = detailAst.getLineNo();
+        columnNo = detailAst.getColumnNo();
+        hiddenAfter = detailAst.getHiddenAfter();
+        hiddenBefore = detailAst.getHiddenBefore();
+    }
+
+    @Override
+    public void setFirstChild(AST ast) {
+        clearBranchTokenTypes();
+        clearChildCountCache(this);
+        super.setFirstChild(ast);
+        if (ast != null) {
+            ((DetailAstImpl) ast).setParent(this);
+        }
+    }
+
+    @Override
+    public void setNextSibling(AST ast) {
+        clearBranchTokenTypes();
+        clearChildCountCache(parent);
+        super.setNextSibling(ast);
+        if (ast != null && parent != null) {
+            ((DetailAstImpl) ast).setParent(parent);
+        }
+        if (ast != null) {
+            ((DetailAstImpl) ast).previousSibling = this;
+        }
+    }
+
+    @Override
+    public void addPreviousSibling(DetailAST ast) {
+        clearBranchTokenTypes();
+        clearChildCountCache(parent);
+        if (ast != null) {
+            //parent is set in setNextSibling or parent.setFirstChild
+            final DetailAstImpl previousSiblingNode = previousSibling;
+            final DetailAstImpl astImpl = (DetailAstImpl) ast;
+
+            if (previousSiblingNode != null) {
+                astImpl.previousSibling = previousSiblingNode;
+                previousSiblingNode.setNextSibling(astImpl);
+            }
+            else if (parent != null) {
+                parent.setFirstChild(astImpl);
+            }
+
+            astImpl.setNextSibling(this);
+            previousSibling = astImpl;
+        }
+    }
+
+    @Override
+    public void addNextSibling(DetailAST ast) {
+        clearBranchTokenTypes();
+        clearChildCountCache(parent);
+        if (ast != null) {
+            //parent is set in setNextSibling
+            final DetailAstImpl nextSibling = getNextSibling();
+            final DetailAstImpl astImpl = (DetailAstImpl) ast;
+
+            if (nextSibling != null) {
+                astImpl.setNextSibling(nextSibling);
+                nextSibling.previousSibling = astImpl;
+            }
+
+            astImpl.previousSibling = this;
+            setNextSibling(astImpl);
+        }
+    }
+
+    @Override
+    public void addChild(AST ast) {
+        clearBranchTokenTypes();
+        clearChildCountCache(this);
+        if (ast != null) {
+            final DetailAstImpl astImpl = (DetailAstImpl) ast;
+            astImpl.setParent(this);
+            astImpl.previousSibling = (DetailAstImpl) getLastChild();
+        }
+        super.addChild(ast);
+    }
+
+    @Override
+    public int getChildCount() {
+        // lazy init
+        if (childCount == NOT_INITIALIZED) {
+            childCount = 0;
+            AST child = getFirstChild();
+
+            while (child != null) {
+                childCount += 1;
+                child = child.getNextSibling();
+            }
+        }
+        return childCount;
+    }
+
+    @Override
+    public int getChildCount(int type) {
+        int count = 0;
+        for (AST ast = getFirstChild(); ast != null; ast = ast.getNextSibling()) {
+            if (ast.getType() == type) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Set the parent token.
+     * @param parent the parent token
+     */
+    private void setParent(DetailAstImpl parent) {
+        DetailAstImpl instance = this;
+        do {
+            instance.clearBranchTokenTypes();
+            instance.parent = parent;
+            instance = instance.getNextSibling();
+        } while (instance != null);
+    }
+
+    @Override
+    public DetailAST getParent() {
+        return parent;
+    }
+
+    @Override
+    public int getLineNo() {
+        int resultNo = -1;
+
+        if (lineNo == NOT_INITIALIZED) {
+            // an inner AST that has been initialized
+            // with initialize(String text)
+            resultNo = findLineNo(getFirstChild());
+
+            if (resultNo == -1) {
+                resultNo = findLineNo(getNextSibling());
+            }
+        }
+        if (resultNo == -1) {
+            resultNo = lineNo;
+        }
+        return resultNo;
+    }
+
+    @Override
+    public void setLineNo(int lineNo) {
+        this.lineNo = lineNo;
+    }
+
+    @Override
+    public int getColumnNo() {
+        int resultNo = -1;
+
+        if (columnNo == NOT_INITIALIZED) {
+            // an inner AST that has been initialized
+            // with initialize(String text)
+            resultNo = findColumnNo(getFirstChild());
+
+            if (resultNo == -1) {
+                resultNo = findColumnNo(getNextSibling());
+            }
+        }
+        if (resultNo == -1) {
+            resultNo = columnNo;
+        }
+        return resultNo;
+    }
+
+    @Override
+    public void setColumnNo(int columnNo) {
+        this.columnNo = columnNo;
+    }
+
+    @Override
+    public DetailAST getLastChild() {
+        DetailAST ast = getFirstChild();
+        while (ast != null && ast.getNextSibling() != null) {
+            ast = ast.getNextSibling();
+        }
+        return ast;
+    }
+
+    /**
+     * Finds column number in the first non-comment node.
+     *
+     * @param ast DetailAST node.
+     * @return Column number if non-comment node exists, -1 otherwise.
+     */
+    private static int findColumnNo(DetailAST ast) {
+        int resultNo = -1;
+        DetailAST node = ast;
+        while (node != null) {
+            // comment node can't be start of any java statement/definition
+            if (TokenUtil.isCommentType(node.getType())) {
+                node = node.getNextSibling();
+            }
+            else {
+                resultNo = node.getColumnNo();
+                break;
+            }
+        }
+        return resultNo;
+    }
+
+    /**
+     * Finds line number in the first non-comment node.
+     *
+     * @param ast DetailAST node.
+     * @return Line number if non-comment node exists, -1 otherwise.
+     */
+    private static int findLineNo(DetailAST ast) {
+        int resultNo = -1;
+        DetailAST node = ast;
+        while (node != null) {
+            // comment node can't be start of any java statement/definition
+            if (TokenUtil.isCommentType(node.getType())) {
+                node = node.getNextSibling();
+            }
+            else {
+                resultNo = node.getLineNo();
+                break;
+            }
+        }
+        return resultNo;
+    }
+
+    /**
+     * Returns token type with branch.
+     * @return the token types that occur in the branch as a sorted set.
+     */
+    private BitSet getBranchTokenTypes() {
+        // lazy init
+        if (branchTokenTypes == null) {
+            branchTokenTypes = new BitSet();
+            branchTokenTypes.set(getType());
+
+            // add union of all children
+            DetailAstImpl child = getFirstChild();
+            while (child != null) {
+                final BitSet childTypes = child.getBranchTokenTypes();
+                branchTokenTypes.or(childTypes);
+
+                child = child.getNextSibling();
+            }
+        }
+        return branchTokenTypes;
+    }
+
+    @Override
+    public boolean branchContains(int type) {
+        return getBranchTokenTypes().get(type);
+    }
+
+    @Override
+    public DetailAST getPreviousSibling() {
+        return previousSibling;
+    }
+
+    @Override
+    public DetailAST findFirstToken(int type) {
+        DetailAST returnValue = null;
+        for (DetailAST ast = getFirstChild(); ast != null; ast = ast.getNextSibling()) {
+            if (ast.getType() == type) {
+                returnValue = ast;
+                break;
+            }
+        }
+        return returnValue;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + "[" + getLineNo() + "x" + getColumnNo() + "]";
+    }
+
+    @Override
+    public DetailAstImpl getNextSibling() {
+        return (DetailAstImpl) super.getNextSibling();
+    }
+
+    @Override
+    public DetailAstImpl getFirstChild() {
+        return (DetailAstImpl) super.getFirstChild();
+    }
+
+    /**
+     * Clears the child count for the ast instance.
+     * @param ast The ast to clear.
+     */
+    private static void clearChildCountCache(DetailAstImpl ast) {
+        if (ast != null) {
+            ast.childCount = NOT_INITIALIZED;
+        }
+    }
+
+    /**
+     * Clears branchTokenTypes cache for all parents of the current DetailAST instance, and the
+     * child count for the current DetailAST instance.
+     */
+    private void clearBranchTokenTypes() {
+        DetailAstImpl prevParent = parent;
+        while (prevParent != null) {
+            prevParent.branchTokenTypes = null;
+            prevParent = prevParent.parent;
+        }
+    }
+
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java
@@ -26,6 +26,7 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
+import antlr.CommonASTWithHiddenTokens;
 import antlr.CommonHiddenStreamToken;
 import antlr.RecognitionException;
 import antlr.Token;
@@ -44,6 +45,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * Helper methods to parse java source files.
  *
  */
+// -@cs[ClassDataAbstractionCoupling] No way to split up class usage.
 public final class JavaParser {
 
     /**
@@ -92,7 +94,7 @@ public final class JavaParser {
             }
         };
         parser.setFilename(contents.getFileName());
-        parser.setASTNodeClass(DetailAST.class.getName());
+        parser.setASTNodeClass(DetailAstImpl.class.getName());
         try {
             parser.compilationUnit();
         }
@@ -153,7 +155,8 @@ public final class JavaParser {
         while (curNode != null) {
             lastNode = curNode;
 
-            CommonHiddenStreamToken tokenBefore = curNode.getHiddenBefore();
+            CommonHiddenStreamToken tokenBefore = ((CommonASTWithHiddenTokens) curNode)
+                    .getHiddenBefore();
             DetailAST currentSibling = curNode;
             while (tokenBefore != null) {
                 final DetailAST newCommentNode =
@@ -177,7 +180,8 @@ public final class JavaParser {
             curNode = toVisit;
         }
         if (lastNode != null) {
-            CommonHiddenStreamToken tokenAfter = lastNode.getHiddenAfter();
+            CommonHiddenStreamToken tokenAfter = ((CommonASTWithHiddenTokens) lastNode)
+                    .getHiddenAfter();
             DetailAST currentSibling = lastNode;
             while (tokenAfter != null) {
                 final DetailAST newCommentNode =
@@ -215,7 +219,7 @@ public final class JavaParser {
      * @return DetailAST with SINGLE_LINE_COMMENT type
      */
     private static DetailAST createSlCommentNode(Token token) {
-        final DetailAST slComment = new DetailAST();
+        final DetailAstImpl slComment = new DetailAstImpl();
         slComment.setType(TokenTypes.SINGLE_LINE_COMMENT);
         slComment.setText("//");
 
@@ -223,7 +227,7 @@ public final class JavaParser {
         slComment.setColumnNo(token.getColumn() - 1);
         slComment.setLineNo(token.getLine());
 
-        final DetailAST slCommentContent = new DetailAST();
+        final DetailAstImpl slCommentContent = new DetailAstImpl();
         slCommentContent.setType(TokenTypes.COMMENT_CONTENT);
 
         // column counting begins from 0

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -19,340 +19,116 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
-import java.util.BitSet;
-
-import antlr.CommonASTWithHiddenTokens;
-import antlr.Token;
-import antlr.collections.AST;
-import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
-
 /**
- * An extension of the CommonAST that records the line and column number.
+ * A interface of Checkstyle's AST nodes for traversing trees generated from the
+ * Java code. The main purpose of this interface is to abstract away ANTLR
+ * specific classes from API package so other libraries won't require it.
  *
  * @see <a href="https://www.antlr.org/">ANTLR Website</a>
- * @noinspection FieldNotUsedInToString, SerializableHasSerializationMethods
  */
-public final class DetailAST extends CommonASTWithHiddenTokens {
-
-    private static final long serialVersionUID = -2580884815577559874L;
-
-    /** Constant to indicate if not calculated the child count. */
-    private static final int NOT_INITIALIZED = Integer.MIN_VALUE;
-
-    /** The line number. **/
-    private int lineNo = NOT_INITIALIZED;
-    /** The column number. **/
-    private int columnNo = NOT_INITIALIZED;
-
-    /** Number of children. */
-    private int childCount = NOT_INITIALIZED;
-    /** The parent token. */
-    private DetailAST parent;
-    /** Previous sibling. */
-    private DetailAST previousSibling;
-
-    /**
-     * All token types in this branch.
-     * Token 'x' (where x is an int) is in this branch
-     * if branchTokenTypes.get(x) is true.
-     */
-    private BitSet branchTokenTypes;
-
-    @Override
-    public void initialize(Token tok) {
-        super.initialize(tok);
-        lineNo = tok.getLine();
-
-        // expect columns to start @ 0
-        columnNo = tok.getColumn() - 1;
-    }
-
-    @Override
-    public void initialize(AST ast) {
-        final DetailAST detailAst = (DetailAST) ast;
-        setText(detailAst.getText());
-        setType(detailAst.getType());
-        lineNo = detailAst.getLineNo();
-        columnNo = detailAst.getColumnNo();
-        hiddenAfter = detailAst.getHiddenAfter();
-        hiddenBefore = detailAst.getHiddenBefore();
-    }
-
-    @Override
-    public void setFirstChild(AST ast) {
-        clearBranchTokenTypes();
-        clearChildCountCache(this);
-        super.setFirstChild(ast);
-        if (ast != null) {
-            ((DetailAST) ast).setParent(this);
-        }
-    }
-
-    @Override
-    public void setNextSibling(AST ast) {
-        clearBranchTokenTypes();
-        clearChildCountCache(parent);
-        super.setNextSibling(ast);
-        if (ast != null && parent != null) {
-            ((DetailAST) ast).setParent(parent);
-        }
-        if (ast != null) {
-            ((DetailAST) ast).previousSibling = this;
-        }
-    }
+public interface DetailAST {
 
     /**
      * Add previous sibling.
      * @param ast
      *        DetailAST object.
      */
-    public void addPreviousSibling(DetailAST ast) {
-        clearBranchTokenTypes();
-        clearChildCountCache(parent);
-        if (ast != null) {
-            //parent is set in setNextSibling or parent.setFirstChild
-            final DetailAST previousSiblingNode = previousSibling;
-
-            if (previousSiblingNode != null) {
-                ast.previousSibling = previousSiblingNode;
-                previousSiblingNode.setNextSibling(ast);
-            }
-            else if (parent != null) {
-                parent.setFirstChild(ast);
-            }
-
-            ast.setNextSibling(this);
-            previousSibling = ast;
-        }
-    }
+    void addPreviousSibling(DetailAST ast);
 
     /**
      * Add next sibling.
      * @param ast
      *        DetailAST object.
      */
-    public void addNextSibling(DetailAST ast) {
-        clearBranchTokenTypes();
-        clearChildCountCache(parent);
-        if (ast != null) {
-            //parent is set in setNextSibling
-            final DetailAST nextSibling = getNextSibling();
-
-            if (nextSibling != null) {
-                ast.setNextSibling(nextSibling);
-                nextSibling.previousSibling = ast;
-            }
-
-            ast.previousSibling = this;
-            setNextSibling(ast);
-        }
-    }
-
-    @Override
-    public void addChild(AST ast) {
-        clearBranchTokenTypes();
-        clearChildCountCache(this);
-        if (ast != null) {
-            ((DetailAST) ast).setParent(this);
-            ((DetailAST) ast).previousSibling = getLastChild();
-        }
-        super.addChild(ast);
-    }
+    void addNextSibling(DetailAST ast);
 
     /**
      * Returns the number of child nodes one level below this node. That is is
      * does not recurse down the tree.
      * @return the number of child nodes
      */
-    public int getChildCount() {
-        // lazy init
-        if (childCount == NOT_INITIALIZED) {
-            childCount = 0;
-            AST child = getFirstChild();
-
-            while (child != null) {
-                childCount += 1;
-                child = child.getNextSibling();
-            }
-        }
-        return childCount;
-    }
+    int getChildCount();
 
     /**
      * Returns the number of direct child tokens that have the specified type.
      * @param type the token type to match
      * @return the number of matching token
      */
-    public int getChildCount(int type) {
-        int count = 0;
-        for (AST ast = getFirstChild(); ast != null; ast = ast.getNextSibling()) {
-            if (ast.getType() == type) {
-                count++;
-            }
-        }
-        return count;
-    }
-
-    /**
-     * Set the parent token.
-     * @param parent the parent token
-     */
-    private void setParent(DetailAST parent) {
-        DetailAST instance = this;
-        do {
-            instance.clearBranchTokenTypes();
-            instance.parent = parent;
-            instance = instance.getNextSibling();
-        } while (instance != null);
-    }
+    int getChildCount(int type);
 
     /**
      * Returns the parent token.
      * @return the parent token
      */
-    public DetailAST getParent() {
-        return parent;
-    }
+    DetailAST getParent();
+
+    /**
+     * Gets the text of this AST.
+     * @return the text.
+     */
+    String getText();
+
+    /**
+     * Set the text for this AST.
+     * @param text the text.
+     */
+    void setText(String text);
+
+    /**
+     * Gets the type of this AST.
+     * @return the type.
+     */
+    int getType();
+
+    /**
+     * Set the type for this AST.
+     * @param type the type.
+     */
+    void setType(int type);
 
     /**
      * Gets line number.
      * @return the line number
      */
-    public int getLineNo() {
-        int resultNo = -1;
-
-        if (lineNo == NOT_INITIALIZED) {
-            // an inner AST that has been initialized
-            // with initialize(String text)
-            resultNo = findLineNo(getFirstChild());
-
-            if (resultNo == -1) {
-                resultNo = findLineNo(getNextSibling());
-            }
-        }
-        if (resultNo == -1) {
-            resultNo = lineNo;
-        }
-        return resultNo;
-    }
+    int getLineNo();
 
     /**
      * Set line number.
      * @param lineNo
      *        line number.
      */
-    public void setLineNo(int lineNo) {
-        this.lineNo = lineNo;
-    }
+    void setLineNo(int lineNo);
 
     /**
      * Gets column number.
      * @return the column number
      */
-    public int getColumnNo() {
-        int resultNo = -1;
-
-        if (columnNo == NOT_INITIALIZED) {
-            // an inner AST that has been initialized
-            // with initialize(String text)
-            resultNo = findColumnNo(getFirstChild());
-
-            if (resultNo == -1) {
-                resultNo = findColumnNo(getNextSibling());
-            }
-        }
-        if (resultNo == -1) {
-            resultNo = columnNo;
-        }
-        return resultNo;
-    }
+    int getColumnNo();
 
     /**
      * Set column number.
      * @param columnNo
      *        column number.
      */
-    public void setColumnNo(int columnNo) {
-        this.columnNo = columnNo;
-    }
+    void setColumnNo(int columnNo);
+
+    /**
+     * Gets the line number of this AST from the file.
+     * @return the line number
+     */
+    int getLine();
+
+    /**
+     * Gets the column number of this AST from the file.
+     * @return the line number
+     */
+    int getColumn();
 
     /**
      * Gets the last child node.
      * @return the last child node
      */
-    public DetailAST getLastChild() {
-        DetailAST ast = getFirstChild();
-        while (ast != null && ast.getNextSibling() != null) {
-            ast = ast.getNextSibling();
-        }
-        return ast;
-    }
-
-    /**
-     * Finds column number in the first non-comment node.
-     *
-     * @param ast DetailAST node.
-     * @return Column number if non-comment node exists, -1 otherwise.
-     */
-    private static int findColumnNo(DetailAST ast) {
-        int resultNo = -1;
-        DetailAST node = ast;
-        while (node != null) {
-            // comment node can't be start of any java statement/definition
-            if (TokenUtil.isCommentType(node.getType())) {
-                node = node.getNextSibling();
-            }
-            else {
-                resultNo = node.getColumnNo();
-                break;
-            }
-        }
-        return resultNo;
-    }
-
-    /**
-     * Finds line number in the first non-comment node.
-     *
-     * @param ast DetailAST node.
-     * @return Line number if non-comment node exists, -1 otherwise.
-     */
-    private static int findLineNo(DetailAST ast) {
-        int resultNo = -1;
-        DetailAST node = ast;
-        while (node != null) {
-            // comment node can't be start of any java statement/definition
-            if (TokenUtil.isCommentType(node.getType())) {
-                node = node.getNextSibling();
-            }
-            else {
-                resultNo = node.getLineNo();
-                break;
-            }
-        }
-        return resultNo;
-    }
-
-    /**
-     * Returns token type with branch.
-     * @return the token types that occur in the branch as a sorted set.
-     */
-    private BitSet getBranchTokenTypes() {
-        // lazy init
-        if (branchTokenTypes == null) {
-            branchTokenTypes = new BitSet();
-            branchTokenTypes.set(getType());
-
-            // add union of all children
-            DetailAST child = getFirstChild();
-            while (child != null) {
-                final BitSet childTypes = child.getBranchTokenTypes();
-                branchTokenTypes.or(childTypes);
-
-                child = child.getNextSibling();
-            }
-        }
-        return branchTokenTypes;
-    }
+    DetailAST getLastChild();
 
     /**
      * Checks if this branch of the parse tree contains a token
@@ -361,69 +137,39 @@ public final class DetailAST extends CommonASTWithHiddenTokens {
      * @return true if and only if this branch (including this node)
      *     contains a token of type {@code type}.
      */
-    public boolean branchContains(int type) {
-        return getBranchTokenTypes().get(type);
-    }
+    boolean branchContains(int type);
 
     /**
      * Returns the previous sibling or null if no such sibling exists.
      * @return the previous sibling or null if no such sibling exists.
      */
-    public DetailAST getPreviousSibling() {
-        return previousSibling;
-    }
+    DetailAST getPreviousSibling();
 
     /**
      * Returns the first child token that makes a specified type.
      * @param type the token type to match
      * @return the matching token, or null if no match
      */
-    public DetailAST findFirstToken(int type) {
-        DetailAST returnValue = null;
-        for (DetailAST ast = getFirstChild(); ast != null; ast = ast.getNextSibling()) {
-            if (ast.getType() == type) {
-                returnValue = ast;
-                break;
-            }
-        }
-        return returnValue;
-    }
-
-    @Override
-    public String toString() {
-        return super.toString() + "[" + getLineNo() + "x" + getColumnNo() + "]";
-    }
-
-    @Override
-    public DetailAST getNextSibling() {
-        return (DetailAST) super.getNextSibling();
-    }
-
-    @Override
-    public DetailAST getFirstChild() {
-        return (DetailAST) super.getFirstChild();
-    }
+    DetailAST findFirstToken(int type);
 
     /**
-     * Clears the child count for the ast instance.
-     * @param ast The ast to clear.
+     * Get the next sibling in line after this one.
+     * @return the next sibling or null if none.
      */
-    private static void clearChildCountCache(DetailAST ast) {
-        if (ast != null) {
-            ast.childCount = NOT_INITIALIZED;
-        }
-    }
+    DetailAST getNextSibling();
 
     /**
-     * Clears branchTokenTypes cache for all parents of the current DetailAST instance, and the
-     * child count for the current DetailAST instance.
+     * Get the first child of this AST.
+     * @return the first child or null if none.
      */
-    private void clearBranchTokenTypes() {
-        DetailAST prevParent = parent;
-        while (prevParent != null) {
-            prevParent.branchTokenTypes = null;
-            prevParent = prevParent.parent;
-        }
-    }
+    DetailAST getFirstChild();
 
+    /**
+     * Get number of children of this AST.
+     * @return the number of children.
+     */
+    int getNumberOfChildren();
+
+    /** Remove all children. */
+    void removeChildren();
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -19,8 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.api;
 
-import org.antlr.v4.runtime.Recognizer;
-
 import com.puppycrawl.tools.checkstyle.grammar.javadoc.JavadocParser;
 
 /**
@@ -1204,9 +1202,11 @@ public final class JavadocTokenTypes {
     public static final int WS = JavadocParser.WS;
 
     /**
-     * End Of File symbol.
+     * End Of File symbol. Copied from
+     * {@link org.antlr.v4.runtime.Recognizer#EOF} to avoid ANTLR dependency in
+     * API.
      */
-    public static final int EOF = Recognizer.EOF;
+    public static final int EOF = -1;
 
     //--------------------------------------------------------------------------------------------//
     //------- JAVADOC TAGS DEPENDING ON RULE TYPES OFFSET ----------------------------------------//

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 
 import java.util.Locale;
 
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -535,7 +536,7 @@ public class RightCurlyCheck extends AbstractCheck {
             if (next == null) {
                 // a DetailAST object with DetailAST#NOT_INITIALIZED for line and column numbers
                 // that no 'actual' DetailAST objects can have.
-                next = new DetailAST();
+                next = new DetailAstImpl();
             }
             else {
                 next = CheckUtil.getFirstNode(next);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -746,7 +746,7 @@ public class RequireThisCheck extends AbstractCheck {
     private static boolean isAstInside(DetailAST tree, DetailAST ast) {
         boolean result = false;
 
-        if (tree.equals(ast)) {
+        if (isAstSimilar(tree, ast)) {
             result = true;
         }
         else {
@@ -971,7 +971,7 @@ public class RequireThisCheck extends AbstractCheck {
                 vertex = stack.pop();
             }
             while (vertex != null) {
-                if (token.equals(vertex)
+                if (isAstSimilar(token, vertex)
                         && vertex.getLineNo() <= endLineNumber) {
                     result.add(vertex);
                 }
@@ -1120,6 +1120,16 @@ public class RequireThisCheck extends AbstractCheck {
             }
         }
         return isLambdaParameter;
+    }
+
+    /**
+     * Checks if 2 AST are similar by their type and text.
+     * @param left The first AST to check.
+     * @param right The second AST to check.
+     * @return {@code true} if they are similar.
+     */
+    private static boolean isAstSimilar(DetailAST left, DetailAST right) {
+        return left.getType() == right.getType() && left.getText().equals(right.getText());
     }
 
     /** An AbstractFrame type. */
@@ -1414,7 +1424,7 @@ public class RequireThisCheck extends AbstractCheck {
             for (DetailAST member : instanceMembers) {
                 final DetailAST mods = member.getParent().findFirstToken(TokenTypes.MODIFIERS);
                 final boolean finalMod = mods.findFirstToken(TokenTypes.FINAL) != null;
-                if (finalMod && member.equals(instanceMember)) {
+                if (finalMod && isAstSimilar(member, instanceMember)) {
                     result = true;
                     break;
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -858,7 +858,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
         DetailAST curNode = parent.getFirstChild();
 
         while (curNode != null) {
-            if (curNode.equals(ast)) {
+            if (curNode.getType() == ast.getType() && curNode.getText().equals(ast.getText())) {
                 isChild = true;
                 break;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentation.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import antlr.ASTFactory;
 import antlr.collections.AST;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
@@ -75,7 +76,7 @@ public class ParseTreeTablePresentation {
      * @param parseTree DetailAST parse tree.
      */
     protected final void setParseTree(DetailAST parseTree) {
-        ((AST) root).setFirstChild(parseTree);
+        ((AST) root).setFirstChild((AST) parseTree);
     }
 
     /**
@@ -256,7 +257,7 @@ public class ParseTreeTablePresentation {
      */
     private static DetailAST createArtificialTreeRoot() {
         final ASTFactory factory = new ASTFactory();
-        factory.setASTNodeClass(DetailAST.class.getName());
+        factory.setASTNodeClass(DetailAstImpl.class.getName());
         return (DetailAST) factory.create(TokenTypes.EOF, "ROOT");
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -39,6 +39,7 @@ import java.util.regex.PatternSyntaxException;
 import org.apache.commons.beanutils.ConversionException;
 
 import antlr.Token;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -119,13 +120,13 @@ public final class CommonUtil {
      * @return DetailAST block comment
      */
     public static DetailAST createBlockCommentNode(String content) {
-        final DetailAST blockCommentBegin = new DetailAST();
+        final DetailAstImpl blockCommentBegin = new DetailAstImpl();
         blockCommentBegin.setType(TokenTypes.BLOCK_COMMENT_BEGIN);
         blockCommentBegin.setText(BLOCK_MULTIPLE_COMMENT_BEGIN);
         blockCommentBegin.setLineNo(0);
         blockCommentBegin.setColumnNo(-JAVADOC_START.length());
 
-        final DetailAST commentContent = new DetailAST();
+        final DetailAstImpl commentContent = new DetailAstImpl();
         commentContent.setType(TokenTypes.COMMENT_CONTENT);
         commentContent.setText("*" + content);
         commentContent.setLineNo(0);
@@ -133,7 +134,7 @@ public final class CommonUtil {
         // that contains javadoc identifier has -1 column
         commentContent.setColumnNo(-1);
 
-        final DetailAST blockCommentEnd = new DetailAST();
+        final DetailAstImpl blockCommentEnd = new DetailAstImpl();
         blockCommentEnd.setType(TokenTypes.BLOCK_COMMENT_END);
         blockCommentEnd.setText(BLOCK_MULTIPLE_COMMENT_END);
 
@@ -149,14 +150,14 @@ public final class CommonUtil {
      * @return DetailAST with BLOCK_COMMENT type.
      */
     public static DetailAST createBlockCommentNode(Token token) {
-        final DetailAST blockComment = new DetailAST();
+        final DetailAstImpl blockComment = new DetailAstImpl();
         blockComment.initialize(TokenTypes.BLOCK_COMMENT_BEGIN, BLOCK_MULTIPLE_COMMENT_BEGIN);
 
         // column counting begins from 0
         blockComment.setColumnNo(token.getColumn() - 1);
         blockComment.setLineNo(token.getLine());
 
-        final DetailAST blockCommentContent = new DetailAST();
+        final DetailAstImpl blockCommentContent = new DetailAstImpl();
         blockCommentContent.setType(TokenTypes.COMMENT_CONTENT);
 
         // column counting begins from 0
@@ -165,7 +166,7 @@ public final class CommonUtil {
         blockCommentContent.setLineNo(token.getLine());
         blockCommentContent.setText(token.getText());
 
-        final DetailAST blockCommentClose = new DetailAST();
+        final DetailAstImpl blockCommentClose = new DetailAstImpl();
         blockCommentClose.initialize(TokenTypes.BLOCK_COMMENT_END, BLOCK_MULTIPLE_COMMENT_END);
 
         final Map.Entry<Integer, Integer> linesColumns = countLinesColumns(

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammar/java.g
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammar/java.g
@@ -19,7 +19,7 @@
 header {
 package com.puppycrawl.tools.checkstyle.grammar;
 
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import java.text.MessageFormat;
 import antlr.CommonHiddenStreamToken;
 }
@@ -138,13 +138,13 @@ tokens {
      * AST nodes we emit to have '<' & '>' balanced trees when encountering
      * SR and BSR tokens.
      */
-    private DetailAST currentGtSequence = null;
+    private DetailAstImpl currentGtSequence = null;
 
     /**
      * Consume a sequence of '>' characters (GT, SR or BSR)
      * and match these against the '<' characters seen.
      */
-    private void consumeCurrentGtSequence(DetailAST gtSequence)
+    private void consumeCurrentGtSequence(DetailAstImpl gtSequence)
     {
         currentGtSequence = gtSequence;
         gtToReconcile += currentGtSequence.getText().length();
@@ -159,14 +159,14 @@ tokens {
      *
      * @see #areThereGtsToEmit
      */
-    private DetailAST emitSingleGt()
+    private DetailAstImpl emitSingleGt()
     {
         gtToReconcile -= 1;
         CommonHiddenStreamToken gtToken = new CommonHiddenStreamToken(GENERIC_END, ">");
         gtToken.setLine(currentGtSequence.getLineNo());
         gtToken.setColumn(currentGtSequence.getColumnNo()
                             + (currentGtSequence.getText().length() - gtToReconcile));
-        return (DetailAST)astFactory.create(gtToken);
+        return (DetailAstImpl)astFactory.create(gtToken);
     }
 
     /**
@@ -349,9 +349,9 @@ typeArguments[boolean addImagNode]
 // this gobbles up *some* amount of '>' characters, and counts how many
 // it gobbled.
 protected typeArgumentsOrParametersEnd!
-    :   g:GT {consumeCurrentGtSequence((DetailAST)#g);}
-    |   sr:SR {consumeCurrentGtSequence((DetailAST)#sr);}
-    |   bsr:BSR {consumeCurrentGtSequence((DetailAST)#bsr);}
+    :   g:GT {consumeCurrentGtSequence((DetailAstImpl)#g);}
+    |   sr:SR {consumeCurrentGtSequence((DetailAstImpl)#sr);}
+    |   bsr:BSR {consumeCurrentGtSequence((DetailAstImpl)#bsr);}
     ;
 
 typeArgumentBounds[boolean addImagNode]

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -17,7 +17,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ////////////////////////////////////////////////////////////////////////////////
 
-package com.puppycrawl.tools.checkstyle.api;
+package com.puppycrawl.tools.checkstyle;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -42,16 +42,16 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.powermock.reflect.Whitebox;
 
-import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.JavaParser;
+import antlr.CommonHiddenStreamToken;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
  * TestCase to check DetailAST.
  */
-public class DetailASTTest extends AbstractModuleTestSupport {
+public class DetailAstImplTest extends AbstractModuleTestSupport {
 
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -62,19 +62,53 @@ public class DetailASTTest extends AbstractModuleTestSupport {
     }
 
     private static Method getSetParentMethod() throws Exception {
-        final Class<DetailAST> detailAstClass = DetailAST.class;
+        final Class<DetailAstImpl> detailAstClass = DetailAstImpl.class;
         final Method setParentMethod =
-            detailAstClass.getDeclaredMethod("setParent", DetailAST.class);
+            detailAstClass.getDeclaredMethod("setParent", DetailAstImpl.class);
         setParentMethod.setAccessible(true);
         return setParentMethod;
     }
 
     @Test
+    public void testInitialize() {
+        final DetailAstImpl ast = new DetailAstImpl();
+        ast.setText("test");
+        ast.setType(1);
+        ast.setLineNo(2);
+        ast.setColumnNo(3);
+
+        final DetailAstImpl copy = new DetailAstImpl();
+        copy.initialize(ast);
+
+        assertEquals("Invalid text", "test", copy.getText());
+        assertEquals("Invalid type", 1, copy.getType());
+        assertEquals("Invalid line number", 2, copy.getLineNo());
+        assertEquals("Invalid column number", 3, copy.getColumnNo());
+    }
+
+    @Test
+    public void testInitializeToken() {
+        final CommonHiddenStreamToken token = new CommonHiddenStreamToken();
+        token.setText("test");
+        token.setType(1);
+        token.setLine(2);
+        token.setColumn(4);
+
+        final DetailAstImpl ast = new DetailAstImpl();
+        ast.initialize(token);
+
+        assertEquals("Invalid text", "test", ast.getText());
+        assertEquals("Invalid type", 1, ast.getType());
+        assertEquals("Invalid line number", 2, ast.getLineNo());
+        assertEquals("Invalid column number", 3, ast.getColumnNo());
+    }
+
+    @Test
     public void testGetChildCount() throws Exception {
-        final DetailAST root = new DetailAST();
-        final DetailAST firstLevelA = new DetailAST();
-        final DetailAST firstLevelB = new DetailAST();
-        final DetailAST secondLevelA = new DetailAST();
+        final DetailAstImpl root = new DetailAstImpl();
+        final DetailAstImpl firstLevelA = new DetailAstImpl();
+        final DetailAstImpl firstLevelB = new DetailAstImpl();
+        final DetailAstImpl secondLevelA = new DetailAstImpl();
 
         root.setFirstChild(firstLevelA);
 
@@ -101,9 +135,9 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testGetChildCountType() throws Exception {
-        final DetailAST root = new DetailAST();
-        final DetailAST firstLevelA = new DetailAST();
-        final DetailAST firstLevelB = new DetailAST();
+        final DetailAstImpl root = new DetailAstImpl();
+        final DetailAstImpl firstLevelA = new DetailAstImpl();
+        final DetailAstImpl firstLevelB = new DetailAstImpl();
 
         root.setFirstChild(firstLevelA);
 
@@ -125,8 +159,8 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testSetSiblingNull() throws Exception {
-        final DetailAST root = new DetailAST();
-        final DetailAST firstLevelA = new DetailAST();
+        final DetailAstImpl root = new DetailAstImpl();
+        final DetailAstImpl firstLevelA = new DetailAstImpl();
 
         root.setFirstChild(firstLevelA);
 
@@ -141,9 +175,9 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testAddPreviousSibling() {
-        final DetailAST previousSibling = new DetailAST();
-        final DetailAST instance = new DetailAST();
-        final DetailAST parent = new DetailAST();
+        final DetailAST previousSibling = new DetailAstImpl();
+        final DetailAstImpl instance = new DetailAstImpl();
+        final DetailAstImpl parent = new DetailAstImpl();
 
         parent.setFirstChild(instance);
 
@@ -152,7 +186,7 @@ public class DetailASTTest extends AbstractModuleTestSupport {
         assertEquals("unexpected result", previousSibling, instance.getPreviousSibling());
         assertEquals("unexpected result", previousSibling, parent.getFirstChild());
 
-        final DetailAST newPreviousSibling = new DetailAST();
+        final DetailAST newPreviousSibling = new DetailAstImpl();
 
         instance.addPreviousSibling(newPreviousSibling);
 
@@ -164,8 +198,8 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testAddPreviousSiblingNullParent() {
-        final DetailAST child = new DetailAST();
-        final DetailAST newSibling = new DetailAST();
+        final DetailAST child = new DetailAstImpl();
+        final DetailAST newSibling = new DetailAstImpl();
 
         child.addPreviousSibling(newSibling);
 
@@ -175,10 +209,10 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testInsertSiblingBetween() throws Exception {
-        final DetailAST root = new DetailAST();
-        final DetailAST firstLevelA = new DetailAST();
-        final DetailAST firstLevelB = new DetailAST();
-        final DetailAST firstLevelC = new DetailAST();
+        final DetailAstImpl root = new DetailAstImpl();
+        final DetailAstImpl firstLevelA = new DetailAstImpl();
+        final DetailAST firstLevelB = new DetailAstImpl();
+        final DetailAST firstLevelC = new DetailAstImpl();
 
         assertEquals("Invalid child count", 0, root.getChildCount());
 
@@ -201,16 +235,16 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testBranchContains() {
-        final DetailAST root = createToken(null, TokenTypes.CLASS_DEF);
-        final DetailAST modifiers = createToken(root, TokenTypes.MODIFIERS);
+        final DetailAstImpl root = createToken(null, TokenTypes.CLASS_DEF);
+        final DetailAstImpl modifiers = createToken(root, TokenTypes.MODIFIERS);
         createToken(modifiers, TokenTypes.LITERAL_PUBLIC);
 
         assertTrue("invalid result", root.branchContains(TokenTypes.LITERAL_PUBLIC));
         assertFalse("invalid result", root.branchContains(TokenTypes.OBJBLOCK));
     }
 
-    private static DetailAST createToken(DetailAST root, int type) {
-        final DetailAST result = new DetailAST();
+    private static DetailAstImpl createToken(DetailAstImpl root, int type) {
+        final DetailAstImpl result = new DetailAstImpl();
         result.setType(type);
         if (root != null) {
             root.addChild(result);
@@ -220,11 +254,11 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testClearBranchTokenTypes() throws Exception {
-        final DetailAST parent = new DetailAST();
-        final DetailAST child = new DetailAST();
+        final DetailAstImpl parent = new DetailAstImpl();
+        final DetailAstImpl child = new DetailAstImpl();
         parent.setFirstChild(child);
 
-        final List<Consumer<DetailAST>> clearBranchTokenTypesMethods = Arrays.asList(
+        final List<Consumer<DetailAstImpl>> clearBranchTokenTypesMethods = Arrays.asList(
                 child::setFirstChild,
                 child::setNextSibling,
                 child::addPreviousSibling,
@@ -241,7 +275,7 @@ public class DetailASTTest extends AbstractModuleTestSupport {
             }
         );
 
-        for (Consumer<DetailAST> method : clearBranchTokenTypesMethods) {
+        for (Consumer<DetailAstImpl> method : clearBranchTokenTypesMethods) {
             final BitSet branchTokenTypes = Whitebox.invokeMethod(parent, "getBranchTokenTypes");
             method.accept(null);
             final BitSet branchTokenTypes2 = Whitebox.invokeMethod(parent, "getBranchTokenTypes");
@@ -253,7 +287,7 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testCacheBranchTokenTypes() {
-        final DetailAST root = new DetailAST();
+        final DetailAST root = new DetailAstImpl();
         final BitSet bitSet = new BitSet();
         bitSet.set(999);
 
@@ -263,17 +297,17 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testClearChildCountCache() {
-        final DetailAST parent = new DetailAST();
-        final DetailAST child = new DetailAST();
+        final DetailAstImpl parent = new DetailAstImpl();
+        final DetailAstImpl child = new DetailAstImpl();
         parent.setFirstChild(child);
 
-        final List<Consumer<DetailAST>> clearChildCountCacheMethods = Arrays.asList(
+        final List<Consumer<DetailAstImpl>> clearChildCountCacheMethods = Arrays.asList(
                 child::setNextSibling,
                 child::addPreviousSibling,
                 child::addNextSibling
         );
 
-        for (Consumer<DetailAST> method : clearChildCountCacheMethods) {
+        for (Consumer<DetailAstImpl> method : clearChildCountCacheMethods) {
             final int startCount = parent.getChildCount();
             method.accept(null);
             final int intermediateCount = Whitebox.getInternalState(parent, "childCount");
@@ -292,7 +326,7 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testCacheGetChildCount() {
-        final DetailAST root = new DetailAST();
+        final DetailAST root = new DetailAstImpl();
 
         Whitebox.setInternalState(root, "childCount", 999);
         assertEquals("Child count has changed", 999, root.getChildCount());
@@ -300,10 +334,10 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testAddNextSibling() {
-        final DetailAST parent = new DetailAST();
-        final DetailAST child = new DetailAST();
-        final DetailAST sibling = new DetailAST();
-        final DetailAST newSibling = new DetailAST();
+        final DetailAstImpl parent = new DetailAstImpl();
+        final DetailAstImpl child = new DetailAstImpl();
+        final DetailAstImpl sibling = new DetailAstImpl();
+        final DetailAST newSibling = new DetailAstImpl();
         parent.setFirstChild(child);
         child.setNextSibling(sibling);
         child.addNextSibling(newSibling);
@@ -315,9 +349,9 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testAddNextSiblingNullParent() {
-        final DetailAST child = new DetailAST();
-        final DetailAST newSibling = new DetailAST();
-        final DetailAST oldParent = new DetailAST();
+        final DetailAST child = new DetailAstImpl();
+        final DetailAstImpl newSibling = new DetailAstImpl();
+        final DetailAstImpl oldParent = new DetailAstImpl();
         oldParent.addChild(newSibling);
         child.addNextSibling(newSibling);
 
@@ -328,24 +362,24 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testGetLineNo() {
-        final DetailAST root1 = new DetailAST();
+        final DetailAST root1 = new DetailAstImpl();
         root1.setLineNo(1);
         assertEquals("Invalid line number", 1, root1.getLineNo());
 
-        final DetailAST root2 = new DetailAST();
-        final DetailAST firstChild = new DetailAST();
+        final DetailAstImpl root2 = new DetailAstImpl();
+        final DetailAstImpl firstChild = new DetailAstImpl();
         firstChild.setLineNo(2);
         root2.setFirstChild(firstChild);
         assertEquals("Invalid line number", 2, root2.getLineNo());
 
-        final DetailAST root3 = new DetailAST();
-        final DetailAST nextSibling = new DetailAST();
+        final DetailAstImpl root3 = new DetailAstImpl();
+        final DetailAstImpl nextSibling = new DetailAstImpl();
         nextSibling.setLineNo(3);
         root3.setNextSibling(nextSibling);
         assertEquals("Invalid line number", 3, root3.getLineNo());
 
-        final DetailAST root4 = new DetailAST();
-        final DetailAST comment = new DetailAST();
+        final DetailAstImpl root4 = new DetailAstImpl();
+        final DetailAstImpl comment = new DetailAstImpl();
         comment.setType(TokenTypes.SINGLE_LINE_COMMENT);
         comment.setLineNo(3);
         root4.setFirstChild(comment);
@@ -354,24 +388,24 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testGetColumnNo() {
-        final DetailAST root1 = new DetailAST();
+        final DetailAST root1 = new DetailAstImpl();
         root1.setColumnNo(1);
         assertEquals("Invalid column number", 1, root1.getColumnNo());
 
-        final DetailAST root2 = new DetailAST();
-        final DetailAST firstChild = new DetailAST();
+        final DetailAstImpl root2 = new DetailAstImpl();
+        final DetailAstImpl firstChild = new DetailAstImpl();
         firstChild.setColumnNo(2);
         root2.setFirstChild(firstChild);
         assertEquals("Invalid column number", 2, root2.getColumnNo());
 
-        final DetailAST root3 = new DetailAST();
-        final DetailAST nextSibling = new DetailAST();
+        final DetailAstImpl root3 = new DetailAstImpl();
+        final DetailAstImpl nextSibling = new DetailAstImpl();
         nextSibling.setColumnNo(3);
         root3.setNextSibling(nextSibling);
         assertEquals("Invalid column number", 3, root3.getColumnNo());
 
-        final DetailAST root4 = new DetailAST();
-        final DetailAST comment = new DetailAST();
+        final DetailAstImpl root4 = new DetailAstImpl();
+        final DetailAstImpl comment = new DetailAstImpl();
         comment.setType(TokenTypes.SINGLE_LINE_COMMENT);
         comment.setColumnNo(3);
         root4.setFirstChild(comment);
@@ -380,12 +414,12 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testFindFirstToken() {
-        final DetailAST root = new DetailAST();
-        final DetailAST firstChild = new DetailAST();
+        final DetailAstImpl root = new DetailAstImpl();
+        final DetailAstImpl firstChild = new DetailAstImpl();
         firstChild.setType(TokenTypes.IDENT);
-        final DetailAST secondChild = new DetailAST();
+        final DetailAstImpl secondChild = new DetailAstImpl();
         secondChild.setType(TokenTypes.EXPR);
-        final DetailAST thirdChild = new DetailAST();
+        final DetailAstImpl thirdChild = new DetailAstImpl();
         thirdChild.setType(TokenTypes.IDENT);
 
         root.addChild(firstChild);
@@ -427,7 +461,7 @@ public class DetailASTTest extends AbstractModuleTestSupport {
 
     @Test
     public void testToString() {
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
         ast.setText("text");
         ast.setColumnNo(0);
         ast.setLineNo(0);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
@@ -35,11 +35,12 @@ import java.util.SortedSet;
 
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
-public class AbstractCheckTest extends AbstractPathTestSupport {
+public class AbstractCheckTest extends AbstractModuleTestSupport {
 
     @Override
     protected String getPackageLocation() {
@@ -323,7 +324,7 @@ public class AbstractCheckTest extends AbstractPathTestSupport {
         check.setFileContents(new FileContents(theText));
         check.clearMessages();
 
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
         ast.setLineNo(1);
         ast.setColumnNo(4);
         check.visitToken(ast);
@@ -335,6 +336,16 @@ public class AbstractCheckTest extends AbstractPathTestSupport {
         final LocalizedMessage firstMessage = internalMessages.iterator().next();
         assertEquals("expected line", 1, firstMessage.getLineNo());
         assertEquals("expected column", 5, firstMessage.getColumnNo());
+    }
+
+    @Test
+    public void testCheck() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(ViolationAstCheck.class);
+
+        final String[] expected = {
+            "1:1: Violation.",
+        };
+        verify(checkConfig, getPath("InputAbstractCheckTestFileContents.java"), expected);
     }
 
     private static final class DummyAbstractCheck extends AbstractCheck {
@@ -424,17 +435,19 @@ public class AbstractCheckTest extends AbstractPathTestSupport {
 
         @Override
         public int[] getDefaultTokens() {
-            return CommonUtil.EMPTY_INT_ARRAY;
+            return getRequiredTokens();
         }
 
         @Override
         public int[] getAcceptableTokens() {
-            return CommonUtil.EMPTY_INT_ARRAY;
+            return getRequiredTokens();
         }
 
         @Override
         public int[] getRequiredTokens() {
-            return CommonUtil.EMPTY_INT_ARRAY;
+            return new int[] {
+                TokenTypes.PACKAGE_DEF,
+            };
         }
 
         @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
@@ -35,11 +35,11 @@ import java.util.TreeSet;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
-public class AbstractFileSetCheckTest extends AbstractPathTestSupport {
+public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
 
     @Override
     protected String getPackageLocation() {
@@ -184,6 +184,16 @@ public class AbstractFileSetCheckTest extends AbstractPathTestSupport {
         check.setMessageDispatcher(checker);
 
         assertEquals("Invalid message dispatcher", checker, check.getMessageDispatcher());
+    }
+
+    @Test
+    public void testCheck() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(ViolationFileSetCheck.class);
+
+        final String[] expected = {
+            "1:6: Violation.",
+        };
+        verify(checkConfig, getPath("InputAbstractFileSetLineColumn.txt"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
@@ -26,6 +26,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 
 public class FullIdentTest extends AbstractModuleTestSupport {
@@ -37,7 +38,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
 
     @Test
     public void testToString() {
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
         ast.setType(TokenTypes.LITERAL_NEW);
         ast.setColumnNo(14);
         ast.setLineNo(15);
@@ -52,7 +53,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
 
     @Test
     public void testCreateFullIdentBelow() {
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
 
         final FullIdent indent = FullIdent.createFullIdentBelow(ast);
         Assert.assertEquals("Invalid full indent", "", indent.getText());
@@ -97,19 +98,19 @@ public class FullIdentTest extends AbstractModuleTestSupport {
     }
 
     private static FullIdent prepareFullIdentWithCoordinates(int columnNo, int lineNo) {
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.setType(TokenTypes.DOT);
         ast.setColumnNo(1);
         ast.setLineNo(2);
         ast.setText("Root");
 
-        final DetailAST ast2 = new DetailAST();
+        final DetailAstImpl ast2 = new DetailAstImpl();
         ast2.setType(TokenTypes.LE);
         ast2.setColumnNo(columnNo);
         ast2.setLineNo(lineNo);
         ast2.setText("MyTestik");
 
-        final DetailAST ast1 = new DetailAST();
+        final DetailAstImpl ast1 = new DetailAstImpl();
         ast1.setType(TokenTypes.LITERAL_NEW);
         ast1.setColumnNo(14);
         ast1.setLineNo(15);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -40,6 +40,7 @@ import org.powermock.reflect.Whitebox;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
@@ -275,16 +276,16 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
                 .getDeclaredMethod("getAllAnnotationValues", DetailAST.class);
         getAllAnnotationValues.setAccessible(true);
 
-        final DetailAST methodDef = new DetailAST();
+        final DetailAstImpl methodDef = new DetailAstImpl();
         methodDef.setType(TokenTypes.METHOD_DEF);
         methodDef.setText("Method Def");
         methodDef.setLineNo(0);
         methodDef.setColumnNo(0);
 
-        final DetailAST lparen = new DetailAST();
+        final DetailAstImpl lparen = new DetailAstImpl();
         lparen.setType(TokenTypes.LPAREN);
 
-        final DetailAST parent = new DetailAST();
+        final DetailAstImpl parent = new DetailAstImpl();
         parent.addChild(lparen);
         parent.addChild(methodDef);
 
@@ -307,7 +308,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
                 .getDeclaredMethod("getAnnotationValues", DetailAST.class);
         getAllAnnotationValues.setAccessible(true);
 
-        final DetailAST methodDef = new DetailAST();
+        final DetailAST methodDef = new DetailAstImpl();
         methodDef.setType(TokenTypes.METHOD_DEF);
         methodDef.setText("Method Def");
         methodDef.setLineNo(0);
@@ -333,11 +334,11 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
                 .getDeclaredMethod("getAnnotationTarget", DetailAST.class);
         getAnnotationTarget.setAccessible(true);
 
-        final DetailAST methodDef = new DetailAST();
+        final DetailAstImpl methodDef = new DetailAstImpl();
         methodDef.setType(TokenTypes.METHOD_DEF);
         methodDef.setText("Method Def");
 
-        final DetailAST parent = new DetailAST();
+        final DetailAstImpl parent = new DetailAstImpl();
         parent.setType(TokenTypes.ASSIGN);
         parent.setText("Parent ast");
         parent.addChild(methodDef);
@@ -359,7 +360,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
     @Test
     public void testAstWithoutChildren() {
         final SuppressWarningsHolder holder = new SuppressWarningsHolder();
-        final DetailAST methodDef = new DetailAST();
+        final DetailAST methodDef = new DetailAstImpl();
         methodDef.setType(TokenTypes.METHOD_DEF);
 
         try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
@@ -110,7 +110,7 @@ public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
     public void testCallVisitToken() {
         final TrailingCommentCheck check = new TrailingCommentCheck();
         try {
-            check.visitToken(new DetailAST());
+            check.visitToken(new DetailAstImpl());
             Assert.fail("IllegalStateException is expected");
         }
         catch (IllegalStateException ex) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -113,7 +113,7 @@ public class UncommentedMainCheckTest
     @Test
     public void testIllegalStateException() {
         final UncommentedMainCheck check = new UncommentedMainCheck();
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonHiddenStreamToken(TokenTypes.CTOR_DEF, "ctor"));
         try {
             check.visitToken(ast);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
@@ -135,12 +135,12 @@ public class DeclarationOrderCheckTest
 
     @Test
     public void testParents() {
-        final DetailAST parent = new DetailAST();
+        final DetailAstImpl parent = new DetailAstImpl();
         parent.setType(TokenTypes.STATIC_INIT);
-        final DetailAST method = new DetailAST();
+        final DetailAstImpl method = new DetailAstImpl();
         method.setType(TokenTypes.METHOD_DEF);
         parent.setFirstChild(method);
-        final DetailAST ctor = new DetailAST();
+        final DetailAstImpl ctor = new DetailAstImpl();
         ctor.setType(TokenTypes.CTOR_DEF);
         method.setNextSibling(ctor);
 
@@ -159,9 +159,9 @@ public class DeclarationOrderCheckTest
 
     @Test
     public void testImproperToken() {
-        final DetailAST parent = new DetailAST();
+        final DetailAstImpl parent = new DetailAstImpl();
         parent.setType(TokenTypes.STATIC_INIT);
-        final DetailAST array = new DetailAST();
+        final DetailAstImpl array = new DetailAstImpl();
         array.setType(TokenTypes.ARRAY_INIT);
         parent.setFirstChild(array);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -185,7 +186,7 @@ public class FinalLocalVariableCheckTest
     public void testImproperToken() {
         final FinalLocalVariableCheck check = new FinalLocalVariableCheck();
 
-        final DetailAST lambdaAst = new DetailAST();
+        final DetailAST lambdaAst = new DetailAstImpl();
         lambdaAst.setType(TokenTypes.LAMBDA);
 
         try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -152,7 +153,7 @@ public class IllegalInstantiationCheckTest
     public void testImproperToken() {
         final IllegalInstantiationCheck check = new IllegalInstantiationCheck();
 
-        final DetailAST lambdaAst = new DetailAST();
+        final DetailAST lambdaAst = new DetailAstImpl();
         lambdaAst.setType(TokenTypes.LAMBDA);
 
         try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -324,7 +325,7 @@ public class IllegalTypeCheckTest extends AbstractModuleTestSupport {
     public void testImproperToken() {
         final IllegalTypeCheck check = new IllegalTypeCheck();
 
-        final DetailAST classDefAst = new DetailAST();
+        final DetailAST classDefAst = new DetailAstImpl();
         classDefAst.setType(TokenTypes.DOT);
 
         try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -112,7 +113,7 @@ public class ModifiedControlVariableCheckTest
     public void testImproperToken() {
         final ModifiedControlVariableCheck check = new ModifiedControlVariableCheck();
 
-        final DetailAST classDefAst = new DetailAST();
+        final DetailAST classDefAst = new DetailAstImpl();
         classDefAst.setType(TokenTypes.CLASS_DEF);
 
         try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -79,7 +80,7 @@ public class ParameterAssignmentCheckTest extends AbstractModuleTestSupport {
     public void testImproperToken() {
         final ParameterAssignmentCheck check = new ParameterAssignmentCheck();
 
-        final DetailAST classDefAst = new DetailAST();
+        final DetailAST classDefAst = new DetailAstImpl();
         classDefAst.setType(TokenTypes.CLASS_DEF);
 
         try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
@@ -167,7 +168,7 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
     public void testDefaultSwitch() {
         final RequireThisCheck check = new RequireThisCheck();
 
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonHiddenStreamToken(TokenTypes.ENUM, "ENUM"));
 
         check.visitToken(ast);
@@ -364,7 +365,7 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testUnusedMethod() throws Exception {
-        final DetailAST ident = new DetailAST();
+        final DetailAST ident = new DetailAstImpl();
         ident.setText("testName");
 
         final Class<?> cls = Class.forName(RequireThisCheck.class.getName() + "$CatchFrame");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -123,7 +124,7 @@ public class ReturnCountCheckTest extends AbstractModuleTestSupport {
     public void testImproperToken() {
         final ReturnCountCheck check = new ReturnCountCheck();
 
-        final DetailAST classDefAst = new DetailAST();
+        final DetailAST classDefAst = new DetailAstImpl();
         classDefAst.setType(TokenTypes.CLASS_DEF);
 
         try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -30,6 +30,7 @@ import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
@@ -91,7 +92,7 @@ public class FinalClassCheckTest
     @Test
     public void testImproperToken() {
         final FinalClassCheck finalClassCheck = new FinalClassCheck();
-        final DetailAST badAst = new DetailAST();
+        final DetailAST badAst = new DetailAstImpl();
         final int unsupportedTokenByCheck = TokenTypes.EOF;
         badAst.setType(unsupportedTokenByCheck);
         try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckTest.java
@@ -34,7 +34,7 @@ import antlr.CommonHiddenStreamToken;
 import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -119,7 +119,7 @@ public class MutableExceptionCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testWrongTokenType() {
         final MutableExceptionCheck obj = new MutableExceptionCheck();
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonHiddenStreamToken(TokenTypes.INTERFACE_DEF, "interface"));
         try {
             obj.visitToken(ast);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class ThrowsCountCheckTest extends AbstractModuleTestSupport {
@@ -84,7 +84,7 @@ public class ThrowsCountCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testWrongTokenType() {
         final ThrowsCountCheck obj = new ThrowsCountCheck();
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonHiddenStreamToken(TokenTypes.CLASS_DEF, "class"));
         try {
             obj.visitToken(ast);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -34,6 +34,7 @@ import org.powermock.reflect.Whitebox;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -418,7 +419,7 @@ public class VisibilityModifierCheckTest
     @Test
     public void testWrongTokenType() {
         final VisibilityModifierCheck obj = new VisibilityModifierCheck();
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonHiddenStreamToken(TokenTypes.CLASS_DEF, "class"));
         try {
             obj.visitToken(ast);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -657,8 +658,8 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testVisitTokenSwitchReflection() throws Exception {
         // Create mock ast
-        final DetailAST astImport = mockAST(TokenTypes.IMPORT, "import", "mockfile", 0, 0);
-        final DetailAST astIdent = mockAST(TokenTypes.IDENT, "myTestImport", "mockfile", 0, 0);
+        final DetailAstImpl astImport = mockAST(TokenTypes.IMPORT, "import", "mockfile", 0, 0);
+        final DetailAstImpl astIdent = mockAST(TokenTypes.IDENT, "myTestImport", "mockfile", 0, 0);
         astImport.addChild(astIdent);
         final DetailAST astSemi = mockAST(TokenTypes.SEMI, ";", "mockfile", 0, 0);
         astIdent.addNextSibling(astSemi);
@@ -686,7 +687,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
      * @param tokenColumn token position in a file (column)
      * @return AST node for the token
      */
-    private static DetailAST mockAST(final int tokenType, final String tokenText,
+    private static DetailAstImpl mockAST(final int tokenType, final String tokenText,
             final String tokenFileName, final int tokenRow, final int tokenColumn) {
         final CommonHiddenStreamToken tokenImportSemi = new CommonHiddenStreamToken();
         tokenImportSemi.setType(tokenType);
@@ -694,7 +695,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         tokenImportSemi.setLine(tokenRow);
         tokenImportSemi.setColumn(tokenColumn);
         tokenImportSemi.setFilename(tokenFileName);
-        final DetailAST astSemi = new DetailAST();
+        final DetailAstImpl astSemi = new DetailAstImpl();
         astSemi.initialize(tokenImportSemi);
         return astSemi;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -208,7 +209,7 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testVisitToken() {
         final CommentsIndentationCheck check = new CommentsIndentationCheck();
-        final DetailAST methodDef = new DetailAST();
+        final DetailAST methodDef = new DetailAstImpl();
         methodDef.setType(TokenTypes.METHOD_DEF);
         methodDef.setText("methodStub");
         try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Method;
 
 import org.junit.Test;
 
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
@@ -70,7 +71,7 @@ public class JavadocTagInfoTest {
 
     @Test
     public void testAuthor() {
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
 
         final int[] validTypes = {
             TokenTypes.PACKAGE_DEF,
@@ -103,11 +104,12 @@ public class JavadocTagInfoTest {
             JavadocTagInfo.VALUE,
         };
         for (JavadocTagInfo tagInfo : tags) {
-            final DetailAST astParent = new DetailAST();
+            final DetailAstImpl astParent = new DetailAstImpl();
             astParent.setType(TokenTypes.LITERAL_CATCH);
 
-            final DetailAST ast = new DetailAST();
-            final Method setParent = ast.getClass().getDeclaredMethod("setParent", DetailAST.class);
+            final DetailAST ast = new DetailAstImpl();
+            final Method setParent = ast.getClass().getDeclaredMethod("setParent",
+                    DetailAstImpl.class);
             setParent.setAccessible(true);
             setParent.invoke(ast, astParent);
 
@@ -140,10 +142,10 @@ public class JavadocTagInfoTest {
 
     @Test
     public void testDeprecated() throws ReflectiveOperationException {
-        final DetailAST ast = new DetailAST();
-        final DetailAST astParent = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
+        final DetailAstImpl astParent = new DetailAstImpl();
         astParent.setType(TokenTypes.LITERAL_CATCH);
-        final Method setParent = ast.getClass().getDeclaredMethod("setParent", DetailAST.class);
+        final Method setParent = ast.getClass().getDeclaredMethod("setParent", DetailAstImpl.class);
         setParent.setAccessible(true);
         setParent.invoke(ast, astParent);
 
@@ -176,10 +178,10 @@ public class JavadocTagInfoTest {
 
     @Test
     public void testSerial() throws ReflectiveOperationException {
-        final DetailAST ast = new DetailAST();
-        final DetailAST astParent = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
+        final DetailAstImpl astParent = new DetailAstImpl();
         astParent.setType(TokenTypes.LITERAL_CATCH);
-        final Method setParent = ast.getClass().getDeclaredMethod("setParent", DetailAST.class);
+        final Method setParent = ast.getClass().getDeclaredMethod("setParent", DetailAstImpl.class);
         setParent.setAccessible(true);
         setParent.invoke(ast, astParent);
 
@@ -204,7 +206,7 @@ public class JavadocTagInfoTest {
 
     @Test
     public void testException() {
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
 
         final int[] validTypes = {
             TokenTypes.METHOD_DEF,
@@ -223,7 +225,7 @@ public class JavadocTagInfoTest {
 
     @Test
     public void testThrows() {
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
 
         final int[] validTypes = {
             TokenTypes.METHOD_DEF,
@@ -242,7 +244,7 @@ public class JavadocTagInfoTest {
 
     @Test
     public void testVersions() {
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
 
         final int[] validTypes = {
             TokenTypes.PACKAGE_DEF,
@@ -264,7 +266,7 @@ public class JavadocTagInfoTest {
 
     @Test
     public void testParam() {
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
 
         final int[] validTypes = {
             TokenTypes.CLASS_DEF,
@@ -285,11 +287,11 @@ public class JavadocTagInfoTest {
 
     @Test
     public void testReturn() {
-        final DetailAST ast = new DetailAST();
-        final DetailAST astChild = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
+        final DetailAstImpl astChild = new DetailAstImpl();
         astChild.setType(TokenTypes.TYPE);
         ast.setFirstChild(astChild);
-        final DetailAST astChild2 = new DetailAST();
+        final DetailAstImpl astChild2 = new DetailAstImpl();
         astChild2.setType(TokenTypes.LITERAL_INT);
         astChild.setFirstChild(astChild2);
 
@@ -313,11 +315,11 @@ public class JavadocTagInfoTest {
 
     @Test
     public void testSerialField() {
-        final DetailAST ast = new DetailAST();
-        final DetailAST astChild = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
+        final DetailAstImpl astChild = new DetailAstImpl();
         astChild.setType(TokenTypes.TYPE);
         ast.setFirstChild(astChild);
-        final DetailAST astChild2 = new DetailAST();
+        final DetailAstImpl astChild2 = new DetailAstImpl();
         astChild2.setType(TokenTypes.ARRAY_DECLARATOR);
         astChild2.setText("ObjectStreamField");
         astChild.setFirstChild(astChild2);
@@ -346,9 +348,9 @@ public class JavadocTagInfoTest {
 
     @Test
     public void testSerialData() {
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.setType(TokenTypes.METHOD_DEF);
-        final DetailAST astChild = new DetailAST();
+        final DetailAstImpl astChild = new DetailAstImpl();
         astChild.setType(TokenTypes.IDENT);
         astChild.setText("writeObject");
         ast.setFirstChild(astChild);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -81,7 +81,7 @@ public class BooleanExpressionComplexityCheckTest extends AbstractModuleTestSupp
     public void testWrongToken() {
         final BooleanExpressionComplexityCheck booleanExpressionComplexityCheckObj =
             new BooleanExpressionComplexityCheck();
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonHiddenStreamToken(TokenTypes.INTERFACE_DEF, "interface"));
         try {
             booleanExpressionComplexityCheckObj.visitToken(ast);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckTest.java
@@ -30,8 +30,8 @@ import org.junit.Test;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -172,7 +172,7 @@ public class ClassDataAbstractionCouplingCheckTest extends AbstractModuleTestSup
     public void testWrongToken() {
         final ClassDataAbstractionCouplingCheck classDataAbstractionCouplingCheckObj =
             new ClassDataAbstractionCouplingCheck();
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonHiddenStreamToken(TokenTypes.CTOR_DEF, "ctor"));
         try {
             classDataAbstractionCouplingCheckObj.visitToken(ast);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.api.Context;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -132,7 +133,7 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     @SuppressWarnings("unchecked")
     public void testStatefulFieldsClearedOnBeginTree1() throws Exception {
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
         ast.setType(TokenTypes.LITERAL_ELSE);
 
         final NPathComplexityCheck check = new NPathComplexityCheck();
@@ -147,10 +148,10 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     @SuppressWarnings("unchecked")
     public void testStatefulFieldsClearedOnBeginTree2() throws Exception {
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.setType(TokenTypes.LITERAL_RETURN);
         ast.setLineNo(5);
-        final DetailAST child = new DetailAST();
+        final DetailAstImpl child = new DetailAstImpl();
         child.setType(TokenTypes.SEMI);
         ast.addChild(child);
 
@@ -255,7 +256,7 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testDefaultHooks() {
         final NPathComplexityCheck npathComplexityCheckObj = new NPathComplexityCheck();
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonHiddenStreamToken(TokenTypes.INTERFACE_DEF, "interface"));
 
         npathComplexityCheckObj.visitToken(ast);
@@ -285,7 +286,7 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
         final NPathComplexityCheck check = new NPathComplexityCheck();
         final Object tokenEnd = TestUtil.getClassDeclaredField(NPathComplexityCheck.class,
                 "processingTokenEnd").get(check);
-        final DetailAST token = new DetailAST();
+        final DetailAST token = new DetailAstImpl();
         token.setLineNo(0);
         token.setColumnNo(0);
 
@@ -297,17 +298,17 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testVisitTokenBeforeExpressionRange() {
         // Create first ast
-        final DetailAST astIf = mockAST(TokenTypes.LITERAL_IF, "if", "mockfile", 2, 2);
-        final DetailAST astIfLeftParen = mockAST(TokenTypes.LPAREN, "(", "mockfile", 3, 3);
+        final DetailAstImpl astIf = mockAST(TokenTypes.LITERAL_IF, "if", "mockfile", 2, 2);
+        final DetailAstImpl astIfLeftParen = mockAST(TokenTypes.LPAREN, "(", "mockfile", 3, 3);
         astIf.addChild(astIfLeftParen);
-        final DetailAST astIfTrue =
+        final DetailAstImpl astIfTrue =
                 mockAST(TokenTypes.LITERAL_TRUE, "true", "mockfile", 3, 3);
         astIf.addChild(astIfTrue);
-        final DetailAST astIfRightParen = mockAST(TokenTypes.RPAREN, ")", "mockfile", 4, 4);
+        final DetailAstImpl astIfRightParen = mockAST(TokenTypes.RPAREN, ")", "mockfile", 4, 4);
         astIf.addChild(astIfRightParen);
         // Create ternary ast
-        final DetailAST astTernary = mockAST(TokenTypes.QUESTION, "?", "mockfile", 1, 1);
-        final DetailAST astTernaryTrue =
+        final DetailAstImpl astTernary = mockAST(TokenTypes.QUESTION, "?", "mockfile", 1, 1);
+        final DetailAstImpl astTernaryTrue =
                 mockAST(TokenTypes.LITERAL_TRUE, "true", "mockfile", 1, 2);
         astTernary.addChild(astTernaryTrue);
 
@@ -335,7 +336,7 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
      * @param tokenColumn token position in a file (column)
      * @return AST node for the token
      */
-    private static DetailAST mockAST(final int tokenType, final String tokenText,
+    private static DetailAstImpl mockAST(final int tokenType, final String tokenText,
             final String tokenFileName, final int tokenRow, final int tokenColumn) {
         final CommonHiddenStreamToken tokenImportSemi = new CommonHiddenStreamToken();
         tokenImportSemi.setType(tokenType);
@@ -343,7 +344,7 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
         tokenImportSemi.setLine(tokenRow);
         tokenImportSemi.setColumn(tokenColumn);
         tokenImportSemi.setFilename(tokenFileName);
-        final DetailAST astSemi = new DetailAST();
+        final DetailAstImpl astSemi = new DetailAstImpl();
         astSemi.initialize(tokenImportSemi);
         return astSemi;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -112,12 +112,12 @@ public class ClassMemberImpliedModifierCheckTest
 
     @Test
     public void testIllegalState() {
-        final DetailAST init = new DetailAST();
+        final DetailAstImpl init = new DetailAstImpl();
         init.setType(TokenTypes.STATIC_INIT);
-        final DetailAST objBlock = new DetailAST();
+        final DetailAstImpl objBlock = new DetailAstImpl();
         objBlock.setType(TokenTypes.OBJBLOCK);
         objBlock.addChild(init);
-        final DetailAST interfaceAst = new DetailAST();
+        final DetailAstImpl interfaceAst = new DetailAstImpl();
         interfaceAst.setType(TokenTypes.CLASS_DEF);
         interfaceAst.addChild(objBlock);
         final ClassMemberImpliedModifierCheck check =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -391,12 +391,12 @@ public class InterfaceMemberImpliedModifierCheckTest
 
     @Test
     public void testIllegalState() {
-        final DetailAST init = new DetailAST();
+        final DetailAstImpl init = new DetailAstImpl();
         init.setType(TokenTypes.STATIC_INIT);
-        final DetailAST objBlock = new DetailAST();
+        final DetailAstImpl objBlock = new DetailAstImpl();
         objBlock.setType(TokenTypes.OBJBLOCK);
         objBlock.addChild(init);
-        final DetailAST interfaceAst = new DetailAST();
+        final DetailAstImpl interfaceAst = new DetailAstImpl();
         interfaceAst.setType(TokenTypes.INTERFACE_DEF);
         interfaceAst.addChild(objBlock);
         final InterfaceMemberImpliedModifierCheck check =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.Context;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -48,7 +49,7 @@ public class ExecutableStatementCountCheckTest
     @Test
     @SuppressWarnings("unchecked")
     public void testStatefulFieldsClearedOnBeginTree() throws Exception {
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
         ast.setType(TokenTypes.STATIC_INIT);
         final ExecutableStatementCountCheck check = new ExecutableStatementCountCheck();
         Assert.assertTrue("Stateful field is not cleared after beginTree",
@@ -149,7 +150,7 @@ public class ExecutableStatementCountCheckTest
     public void testVisitTokenWithWrongTokenType() {
         final ExecutableStatementCountCheck checkObj =
             new ExecutableStatementCountCheck();
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(
             new CommonHiddenStreamToken(TokenTypes.ENUM, "ENUM"));
         try {
@@ -165,7 +166,7 @@ public class ExecutableStatementCountCheckTest
     public void testLeaveTokenWithWrongTokenType() {
         final ExecutableStatementCountCheck checkObj =
             new ExecutableStatementCountCheck();
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(
             new CommonHiddenStreamToken(TokenTypes.ENUM, "ENUM"));
         try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -159,7 +159,7 @@ public class GenericWhitespaceCheckTest
     @Test
     public void testWrongTokenType() {
         final GenericWhitespaceCheck genericWhitespaceCheckObj = new GenericWhitespaceCheck();
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(new CommonHiddenStreamToken(TokenTypes.INTERFACE_DEF, "interface"));
         try {
             genericWhitespaceCheckObj.visitToken(ast);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 public class NoWhitespaceAfterCheckTest
@@ -230,9 +230,10 @@ public class NoWhitespaceAfterCheckTest
     @Test
     public void testVisitTokenSwitchReflection() {
         //unexpected parent for ARRAY_DECLARATOR token
-        final DetailAST astImport = mockAST(TokenTypes.IMPORT, "import", "mockfile");
-        final DetailAST astArrayDeclarator = mockAST(TokenTypes.ARRAY_DECLARATOR, "[", "mockfile");
-        final DetailAST astRightBracket = mockAST(TokenTypes.RBRACK, "[", "mockfile");
+        final DetailAstImpl astImport = mockAST(TokenTypes.IMPORT, "import", "mockfile");
+        final DetailAstImpl astArrayDeclarator = mockAST(TokenTypes.ARRAY_DECLARATOR, "[",
+                "mockfile");
+        final DetailAstImpl astRightBracket = mockAST(TokenTypes.RBRACK, "[", "mockfile");
         astImport.addChild(astArrayDeclarator);
         astArrayDeclarator.addChild(astRightBracket);
 
@@ -288,13 +289,13 @@ public class NoWhitespaceAfterCheckTest
      * @param tokenFileName file name of token
      * @return AST node for the token
      */
-    private static DetailAST mockAST(final int tokenType, final String tokenText,
+    private static DetailAstImpl mockAST(final int tokenType, final String tokenText,
             final String tokenFileName) {
         final CommonHiddenStreamToken tokenImportSemi = new CommonHiddenStreamToken();
         tokenImportSemi.setType(tokenType);
         tokenImportSemi.setText(tokenText);
         tokenImportSemi.setFilename(tokenFileName);
-        final DetailAST astSemi = new DetailAST();
+        final DetailAstImpl astSemi = new DetailAstImpl();
         astSemi.initialize(tokenImportSemi);
         return astSemi;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
@@ -34,6 +34,7 @@ import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -480,7 +481,7 @@ public class ParenPadCheckTest
         final ParenPadCheck check = new ParenPadCheck();
         final Method method = Whitebox.getMethod(ParenPadCheck.class,
             "isAcceptableToken", DetailAST.class);
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
         final String message = "Expected that all acceptable tokens will pass isAcceptableToken "
             + "method, but some token don't: ";
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
@@ -187,7 +188,7 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
         }
 
         Assert.assertEquals("Invalid child index",
-                -1, parseTree.getIndexOfChild(tree, new DetailAST()));
+                -1, parseTree.getIndexOfChild(tree, new DetailAstImpl()));
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
@@ -75,7 +76,7 @@ public class AnnotationUtilTest {
 
     @Test
     public void testContainsAnnotationFalse() {
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
         ast.setType(1);
         assertFalse("AnnotationUtil should not contain " + ast,
                 AnnotationUtil.containsAnnotation(ast));
@@ -83,9 +84,9 @@ public class AnnotationUtilTest {
 
     @Test
     public void testContainsAnnotationFalse2() {
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.setType(1);
-        final DetailAST ast2 = new DetailAST();
+        final DetailAstImpl ast2 = new DetailAstImpl();
         ast2.setType(TokenTypes.MODIFIERS);
         ast.addChild(ast2);
         assertFalse("AnnotationUtil should not contain " + ast,
@@ -94,12 +95,12 @@ public class AnnotationUtilTest {
 
     @Test
     public void testContainsAnnotationTrue() {
-        final DetailAST ast = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.setType(1);
-        final DetailAST ast2 = new DetailAST();
+        final DetailAstImpl ast2 = new DetailAstImpl();
         ast2.setType(TokenTypes.MODIFIERS);
         ast.addChild(ast2);
-        final DetailAST ast3 = new DetailAST();
+        final DetailAstImpl ast3 = new DetailAstImpl();
         ast3.setType(TokenTypes.ANNOTATION);
         ast2.addChild(ast3);
         assertTrue("AnnotationUtil should contain " + ast,
@@ -133,7 +134,7 @@ public class AnnotationUtilTest {
     @Test
     public void testAnnotationNull2() {
         try {
-            AnnotationUtil.getAnnotation(new DetailAST(), null);
+            AnnotationUtil.getAnnotation(new DetailAstImpl(), null);
             Assert.fail("IllegalArgumentException is expected");
         }
         catch (IllegalArgumentException ex) {
@@ -145,7 +146,7 @@ public class AnnotationUtilTest {
     @Test
     public void testAnnotationEmpty() {
         try {
-            AnnotationUtil.getAnnotation(new DetailAST(), "");
+            AnnotationUtil.getAnnotation(new DetailAstImpl(), "");
             Assert.fail("IllegalArgumentException is expected");
         }
         catch (IllegalArgumentException ex) {
@@ -180,7 +181,7 @@ public class AnnotationUtilTest {
 
     @Test
     public void testContainsAnnotationListWithNullList() {
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
         final List<String> annotations = null;
         try {
             AnnotationUtil.containsAnnotation(ast, annotations);
@@ -194,7 +195,7 @@ public class AnnotationUtilTest {
 
     @Test
     public void testContainsAnnotationListWithEmptyList() {
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
         final List<String> annotations = new ArrayList<>();
         final boolean result = AnnotationUtil.containsAnnotation(ast, annotations);
         assertFalse("An empty list should lead to a false result", result);
@@ -202,8 +203,8 @@ public class AnnotationUtilTest {
 
     @Test
     public void testContainsAnnotationListWithNoAnnotationNode() {
-        final DetailAST ast = new DetailAST();
-        final DetailAST modifiersAst = new DetailAST();
+        final DetailAstImpl ast = new DetailAstImpl();
+        final DetailAstImpl modifiersAst = new DetailAstImpl();
         modifiersAst.setType(TokenTypes.MODIFIERS);
         ast.addChild(modifiersAst);
         final List<String> annotations = Collections.singletonList("Override");
@@ -213,8 +214,8 @@ public class AnnotationUtilTest {
 
     @Test
     public void testContainsAnnotationListWithEmptyAnnotationNode() {
-        final DetailAST ast = new DetailAST();
-        final DetailAST modifiersAst = create(
+        final DetailAstImpl ast = new DetailAstImpl();
+        final DetailAstImpl modifiersAst = create(
                 TokenTypes.MODIFIERS,
                 create(
                         TokenTypes.ANNOTATION,
@@ -234,8 +235,8 @@ public class AnnotationUtilTest {
 
     @Test
     public void testContainsAnnotationListWithNoMatchingAnnotation() {
-        final DetailAST ast = new DetailAST();
-        final DetailAST modifiersAst = create(
+        final DetailAstImpl ast = new DetailAstImpl();
+        final DetailAstImpl modifiersAst = create(
                 TokenTypes.MODIFIERS,
                 create(
                         TokenTypes.ANNOTATION,
@@ -255,13 +256,13 @@ public class AnnotationUtilTest {
 
     @Test
     public void testContainsAnnotation() {
-        final DetailAST astForTest = new DetailAST();
+        final DetailAstImpl astForTest = new DetailAstImpl();
         astForTest.setType(TokenTypes.PACKAGE_DEF);
-        final DetailAST child = new DetailAST();
-        final DetailAST annotations = new DetailAST();
-        final DetailAST annotation = new DetailAST();
-        final DetailAST annotationNameHolder = new DetailAST();
-        final DetailAST annotationName = new DetailAST();
+        final DetailAstImpl child = new DetailAstImpl();
+        final DetailAstImpl annotations = new DetailAstImpl();
+        final DetailAstImpl annotation = new DetailAstImpl();
+        final DetailAstImpl annotationNameHolder = new DetailAstImpl();
+        final DetailAstImpl annotationName = new DetailAstImpl();
         annotations.setType(TokenTypes.ANNOTATIONS);
         annotation.setType(TokenTypes.ANNOTATION);
         annotationNameHolder.setType(TokenTypes.AT);
@@ -279,13 +280,13 @@ public class AnnotationUtilTest {
 
     @Test
     public void testContainsAnnotationWithStringFalse() {
-        final DetailAST astForTest = new DetailAST();
+        final DetailAstImpl astForTest = new DetailAstImpl();
         astForTest.setType(TokenTypes.PACKAGE_DEF);
-        final DetailAST child = new DetailAST();
-        final DetailAST annotations = new DetailAST();
-        final DetailAST annotation = new DetailAST();
-        final DetailAST annotationNameHolder = new DetailAST();
-        final DetailAST annotationName = new DetailAST();
+        final DetailAstImpl child = new DetailAstImpl();
+        final DetailAstImpl annotations = new DetailAstImpl();
+        final DetailAstImpl annotation = new DetailAstImpl();
+        final DetailAstImpl annotationNameHolder = new DetailAstImpl();
+        final DetailAstImpl annotationName = new DetailAstImpl();
         annotations.setType(TokenTypes.ANNOTATIONS);
         annotation.setType(TokenTypes.ANNOTATION);
         annotationNameHolder.setType(TokenTypes.AT);
@@ -303,14 +304,14 @@ public class AnnotationUtilTest {
 
     @Test
     public void testContainsAnnotationWithComment() {
-        final DetailAST astForTest = new DetailAST();
+        final DetailAstImpl astForTest = new DetailAstImpl();
         astForTest.setType(TokenTypes.PACKAGE_DEF);
-        final DetailAST child = new DetailAST();
-        final DetailAST annotations = new DetailAST();
-        final DetailAST annotation = new DetailAST();
-        final DetailAST annotationNameHolder = new DetailAST();
-        final DetailAST annotationName = new DetailAST();
-        final DetailAST comment = new DetailAST();
+        final DetailAstImpl child = new DetailAstImpl();
+        final DetailAstImpl annotations = new DetailAstImpl();
+        final DetailAstImpl annotation = new DetailAstImpl();
+        final DetailAstImpl annotationNameHolder = new DetailAstImpl();
+        final DetailAstImpl annotationName = new DetailAstImpl();
+        final DetailAstImpl comment = new DetailAstImpl();
         annotations.setType(TokenTypes.ANNOTATIONS);
         annotation.setType(TokenTypes.ANNOTATION);
         annotationNameHolder.setType(TokenTypes.AT);
@@ -328,20 +329,20 @@ public class AnnotationUtilTest {
                 AnnotationUtil.containsAnnotation(astForTest, "Annotation"));
     }
 
-    private static DetailAST create(int tokenType) {
-        final DetailAST ast = new DetailAST();
+    private static DetailAstImpl create(int tokenType) {
+        final DetailAstImpl ast = new DetailAstImpl();
         ast.setType(tokenType);
         return ast;
     }
 
-    private static DetailAST create(int tokenType, String text) {
-        final DetailAST ast = create(tokenType);
+    private static DetailAstImpl create(int tokenType, String text) {
+        final DetailAstImpl ast = create(tokenType);
         ast.setText(text);
         return ast;
     }
 
-    private static DetailAST create(int tokenType, DetailAST child) {
-        final DetailAST ast = create(tokenType);
+    private static DetailAstImpl create(int tokenType, DetailAstImpl child) {
+        final DetailAstImpl ast = create(tokenType);
         ast.addChild(child);
         return ast;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -62,17 +63,17 @@ public class CheckUtilTest extends AbstractPathTestSupport {
 
     @Test
     public void testElseWithCurly() {
-        final DetailAST ast = new DetailAST();
+        final DetailAST ast = new DetailAstImpl();
         ast.setType(TokenTypes.ASSIGN);
         ast.setText("ASSIGN");
         assertFalse("Invalid elseIf check result 'ASSIGN' is not 'else if'",
                 CheckUtil.isElseIf(ast));
 
-        final DetailAST parentAst = new DetailAST();
+        final DetailAstImpl parentAst = new DetailAstImpl();
         parentAst.setType(TokenTypes.LCURLY);
         parentAst.setText("LCURLY");
 
-        final DetailAST ifAst = new DetailAST();
+        final DetailAstImpl ifAst = new DetailAstImpl();
         ifAst.setType(TokenTypes.LITERAL_IF);
         ifAst.setText("IF");
         parentAst.addChild(ifAst);
@@ -80,7 +81,7 @@ public class CheckUtilTest extends AbstractPathTestSupport {
         assertFalse("Invalid elseIf check result: 'IF' is not 'else if'",
                 CheckUtil.isElseIf(ifAst));
 
-        final DetailAST parentAst2 = new DetailAST();
+        final DetailAstImpl parentAst2 = new DetailAstImpl();
         parentAst2.setType(TokenTypes.SLIST);
         parentAst2.setText("SLIST");
 
@@ -89,7 +90,7 @@ public class CheckUtilTest extends AbstractPathTestSupport {
         assertFalse("Invalid elseIf check result: 'SLIST' is not 'else if'",
                 CheckUtil.isElseIf(ifAst));
 
-        final DetailAST elseAst = new DetailAST();
+        final DetailAstImpl elseAst = new DetailAstImpl();
         elseAst.setType(TokenTypes.LITERAL_ELSE);
 
         elseAst.setFirstChild(ifAst);
@@ -98,14 +99,14 @@ public class CheckUtilTest extends AbstractPathTestSupport {
 
     @Test
     public void testEquals() {
-        final DetailAST litStatic = new DetailAST();
+        final DetailAstImpl litStatic = new DetailAstImpl();
         litStatic.setType(TokenTypes.LITERAL_STATIC);
 
-        final DetailAST modifiers = new DetailAST();
+        final DetailAstImpl modifiers = new DetailAstImpl();
         modifiers.setType(TokenTypes.MODIFIERS);
         modifiers.addChild(litStatic);
 
-        final DetailAST metDef = new DetailAST();
+        final DetailAstImpl metDef = new DetailAstImpl();
         metDef.setType(TokenTypes.METHOD_DEF);
         metDef.addChild(modifiers);
 
@@ -114,19 +115,19 @@ public class CheckUtilTest extends AbstractPathTestSupport {
 
         metDef.removeChildren();
 
-        final DetailAST metName = new DetailAST();
+        final DetailAstImpl metName = new DetailAstImpl();
         metName.setType(TokenTypes.IDENT);
         metName.setText("equals");
         metDef.addChild(metName);
 
-        final DetailAST modifiers2 = new DetailAST();
+        final DetailAstImpl modifiers2 = new DetailAstImpl();
         modifiers2.setType(TokenTypes.MODIFIERS);
         metDef.addChild(modifiers2);
 
-        final DetailAST parameter1 = new DetailAST();
-        final DetailAST parameter2 = new DetailAST();
+        final DetailAstImpl parameter1 = new DetailAstImpl();
+        final DetailAstImpl parameter2 = new DetailAstImpl();
 
-        final DetailAST parameters = new DetailAST();
+        final DetailAstImpl parameters = new DetailAstImpl();
         parameters.setType(TokenTypes.PARAMETERS);
 
         parameters.addChild(parameter2);
@@ -140,7 +141,7 @@ public class CheckUtilTest extends AbstractPathTestSupport {
 
     @Test
     public void testGetAccessModifierFromModifiersTokenWrongTokenType() {
-        final DetailAST modifiers = new DetailAST();
+        final DetailAST modifiers = new DetailAstImpl();
         modifiers.setType(TokenTypes.METHOD_DEF);
 
         try {
@@ -296,11 +297,11 @@ public class CheckUtilTest extends AbstractPathTestSupport {
 
     @Test
     public void testGetFirstNode1() {
-        final DetailAST child = new DetailAST();
+        final DetailAstImpl child = new DetailAstImpl();
         child.setLineNo(5);
         child.setColumnNo(6);
 
-        final DetailAST root = new DetailAST();
+        final DetailAstImpl root = new DetailAstImpl();
         root.setLineNo(5);
         root.setColumnNo(6);
 
@@ -311,11 +312,11 @@ public class CheckUtilTest extends AbstractPathTestSupport {
 
     @Test
     public void testGetFirstNode2() {
-        final DetailAST child = new DetailAST();
+        final DetailAstImpl child = new DetailAstImpl();
         child.setLineNo(6);
         child.setColumnNo(5);
 
-        final DetailAST root = new DetailAST();
+        final DetailAstImpl root = new DetailAstImpl();
         root.setLineNo(5);
         root.setColumnNo(6);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilTest.java
@@ -29,8 +29,8 @@ import java.util.List;
 
 import org.junit.Test;
 
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.Comment;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -172,15 +172,15 @@ public class JavadocUtilTest {
 
     @Test
     public void testEmptyBlockCommentAst() {
-        final DetailAST commentBegin = new DetailAST();
+        final DetailAstImpl commentBegin = new DetailAstImpl();
         commentBegin.setType(TokenTypes.BLOCK_COMMENT_BEGIN);
         commentBegin.setText("/*");
 
-        final DetailAST commentContent = new DetailAST();
+        final DetailAstImpl commentContent = new DetailAstImpl();
         commentContent.setType(TokenTypes.COMMENT_CONTENT);
         commentContent.setText("");
 
-        final DetailAST commentEnd = new DetailAST();
+        final DetailAstImpl commentEnd = new DetailAstImpl();
         commentEnd.setType(TokenTypes.BLOCK_COMMENT_END);
         commentEnd.setText("*/");
 
@@ -200,26 +200,26 @@ public class JavadocUtilTest {
 
     @Test
     public void testEmptyJavadocCommentAst() {
-        final DetailAST commentBegin = new DetailAST();
+        final DetailAstImpl commentBegin = new DetailAstImpl();
         commentBegin.setType(TokenTypes.BLOCK_COMMENT_BEGIN);
         commentBegin.setText("/*");
 
-        final DetailAST javadocCommentContent = new DetailAST();
+        final DetailAstImpl javadocCommentContent = new DetailAstImpl();
         javadocCommentContent.setType(TokenTypes.COMMENT_CONTENT);
         javadocCommentContent.setText("*");
 
-        final DetailAST commentEnd = new DetailAST();
+        final DetailAstImpl commentEnd = new DetailAstImpl();
         commentEnd.setType(TokenTypes.BLOCK_COMMENT_END);
         commentEnd.setText("*/");
 
         commentBegin.setFirstChild(javadocCommentContent);
         javadocCommentContent.setNextSibling(commentEnd);
 
-        final DetailAST commentBeginParent = new DetailAST();
+        final DetailAstImpl commentBeginParent = new DetailAstImpl();
         commentBeginParent.setType(TokenTypes.MODIFIERS);
         commentBeginParent.setFirstChild(commentBegin);
 
-        final DetailAST aJavadocPosition = new DetailAST();
+        final DetailAstImpl aJavadocPosition = new DetailAstImpl();
         aJavadocPosition.setType(TokenTypes.METHOD_DEF);
         aJavadocPosition.setFirstChild(commentBeginParent);
         assertTrue("Should return true when empty javadoc comment ast is passed",
@@ -319,8 +319,8 @@ public class JavadocUtilTest {
 
     @Test
     public void testGetJavadocCommentContent() {
-        final DetailAST detailAST = new DetailAST();
-        final DetailAST javadoc = new DetailAST();
+        final DetailAstImpl detailAST = new DetailAstImpl();
+        final DetailAstImpl javadoc = new DetailAstImpl();
 
         javadoc.setText("1javadoc");
         detailAST.setFirstChild(javadoc);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtilTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import antlr.collections.AST;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -41,7 +43,7 @@ public class ScopeUtilTest {
     @Test
     public void testInClassBlock() {
         assertFalse("Should return false when passed is not class",
-                ScopeUtil.isInClassBlock(new DetailAST()));
+                ScopeUtil.isInClassBlock(new DetailAstImpl()));
         assertFalse("Should return false when passed is not class",
                 ScopeUtil.isInClassBlock(getNode(TokenTypes.LITERAL_NEW,
                         TokenTypes.MODIFIERS)));
@@ -67,7 +69,7 @@ public class ScopeUtilTest {
     @Test
     public void testInEnumBlock() {
         assertFalse("Should return false when passed is not enum",
-                ScopeUtil.isInEnumBlock(new DetailAST()));
+                ScopeUtil.isInEnumBlock(new DetailAstImpl()));
         assertFalse("Should return false when passed is not enum",
                 ScopeUtil.isInEnumBlock(getNode(TokenTypes.LITERAL_NEW,
                         TokenTypes.MODIFIERS)));
@@ -259,11 +261,11 @@ public class ScopeUtilTest {
                 getNode(TokenTypes.ENUM_DEF, TokenTypes.OBJBLOCK)));
     }
 
-    private static DetailAST getNode(int... nodeTypes) {
-        DetailAST ast = new DetailAST();
+    private static DetailAstImpl getNode(int... nodeTypes) {
+        DetailAstImpl ast = new DetailAstImpl();
         ast.setType(nodeTypes[0]);
         for (int i = 1; i < nodeTypes.length; i++) {
-            final DetailAST astChild = new DetailAST();
+            final DetailAstImpl astChild = new DetailAstImpl();
             astChild.setType(nodeTypes[i]);
             ast.addChild(astChild);
             ast = astChild;
@@ -275,8 +277,8 @@ public class ScopeUtilTest {
                                                     int parentTokenType) {
         final DetailAST ast = getNode(parentTokenType, TokenTypes.MODIFIERS, literal);
         ast.setText(scope);
-        final DetailAST ast2 = getNode(TokenTypes.OBJBLOCK);
-        ast.getParent().getParent().addChild(ast2);
+        final DetailAstImpl ast2 = getNode(TokenTypes.OBJBLOCK);
+        ((AST) ast.getParent().getParent()).addChild(ast2);
         return ast;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
@@ -36,6 +36,7 @@ import java.util.TreeMap;
 
 import org.junit.Test;
 
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
@@ -261,11 +262,11 @@ public class TokenUtilTest {
 
     @Test
     public void testFindFirstTokenByPredicate() {
-        final DetailAST astForTest = new DetailAST();
-        final DetailAST child = new DetailAST();
-        final DetailAST firstSibling = new DetailAST();
-        final DetailAST secondSibling = new DetailAST();
-        final DetailAST thirdSibling = new DetailAST();
+        final DetailAstImpl astForTest = new DetailAstImpl();
+        final DetailAstImpl child = new DetailAstImpl();
+        final DetailAstImpl firstSibling = new DetailAstImpl();
+        final DetailAstImpl secondSibling = new DetailAstImpl();
+        final DetailAstImpl thirdSibling = new DetailAstImpl();
         firstSibling.setText("first");
         secondSibling.setText("second");
         thirdSibling.setText("third");
@@ -281,11 +282,11 @@ public class TokenUtilTest {
 
     @Test
     public void testForEachChild() {
-        final DetailAST astForTest = new DetailAST();
-        final DetailAST child = new DetailAST();
-        final DetailAST firstSibling = new DetailAST();
-        final DetailAST secondSibling = new DetailAST();
-        final DetailAST thirdSibling = new DetailAST();
+        final DetailAstImpl astForTest = new DetailAstImpl();
+        final DetailAstImpl child = new DetailAstImpl();
+        final DetailAstImpl firstSibling = new DetailAstImpl();
+        final DetailAstImpl secondSibling = new DetailAstImpl();
+        final DetailAstImpl thirdSibling = new DetailAstImpl();
         firstSibling.setType(TokenTypes.DOT);
         secondSibling.setType(TokenTypes.CLASS_DEF);
         thirdSibling.setType(TokenTypes.IDENT);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/XpathUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/XpathUtilTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
@@ -72,13 +73,13 @@ public class XpathUtilTest {
     }
 
     private static DetailAST createDetailAST(int type) {
-        final DetailAST detailAST = new DetailAST();
+        final DetailAST detailAST = new DetailAstImpl();
         detailAST.setType(type);
         return detailAST;
     }
 
     private static DetailAST createDetailAST(int type, String text) {
-        final DetailAST detailAST = new DetailAST();
+        final DetailAST detailAST = new DetailAstImpl();
         detailAST.setType(type);
         detailAST.setText(text);
         return detailAST;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/ElementNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/ElementNodeTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -104,7 +105,7 @@ public class ElementNodeTest extends AbstractPathTestSupport {
 
     @Test
     public void testGetAttributeValue() {
-        final DetailAST detailAST = new DetailAST();
+        final DetailAST detailAST = new DetailAstImpl();
         detailAST.setType(TokenTypes.IDENT);
         detailAST.setText("HelloWorld");
 
@@ -116,7 +117,7 @@ public class ElementNodeTest extends AbstractPathTestSupport {
 
     @Test
     public void testGetAttributeValueNoAttribute() {
-        final DetailAST detailAST = new DetailAST();
+        final DetailAST detailAST = new DetailAstImpl();
         detailAST.setType(TokenTypes.CLASS_DEF);
         detailAST.setText("HelloWorld");
 
@@ -127,7 +128,7 @@ public class ElementNodeTest extends AbstractPathTestSupport {
 
     @Test
     public void testGetAttributeValueWrongAttribute() {
-        final DetailAST detailAST = new DetailAST();
+        final DetailAST detailAST = new DetailAstImpl();
         detailAST.setType(TokenTypes.IDENT);
         detailAST.setText("HelloWorld");
 
@@ -138,7 +139,7 @@ public class ElementNodeTest extends AbstractPathTestSupport {
 
     @Test
     public void testIterateAxisEmptyChildren() {
-        final DetailAST detailAST = new DetailAST();
+        final DetailAST detailAST = new DetailAstImpl();
         detailAST.setType(TokenTypes.METHOD_DEF);
         final ElementNode elementNode = new ElementNode(rootNode, null, detailAST);
         try (AxisIterator iterator = elementNode.iterateAxis(AxisInfo.CHILD)) {
@@ -151,9 +152,9 @@ public class ElementNodeTest extends AbstractPathTestSupport {
 
     @Test
     public void testIterateAxisWithChildren() {
-        final DetailAST detailAST = new DetailAST();
+        final DetailAstImpl detailAST = new DetailAstImpl();
         detailAST.setType(TokenTypes.METHOD_DEF);
-        final DetailAST childAst = new DetailAST();
+        final DetailAstImpl childAst = new DetailAstImpl();
         childAst.setType(TokenTypes.VARIABLE_DEF);
         detailAST.addChild(childAst);
         final ElementNode elementNode = new ElementNode(rootNode, null, detailAST);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/detailastimpl/InputDetailAstImplJustToMakeStackoverflowError.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/detailastimpl/InputDetailAstImplJustToMakeStackoverflowError.java
@@ -1,5 +1,5 @@
-package com.puppycrawl.tools.checkstyle.api.detailast;
-public class InputDetailASTJustToMakeStackoverflowError {
+package com.puppycrawl.tools.checkstyle.detailastimpl;
+public class InputDetailAstImplJustToMakeStackoverflowError {
   private String str = ""
       +""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""
       +""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""+""


### PR DESCRIPTION
Issue #3417

This split DetailAST (class) into DetailAST (interface) and DetailASTImpl (class).
This also stricted usage of antlr classes everywhere. More will be done in https://github.com/checkstyle/checkstyle/issues/6628 .