### PR TITLE
 Issue #6463: Only handle fields for VARIABLE_DEF in AnnotationLocation check, not local variables

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -147,6 +147,7 @@
       <property name="tokens" value="ANNOTATION_FIELD_DEF"/>
       <property name="tokens" value="PACKAGE_DEF"/>
       <property name="tokens" value="ENUM_CONSTANT_DEF"/>
+      <property name="tokens" value="VARIABLE_DEF"/>
       <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
     </module>
     <module name="AnnotationOnSameLine">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -31,13 +31,20 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Check location of annotation on language elements.
  * By default, Check enforce to locate annotations immediately after
  * documentation block and before target element, annotation should be located
- * on separate line from target element.
+ * on separate line from target element. This check also verifies that the annotations
+ * are on the same indenting level as the annotated element if they are not on the same line.
+ * </p>
+ * <p>
+ * Attention: Elements that cannot have JavaDoc comments like local variables are not in the
+ * scope of this check even though a token type like {@code VARIABLE_DEF} would match them.
  * </p>
  * <p>
  * Attention: Annotations among modifiers are ignored (looks like false-negative)
  * as there might be a problem with annotations for return types:
  * </p>
- * <pre>public @Nullable Long getStartTimeOrNull() { ... }</pre>
+ * <pre>
+ * public @Nullable Long getStartTimeOrNull() { ... }
+ * </pre>
  * <p>
  * Such annotations are better to keep close to type.
  * Due to limitations, Checkstyle can not examine the target of an annotation.
@@ -140,34 +147,6 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
- * <p>
- * The following example demonstrates how the check validates annotations of
- * for-each and for-loop variable definitions.
- * </p>
- * <p>
- * Configuration:
- * </p>
- * <pre>
- * &lt;module name=&quot;AnnotationLocation&quot;&gt;
- *   &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;false&quot;/&gt;
- *   &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
- *     value=&quot;false&quot;/&gt;
- *   &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
- *   &lt;property name=&quot;tokens&quot; value=&quot;VARIABLE_DEF&quot;/&gt;
- *  &lt;/module&gt;
- * </pre>
- * <p>
- * Code example:
- * </p>
- * <pre>
- * public void test(String s) {
- *   ...
- *   for (&#64;MyAnnotation char c : s.toCharArray()) { ... }  // OK
- *   ...
- *   for (&#64;MyAnnotation int i = 0; i &lt; 10; i++) { ... } // OK
- *   ...
- * }
- * </pre>
  *
  * @since 6.0
  */
@@ -185,10 +164,6 @@ public class AnnotationLocationCheck extends AbstractCheck {
      * file.
      */
     public static final String MSG_KEY_ANNOTATION_LOCATION = "annotation.location";
-
-    /** Array of single line annotation parents. */
-    private static final int[] SINGLELINE_ANNOTATION_PARENTS = {TokenTypes.FOR_EACH_CLAUSE,
-                                                                TokenTypes.FOR_INIT, };
 
     /**
      * Allow single parameterless annotation to be located on the same line as
@@ -272,11 +247,15 @@ public class AnnotationLocationCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        DetailAST node = ast.findFirstToken(TokenTypes.MODIFIERS);
-        if (node == null) {
-            node = ast.findFirstToken(TokenTypes.ANNOTATIONS);
+        // ignore variable def tokens that are not field definitions
+        if (ast.getType() != TokenTypes.VARIABLE_DEF
+                || ast.getParent().getType() == TokenTypes.OBJBLOCK) {
+            DetailAST node = ast.findFirstToken(TokenTypes.MODIFIERS);
+            if (node == null) {
+                node = ast.findFirstToken(TokenTypes.ANNOTATIONS);
+            }
+            checkAnnotations(node, getExpectedAnnotationIndentation(node));
         }
-        checkAnnotations(node, getExpectedAnnotationIndentation(node));
     }
 
     /**
@@ -348,8 +327,7 @@ public class AnnotationLocationCheck extends AbstractCheck {
      * the value of {@link AnnotationLocationCheck#allowSamelineParameterizedAnnotation};
      * 2) checks parameterless annotation location considering
      * the value of {@link AnnotationLocationCheck#allowSamelineSingleParameterlessAnnotation};
-     * 3) checks annotation location considering the elements
-     * of {@link AnnotationLocationCheck#SINGLELINE_ANNOTATION_PARENTS};
+     * 3) checks annotation location;
      * @param annotation annotation node.
      * @param hasParams whether an annotation has parameters.
      * @return true if the annotation has a correct location.
@@ -365,8 +343,7 @@ public class AnnotationLocationCheck extends AbstractCheck {
         }
         return allowSamelineMultipleAnnotations
             || allowingCondition && !hasNodeBefore(annotation)
-            || !allowingCondition && (!hasNodeBeside(annotation)
-            || isAllowedPosition(annotation, SINGLELINE_ANNOTATION_PARENTS));
+            || !hasNodeBeside(annotation);
     }
 
     /**
@@ -404,41 +381,6 @@ public class AnnotationLocationCheck extends AbstractCheck {
         }
 
         return annotationLineNo == nextNode.getLineNo();
-    }
-
-    /**
-     * Checks whether position of annotation is allowed.
-     * @param annotation annotation token.
-     * @param allowedPositions an array of allowed annotation positions.
-     * @return true if position of annotation is allowed.
-     */
-    private static boolean isAllowedPosition(DetailAST annotation, int... allowedPositions) {
-        boolean allowed = false;
-        for (int position : allowedPositions) {
-            if (isInSpecificCodeBlock(annotation, position)) {
-                allowed = true;
-                break;
-            }
-        }
-        return allowed;
-    }
-
-    /**
-     * Checks whether the scope of a node is restricted to a specific code block.
-     * @param node node.
-     * @param blockType block type.
-     * @return true if the scope of a node is restricted to a specific code block.
-     */
-    private static boolean isInSpecificCodeBlock(DetailAST node, int blockType) {
-        boolean returnValue = false;
-        for (DetailAST token = node.getParent(); token != null; token = token.getParent()) {
-            final int type = token.getType();
-            if (type == blockType) {
-                returnValue = true;
-                break;
-            }
-        }
-        return returnValue;
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
@@ -306,8 +306,6 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
             "23: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
             "25: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
             "27: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
-            "31: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
-            "33: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
         };
         verify(checkConfig, getPath("InputAnnotationLocationSingleParameterless.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationSingleParameterless.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationSingleParameterless.java
@@ -28,9 +28,9 @@ class InputAnnotationLocationSingleParameterless {
 
     void parameterlessSamelineInForEach() {
         for (@Annotation Object o : new Object[0]) break; //ok
-        for (@Annotation @Annotation Object o : new Object[0]) break; //warn
+        for (@Annotation @Annotation Object o : new Object[0]) break; //ok
         for (@Annotation Object o;;) break; // ok
-        for (@Annotation @Annotation Object o;;) break; //warn
+        for (@Annotation @Annotation Object o;;) break; //ok
     }
 
     @Repeatable(Annotations.class)

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -29,7 +29,13 @@
           Check location of annotation on language elements.
           By default, Check enforce to locate annotations immediately after documentation block
           and before target element, annotation should be located on separate line from target
-          element.
+          element. This check also verifies that the annotations are on the same indenting level as
+          the annotated element if they are not on the same line.
+        </p>
+        <p>
+          Attention: Elements that cannot have JavaDoc comments like local variables are not in the
+          scope of this check even though a token type like <code>VARIABLE_DEF</code> would match
+          them.
         </p>
         <p>
           Attention: Annotations among modifiers are ignored (looks like false-negative)
@@ -186,30 +192,6 @@ public String getNameIfPresent() { ... }
   &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
-       <p>
-         The following example demonstrates how the check validates annotations of
-         for-each and for-loop variable definitions.
-       </p>
-       <p>Configuration:</p>
-       <source>
-&lt;module name=&quot;AnnotationLocation&quot;&gt;
-  &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;false&quot;/&gt;
-  &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
-    value=&quot;false&quot;/&gt;
-  &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
-  &lt;property name=&quot;tokens&quot; value=&quot;VARIABLE_DEF&quot;/&gt;
- &lt;/module&gt;
-       </source>
-       <p>Code example:</p>
-       <source>
-public void test(String s) {
-  ...
-  for (&#64;MyAnnotation char c : s.toCharArray()) { ... }  // OK
-  ...
-  for (&#64;MyAnnotation int i = 0; i &lt; 10; i++) { ... } // OK
-  ...
-}
-       </source>
       </subsection>
 
       <subsection name="Example of Usage" id="AnnotationLocation_Example_of_Usage">


### PR DESCRIPTION
Splitting followup part 2 for #6530
Fixes #6463
Regression report: http://kautler.net/cs-regression-6463/

Draft because based on fix for #6462, will rebase and un-draft once #6653 was merged.