### PR TITLE
Issue #6883: Add ID format property to SuppressionCommentFilter

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -312,7 +312,8 @@ public class SuppressionCommentFilterTest
         final Object tag = getTagsAfterExecutionOnDefaultFilter("//CHECKSTYLE:OFF").get(0);
         assertEquals("Invalid toString result",
             "Tag[text='CHECKSTYLE:OFF', line=1, column=0, type=OFF,"
-                    + " tagCheckRegexp=.*, tagMessageRegexp=null]", tag.toString());
+                    + " tagCheckRegexp=.*, tagMessageRegexp=null, tagIdRegexp=null]",
+                    tag.toString());
     }
 
     @Test
@@ -323,7 +324,7 @@ public class SuppressionCommentFilterTest
                 getTagsAfterExecution(filter, "filename", "//CHECKSTYLE:ON").get(0);
         assertEquals("Invalid toString result",
             "Tag[text='CHECKSTYLE:ON', line=1, column=0, type=ON,"
-                + " tagCheckRegexp=.*, tagMessageRegexp=.*]", tag.toString());
+                + " tagCheckRegexp=.*, tagMessageRegexp=.*, tagIdRegexp=null]", tag.toString());
     }
 
     @Test
@@ -406,12 +407,93 @@ public class SuppressionCommentFilterTest
     }
 
     @Test
+    public void testSuppressByCheck() throws Exception {
+        final DefaultConfiguration filterConfig =
+            createModuleConfig(SuppressionCommentFilter.class);
+        filterConfig.addAttribute("offCommentFormat", "CSOFF (\\w+) \\(\\w+\\)");
+        filterConfig.addAttribute("onCommentFormat", "CSON (\\w+)");
+        filterConfig.addAttribute("checkFormat", "MemberNameCheck");
+        final String[] suppressedViolationMessages = {
+            "6:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "12:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
+            };
+        final String[] expectedViolationMessages = {
+            "6:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "9:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "abc", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+            "12:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
+            "15:18: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "ID", "^[a-z][a-zA-Z0-9]*$"),
+            "18:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "DEF", "^[a-z][a-zA-Z0-9]*$"),
+            "21:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "XYZ", "^[a-z][a-zA-Z0-9]*$"),
+            };
+
+        verifySuppressed(filterConfig, getPath("InputSuppressionCommentFilterSuppressById.java"),
+                expectedViolationMessages, suppressedViolationMessages);
+    }
+
+    @Test
     public void testSuppressById() throws Exception {
         final DefaultConfiguration filterConfig =
             createModuleConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("offCommentFormat", "CSOFF (\\w+) \\(\\w+\\)");
         filterConfig.addAttribute("onCommentFormat", "CSON (\\w+)");
-        filterConfig.addAttribute("checkFormat", "$1");
+        filterConfig.addAttribute("idFormat", "$1");
+        final String[] suppressedViolationMessages = {
+            "6:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "12:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
+            };
+        final String[] expectedViolationMessages = {
+            "6:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "9:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "abc", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+            "12:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
+            "15:18: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "ID", "^[a-z][a-zA-Z0-9]*$"),
+            "18:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "DEF", "^[a-z][a-zA-Z0-9]*$"),
+            "21:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "XYZ", "^[a-z][a-zA-Z0-9]*$"),
+            };
+
+        verifySuppressed(filterConfig, getPath("InputSuppressionCommentFilterSuppressById.java"),
+                expectedViolationMessages, suppressedViolationMessages);
+    }
+
+    @Test
+    public void testSuppressByCheckAndId() throws Exception {
+        final DefaultConfiguration filterConfig =
+            createModuleConfig(SuppressionCommentFilter.class);
+        filterConfig.addAttribute("offCommentFormat", "CSOFF (\\w+) \\(\\w+\\)");
+        filterConfig.addAttribute("onCommentFormat", "CSON (\\w+)");
+        filterConfig.addAttribute("checkFormat", "MemberNameCheck");
+        filterConfig.addAttribute("idFormat", "$1");
         final String[] suppressedViolationMessages = {
             "6:17: "
                 + getCheckMessage(AbstractNameCheck.class,
@@ -451,7 +533,45 @@ public class SuppressionCommentFilterTest
             createModuleConfig(SuppressionCommentFilter.class);
         filterConfig.addAttribute("offCommentFormat", "CSOFF (\\w+) \\(allow (\\w+)\\)");
         filterConfig.addAttribute("onCommentFormat", "CSON (\\w+)");
-        filterConfig.addAttribute("checkFormat", "$1");
+        filterConfig.addAttribute("idFormat", "$1");
+        filterConfig.addAttribute("messageFormat", "$2");
+        final String[] suppressedViolationMessages = {
+            "18:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "DEF", "^[a-z][a-zA-Z0-9]*$"),
+            };
+        final String[] expectedViolationMessages = {
+            "6:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "9:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "abc", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+            "12:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
+            "15:18: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "ID", "^[a-z][a-zA-Z0-9]*$"),
+            "18:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "DEF", "^[a-z][a-zA-Z0-9]*$"),
+            "21:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "XYZ", "^[a-z][a-zA-Z0-9]*$"),
+            };
+
+        verifySuppressed(filterConfig, getPath("InputSuppressionCommentFilterSuppressById.java"),
+                expectedViolationMessages, suppressedViolationMessages);
+    }
+
+    @Test
+    public void testSuppressByCheckAndMessage() throws Exception {
+        final DefaultConfiguration filterConfig =
+            createModuleConfig(SuppressionCommentFilter.class);
+        filterConfig.addAttribute("offCommentFormat", "CSOFF (\\w+) \\(allow (\\w+)\\)");
+        filterConfig.addAttribute("onCommentFormat", "CSON (\\w+)");
+        filterConfig.addAttribute("checkFormat", "MemberNameCheck");
         filterConfig.addAttribute("messageFormat", "$2");
         final String[] suppressedViolationMessages = {
             "18:17: "

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -832,6 +832,7 @@ public class XdocsPagesTest {
                 || "SuppressWithPlainTextCommentFilter".equals(sectionName))
                     && ("checkFormat".equals(propertyName)
                         || "messageFormat".equals(propertyName)
+                        || "idFormat".equals(propertyName)
                         || "influenceFormat".equals(propertyName))
                 || ("RegexpMultiline".equals(sectionName)
                     || "RegexpSingleline".equals(sectionName)

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -167,6 +167,13 @@
                   <td>3.5</td>
               </tr>
               <tr>
+                  <td>idFormat</td>
+                  <td>Specify check ID pattern to suppress.</td>
+                  <td><a href="property_types.html#regexp">Regular Expression</a></td>
+                  <td><code>null</code></td>
+                  <td>8.24</td>
+              </tr>
+              <tr>
                   <td>checkCPP</td>
                   <td>Control whether to check C++ style comments (<code>//</code>).</td>
                   <td><a href="property_types.html#boolean">Boolean</a></td>
@@ -368,7 +375,7 @@ HashSet hashSet;
 &lt;module name="SuppressionCommentFilter&quot;&gt;
   &lt;property name="offCommentFormat" value="CSOFF (\w+) \(\w+\)"/&gt;
   &lt;property name="onCommentFormat" value="CSON (\w+)"/&gt;
-  &lt;property name="checkFormat" value="$1"/&gt;
+  &lt;property name="idFormat" value="$1"/&gt;
 &lt;/module&gt;
           </source>
           <source>


### PR DESCRIPTION
This PR addresses issue #6883 - adding an `idFormat` property to SuppressionCommentFilter. 

Currently, when deciding if an audit event should be suppressed, this filter first matches the event source against the `checkFormat`. If that fails, it matches the event module ID against the `checkFormat`. With this PR, the filter instead matches the event module ID against the new `idFormat` property (additional details in issue description).

Initial questions/notes:
* Should `idFormat` be a string or regular expression? It's a regular expression in this PR, but I think either way could make sense to me and would be happy to change it to a string.

* I think we'll want a regression report for this change? I'll run one tomorrow...