### PR TITLE
Issue #6749: aligned javadoc/xdoc for NoWhitespaceAfter

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -49,7 +49,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </p>
  * <ul>
  * <li>
- * Property {@code allowLineBreaks} - Control whether whitespace is flagged at linebreaks.
+ * Property {@code allowLineBreaks} - Control whether whitespace is allowed
+ * if the token is at a linebreak.
  * Default value is {@code true}.
  * </li>
  * <li>
@@ -111,7 +112,7 @@ public class NoWhitespaceAfterCheck extends AbstractCheck {
      */
     public static final String MSG_KEY = "ws.followed";
 
-    /** Control whether whitespace is flagged at linebreaks. */
+    /** Control whether whitespace is allowed if the token is at a linebreak. */
     private boolean allowLineBreaks = true;
 
     @Override
@@ -157,7 +158,7 @@ public class NoWhitespaceAfterCheck extends AbstractCheck {
     }
 
     /**
-     * Setter to control whether whitespace is flagged at linebreaks.
+     * Setter to control whether whitespace is allowed if the token is at a linebreak.
      * @param allowLineBreaks whether whitespace should be
      *     flagged at linebreaks.
      */

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1059,7 +1059,7 @@ import static java.math.BigInteger.ZERO;
           <tr>
             <td>allowLineBreaks</td>
             <td>
-              Control whether whitespace is flagged at linebreaks.
+              Control whether whitespace is allowed if the token is at a linebreak.
             </td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
             <td><code>true</code></td>


### PR DESCRIPTION
Issue #6749 (sequel for #6763) 

Minor changes to keep in sync with `NoWhitespaceBefore`