### PR TITLE
minor: refactor isMessageMatch in comment filters

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -609,11 +609,8 @@ public class SuppressWithNearbyCommentFilter
          * @return true if the {@link TreeWalkerAuditEvent} message matches the message format.
          */
         private boolean isMessageMatch(TreeWalkerAuditEvent event) {
-            final boolean match;
-            if (tagMessageRegexp == null) {
-                match = true;
-            }
-            else {
+            boolean match = true;
+            if (tagMessageRegexp != null) {
                 final Matcher messageMatcher = tagMessageRegexp.matcher(event.getMessage());
                 match = messageMatcher.find();
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -740,11 +740,8 @@ public class SuppressionCommentFilter
          * @return true if the {@link TreeWalkerAuditEvent} message matches the message format.
          */
         private boolean isMessageMatch(TreeWalkerAuditEvent event) {
-            final boolean match;
-            if (tagMessageRegexp == null) {
-                match = true;
-            }
-            else {
+            boolean match = true;
+            if (tagMessageRegexp != null) {
                 final Matcher messageMatcher = tagMessageRegexp.matcher(event.getMessage());
                 match = messageMatcher.find();
             }


### PR DESCRIPTION
This is a minor refactoring PR that cleans up `isMessageMatch` in SuppressionCommentFilter and SuppressWithNearbyComment filter, identified in https://github.com/checkstyle/checkstyle/pull/6899#discussion_r303358544