### PR TITLE
Issue #6821: resolve 'Simplifiable JUnit assertion'

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
@@ -49,7 +49,7 @@ public class AllTestsTest {
             grabAllTests(allTests, filePath.toFile());
         });
 
-        Assert.assertTrue("found tests", !allTests.keySet().isEmpty());
+        Assert.assertFalse("tests should exists", allTests.keySet().isEmpty());
 
         walk(Paths.get("src/test/resources/com/puppycrawl"), filePath -> {
             verifyInputFile(allTests, filePath.toFile());
@@ -67,7 +67,7 @@ public class AllTestsTest {
             grabAllFiles(allTests, filePath.toFile());
         });
 
-        Assert.assertTrue("found tests", !allTests.keySet().isEmpty());
+        Assert.assertFalse("tests should exists", allTests.keySet().isEmpty());
 
         walk(Paths.get("src/test/java"), filePath -> {
             verifyHasProductionFile(allTests, filePath.toFile());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -419,8 +419,8 @@ public class XdocsPagesTest {
                     continue;
                 }
 
-                Assert.assertTrue(fileName + " section '" + sectionName
-                        + "' shouldn't end with 'Check'", !sectionName.endsWith("Check"));
+                Assert.assertFalse(fileName + " section '" + sectionName
+                        + "' shouldn't end with 'Check'", sectionName.endsWith("Check"));
                 if (lastSectionName != null) {
                     Assert.assertTrue(
                             fileName + " section '" + sectionName
@@ -592,8 +592,8 @@ public class XdocsPagesTest {
         fixCapturedProperties(sectionName, instance, clss, properties);
 
         if (subSection != null) {
-            Assert.assertTrue(fileName + " section '" + sectionName
-                    + "' should have no properties to show", !properties.isEmpty());
+            Assert.assertFalse(fileName + " section '" + sectionName
+                    + "' should have no properties to show", properties.isEmpty());
 
             final Set<Node> nodes = XmlUtil.getChildrenElements(subSection);
             Assert.assertEquals(fileName + " section '" + sectionName
@@ -1592,8 +1592,8 @@ public class XdocsPagesTest {
                 continue;
             }
 
-            Assert.assertTrue(styleName + "_style.xml rule '" + ruleName + "' module '" + moduleName
-                    + "' shouldn't end with 'Check'", !moduleName.endsWith("Check"));
+            Assert.assertFalse(styleName + "_style.xml rule '" + ruleName + "' module '" + moduleName
+                    + "' shouldn't end with 'Check'", moduleName.endsWith("Check"));
 
             styleChecks.remove(moduleName);
 


### PR DESCRIPTION
#6821 

Below are violation, BUT after a fix a realized that assert become harder to read.
When it was "AssertTrue" .... you simply read message and move further to condition and expresson like
`!sectionName.endsWith("Check")` is easy to read as `not sectionName endsWith("Check")`
You do not need to remember what was in the beginning of AssertTrue or AssertFalse. 
Your reading is simple, last expression should be TRUE, `!` is located very close to expression so it is easy to interpretate it.

BUT

after a fix, you have to pay attention to type of assertion, as it might be negative `AssertFalse`, so last expression should be interpretated with caution, and negative sign is located too far from expression.
This become more the issue as we use messages in each assert, so 
`AssertFalse(sectionName.endsWith("Check"))`
is not same as
```
AssertFalse(fileName + " section '" + sectionName
                        + "' shouldn't end with 'Check'", sectionName.endsWith("Check"))
```
======

I am in favor to disable this condition, in our case it make code hard to read.
Before I will do this, please read this PR, and lets discuss.

======

Voilations:
src/test/java/com/puppycrawl/tools/checkstyle/internal
AllTestsTest.java (2)
52: testAllInputsHaveTest() assertTrue() can be simplified to 'assertFalse()' 
70: testAllTestsHaveProductionCode() assertTrue() can be simplified to 'assertFalse()' 
XdocsPagesTest.java (3)
422: testAllCheckSections() assertTrue() can be simplified to 'assertFalse()' 
595: validatePropertySection() assertTrue() can be simplified to 'assertFalse()' 
1595: validateStyleModules() assertTrue() can be simplified to 'assertFalse()' 
