### PR TITLE
config: upgrade picocli to 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
-      <version>3.9.6</version>
+      <version>4.0.0</version>
     </dependency>
     <dependency>
       <groupId>antlr</groupId>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
@@ -44,10 +44,7 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
     private static final String EOL = System.lineSeparator();
     private static final String USAGE = String.format(Locale.ROOT,
           "Usage: java com.puppycrawl.tools.checkstyle.JavadocPropertiesGenerator [-hV]%n"
-          + "                                                                       "
-          + "--destfile=<outputFile>%n"
-          + "                                                                       "
-          + "<inputFile>%n"
+          + "       --destfile=<outputFile> <inputFile>%n"
           + "      <inputFile>   The input file.%n"
           + "      --destfile=<outputFile>%n"
           + "                    The output file.%n"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -91,8 +91,8 @@ public class MainTest {
           + " Defaults to plain%n"
           + "  -g, --generate-xpath-suppression%n"
           + "                            Generates to output a suppression.xml to use to suppress"
-          + " all violations from%n"
-          + "                              user's config%n"
+          + " all violations%n"
+          + "                              from user's config%n"
           + "  -h, --help                Show this help message and exit.%n"
           + "  -j, --javadocTree         Print Parse tree of the Javadoc comment%n"
           + "  -J, --treeWithJavadoc     Print full Abstract Syntax Tree of the file%n"
@@ -100,20 +100,21 @@ public class MainTest {
           + "  -p=<propertiesFile>       Loads the properties file%n"
           + "  -s=<suppressionLineColumnNumber>%n"
           + "                            Print xpath suppressions at the file's line and column"
-          + " position. Argument is%n"
-          + "                              the line and column number (separated by a : ) in the"
-          + " file that the%n"
-          + "                              suppression should be generated for%n"
+          + " position.%n"
+          + "                              Argument is the line and column number (separated by"
+          + " a : ) in the%n"
+          + "                              file that the suppression should be generated for%n"
           + "  -t, --tree                Print Abstract Syntax Tree(AST) of the file%n"
           + "  -T, --treeWithComments    Print Abstract Syntax Tree(AST) of the file including"
           + " comments%n"
           + "  -V, --version             Print version information and exit.%n"
           + "  -w, --tabWidth=<tabWidth> Sets the length of the tab character. Used only with"
-          + " \"-s\" option. Default%n"
-          + "                              value is 8%n"
+          + " \"-s\" option.%n"
+          + "                              Default value is 8%n"
           + "  -W, --tree-walker-threads-number=<treeWalkerThreadsNumber>%n"
           + "                            (experimental) The number of TreeWalker threads (must be"
-          + " greater than zero)%n"
+          + " greater than%n"
+          + "                              zero)%n"
           + "  -x, --exclude-regexp=<excludeRegex>%n"
           + "                            Regular expression of directory/file to exclude from"
           + " CheckStyle%n");
@@ -214,7 +215,7 @@ public class MainTest {
             throws Exception {
         exit.expectSystemExitWithStatus(-1);
         exit.checkAssertionAfterwards(() -> {
-            final String usage = "Unknown option: -q" + EOL
+            final String usage = "Unknown option: '-q'" + EOL
                     + SHORT_USAGE;
             assertEquals("Unexpected output log", "", systemOut.getLog());
             assertEquals("Unexpected system error log", usage, systemErr.getLog());


### PR DESCRIPTION
````
[Console output redirected to file:M:\output.txt]
Usage: checkstyle [-dEghjJtTV] [-c=<configurationFile>] [-C=<checkerThreadsNumber>] [-f=<format>]
                  [-o=<outputPath>] [-p=<propertiesFile>] [-s=<suppressionLineColumnNumber>]
                  [-w=<tabWidth>] [-W=<treeWalkerThreadsNumber>] [-e=<exclude>]...
                  [-x=<excludeRegex>]... <files>...
Checkstyle verifies that the specified source code files adhere to the specified rules. By default
errors are reported to standard out in plain format. Checkstyle requires a configuration XML file
that configures the checks to apply.
      <files>...            One or more source files to verify
  -c=<configurationFile>    Sets the check configuration file to use.
  -C, --checker-threads-number=<checkerThreadsNumber>
                            (experimental) The number of Checker threads (must be greater than zero)
  -d, --debug               Print all debug logging of CheckStyle utility
  -e, --exclude=<exclude>   Directory/File path to exclude from CheckStyle
  -E, --executeIgnoredModules
                            Allows ignored modules to be run.
  -f=<format>               Sets the output format. Valid values: xml, plain. Defaults to plain
  -g, --generate-xpath-suppression
                            Generates to output a suppression.xml to use to suppress all violations
                              from user's config
  -h, --help                Show this help message and exit.
  -j, --javadocTree         Print Parse tree of the Javadoc comment
  -J, --treeWithJavadoc     Print full Abstract Syntax Tree of the file
  -o=<outputPath>           Sets the output file. Defaults to stdout
  -p=<propertiesFile>       Loads the properties file
  -s=<suppressionLineColumnNumber>
                            Print xpath suppressions at the file's line and column position.
                              Argument is the line and column number (separated by a : ) in the
                              file that the suppression should be generated for
  -t, --tree                Print Abstract Syntax Tree(AST) of the file
  -T, --treeWithComments    Print Abstract Syntax Tree(AST) of the file including comments
  -V, --version             Print version information and exit.
  -w, --tabWidth=<tabWidth> Sets the length of the tab character. Used only with "-s" option.
                              Default value is 8
  -W, --tree-walker-threads-number=<treeWalkerThreadsNumber>
                            (experimental) The number of TreeWalker threads (must be greater than
                              zero)
  -x, --exclude-regexp=<excludeRegex>
                            Regular expression of directory/file to exclude from CheckStyle
````