### PR TITLE
Issue #6694: refactor AbbreviationAsWordInName to recognize numbers

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -379,7 +379,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
                     beginIndex = index;
                 }
             }
-            else if (abbrStarted) {
+            else if (abbrStarted && !Character.isDigit(symbol)) {
                 abbrStarted = false;
 
                 final int endIndex = index - 1;


### PR DESCRIPTION
Issue: https://github.com/checkstyle/checkstyle/pull/6694

Recognizes numbers as part of abbreviations, as described in the issue.
