### PR TITLE
Issue #6659: Increase mutation threshold for pitest-filters profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2925,7 +2925,7 @@
                 <param>*.Input*</param>
               </excludedTestClasses>
               <coverageThreshold>100</coverageThreshold>
-              <mutationThreshold>97</mutationThreshold>
+              <mutationThreshold>100</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION
This PR updates the mutation threshold for the pitest-filters profile to 100 in `pom.xml` (forgot to do as part of PR #6889 for Issue #6659)