### PR TITLE
Xdoc 'properties' subsection shoud be just one table

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -595,7 +595,17 @@ public class XdocsPagesTest {
             Assert.assertTrue(fileName + " section '" + sectionName
                     + "' should have no properties to show", !properties.isEmpty());
 
-            validatePropertySectionProperties(fileName, sectionName, subSection, instance,
+            final Set<Node> nodes = XmlUtil.getChildrenElements(subSection);
+            Assert.assertEquals(fileName + " section '" + sectionName
+                    + "' subsection 'Properties' should have one child node",
+                1, nodes.size());
+
+            final Node table = nodes.iterator().next();
+            Assert.assertEquals(fileName + " section '" + sectionName
+                    + "' subsection 'Properties' has unexpected child node",
+                "table", table.getNodeName());
+
+            validatePropertySectionProperties(fileName, sectionName, table, instance,
                     properties);
         }
 
@@ -663,12 +673,12 @@ public class XdocsPagesTest {
     }
 
     private static void validatePropertySectionProperties(String fileName, String sectionName,
-            Node subSection, Object instance, Set<String> properties) throws Exception {
+            Node table, Object instance, Set<String> properties) throws Exception {
         boolean skip = true;
         boolean didJavadocTokens = false;
         boolean didTokens = false;
 
-        for (Node row : XmlUtil.getChildrenElements(XmlUtil.getFirstChildElement(subSection))) {
+        for (Node row : XmlUtil.getChildrenElements(table)) {
             final List<Node> columns = new ArrayList<>(XmlUtil.getChildrenElements(row));
 
             Assert.assertEquals(fileName + " section '" + sectionName

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -175,6 +175,8 @@
                   <td>3.5</td>
               </tr>
           </table>
+      </subsection>
+      <subsection name="Notes" id="SuppressionCommentFilter_Notes">
           <p>
               offCommentFormat and onCommentFormat must have equal
               <a href="https://docs.oracle.com/javase/7/docs/api/java/util/regex/Matcher.html#groupCount()">
@@ -476,6 +478,8 @@ public class UserService {
                <td>6.15</td>
              </tr>
           </table>
+      </subsection>
+      <subsection name="Notes" id="SuppressionFilter_Notes">
           <p>
             A <a href="dtds/suppressions_1_2.dtd"><em>suppressions XML
             document</em></a> contains a set
@@ -1982,6 +1986,8 @@ public class UserService {
                       <td>8.6</td>
                   </tr>
               </table>
+          </subsection>
+          <subsection name="Notes" id="SuppressWithPlainTextCommentFilter_Notes">
               <p>
                   offCommentFormat and onCommentFormat must have equal
                   <a href="https://docs.oracle.com/javase/7/docs/api/java/util/regex/Matcher.html#groupCount()">


### PR DESCRIPTION
Issue #6800

This PR affects only `xdocs/config_filters.xml`, other xdocs are OK.