### PR TITLE
Issue #5008: Removed remaining coding pitest

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -37,7 +37,8 @@ pitest-annotation|pitest-design \
 |pitest-api \
 |pitest-packagenamesloader \
 |pitest-common-2|pitest-misc|pitest-xpath \
-|pitest-filters)
+|pitest-filters \
+|pitest-coding)
   mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
   declare -a ignoredItems=();
   checkPitestReport "${ignoredItems[@]}"
@@ -169,15 +170,6 @@ pitest-blocks)
   "RightCurlyCheck.java.html:<td class='covered'><pre><span  class='survived'>            else if (tokenType == TokenTypes.LITERAL_CATCH) {</span></pre></td></tr>"
   "RightCurlyCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (tokenType == TokenTypes.LITERAL_IF) {</span></pre></td></tr>"
   "RightCurlyCheck.java.html:<td class='covered'><pre><span  class='survived'>        return rcurly.getParent().getParent().getType() == TokenTypes.INSTANCE_INIT</span></pre></td></tr>"
-  );
-  checkPitestReport "${ignoredItems[@]}"
-  ;;
-
-pitest-coding)
-  mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
-  declare -a ignoredItems=(
-  "EqualsAvoidNullCheck.java.html:<td class='covered'><pre><span  class='survived'>                    &#38;&#38; field.getColumnNo() + minimumSymbolsBetween &#60;= objCalledOn.getColumnNo()) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>                    &#38;&#38; ast1.getColumnNo() &#60; ast2.getColumnNo()) {</span></pre></td></tr>"
   );
   checkPitestReport "${ignoredItems[@]}"
   ;;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
 
 /**
  * <p>
@@ -475,18 +476,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
      */
     private static boolean checkLineNo(DetailAST field, DetailAST objCalledOn) {
         boolean result = false;
-        // Required for pitest coverage. We should specify columnNo passing condition
-        // in such a way, so that the minimal possible distance between field and
-        // objCalledOn will be the maximal condition to pass this check.
-        // The minimal distance between objCalledOn and field (of type String) initialization
-        // is calculated as follows:
-        // String(6) + space(1) + variableName(1) + assign(1) +
-        // anotherStringVariableName(1) + semicolon(1) = 11
-        // Example: length of "String s=d;" is 11 symbols.
-        final int minimumSymbolsBetween = 11;
-        if (field.getLineNo() < objCalledOn.getLineNo()
-                || field.getLineNo() == objCalledOn.getLineNo()
-                    && field.getColumnNo() + minimumSymbolsBetween <= objCalledOn.getColumnNo()) {
+        if (CheckUtil.isBeforeInSource(field, objCalledOn)) {
             result = true;
         }
         return result;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -1254,25 +1254,8 @@ public class RequireThisCheck extends AbstractCheck {
         protected boolean isProperDefinition(DetailAST ident, DetailAST ast) {
             final String nameToFind = ident.getText();
             return nameToFind.equals(ast.getText())
-                && checkPosition(ast, ident);
+                && CheckUtil.isBeforeInSource(ast, ident);
         }
-
-        /**
-         * Whether the declaration is located before the checked ast.
-         * @param ast1 the IDENT ast of the declaration.
-         * @param ast2 the IDENT ast to check.
-         * @return true, if the declaration is located before the checked ast.
-         */
-        private static boolean checkPosition(DetailAST ast1, DetailAST ast2) {
-            boolean result = false;
-            if (ast1.getLineNo() < ast2.getLineNo()
-                    || ast1.getLineNo() == ast2.getLineNo()
-                    && ast1.getColumnNo() < ast2.getColumnNo()) {
-                result = true;
-            }
-            return result;
-        }
-
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -241,15 +241,25 @@ public final class CheckUtil {
         DetailAST child = node.getFirstChild();
         while (child != null) {
             final DetailAST newNode = getFirstNode(child);
-            if (newNode.getLineNo() < currentNode.getLineNo()
-                || newNode.getLineNo() == currentNode.getLineNo()
-                    && newNode.getColumnNo() < currentNode.getColumnNo()) {
+            if (isBeforeInSource(newNode, currentNode)) {
                 currentNode = newNode;
             }
             child = child.getNextSibling();
         }
 
         return currentNode;
+    }
+
+    /**
+     * Retrieves whether ast1 is located before ast2.
+     * @param ast1 the first node.
+     * @param ast2 the second node.
+     * @return true, if ast1 is located before ast2.
+     */
+    public static boolean isBeforeInSource(DetailAST ast1, DetailAST ast2) {
+        return ast1.getLineNo() < ast2.getLineNo()
+            || ast1.getLineNo() == ast2.getLineNo()
+                && ast1.getColumnNo() < ast2.getColumnNo();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheckTest.java
@@ -162,6 +162,7 @@ public class EqualsAvoidNullCheckTest extends AbstractModuleTestSupport {
 
         final String[] expected = {
             "7:28: " + getCheckMessage(MSG_EQUALS_AVOID_NULL),
+            "14:17: " + getCheckMessage(MSG_EQUALS_AVOID_NULL),
         };
         verify(checkConfig, getPath("InputEqualsAvoidNullOnTheSameLine.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullOnTheSameLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullOnTheSameLine.java
@@ -6,4 +6,17 @@ public class InputEqualsAvoidNullOnTheSameLine {
         String b = "onion";
         String a=b;a.equals("ONION");
     }
+
+    private String a = "";
+    private A b = null;
+
+    public void shouldWarn() {
+        a.equals("");A a=b;
+    }
+
+    public void shouldNotWarn() {
+        A a=b;a.equals("");
+    }
+
+    class A {}
 }


### PR DESCRIPTION
Issue #5008. 

Removed the remaining pitest mutations by introducing a utility method for testing which node is first in the AST. 

The reason not to cover the mutations where they were located previously is that it requires two ast nodes with the exact same location, which in an ast build from a source file will only be the case if the compared nodes are the same node. And since the checks enforces that one of the nodes are a method invocation or field access and the other is a declaration it will never  happen that it is the same node that is being compared to it self. 

I further added a test that shows a false warning generated by current master in EqualsAvoidNullCheck, due to the pitest hack with minimumSymbolsBetween. 