### PR TITLE
minor: Small fix in unit tests: Extract initial setup into before method

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheckTest.java
@@ -24,6 +24,7 @@ import static com.puppycrawl.tools.checkstyle.checks.DescendantTokenCheck.MSG_KE
 import static com.puppycrawl.tools.checkstyle.checks.DescendantTokenCheck.MSG_KEY_SUM_MAX;
 import static com.puppycrawl.tools.checkstyle.checks.DescendantTokenCheck.MSG_KEY_SUM_MIN;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -32,16 +33,20 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
 
+    private DefaultConfiguration checkConfig;
     @Override
     protected String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/descendanttoken";
     }
 
+    @Before
+    public void setup() {
+        checkConfig = createModuleConfig(DescendantTokenCheck.class);
+    }
+
     @Test
     public void testDefault()
             throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(DescendantTokenCheck.class);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputDescendantTokenIllegalTokens.java"), expected);
     }
@@ -49,8 +54,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMaximumNumber()
             throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_NATIVE");
         checkConfig.addAttribute("limitedTokens", "LITERAL_NATIVE");
         checkConfig.addAttribute("maximumNumber", "0");
@@ -63,8 +66,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMessage()
             throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_NATIVE");
         checkConfig.addAttribute("limitedTokens", "LITERAL_NATIVE");
         checkConfig.addAttribute("maximumNumber", "0");
@@ -78,8 +79,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMinimumNumber()
             throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_SWITCH");
         checkConfig.addAttribute("limitedTokens", "LITERAL_DEFAULT");
         checkConfig.addAttribute("minimumNumber", "2");
@@ -92,8 +91,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMinimumDepth()
             throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_SWITCH");
         checkConfig.addAttribute("limitedTokens", "LITERAL_DEFAULT");
         checkConfig.addAttribute("maximumNumber", "0");
@@ -105,8 +102,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMaximumDepth()
             throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_SWITCH");
         checkConfig.addAttribute("limitedTokens", "LITERAL_DEFAULT");
         checkConfig.addAttribute("maximumNumber", "0");
@@ -118,8 +113,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testEmptyStatements()
             throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "EMPTY_STAT");
         checkConfig.addAttribute("limitedTokens", "EMPTY_STAT");
         checkConfig.addAttribute("maximumNumber", "0");
@@ -150,8 +143,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testMissingSwitchDefault() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_SWITCH");
         checkConfig.addAttribute("limitedTokens", "LITERAL_DEFAULT");
         checkConfig.addAttribute("minimumNumber", "1");
@@ -167,8 +158,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testStringLiteralEquality() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "EQUAL,NOT_EQUAL");
         checkConfig.addAttribute("limitedTokens", "STRING_LITERAL");
         checkConfig.addAttribute("maximumNumber", "0");
@@ -186,8 +175,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testIllegalTokenDefault() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_SWITCH, POST_INC, POST_DEC");
         checkConfig.addAttribute("limitedTokens", "LITERAL_SWITCH, POST_INC, POST_DEC");
         checkConfig.addAttribute("maximumNumber", "0");
@@ -204,8 +191,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testIllegalTokenNative() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_NATIVE");
         checkConfig.addAttribute("limitedTokens", "LITERAL_NATIVE");
         checkConfig.addAttribute("maximumNumber", "0");
@@ -220,8 +205,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testReturnFromCatch() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(DescendantTokenCheck.class);
-
         checkConfig.addAttribute("tokens", "LITERAL_CATCH");
         checkConfig.addAttribute("limitedTokens", "LITERAL_RETURN");
         checkConfig.addAttribute("maximumNumber", "0");
@@ -237,8 +220,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testReturnFromFinally() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(DescendantTokenCheck.class);
-
         checkConfig.addAttribute("tokens", "LITERAL_FINALLY");
         checkConfig.addAttribute("limitedTokens", "LITERAL_RETURN");
         checkConfig.addAttribute("maximumNumber", "0");
@@ -254,8 +235,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testNoSum() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(DescendantTokenCheck.class);
-
         checkConfig.addAttribute("tokens", "NOT_EQUAL,EQUAL");
         checkConfig.addAttribute("limitedTokens", "LITERAL_THIS,LITERAL_NULL");
         checkConfig.addAttribute("maximumNumber", "1");
@@ -268,7 +247,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testWithSumCustomMsg() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "NOT_EQUAL,EQUAL");
         checkConfig.addAttribute("limitedTokens", "LITERAL_THIS,LITERAL_NULL");
         checkConfig.addAttribute("maximumNumber", "1");
@@ -288,7 +266,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testWithSumDefaultMsg() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "NOT_EQUAL,EQUAL");
         checkConfig.addAttribute("limitedTokens", "LITERAL_THIS,LITERAL_NULL");
         checkConfig.addAttribute("maximumNumber", "1");
@@ -307,7 +284,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testWithSumLessThenMinDefMsg() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "NOT_EQUAL,EQUAL");
         checkConfig.addAttribute("limitedTokens", "LITERAL_THIS,LITERAL_NULL");
         checkConfig.addAttribute("minimumNumber", "3");
@@ -328,7 +304,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testWithSumLessThenMinCustomMsg() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "NOT_EQUAL,EQUAL");
         checkConfig.addAttribute("limitedTokens", "LITERAL_THIS,LITERAL_NULL");
         checkConfig.addAttribute("minimumNumber", "3");
@@ -350,8 +325,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testMaxTokenType() throws Exception {
-        final DefaultConfiguration checkConfig =
-                createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "OBJBLOCK");
         checkConfig.addAttribute("limitedTokens", "LCURLY,RCURLY");
         checkConfig.addAttribute("maximumNumber", "0");
@@ -365,8 +338,6 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testMaxTokenTypeReverseOrder() throws Exception {
-        final DefaultConfiguration checkConfig =
-                createModuleConfig(DescendantTokenCheck.class);
         checkConfig.addAttribute("tokens", "OBJBLOCK");
         checkConfig.addAttribute("limitedTokens", "RCURLY,LCURLY");
         checkConfig.addAttribute("maximumNumber", "0");
@@ -377,5 +348,4 @@ public class DescendantTokenCheckTest extends AbstractModuleTestSupport {
         };
         verify(checkConfig, getPath("InputDescendantTokenLastTokenType.java"), expected);
     }
-
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.FinalParametersCheck.MSG_KEY;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -29,15 +30,20 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class FinalParametersCheckTest extends AbstractModuleTestSupport {
 
+    private DefaultConfiguration checkConfig;
+
     @Override
     protected String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/finalparameters";
     }
+	
+    @Before
+    public void setup() {
+        checkConfig = createModuleConfig(FinalParametersCheck.class);
+    }
 
     @Test
     public void testDefaultTokens() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(FinalParametersCheck.class);
         final String[] expected = {
             "23:26: " + getCheckMessage(MSG_KEY, "s"),
             "38:26: " + getCheckMessage(MSG_KEY, "i"),
@@ -56,8 +62,6 @@ public class FinalParametersCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testCtorToken() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(FinalParametersCheck.class);
         checkConfig.addAttribute("tokens", "CTOR_DEF");
         final String[] expected = {
             "23:26: " + getCheckMessage(MSG_KEY, "s"),
@@ -69,8 +73,6 @@ public class FinalParametersCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testMethodToken() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(FinalParametersCheck.class);
         checkConfig.addAttribute("tokens", "METHOD_DEF");
         final String[] expected = {
             "53:17: " + getCheckMessage(MSG_KEY, "s"),
@@ -87,8 +89,6 @@ public class FinalParametersCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testCatchToken() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(FinalParametersCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_CATCH");
         final String[] expected = {
             "125:16: " + getCheckMessage(MSG_KEY, "npe"),
@@ -100,8 +100,6 @@ public class FinalParametersCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testForEachClauseToken() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(FinalParametersCheck.class);
         checkConfig.addAttribute("tokens", "FOR_EACH_CLAUSE");
         final String[] expected = {
             "152:13: " + getCheckMessage(MSG_KEY, "s"),
@@ -112,8 +110,6 @@ public class FinalParametersCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testIgnorePrimitiveTypesParameters() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(FinalParametersCheck.class);
         checkConfig.addAttribute("ignorePrimitiveTypes", "true");
         final String[] expected = {
             "6:22: " + getCheckMessage(MSG_KEY, "k"),
@@ -129,8 +125,6 @@ public class FinalParametersCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testPrimitiveTypesParameters() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(FinalParametersCheck.class);
         final String[] expected = {
             "5:14: " + getCheckMessage(MSG_KEY, "i"),
             "6:15: " + getCheckMessage(MSG_KEY, "i"),
@@ -152,8 +146,6 @@ public class FinalParametersCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testReceiverParameters() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(FinalParametersCheck.class);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputFinalParametersReceiver.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
@@ -46,15 +47,20 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 public class NewlineAtEndOfFileCheckTest
     extends AbstractModuleTestSupport {
 
+    private DefaultConfiguration checkConfig;
+
     @Override
     protected String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/newlineatendoffile";
     }
+	
+    @Before
+    public void setup() {
+        checkConfig = createModuleConfig(NewlineAtEndOfFileCheck.class);
+    }
 
     @Test
     public void testNewlineLfAtEndOfFile() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(NewlineAtEndOfFileCheck.class);
         checkConfig.addAttribute("lineSeparator", LineSeparatorOption.LF.toString());
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(
@@ -65,8 +71,6 @@ public class NewlineAtEndOfFileCheckTest
 
     @Test
     public void testNewlineCrlfAtEndOfFile() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(NewlineAtEndOfFileCheck.class);
         checkConfig.addAttribute("lineSeparator", LineSeparatorOption.CRLF.toString());
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(
@@ -77,8 +81,6 @@ public class NewlineAtEndOfFileCheckTest
 
     @Test
     public void testNewlineCrAtEndOfFile() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(NewlineAtEndOfFileCheck.class);
         checkConfig.addAttribute("lineSeparator", LineSeparatorOption.CR.toString());
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(
@@ -89,8 +91,6 @@ public class NewlineAtEndOfFileCheckTest
 
     @Test
     public void testAnyNewlineAtEndOfFile() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(NewlineAtEndOfFileCheck.class);
         checkConfig.addAttribute("lineSeparator", LineSeparatorOption.LF_CR_CRLF.toString());
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(
@@ -109,8 +109,6 @@ public class NewlineAtEndOfFileCheckTest
 
     @Test
     public void testNoNewlineLfAtEndOfFile() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(NewlineAtEndOfFileCheck.class);
         checkConfig.addAttribute("lineSeparator", LineSeparatorOption.LF.toString());
         final String[] expected = {
             "1: " + getCheckMessage(MSG_KEY_NO_NEWLINE_EOF),
@@ -123,8 +121,6 @@ public class NewlineAtEndOfFileCheckTest
 
     @Test
     public void testNoNewlineAtEndOfFile() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(NewlineAtEndOfFileCheck.class);
         checkConfig.addAttribute("lineSeparator", LineSeparatorOption.LF_CR_CRLF.toString());
         final String[] expected = {
             "1: " + getCheckMessage(MSG_KEY_NO_NEWLINE_EOF),
@@ -138,8 +134,6 @@ public class NewlineAtEndOfFileCheckTest
     @Test
     public void testSetLineSeparatorFailure()
             throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(NewlineAtEndOfFileCheck.class);
         checkConfig.addAttribute("lineSeparator", "ct");
         try {
             createChecker(checkConfig);
@@ -156,8 +150,6 @@ public class NewlineAtEndOfFileCheckTest
 
     @Test
     public void testEmptyFileFile() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(NewlineAtEndOfFileCheck.class);
         checkConfig.addAttribute("lineSeparator", LineSeparatorOption.LF.toString());
         final String[] expected = {
             "1: " + getCheckMessage(MSG_KEY_NO_NEWLINE_EOF),
@@ -170,8 +162,6 @@ public class NewlineAtEndOfFileCheckTest
 
     @Test
     public void testFileWithEmptyLineOnly() throws Exception {
-        final DefaultConfiguration checkConfig =
-                createModuleConfig(NewlineAtEndOfFileCheck.class);
         checkConfig.addAttribute("lineSeparator", LineSeparatorOption.LF.toString());
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(
@@ -182,7 +172,6 @@ public class NewlineAtEndOfFileCheckTest
 
     @Test
     public void testWrongFile() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(NewlineAtEndOfFileCheck.class);
         final NewlineAtEndOfFileCheck check = new NewlineAtEndOfFileCheck();
         check.configure(checkConfig);
         final List<String> lines = new ArrayList<>(1);


### PR DESCRIPTION
Removing some redundancy from a couple of unit tests by extracting common setup into a before-method.