### PR TITLE
Issue #6540: correct false positive AnnotationUseStyle

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -513,17 +513,13 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
     private void checkCheckClosingParens(final DetailAST ast) {
         if (closingParens != ClosingParens.IGNORE) {
             final DetailAST paren = ast.getLastChild();
-            final boolean parenExists = paren.getType() == TokenTypes.RPAREN;
 
             if (closingParens == ClosingParens.ALWAYS) {
-                if (!parenExists) {
+                if (paren.getType() != TokenTypes.RPAREN) {
                     log(ast.getLineNo(), MSG_KEY_ANNOTATION_PARENS_MISSING);
                 }
             }
-            else if (parenExists
-                     && !ast.branchContains(TokenTypes.EXPR)
-                     && !ast.branchContains(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR)
-                     && !ast.branchContains(TokenTypes.ANNOTATION_ARRAY_INIT)) {
+            else if (paren.getPreviousSibling().getType() == TokenTypes.LPAREN) {
                 log(ast.getLineNo(), MSG_KEY_ANNOTATION_PARENS_PRESENT);
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
@@ -90,7 +90,6 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
             "41: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
             "43: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
             "47: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "71: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
             "75: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
             "77: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
         };
@@ -131,7 +130,6 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
             "13: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
             "30: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
             "33: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "71: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
             "75: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
             "77: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
         };


### PR DESCRIPTION
Issue: #6540 
The example from original issue (@Anno(@Value)) was already in test class (line 71), but it was in the list of violations for both ALWAYS and NEVER rules therefore it was removed for NEVER-cases.