### PR TITLE
config: remove oracle-java8-installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
     packages:
       - xsltproc
       - xmlstarlet
-      - oracle-java8-installer
 
 branches:
   only:


### PR DESCRIPTION
It seems that we do not need the package 'oracle-java8-installer'.
This is some kind of atavism. It is not needed for the build process, since the `jdk-switcher` does its job well.