### PR TITLE
config: switch travis to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,113 +28,113 @@ matrix:
         - CMD="./.ci/travis/travis.sh pr-description"
         - SKIP_CI="false"
 
-    # unit tests (oraclejdk8)
-    - jdk: oraclejdk8
+    # unit tests (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="tests and deploy"
         - CMD="mvn -e clean integration-test failsafe:verify -DargLine='-Xms1024m -Xmx2048m'"
         - DEPLOY="true"
 
-    # checkstyle (oraclejdk8)
-    - jdk: oraclejdk8
+    # checkstyle (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="checkstyle and sevntu-checkstyle"
         - CMD="./.ci/travis/travis.sh checkstyle-and-sevntu"
         - SKIP_CI="false"
 
-    # jacoco and codecov (oraclejdk8)
-    - jdk: oraclejdk8
+    # jacoco and codecov (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="jacoco and codecov"
         - CMD="./.ci/travis/travis.sh jacoco"
         - CMD_AFTER_SUCCESS="bash <(curl -s https://codecov.io/bash)"
 
-    # spotbugs and pmd (oraclejdk8)
-    - jdk: oraclejdk8
+    # spotbugs and pmd (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="spotbugs,pmd"
         - CMD="export MAVEN_OPTS='-Xmx2000m' && mvn -e clean compile pmd:check spotbugs:check"
 
     # eclipse static analysis
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       env:
         - DESC="eclipse static analysis"
         - CMD="mvn -e clean compile exec:exec -Peclipse-compiler"
 
     # Releasenotes generation - validation
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       env:
         - DESC="Releasenotes generation"
         - CMD="./.ci/travis/travis.sh releasenotes-gen"
         - SKIP_CI="false"
 
-    # NonDex (oraclejdk8)
-    - jdk: oraclejdk8
+    # NonDex (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="NonDex"
         - CMD="./.ci/travis/travis.sh nondex"
 
     # site
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       env:
         - DESC="site without validations"
         - CMD="./.ci/travis/travis.sh site"
 
-    # unit tests in German locale (oraclejdk8)
-    - jdk: oraclejdk8
+    # unit tests in German locale (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="tests de"
         - CMD="./.ci/travis/travis.sh test-de"
-    # unit tests in Spanish locale (oraclejdk8)
-    - jdk: oraclejdk8
+    # unit tests in Spanish locale (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="tests es"
         - CMD="./.ci/travis/travis.sh test-es"
-    # unit tests in Finnish locale (oraclejdk8)
-    - jdk: oraclejdk8
+    # unit tests in Finnish locale (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="tests fi"
         - CMD="./.ci/travis/travis.sh test-fi"
-    # unit tests in French locale (oraclejdk8)
-    - jdk: oraclejdk8
+    # unit tests in French locale (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="tests fr"
         - CMD="./.ci/travis/travis.sh test-fr"
-    # unit tests in Chinese locale (oraclejdk8)
-    - jdk: oraclejdk8
+    # unit tests in Chinese locale (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="tests zh"
         - CMD="./.ci/travis/travis.sh test-zh"
-    # unit tests in Japanese locale (oraclejdk8)
-    - jdk: oraclejdk8
+    # unit tests in Japanese locale (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="tests ja"
         - CMD="./.ci/travis/travis.sh test-jp"
-    # unit tests in Portuguese locale (oraclejdk8)
-    - jdk: oraclejdk8
+    # unit tests in Portuguese locale (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="tests pt"
         - CMD="./.ci/travis/travis.sh test-pt"
-    # unit tests in Turkish locale (oraclejdk8)
-    - jdk: oraclejdk8
+    # unit tests in Turkish locale (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="tests tr"
         - CMD="./.ci/travis/travis.sh test-tr"
 
-    # assembly (oraclejdk8)
-    - jdk: oraclejdk8
+    # assembly (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="assembly & run '-all' jar"
         - CMD="./.ci/travis/travis.sh assembly-run-all-jar"
 
-    # NoExceptiontest - Guava with google_checks (oraclejdk8)
-    - jdk: oraclejdk8
+    # NoExceptiontest - Guava with google_checks (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="NoExceptionTest - Guava with google_checks"
         - CMD="./.ci/travis/travis.sh no-exception-test-guava-with-google-checks"
 
-    # release dry run (oraclejdk8)
-    - jdk: oraclejdk8
+    # release dry run (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="release dry run"
         - CMD="./.ci/travis/travis.sh release-dry-run"
@@ -146,7 +146,7 @@ matrix:
         - SKIP_CI="false"
 
     # Ensure that all Sevntu check are kused
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       env:
         - DESC="All sevntu checks should be used"
         - CMD="./.ci/travis/travis.sh all-sevntu-checks"
@@ -178,30 +178,24 @@ matrix:
         - CMD2="./.ci/travis/travis.sh osx-jdk12-assembly"
         - CMD="$CMD1 && $CMD2"
 
-    # https://sonarcloud.io (oraclejdk8)
-    - jdk: oraclejdk8
+    # https://sonarcloud.io (openjdk8)
+    - jdk: openjdk8
       env:
         - DESC="sonarcloud.io"
         - CMD="./.ci/travis/travis.sh sonarqube"
 
     # No error testing - simple-binary-encoding
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       env:
         - DESC="no error test on simple-binary-encoding"
         - CMD="./.ci/travis/travis.sh no-error-test-sbe"
 
     # versions to update
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       env:
         - DESC="print versions to update"
         - CMD="./.ci/travis/travis.sh versions"
         - SKIP_CI="false"
-
-    # OpenJDK8 build
-    - jdk: openjdk8
-      env:
-        - DESC="build with OpenJDK8"
-        - CMD="mvn -e package -Passembly && mvn -e site -Dlinkcheck.skip=true"
 
     # OpenJDK9 build
     - jdk: openjdk9
@@ -246,7 +240,7 @@ matrix:
         - CMD="./.ci/travis/travis.sh javac9"
 
     # compile input files compilation that are not compiled by eclipse
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       env:
         - DESC="compile input files that are not compiled by eclipse"
         - CMD="./.ci/travis/travis.sh javac8"


### PR DESCRIPTION
From https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038

> As of today, Oracle licensing has changed and the JDK cannot be downloaded from Oracle any longer without logging in.

This PR to make sure that everything is going fine with openjdk8.