### PR TITLE
Issue #4764: fix false-positive violation in NeedBracesCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.blocks;
 
+import java.util.Optional;
+
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -189,33 +191,67 @@ public class NeedBracesCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        final DetailAST slistAST = ast.findFirstToken(TokenTypes.SLIST);
-        boolean isElseIf = false;
-        if (ast.getType() == TokenTypes.LITERAL_ELSE
-            && ast.findFirstToken(TokenTypes.LITERAL_IF) != null) {
-            isElseIf = true;
-        }
-        final boolean isInAnnotationField = isInAnnotationField(ast);
-        final boolean skipStatement = isSkipStatement(ast);
-        final boolean skipEmptyLoopBody = allowEmptyLoopBody && isEmptyLoopBody(ast);
-
-        if (slistAST == null && !isElseIf && !isInAnnotationField
-                && !skipStatement && !skipEmptyLoopBody) {
+        final boolean hasNoSlist = ast.findFirstToken(TokenTypes.SLIST) == null;
+        if (hasNoSlist && !isSkipStatement(ast) && isBracesNeeded(ast)) {
             log(ast.getLineNo(), MSG_KEY_NEED_BRACES, ast.getText());
         }
     }
 
     /**
-     * Checks if ast is in an annotation field.
-     * @param ast ast to test.
-     * @return true if current ast is part of an annotation field.
+     * Checks if token needs braces.
+     * Some tokens have additional conditions:
+     * <ul>
+     *     <li>{@link TokenTypes#LITERAL_FOR}</li>
+     *     <li>{@link TokenTypes#LITERAL_WHILE}</li>
+     *     <li>{@link TokenTypes#LITERAL_CASE}</li>
+     *     <li>{@link TokenTypes#LITERAL_DEFAULT}</li>
+     *     <li>{@link TokenTypes#LITERAL_ELSE}</li>
+     * </ul>
+     * For all others default value {@code true} is returned.
+     * @param ast token to check
+     * @return result of additional checks for specific token types,
+     * {@code true} if there is no additional checks for token
      */
-    private static boolean isInAnnotationField(DetailAST ast) {
-        boolean isDefaultInAnnotation = false;
-        if (ast.getParent().getType() == TokenTypes.ANNOTATION_FIELD_DEF) {
-            isDefaultInAnnotation = true;
+    private boolean isBracesNeeded(DetailAST ast) {
+        final boolean result;
+        switch (ast.getType()) {
+            case TokenTypes.LITERAL_FOR:
+            case TokenTypes.LITERAL_WHILE:
+                result = !isEmptyLoopBodyAllowed(ast);
+                break;
+            case TokenTypes.LITERAL_CASE:
+            case TokenTypes.LITERAL_DEFAULT:
+                result = hasUnbracedStatements(ast);
+                break;
+            case TokenTypes.LITERAL_ELSE:
+                result = ast.findFirstToken(TokenTypes.LITERAL_IF) == null;
+                break;
+            default:
+                result = true;
+                break;
         }
-        return isDefaultInAnnotation;
+        return result;
+    }
+
+    /**
+     * Checks if current loop has empty body and can be skipped by this check.
+     * @param ast for, while statements.
+     * @return true if current loop can be skipped by check.
+     */
+    private boolean isEmptyLoopBodyAllowed(DetailAST ast) {
+        return allowEmptyLoopBody && ast.findFirstToken(TokenTypes.EMPTY_STAT) != null;
+    }
+
+    /**
+     * Checks if switch member (case, default statements) has statements without curly braces.
+     * @param ast case, default statements.
+     * @return true if switch member has unbraced statements, false otherwise.
+     */
+    private static boolean hasUnbracedStatements(DetailAST ast) {
+        final DetailAST nextSibling = ast.getNextSibling();
+        return nextSibling != null
+            && nextSibling.getType() == TokenTypes.SLIST
+            && nextSibling.getFirstChild().getType() != TokenTypes.SLIST;
     }
 
     /**
@@ -228,29 +264,13 @@ public class NeedBracesCheck extends AbstractCheck {
     }
 
     /**
-     * Checks if current loop statement does not have body, e.g.:
-     * <p>
-     * {@code
-     *   while (value.incrementValue() < 5);
-     *   ...
-     *   for(int i = 0; i < 10; value.incrementValue());
-     * }
-     * </p>
-     * @param ast ast token.
-     * @return true if current loop statement does not have body.
+     * Checks if two ast nodes are on the same line.
+     * @param first ast to check
+     * @param second ast to check
+     * @return true if elements on same line, false otherwise
      */
-    private static boolean isEmptyLoopBody(DetailAST ast) {
-        boolean noBodyLoop = false;
-
-        if (ast.getType() == TokenTypes.LITERAL_FOR
-                || ast.getType() == TokenTypes.LITERAL_WHILE) {
-            DetailAST currentToken = ast.getFirstChild();
-            while (currentToken.getNextSibling() != null) {
-                currentToken = currentToken.getNextSibling();
-            }
-            noBodyLoop = currentToken.getType() == TokenTypes.EMPTY_STAT;
-        }
-        return noBodyLoop;
+    private static boolean isOnSameLine(DetailAST first, DetailAST second) {
+        return first.getLineNo() == second.getLineNo();
     }
 
     /**
@@ -288,10 +308,8 @@ public class NeedBracesCheck extends AbstractCheck {
                 result = isSingleLineLambda(statement);
                 break;
             case TokenTypes.LITERAL_CASE:
-                result = isSingleLineCase(statement);
-                break;
             case TokenTypes.LITERAL_DEFAULT:
-                result = isSingleLineDefault(statement);
+                result = isSingleLineSwitchMember(statement);
                 break;
             default:
                 result = isSingleLineElse(statement);
@@ -315,7 +333,7 @@ public class NeedBracesCheck extends AbstractCheck {
         boolean result = false;
         if (literalWhile.getParent().getType() == TokenTypes.SLIST) {
             final DetailAST block = literalWhile.getLastChild().getPreviousSibling();
-            result = literalWhile.getLineNo() == block.getLineNo();
+            result = isOnSameLine(literalWhile, block);
         }
         return result;
     }
@@ -334,7 +352,7 @@ public class NeedBracesCheck extends AbstractCheck {
         boolean result = false;
         if (literalDo.getParent().getType() == TokenTypes.SLIST) {
             final DetailAST block = literalDo.getFirstChild();
-            result = block.getLineNo() == literalDo.getLineNo();
+            result = isOnSameLine(block, literalDo);
         }
         return result;
     }
@@ -355,7 +373,7 @@ public class NeedBracesCheck extends AbstractCheck {
             result = true;
         }
         else if (literalFor.getParent().getType() == TokenTypes.SLIST) {
-            result = literalFor.getLineNo() == literalFor.getLastChild().getLineNo();
+            result = isOnSameLine(literalFor, literalFor.getLastChild());
         }
         return result;
     }
@@ -382,7 +400,7 @@ public class NeedBracesCheck extends AbstractCheck {
                 block = literalIfLastChild;
             }
             final DetailAST ifCondition = literalIf.findFirstToken(TokenTypes.EXPR);
-            result = ifCondition.getLineNo() == block.getLineNo();
+            result = isOnSameLine(ifCondition, block);
         }
         return result;
     }
@@ -399,61 +417,29 @@ public class NeedBracesCheck extends AbstractCheck {
      */
     private static boolean isSingleLineLambda(DetailAST lambda) {
         final DetailAST block = lambda.getLastChild();
-        return lambda.getLineNo() == block.getLineNo();
+        return isOnSameLine(lambda, block);
     }
 
     /**
-     * Checks if current case statement is single-line statement, e.g.:
+     * Checks if switch member (case or default statement) is single-line statement, e.g.:
      * <p>
      * {@code
      * case 1: doSomeStuff(); break;
      * case 2: doSomeStuff(); break;
      * case 3: ;
+     * default: doSomeStuff();break;
      * }
      * </p>
-     * @param literalCase {@link TokenTypes#LITERAL_CASE case statement}.
-     * @return true if current case statement is single-line statement.
+     * @param ast {@link TokenTypes#LITERAL_CASE case statement} or
+     * {@link TokenTypes#LITERAL_DEFAULT default statement}.
+     * @return true if current switch member is single-line statement.
      */
-    private static boolean isSingleLineCase(DetailAST literalCase) {
-        boolean result = false;
-        final DetailAST slist = literalCase.getNextSibling();
-        if (slist == null) {
-            result = true;
-        }
-        else {
-            final DetailAST caseBreak = slist.findFirstToken(TokenTypes.LITERAL_BREAK);
-            if (caseBreak != null) {
-                final DetailAST block = slist.getFirstChild();
-                final boolean atOneLine = literalCase.getLineNo() == block.getLineNo();
-                result = atOneLine && block.getLineNo() == caseBreak.getLineNo();
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Checks if current default statement is single-line statement, e.g.:
-     * <p>
-     * {@code
-     * default: doSomeStuff();
-     * }
-     * </p>
-     * @param literalDefault {@link TokenTypes#LITERAL_DEFAULT default statement}.
-     * @return true if current default statement is single-line statement.
-     */
-    private static boolean isSingleLineDefault(DetailAST literalDefault) {
-        boolean result = false;
-        final DetailAST slist = literalDefault.getNextSibling();
-        if (slist == null) {
-            result = true;
-        }
-        else {
-            final DetailAST block = slist.getFirstChild();
-            if (block != null && block.getType() != TokenTypes.SLIST) {
-                result = literalDefault.getLineNo() == block.getLineNo();
-            }
-        }
-        return result;
+    private static boolean isSingleLineSwitchMember(DetailAST ast) {
+        return Optional.of(ast)
+                .map(DetailAST::getNextSibling)
+                .map(DetailAST::getLastChild)
+                .map(lastToken -> isOnSameLine(ast, lastToken))
+                .orElse(true);
     }
 
     /**
@@ -468,7 +454,7 @@ public class NeedBracesCheck extends AbstractCheck {
      */
     private static boolean isSingleLineElse(DetailAST literalElse) {
         final DetailAST block = literalElse.getFirstChild();
-        return literalElse.getLineNo() == block.getLineNo();
+        return isOnSameLine(literalElse, block);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheckTest.java
@@ -93,7 +93,6 @@ public class NeedBracesCheckTest extends AbstractModuleTestSupport {
             "106: " + getCheckMessage(MSG_KEY_NEED_BRACES, "do"),
             "107: " + getCheckMessage(MSG_KEY_NEED_BRACES, "if"),
             "108: " + getCheckMessage(MSG_KEY_NEED_BRACES, "for"),
-            "110: " + getCheckMessage(MSG_KEY_NEED_BRACES, "default"),
         };
         verify(checkConfig, getPath("InputNeedBraces.java"), expected);
     }
@@ -132,6 +131,19 @@ public class NeedBracesCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testDoNotAllowSingleLineLambda() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(NeedBracesCheck.class);
+        checkConfig.addAttribute("tokens", "LAMBDA");
+        final String[] expected = {
+            "5: " + getCheckMessage(MSG_KEY_NEED_BRACES, "->"),
+            "6: " + getCheckMessage(MSG_KEY_NEED_BRACES, "->"),
+            "7: " + getCheckMessage(MSG_KEY_NEED_BRACES, "->"),
+        };
+        verify(checkConfig, getPath("InputNeedBracesSingleLineLambda.java"), expected);
+    }
+
+    @Test
     public void testSingleLineCaseDefault() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(NeedBracesCheck.class);
@@ -140,6 +152,8 @@ public class NeedBracesCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "72: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
             "75: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
+            "122: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
+            "124: " + getCheckMessage(MSG_KEY_NEED_BRACES, "default"),
         };
         verify(checkConfig, getPath("InputNeedBracesSingleLineStatements.java"), expected);
     }
@@ -152,6 +166,22 @@ public class NeedBracesCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("allowSingleLineStatement", "true");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputNeedBracesEmptyDefault.java"), expected);
+    }
+
+    @Test
+    public void testSingleLineCaseDefaultNoSingleLine() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(NeedBracesCheck.class);
+        checkConfig.addAttribute("tokens", "LITERAL_CASE, LITERAL_DEFAULT");
+        final String[] expected = {
+            "14: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
+            "15: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
+            "18: " + getCheckMessage(MSG_KEY_NEED_BRACES, "default"),
+            "21: " + getCheckMessage(MSG_KEY_NEED_BRACES, "default"),
+            "29: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
+            "30: " + getCheckMessage(MSG_KEY_NEED_BRACES, "default"),
+        };
+        verify(checkConfig, getPath("InputNeedBracesCaseDefaultNoSingleLine.java"), expected);
     }
 
     @Test
@@ -169,13 +199,8 @@ public class NeedBracesCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("tokens", "LITERAL_ELSE, LITERAL_CASE, LITERAL_DEFAULT");
         checkConfig.addAttribute("allowSingleLineStatement", "true");
         final String[] expected = {
-            "29: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
-            "35: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
-            "36: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
-            "38: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
             "41: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
             "44: " + getCheckMessage(MSG_KEY_NEED_BRACES, "case"),
-            "49: " + getCheckMessage(MSG_KEY_NEED_BRACES, "default"),
             "56: " + getCheckMessage(MSG_KEY_NEED_BRACES, "default"),
         };
         verify(checkConfig, getPath("InputNeedBracesConditional.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesCaseDefaultNoSingleLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesCaseDefaultNoSingleLine.java
@@ -1,0 +1,47 @@
+package com.puppycrawl.tools.checkstyle.checks.blocks.needbraces;
+
+/**
+ * Config:
+ * tokens = LITERAL_CASE, LITERAL_DEFAULT
+ * allowSingleLineStatement = false
+ */
+public class InputNeedBracesCaseDefaultNoSingleLine {
+
+    public String aMethod(int val) {
+        switch (val){
+        default:
+        case 0:
+        case -1: break; // violation
+        case -2: Math.random(); // violation
+        }
+        switch (val){
+        default: break; // violation
+        }
+        switch (val){
+        default: Math.random(); // violation
+        }
+        switch (val){
+        case 1: {}
+        default:
+        }
+        if(false) {
+            switch (1) {
+                case 1: return "1"; // violation
+                default: return "2"; // violation
+                case 0: {return "2";}
+                case 2: {break;}
+            }
+        }
+        switch (val) {
+        case 0: {
+            return "zero";
+        }
+        case 1: {
+            return "one";
+        }
+        default: {
+            return "non-binary";
+        }
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesEmptyDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesEmptyDefault.java
@@ -17,3 +17,7 @@ public class InputNeedBracesEmptyDefault {
 @interface Example {
     String priority() default "value";
 }
+
+interface IntefaceWithDefaultMethod {
+    default void doIt(){}
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesSingleLineStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesSingleLineStatements.java
@@ -116,4 +116,18 @@ public class InputNeedBracesSingleLineStatements
         for (;;)
         ;
     }
+    private void method(){
+        if(false) {
+            switch (0) {
+                case -1:
+                    return;
+                default:
+                    return;
+            }
+        }
+        switch(1){
+            case 1: return;
+            default: throw new RuntimeException("");
+        }
+    }
 }


### PR DESCRIPTION

https://github.com/checkstyle/checkstyle/issues/4764

1. Fixed false-positive violation for braces for case and default blocks. 
2. Test cases were updated with example from original issue + lambda test case added.
3.  Code was refactored:
- single line checks for `case` and `default` was merged into one
- original logic for violation detection in `visitTree` was refactored to avoid useless checks
- couple of utility methods were added
- `isInAnnotationField` method was removed because this check was applied only to `default` keyword and it is covered by `hasUnbracedStatements` method
