### PR TITLE
Issue #6887: SuppressWithPlainTextCommentFilter ignores messageFormat

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -564,19 +564,9 @@ public class SuppressWithPlainTextCommentFilter extends AutomaticBean implements
          * @return true if the suppression matches {@link AuditEvent}.
          */
         private boolean isMatch(AuditEvent event) {
-            boolean match = false;
-            if (isInScopeOfSuppression(event)) {
-                final Matcher sourceNameMatcher = eventSourceRegexp.matcher(event.getSourceName());
-                if (sourceNameMatcher.find()) {
-                    match = eventMessageRegexp == null
-                        || eventMessageRegexp.matcher(event.getMessage()).find();
-                }
-                else {
-                    match = event.getModuleId() != null
-                        && eventSourceRegexp.matcher(event.getModuleId()).find();
-                }
-            }
-            return match;
+            return isInScopeOfSuppression(event)
+                    && (isCheckMatch(event) || isIdMatch(event))
+                    && isMessageMatch(event);
         }
 
         /**
@@ -588,6 +578,43 @@ public class SuppressWithPlainTextCommentFilter extends AutomaticBean implements
             return lineNo <= event.getLine();
         }
 
+        /**
+         * Checks whether {@link AuditEvent} source name matches the check format.
+         * @param event {@link AuditEvent} instance.
+         * @return true if the {@link AuditEvent} source name matches the check format.
+         */
+        private boolean isCheckMatch(AuditEvent event) {
+            final Matcher checkMatcher = eventSourceRegexp.matcher(event.getSourceName());
+            return checkMatcher.find();
+        }
+
+        /**
+         * Checks whether the {@link AuditEvent} module ID matches the ID format.
+         * @param event {@link AuditEvent} instance.
+         * @return true if the {@link AuditEvent} module ID matches the ID format.
+         */
+        private boolean isIdMatch(AuditEvent event) {
+            boolean match = false;
+            if (event.getModuleId() != null) {
+                final Matcher idMatcher = eventSourceRegexp.matcher(event.getModuleId());
+                match = idMatcher.find();
+            }
+            return match;
+        }
+
+        /**
+         * Checks whether the {@link AuditEvent} message matches the message format.
+         * @param event {@link AuditEvent} instance.
+         * @return true if the {@link AuditEvent} message matches the message format.
+         */
+        private boolean isMessageMatch(AuditEvent event) {
+            boolean match = true;
+            if (eventMessageRegexp != null) {
+                final Matcher messageMatcher = eventMessageRegexp.matcher(event.getMessage());
+                match = messageMatcher.find();
+            }
+            return match;
+        }
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
@@ -501,6 +501,40 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
     }
 
     @Test
+    public void testFilterWithIdAndCustomMessageFormat() throws Exception {
+        final DefaultConfiguration filterCfg =
+            createModuleConfig(SuppressWithPlainTextCommentFilter.class);
+        filterCfg.addAttribute("offCommentFormat", "CHECKSTYLE stop (\\w+) (\\w+)");
+        filterCfg.addAttribute("onCommentFormat", "CHECKSTYLE resume (\\w+) (\\w+)");
+        filterCfg.addAttribute("checkFormat", "$1");
+        filterCfg.addAttribute("messageFormat", "$2");
+
+        final DefaultConfiguration regexpCheckCfg = createModuleConfig(RegexpSinglelineCheck.class);
+        regexpCheckCfg.addAttribute("id", "warning");
+        regexpCheckCfg.addAttribute("format", "^.*COUNT\\(\\*\\).*$");
+
+        final String[] suppressedViolationMessages = {
+            "2: " + getCheckMessage(RegexpSinglelineCheck.class, MSG_REGEXP_EXCEEDED,
+                "^.*COUNT\\(\\*\\).*$"),
+        };
+
+        final String[] expectedViolationMessages = {
+            "2: " + getCheckMessage(RegexpSinglelineCheck.class, MSG_REGEXP_EXCEEDED,
+                "^.*COUNT\\(\\*\\).*$"),
+            "5: " + getCheckMessage(RegexpSinglelineCheck.class, MSG_REGEXP_EXCEEDED,
+                "^.*COUNT\\(\\*\\).*$"),
+            "8: " + getCheckMessage(RegexpSinglelineCheck.class, MSG_REGEXP_EXCEEDED,
+                "^.*COUNT\\(\\*\\).*$"),
+        };
+
+        verifySuppressed(
+            "InputSuppressWithPlainTextCommentFilterCustomMessageFormat.sql",
+            removeSuppressed(expectedViolationMessages, suppressedViolationMessages),
+            filterCfg, regexpCheckCfg
+        );
+    }
+
+    @Test
     public void testFilterWithDirectory() throws IOException {
         final SuppressWithPlainTextCommentFilter filter = new SuppressWithPlainTextCommentFilter();
         final AuditEvent event = new AuditEvent(this, getPath(""), new LocalizedMessage(1, 1,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterCustomMessageFormat.sql
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterCustomMessageFormat.sql
@@ -1,0 +1,8 @@
+-- CHECKSTYLE stop warning COUNT
+SELECT COUNT(*) FROM filters;
+
+-- CHECKSTYLE resume warning COUNT
+SELECT COUNT(*) FROM checks;
+
+-- CHECKSTYLE stop warning NonMatchingMessage
+SELECT COUNT(*) FROM reports;


### PR DESCRIPTION
This PR fixes #6887, updating the suppression `isMatch` logic to always check the message format (instead of only when the event source format matches). It adds a test case that would fail with the current master code.

Previous PR's applied the same logic to SuppressionCommentFilter (#6882) and SuppressWithNearbyCommentFilter (#6876).