### PR TITLE
Issue #5008: Increased coding pitest coverage to 100%

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -177,13 +177,7 @@ pitest-coding)
   mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
   declare -a ignoredItems=(
   "EqualsAvoidNullCheck.java.html:<td class='covered'><pre><span  class='survived'>                    &#38;&#38; field.getColumnNo() + minimumSymbolsBetween &#60;= objCalledOn.getColumnNo()) {</span></pre></td></tr>"
-  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>            processVariable(ast);</span></pre></td></tr>"
-  "MultipleVariableDeclarationsCheck.java.html:<td class='covered'><pre><span  class='survived'>                    &#38;&#38; newNode.getColumnNo() &#62; currentNode.getColumnNo()) {</span></pre></td></tr>"
-  "MultipleVariableDeclarationsCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (newNode.getLineNo() &#62; currentNode.getLineNo()</span></pre></td></tr>"
-  "MultipleVariableDeclarationsCheck.java.html:<td class='covered'><pre><span  class='survived'>                || newNode.getLineNo() == currentNode.getLineNo()</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>                    &#38;&#38; ast1.getColumnNo() &#60; ast2.getColumnNo()) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        final boolean methodNameInMethodCall = parentType == TokenTypes.DOT</span></pre></td></tr>"
-  "UnnecessaryParenthesesCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (type != TokenTypes.ASSIGN</span></pre></td></tr>"
   );
   checkPitestReport "${ignoredItems[@]}"
   ;;

--- a/pom.xml
+++ b/pom.xml
@@ -1974,7 +1974,7 @@
                 <param>*.Input*</param>
               </excludedTestClasses>
               <coverageThreshold>100</coverageThreshold>
-              <mutationThreshold>98</mutationThreshold>
+              <mutationThreshold>100</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -275,10 +275,6 @@ public class HiddenFieldCheck
                 log(firstChild, MSG_KEY, untypedLambdaParameterName);
             }
         }
-        else {
-            // Type of lambda parameter is not omitted.
-            processVariable(ast);
-        }
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleVariableDeclarationsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleVariableDeclarationsCheck.java
@@ -120,15 +120,9 @@ public class MultipleVariableDeclarationsCheck extends AbstractCheck {
      */
     private static DetailAST getLastNode(final DetailAST node) {
         DetailAST currentNode = node;
-        DetailAST child = node.getFirstChild();
-        while (child != null) {
-            final DetailAST newNode = getLastNode(child);
-            if (newNode.getLineNo() > currentNode.getLineNo()
-                || newNode.getLineNo() == currentNode.getLineNo()
-                    && newNode.getColumnNo() > currentNode.getColumnNo()) {
-                currentNode = newNode;
-            }
-            child = child.getNextSibling();
+        final DetailAST child = node.getLastChild();
+        if (child != null) {
+            currentNode = getLastNode(child);
         }
 
         return currentNode;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -451,14 +451,11 @@ public class RequireThisCheck extends AbstractCheck {
      */
     private AbstractFrame getFieldWithoutThis(DetailAST ast, int parentType) {
         final boolean importOrPackage = ScopeUtil.getSurroundingScope(ast) == null;
-        final boolean methodNameInMethodCall = parentType == TokenTypes.DOT
-                && ast.getPreviousSibling() != null;
         final boolean typeName = parentType == TokenTypes.TYPE
                 || parentType == TokenTypes.LITERAL_NEW;
         AbstractFrame frame = null;
 
         if (!importOrPackage
-                && !methodNameInMethodCall
                 && !typeName
                 && !isDeclarationToken(parentType)
                 && !isLambdaParameter(ast)) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
  * Test fixture for the UnnecessaryParenthesesCheck.
@@ -106,7 +105,10 @@ public class UnnecessaryParenthesesCheckTest extends AbstractModuleTestSupport {
     public void test15Extensions() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(UnnecessaryParenthesesCheck.class);
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "15:23: " + getCheckMessage(MSG_EXPR),
+            "15:51: " + getCheckMessage(MSG_LITERAL, "1"),
+        };
         verify(checkConfig, getPath("InputUnnecessaryParentheses15Extensions.java"), expected);
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParentheses15Extensions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParentheses15Extensions.java
@@ -12,6 +12,12 @@ public class InputUnnecessaryParentheses15Extensions
 
 }
 
+@MyAnnotation1(name = ("ABC" + "DEF"), version = (1))
+class AnnotationWithUnnecessaryParentheses
+{
+
+}
+
 enum Enum2
 {
     A, B, C;


### PR DESCRIPTION
#5008

HiddenFieldCheck.java:278: Removed unused call. It was always called with LPAREN, the actual params are handled by visitToken with PARAMETER_DEF.

MultipleVariableDeclarationsCheck.java:124: Cleaned up method since the AST is sorted. 

RequireThisCheck.java:454: Removed check for method call since these has already been handled by parentType == METHOD_CALL in processIdent prior to handling field. 
