### PR TITLE
Issue #6586: aligned javadoc/xdoc for FallThrough

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -68,7 +68,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <li>
  * Property {@code groups} - specify list of <b>type import</b> groups (every group identified
  * either by a common prefix string, or by a regular expression enclosed in forward slashes
- * (e.g.{@code /regexp/}). All type imports, which does not match any group, falls into an
+ * (e.g. {@code /regexp/}). All type imports, which does not match any group, falls into an
  * additional group, located at the end.
  * Thus, the empty list of type groups (the default value) means one group for all type imports.
  * Default value is {@code {}}.
@@ -102,9 +102,9 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <li>
  * Property {@code staticGroups} - specify list of <b>static</b> import groups (every group
  * identified either by a common prefix string, or by a regular expression enclosed in forward
- * slashes (e.g.{@code /regexp/}). All static imports, which does not match any group, falls into an
- * additional group, located at the end. Thus, the empty list of static groups (the default value)
- * means one group for all static imports. This property has effect only when the property
+ * slashes (e.g. {@code /regexp/}). All static imports, which does not match any group, falls into
+ * an additional group, located at the end. Thus, the empty list of static groups (the default
+ * value) means one group for all static imports. This property has effect only when the property
  * {@code option} is set to {@code top} or {@code bottom}.
  * Default value is {@code {}}.
  * </li>
@@ -398,7 +398,7 @@ public class ImportOrderCheck
 
     /**
      * Specify list of <b>type import</b> groups (every group identified either by a common prefix
-     * string, or by a regular expression enclosed in forward slashes (e.g.{@code /regexp/}).
+     * string, or by a regular expression enclosed in forward slashes (e.g. {@code /regexp/}).
      * All type imports, which does not match any group, falls into an additional group,
      * located at the end. Thus, the empty list of type groups (the default value) means one group
      * for all type imports.
@@ -407,7 +407,7 @@ public class ImportOrderCheck
 
     /**
      * Specify list of <b>static</b> import groups (every group identified either by a common prefix
-     * string, or by a regular expression enclosed in forward slashes (e.g.{@code /regexp/}).
+     * string, or by a regular expression enclosed in forward slashes (e.g. {@code /regexp/}).
      * All static imports, which does not match any group, falls into an additional group, located
      * at the end. Thus, the empty list of static groups (the default value) means one group for all
      * static imports. This property has effect only when the property {@code option} is set to
@@ -489,7 +489,7 @@ public class ImportOrderCheck
     /**
      * Setter to specify list of <b>type import</b> groups (every group identified either by a
      * common prefix string, or by a regular expression enclosed in forward slashes
-     * (e.g.{@code /regexp/}). All type imports, which does not match any group, falls into an
+     * (e.g. {@code /regexp/}). All type imports, which does not match any group, falls into an
      * additional group, located at the end. Thus, the empty list of type groups (the default value)
      * means one group for all type imports.
      *
@@ -502,7 +502,7 @@ public class ImportOrderCheck
     /**
      * Setter to specify list of <b>static</b> import groups (every group identified either by a
      * common prefix string, or by a regular expression enclosed in forward slashes
-     * (e.g.{@code /regexp/}). All static imports, which does not match any group, falls into an
+     * (e.g. {@code /regexp/}). All static imports, which does not match any group, falls into an
      * additional group, located at the end. Thus, the empty list of static groups (the default
      * value) means one group for all static imports. This property has effect only when
      * the property {@code option} is set to {@code top} or {@code bottom}.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java
@@ -52,7 +52,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * </li>
  * <li>
  * Property {@code skipAnnotations} - specify the list of annotations that allow missed
- * documentation. Only short names are allowed, e.g.{@code Generated}. Default value is
+ * documentation. Only short names are allowed, e.g. {@code Generated}. Default value is
  * {@code Generated}.
  * </li>
  * <li>
@@ -151,7 +151,7 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
 
     /**
      * Specify the list of annotations that allow missed documentation.
-     * Only short names are allowed, e.g.{@code Generated}.
+     * Only short names are allowed, e.g. {@code Generated}.
      */
     private List<String> skipAnnotations = Collections.singletonList("Generated");
 
@@ -173,7 +173,7 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
 
     /**
      * Setter to specify the list of annotations that allow missed documentation.
-     * Only short names are allowed, e.g.{@code Generated}.
+     * Only short names are allowed, e.g. {@code Generated}.
      * @param userAnnotations user's value.
      */
     public void setSkipAnnotations(String... userAnnotations) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -90,6 +90,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         "EmptyStatement",
         "EqualsAvoidNull",
         "EqualsHashCode",
+        "FallThrough",
         "FinalLocalVariable",
         "IllegalInstantiation",
         "IllegalTokenText",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -388,7 +388,9 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         else {
             final char last = text.charAt(text.length() - 1);
 
-            result = (last == ':' || firstCharToAppend == '@' || Character.isAlphabetic(last)
+            result = (firstCharToAppend == '@'
+                    || Character.getType(last) == Character.OTHER_PUNCTUATION
+                    || Character.isAlphabetic(last)
                     || Character.isAlphabetic(firstCharToAppend)) && !Character.isWhitespace(last);
         }
 

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -996,8 +996,8 @@ public class Test {
     </section>
 
     <section name="FallThrough">
+      <p>Since Checkstyle 3.4</p>
       <subsection name="Description" id="FallThrough_Description">
-        <p>Since Checkstyle 3.4</p>
         <p>
           Checks for fall-through in <code>switch</code>
           statements. Finds locations where a <code>case</code>
@@ -1016,7 +1016,7 @@ public class Test {
           (ugly, but possible).
         </p>
         <source>
-switch (i){
+switch (i) {
 case 0:
   i++; // fall through
 
@@ -1040,6 +1040,20 @@ case 5:
           Note: The check assumes that there is no unreachable
           code in the <code>case</code>.
         </p>
+        <p>
+          The following fragment of code will NOT trigger the check,
+          because of the comment "fallthru" and absence of any Java code
+          in case 5.
+        </p>
+        <pre>
+case 3:
+    x = 2;
+    // fallthru
+case 4:
+case 5:
+case 6:
+    break;
+        </pre>
       </subsection>
 
       <subsection name="Properties" id="FallThrough_Properties">
@@ -1054,7 +1068,7 @@ case 5:
           <tr>
             <td>checkLastCaseGroup</td>
             <td>
-              Whether the last case group must be checked.
+              Control whether the last case group must be checked.
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>false</code></td>
@@ -1063,7 +1077,7 @@ case 5:
           <tr>
             <td>reliefPattern</td>
             <td>
-              Regular expression to match the relief comment that suppresses
+              Define the RegExp to match the relief comment that suppresses
               the warning about a fall through.
             </td>
             <td><a href="property_types.html#regexp">Regular Expression</a></td>


### PR DESCRIPTION
Issue #6586 (part of #5750)

Second commit to force a whitespace after period/comma/etc.