### PR TITLE
doc: Add missing slash for constant name check doc

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
@@ -92,7 +92,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <pre>
  * &lt;module name=&quot;ConstantName&quot;&gt;
  *   &lt;property name="applyToPublic" value="false"/&gt;
- *   &lt;property name="applyToProtected" value="false"&gt;
+ *   &lt;property name="applyToProtected" value="false"/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>Code Example:</p>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -670,7 +670,7 @@ class MyClass {
         <pre>
 &lt;module name=&quot;ConstantName&quot;&gt;
   &lt;property name="applyToPublic" value="false"/&gt;
-  &lt;property name="applyToProtected" value="false"&gt;
+  &lt;property name="applyToProtected" value="false"/&gt;
 &lt;/module&gt;
         </pre>
         <p>Code Example:</p>


### PR DESCRIPTION
The document of [ConstantName](https://checkstyle.sourceforge.io/config_naming.html#ConstantName) misses a slash. And then I check the source, and find the source misses it too. So I create this PR to fix it.