### PR TITLE
Issue #6879: SuppressionCommentFilter ignores messageFormat

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -707,20 +707,46 @@ public class SuppressionCommentFilter
          * @return true if the source of event matches the text of this tag.
          */
         public boolean isMatch(TreeWalkerAuditEvent event) {
+            return (isCheckMatch(event) || isIdMatch(event)) && isMessageMatch(event);
+        }
+
+        /**
+         * Checks whether {@link TreeWalkerAuditEvent} source name matches the check format.
+         * @param event {@link TreeWalkerAuditEvent} instance.
+         * @return true if the {@link TreeWalkerAuditEvent} source name matches the check format.
+         */
+        private boolean isCheckMatch(TreeWalkerAuditEvent event) {
+            final Matcher checkMatcher = tagCheckRegexp.matcher(event.getSourceName());
+            return checkMatcher.find();
+        }
+
+        /**
+         * Checks whether the {@link TreeWalkerAuditEvent} module ID matches the ID format.
+         * @param event {@link TreeWalkerAuditEvent} instance.
+         * @return true if the {@link TreeWalkerAuditEvent} module ID matches the ID format.
+         */
+        private boolean isIdMatch(TreeWalkerAuditEvent event) {
             boolean match = false;
-            final Matcher tagMatcher = tagCheckRegexp.matcher(event.getSourceName());
-            if (tagMatcher.find()) {
-                if (tagMessageRegexp == null) {
-                    match = true;
-                }
-                else {
-                    final Matcher messageMatcher = tagMessageRegexp.matcher(event.getMessage());
-                    match = messageMatcher.find();
-                }
-            }
-            else if (event.getModuleId() != null) {
+            if (event.getModuleId() != null) {
                 final Matcher idMatcher = tagCheckRegexp.matcher(event.getModuleId());
                 match = idMatcher.find();
+            }
+            return match;
+        }
+
+        /**
+         * Checks whether the {@link TreeWalkerAuditEvent} message matches the message format.
+         * @param event {@link TreeWalkerAuditEvent} instance.
+         * @return true if the {@link TreeWalkerAuditEvent} message matches the message format.
+         */
+        private boolean isMessageMatch(TreeWalkerAuditEvent event) {
+            final boolean match;
+            if (tagMessageRegexp == null) {
+                match = true;
+            }
+            else {
+                final Matcher messageMatcher = tagMessageRegexp.matcher(event.getMessage());
+                match = messageMatcher.find();
             }
             return match;
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -390,6 +390,50 @@ public class SuppressionCommentFilterTest
             "15:18: "
                 + getCheckMessage(AbstractNameCheck.class,
                     MSG_INVALID_PATTERN, "ID", "^[a-z][a-zA-Z0-9]*$"),
+            "18:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "DEF", "^[a-z][a-zA-Z0-9]*$"),
+            "21:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "XYZ", "^[a-z][a-zA-Z0-9]*$"),
+            };
+
+        verifySuppressed(filterConfig, getPath("InputSuppressionCommentFilterSuppressById.java"),
+                expectedViolationMessages, suppressedViolationMessages);
+    }
+
+    @Test
+    public void testSuppressByIdAndMessage() throws Exception {
+        final DefaultConfiguration filterConfig =
+            createModuleConfig(SuppressionCommentFilter.class);
+        filterConfig.addAttribute("offCommentFormat", "CSOFF (\\w+) \\(allow (\\w+)\\)");
+        filterConfig.addAttribute("onCommentFormat", "CSON (\\w+)");
+        filterConfig.addAttribute("checkFormat", "$1");
+        filterConfig.addAttribute("messageFormat", "$2");
+        final String[] suppressedViolationMessages = {
+            "18:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "DEF", "^[a-z][a-zA-Z0-9]*$"),
+            };
+        final String[] expectedViolationMessages = {
+            "6:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "9:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "abc", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+            "12:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
+            "15:18: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "ID", "^[a-z][a-zA-Z0-9]*$"),
+            "18:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "DEF", "^[a-z][a-zA-Z0-9]*$"),
+            "21:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "XYZ", "^[a-z][a-zA-Z0-9]*$"),
             };
 
         verifySuppressed(filterConfig, getPath("InputSuppressionCommentFilterSuppressById.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/InputSuppressionCommentFilterSuppressById.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/InputSuppressionCommentFilterSuppressById.java
@@ -13,4 +13,10 @@ public class InputSuppressionCommentFilterSuppressById {
     //CSON ignore
 
     private long ID = 1;
+
+    // CSOFF ignore (allow DEF)
+    private int DEF = 2;
+
+    // CSOFF ignore (allow xyz)
+    private int XYZ = 3;
 }


### PR DESCRIPTION
The goal of this PR is to fix #6879 by updating the `isMatch` method in `SuppressionCommentFilter.Tag` so that it takes into account `messageFormat` when matching on module ID.

Related PR that does the same to `SuppressWithNearbyCommentFilter.Tag`: #6876 