### PR TITLE
minor: add missing deprecated on JavadocMethod properties

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -277,7 +277,9 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * false.
      *
      * @param flag a {@code Boolean} value
+     * @deprecated Use {@link MissingJavadocMethodCheck} instead.
      */
+    @Deprecated
     public void setAllowMissingJavadoc(boolean flag) {
         // deprecated
     }
@@ -287,7 +289,9 @@ public class JavadocMethodCheck extends AbstractTypeAwareCheck {
      * property accessor (setter/getter methods). Defaults to false.
      *
      * @param flag a {@code Boolean} value
+     * @deprecated Use {@link MissingJavadocMethodCheck} instead.
      */
+    @Deprecated
     public void setAllowMissingPropertyJavadoc(final boolean flag) {
         // deprecated
     }


### PR DESCRIPTION
Missed marking some properties as deprecated.