### PR TITLE
Issue #6680: fixed CustomImportOrder regression introduced by #3551

### DIFF
--- a/config/checkstyle_resources_suppressions.xml
+++ b/config/checkstyle_resources_suppressions.xml
@@ -26,6 +26,8 @@
   <suppress checks="PackageDeclarationCheck"
     files="customimportorder[\\/]InputCustomImportOrderNoPackage2\.java"/>
   <suppress checks="PackageDeclarationCheck"
+    files="customimportorder[\\/]InputCustomImportOrderNoPackage3\.java"/>
+  <suppress checks="PackageDeclarationCheck"
     files="customimportorder[\\/]InputCustomImportOrderDefaultPackage\.java"/>
   <suppress checks="PackageDeclarationCheck"
     files="customimportorder[\\/]InputCustomImportOrderSamePackage\.java"/>

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrderValid.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/InputCustomImportOrderValid.java
@@ -1,4 +1,6 @@
 package com.google.checkstyle.test.chapter3filestructure.rule333orderingandspacing;
+// it is not forbidden to have extra lines (more than one) between package and import group
+
 
 import static com.puppycrawl.tools.checkstyle.utils.AnnotationUtil.containsAnnotation;
 import static com.puppycrawl.tools.checkstyle.utils.AnnotationUtil.getAnnotation;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -553,9 +553,6 @@ public class CustomImportOrderCheck extends AbstractCheck {
             final String importGroup = importObject.getImportGroup();
             final String fullImportIdent = importObject.getImportFullPath();
 
-            if (getCountOfEmptyLinesBefore(importObject.getLineNumber()) > 1) {
-                log(importObject.getLineNumber(), MSG_LINE_SEPARATOR, fullImportIdent);
-            }
             if (importGroup.equals(currentGroup)) {
                 if (sortImportsInGroupAlphabetically
                         && previousImportFromCurrentGroup != null
@@ -573,7 +570,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
                     final String nextGroup = getNextImportGroup(currentGroupNumber + 1);
                     if (importGroup.equals(nextGroup)) {
                         if (separateLineBetweenGroups
-                                && getCountOfEmptyLinesBefore(importObject.getLineNumber()) == 0) {
+                                && getCountOfEmptyLinesBefore(importObject.getLineNumber()) != 1) {
                             log(importObject.getLineNumber(), MSG_LINE_SEPARATOR, fullImportIdent);
                         }
                         currentGroup = nextGroup;
@@ -767,7 +764,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
         //  [lineNo - 2] is the number of the previous line
         //  because the numbering starts from zero.
         int lineBeforeIndex = lineNo - 2;
-        while (lineBeforeIndex >= 0
+        while (lineBeforeIndex > -1
                 && CommonUtil.isBlank(lines[lineBeforeIndex])) {
             lineBeforeIndex--;
             result++;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -315,9 +315,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("separateLineBetweenGroups", "true");
         checkConfig.addAttribute("customImportOrderRules",
                 "SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE###STATIC");
-        final String[] expected = {
-            "5: " + getCheckMessage(MSG_LINE_SEPARATOR, "org.junit.*"),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verify(checkConfig,
             getNonCompilablePath("InputCustomImportOrderThirdPartyPackage.java"), expected);
@@ -723,9 +721,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("separateLineBetweenGroups", "true");
 
         createChecker(checkConfig);
-        final String[] expected = {
-            "5: " + getCheckMessage(MSG_LINE_SEPARATOR, "java.util.*"),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getNonCompilablePath("InputCustomImportOrderNoPackage.java"),
             expected);
     }
@@ -741,16 +737,59 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
 
         createChecker(checkConfig);
         final String[] expected = {
-            "3: " + getCheckMessage(MSG_LINE_SEPARATOR,
-                "com.puppycrawl.tools.checkstyle.utils.AnnotationUtil.containsAnnotation"),
             "7: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "com.sun.accessibility.internal.resources.*"),
-            "11: " + getCheckMessage(MSG_LINE_SEPARATOR, "java.util.Arrays"),
-            "19: " + getCheckMessage(MSG_LINE_SEPARATOR,
-                "org.apache.commons.beanutils.converters.ArrayConverter"),
         };
         verify(checkConfig, getNonCompilablePath("InputCustomImportOrderNoPackage2.java"),
             expected);
     }
 
+    @Test
+    public void testNoPackage3() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("customImportOrderRules",
+                "STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS");
+        checkConfig.addAttribute("specialImportsRegExp", "^org\\..+");
+        checkConfig.addAttribute("thirdPartyPackageRegExp", "^com\\.google\\..+");
+        checkConfig.addAttribute("separateLineBetweenGroups", "true");
+
+        createChecker(checkConfig);
+        final String[] expected = {
+            "6: " + getCheckMessage(MSG_LINE_SEPARATOR,
+                "java.util.Map"),
+            "14: " + getCheckMessage(MSG_LINE_SEPARATOR,
+                "org.apache.*"),
+            "18: " + getCheckMessage(MSG_LINE_SEPARATOR,
+                "antlr.*"),
+        };
+        verify(checkConfig, getNonCompilablePath("InputCustomImportOrderNoPackage3.java"),
+            expected);
+    }
+
+    @Test
+    public void testInputCustomImportOrderSingleLine() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("customImportOrderRules",
+                "STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS"
+                        + "###SAME_PACKAGE(3)");
+        checkConfig.addAttribute("specialImportsRegExp", "^org\\..+");
+        checkConfig.addAttribute("thirdPartyPackageRegExp", "^com\\.google\\..+");
+        checkConfig.addAttribute("separateLineBetweenGroups", "true");
+
+        createChecker(checkConfig);
+        final String[] expected = {
+            "1: " + getCheckMessage(MSG_LINE_SEPARATOR,
+                "java.util.Map"),
+            "2: " + getCheckMessage(MSG_LINE_SEPARATOR,
+                "com.google.common.annotations.Beta"),
+            "9: " + getCheckMessage(MSG_LINE_SEPARATOR,
+                "com.puppycrawl.tools.*"),
+            "13: " + getCheckMessage(MSG_LINE_SEPARATOR,
+                "antlr.*"),
+        };
+        verify(checkConfig, getPath("InputCustomImportOrderSingleLine.java"),
+            expected);
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderNoPackage3.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderNoPackage3.java
@@ -1,0 +1,22 @@
+//non-compiled with javac: contains no package declaration
+
+
+import static java.awt.Button.ABORT;
+import static java.io.File.createTempFile;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+
+import com.google.common.annotations.Beta;
+import com.google.common.collect.HashMultimap;
+
+
+import org.apache.*;
+
+
+
+import antlr.*;
+
+
+class InputCustomImportOrderNoPackage3 {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderSingleLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderSingleLine.java
@@ -1,0 +1,15 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder; import static java.awt.Button.ABORT; import java.util.Map; import java.util.Map.Entry;
+import com.google.common.annotations.Beta; import com.google.common.collect.HashMultimap;
+
+import org.junit.rules.*;
+import org.junit.runner.*;
+import org.junit.validator.*;
+
+
+import com.puppycrawl.tools.*;
+
+
+
+import antlr.*;
+
+class InputCustomImportOrderSingleLine {}


### PR DESCRIPTION
#6680

~1. restore the previous behavior of CustomImportOrder before #3551~
~2. add test cases for CommonUtil.getCountOfEmptyLinesBefore()~
~3. slightly changed logic of CommonUtil.getCountOfEmptyLinesBefore() to parse mutation tests~

1. Fixed unexpected violation for extra empty line between package and import
2. Added test cases for CustomImportOrder#getCountOfEmptyLinesBefore(int, String[])
3. Added test cases to prevent future regression