### PR TITLE
config: remove Oracle JDK from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -220,12 +220,6 @@ matrix:
         - DESC="build with OpenJDK12"
         - CMD="./.ci/travis/travis.sh jdk12"
 
-    # OracleJDK11 build
-    - jdk: oraclejdk11
-      env:
-        - DESC="build with OracleJDK11"
-        - CMD="mvn -e package -Passembly && mvn -e site -Dlinkcheck.skip=true"
-
     # OpenJDK9 compile input files with jdk9 specific syntax
     - jdk: openjdk9
       env:


### PR DESCRIPTION
The Oracle JDK License has [changed](https://www.oracle.com/technetwork/java/javase/overview/oracle-jdk-faqs.html) for releases starting April 16, 2019.

Oracle now require users to log in to an Oracle account to download their JDK. It is also not possible to cache installers, as this falls within redistribution restrictions. The only choice we have is to stop running the build against Oracle JDK.