### PR TITLE
Issue 5750 mdash space

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheck.java
@@ -35,7 +35,7 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  * also override method {@code equals(Object)}.
  * </p>
  * <p>
- * Covariant {@code equals()}- method that is similar to {@code equals(Object)},
+ * Covariant {@code equals()} - method that is similar to {@code equals(Object)},
  * but with a covariant parameter type (any subtype of Object).
  * </p>
  * <p>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -404,6 +404,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
             final char last = text.charAt(text.length() - 1);
 
             result = (firstCharToAppend == '@'
+                    || Character.getType(firstCharToAppend) == Character.DASH_PUNCTUATION
                     || Character.getType(last) == Character.OTHER_PUNCTUATION
                     || Character.isAlphabetic(last)
                     || Character.isAlphabetic(firstCharToAppend)) && !Character.isWhitespace(last);


### PR DESCRIPTION
Issue #5750

Minor change to force a space before dash:
`Covariant {@code equals()} - method that...`
as we did it for the `Properties` section:
`Property {@code elementStyle} - Define the...`
