### PR TITLE
minor: remove trailing period to correct the url

### DIFF
--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -5,7 +5,7 @@
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
-    that can be found at https://google.github.io/styleguide/javaguide.html.
+    that can be found at https://google.github.io/styleguide/javaguide.html
 
     Checkstyle is very configurable. Be sure to read the documentation at
     http://checkstyle.sf.net (or in your downloaded distribution).


### PR DESCRIPTION
The google checkstyle url is immediately followed by a period, it appears to be a part of the url if don't pay much attention, so I suggest to remove it.

The commit in this PR follows the advice from the last closed PR #6815.