### PR TITLE
Issue #6903: Ignore JUnit TempDir annotation in VisibilityModifierCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -444,6 +444,7 @@ public class VisibilityModifierCheck
         Arrays.stream(new String[] {
             "org.junit.Rule",
             "org.junit.ClassRule",
+            "org.junit.jupiter.api.io.TempDir",
             "com.google.common.annotations.VisibleForTesting",
         }).collect(Collectors.toList()));
 

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -883,7 +883,8 @@ public class Foo{
         <p>
           <b>ignoreAnnotationCanonicalNames</b> - the list of annotations which ignore variables
           in consideration. If user will provide short annotation name that type will match to any
-          named the same type without consideration of package.
+          named the same type without consideration of package. This option should be used if
+          some framework with annotation based field injection is used (like JUnit rules).
         </p>
         <p>
           <b>allowPublicFinalFields</b> - which allows public final fields.
@@ -899,7 +900,7 @@ public class Foo{
           <li>It's declared as final</li>
           <li>
             Has either a primitive type or instance of class user defined to be immutable
-            (such as String, ImmutableCollection from Guava and etc)
+            (such as String, ImmutableCollection from Guava etc.)
           </li>
         </ul>
         <p>
@@ -988,7 +989,7 @@ public class Foo{
               consideration.
             </td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>org.junit.Rule, org.junit.ClassRule,
+            <td><code>org.junit.Rule, org.junit.ClassRule, org.junit.jupiter.api.io.TempDir,
                 com.google.common.annotations.VisibleForTesting</code></td>
             <td>6.5</td>
           </tr>


### PR DESCRIPTION
Add JUnit TempDir to the list of annotations that lead to ignoring a
field in VisibilityModifierCheck. @TempDir uses field injection like
JUnit @Rule, therefore the user cannot make the field less accessible.

Also improve the documentation to explicitly mention the use case of
field injection for the annotation ignore option of
VisibilityModifierCheck.

There is no unit test, since I did not understand how to add the
necessary JUnit 5 dependency to a test input file
(InputVisibilityModifier*) without breaking the JUnit version of the
checkstyle tests at the same time.