### PR TITLE
Issue #6929: add check JavadocBlockTagLocation

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -626,6 +626,7 @@ Jakub
 jarchitect
 javac
 javadoc
+javadocblocktaglocation
 javadocdetailnodeparser
 javadocmethod
 javadocpackage
@@ -666,6 +667,7 @@ jdt
 jedit
 jenkins
 Jenkinsfile
+jep
 jetbrains
 JFile
 JFrame

--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -458,6 +458,14 @@
     <!-- Javadoc Comments -->
     <module name="AtclauseOrder"/>
     <module name="InvalidJavadocPosition"/>
+    <module name="JavadocBlockTagLocation">
+      <!-- default tags -->
+      <property name="tags" value="author, deprecated, exception, hidden, param, provides"/>
+      <property name="tags" value="return, see, serial, serialData, serialField, since, throws"/>
+      <property name="tags" value="uses, version"/>
+      <!-- additional tags used in the project -->
+      <property name="tags" value="noinspection"/>
+    </module>
     <module name="JavadocMethod">
       <property name="allowUndeclaredRTE" value="true"/>
       <property name="allowThrowsTagsForSubclasses" value="true"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -622,6 +622,8 @@ public class PackageObjectFactory implements ModuleFactory {
                 BASE_PACKAGE + ".checks.javadoc.AtclauseOrderCheck");
         NAME_TO_FULL_MODULE_NAME.put("InvalidJavadocPositionCheck",
                 BASE_PACKAGE + ".checks.javadoc.InvalidJavadocPositionCheck");
+        NAME_TO_FULL_MODULE_NAME.put("JavadocBlockTagLocationCheck",
+                BASE_PACKAGE + ".checks.javadoc.JavadocBlockTagLocationCheck");
         NAME_TO_FULL_MODULE_NAME.put("JavadocMethodCheck",
                 BASE_PACKAGE + ".checks.javadoc.JavadocMethodCheck");
         NAME_TO_FULL_MODULE_NAME.put("JavadocPackageCheck",

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java
@@ -1,0 +1,232 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2019 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import com.puppycrawl.tools.checkstyle.StatelessCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailNode;
+import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
+
+/**
+ * <p>
+ * Checks that a
+ * <a href="https://docs.oracle.com/en/java/javase/11/docs/specs/doc-comment-spec.html#block-tags">
+ * javadoc block tag</a> appears only at the beginning of a line, ignoring
+ * leading asterisks and white space. A block tag is a token that starts with
+ * {@code @} symbol and is preceded by a whitespace. This check ignores block
+ * tags in comments and inside inline tags {&#64;code } and {&#64;literal }.
+ * </p>
+ * <p>
+ * Rationale: according to
+ * <a href="https://docs.oracle.com/en/java/javase/11/docs/specs/doc-comment-spec.html#block-tags">
+ * the specification</a> all javadoc block tags should be placed at the beginning
+ * of a line. Tags that are not placed at the beginning are treated as plain text.
+ * To recognize intentional tag placement to text area it is better to escape the
+ * {@code @} symbol, and all non-escaped tags should be located at the beginning
+ * of the line. See NOTE section for details on how to escape.
+ * </p>
+ * <p>
+ * To place a tag explicitly as text, escape the {@code @} symbol with HTML entity
+ * &amp;#64; or place it inside {@code {@code }}, for example:
+ * </p>
+ * <pre>
+ * &#47;**
+ *  * &amp;#64;serial literal in {&#64;code &#64;serial} Javadoc tag.
+ *  *&#47;
+ * </pre>
+ * <ul>
+ * <li>
+ * Property {@code tags} - Specify the javadoc tags to process.
+ * Default value is {@code author, deprecated, exception, hidden, param, provides,
+ * return, see, serial, serialData, serialField, since, throws, uses, version}.
+ * </li>
+ * <li>
+ * Property {@code violateExecutionOnNonTightHtml} - Control when to print violations
+ * if the Javadoc being examined by this check violates the tight html rules defined at
+ * <a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.
+ * Default value is {@code false}.
+ * </li>
+ * </ul>
+ * <p>
+ * To configure the default check:
+ * </p>
+ * <pre>
+ * &lt;module name="JavadocBlockTagLocation"/&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * &#47;**
+ *  * Escaped tag &amp;#64;version (OK)
+ *  * Plain text with {&#64;code &#64;see} (OK)
+ *  * A @custom tag (OK)
+ *  * <!-- @see commented out (OK) -->
+ *  * email@author (OK)
+ *  * (@param in parentheses) (OK)
+ *  * '@param in single quotes' (OK)
+ *  * &#64;since 1.0 (OK)
+ *  * text &#64;return (violation)
+ *  * * &#64;param (violation)
+ * +* &#64;serial (violation)
+ *  * &#64;see first (OK) &#64;see second (violation)
+ *  *&#47;
+ * public int field;
+ * </pre>
+ * <p>
+ * To configure the check to verify tags from
+ * <a href="https://openjdk.java.net/jeps/8068562">JEP 8068562</a> only:
+ * </p>
+ * <pre>
+ * &lt;module name="JavadocBlockTagLocation"&gt;
+ *   &lt;property name="tags" value="apiNote, implSpec, implNote"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * To configure the check to verify all default tags and some custom tags in addition:
+ * </p>
+ * <pre>
+ * &lt;module name="JavadocBlockTagLocation"&gt;
+ *   &lt;!-- default tags --&gt;
+ *   &lt;property name="tags" value="author, deprecated, exception, hidden"/&gt;
+ *   &lt;property name="tags" value="param, provides, return, see, serial"/&gt;
+ *   &lt;property name="tags" value="serialData, serialField, since, throws"/&gt;
+ *   &lt;property name="tags" value="uses, version"/&gt;
+ *   &lt;!-- additional tags used in the project --&gt;
+ *   &lt;property name="tags" value="noinspection"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ *
+ * @since 8.24
+ */
+@StatelessCheck
+public class JavadocBlockTagLocationCheck extends AbstractJavadocCheck {
+
+    /**
+     * A key is pointing to the warning message text in "messages.properties" file.
+     */
+    public static final String MSG_BLOCK_TAG_LOCATION = "javadoc.blockTagLocation";
+
+    /**
+     * This regexp is used to extract the javadoc tags.
+     */
+    private static final Pattern JAVADOC_BLOCK_TAG_PATTERN = Pattern.compile("\\s@(\\w+)");
+
+    /**
+     * Block tags from Java 11
+     * <a href="https://docs.oracle.com/en/java/javase/11/docs/specs/doc-comment-spec.html">
+     * Documentation Comment Specification</a>.
+     */
+    private static final String[] DEFAULT_TAGS = {
+        "author",
+        "deprecated",
+        "exception",
+        "hidden",
+        "param",
+        "provides",
+        "return",
+        "see",
+        "serial",
+        "serialData",
+        "serialField",
+        "since",
+        "throws",
+        "uses",
+        "version",
+    };
+
+    /**
+     * Specify the javadoc tags to process.
+     */
+    private Set<String> tags;
+
+    /**
+     * Creates a new {@code JavadocBlockTagLocationCheck} instance with default settings.
+     */
+    public JavadocBlockTagLocationCheck() {
+        setTags(DEFAULT_TAGS);
+    }
+
+    /**
+     * Setter to specify the javadoc tags to process.
+     *
+     * @param values user's values.
+     */
+    public final void setTags(String... values) {
+        tags = Arrays.stream(values).collect(Collectors.toSet());
+    }
+
+    /**
+     * The javadoc tokens that this check must be registered for. According to
+     * <a href="https://docs.oracle.com/en/java/javase/11/docs/specs/doc-comment-spec.html#block-tags">
+     * the specs</a> each block tag must appear at the beginning of a line, otherwise
+     * it will be interpreted as a plain text. This check looks for a block tag
+     * in the javadoc text, thus it needs the {@code TEXT} tokens.
+     *
+     * @return the javadoc token set this must be registered for.
+     * @see JavadocTokenTypes
+     */
+    @Override
+    public int[] getRequiredJavadocTokens() {
+        return new int[] {
+            JavadocTokenTypes.TEXT,
+        };
+    }
+
+    @Override
+    public int[] getAcceptableJavadocTokens() {
+        return getRequiredJavadocTokens();
+    }
+
+    @Override
+    public int[] getDefaultJavadocTokens() {
+        return getRequiredJavadocTokens();
+    }
+
+    @Override
+    public void visitJavadocToken(DetailNode ast) {
+        if (!isCommentOrInlineTag(ast.getParent())) {
+            final Matcher tagMatcher = JAVADOC_BLOCK_TAG_PATTERN.matcher(ast.getText());
+            while (tagMatcher.find()) {
+                final String tagName = tagMatcher.group(1);
+                if (tags.contains(tagName)) {
+                    log(ast.getLineNumber(), MSG_BLOCK_TAG_LOCATION, tagName);
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks if the node can contain an unescaped block tag without violation.
+     *
+     * @param node to check
+     * @return {@code true} if node is {@code @code}, {@code @literal} or HTML comment.
+     */
+    private static boolean isCommentOrInlineTag(DetailNode node) {
+        return node.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG
+                || node.getType() == JavadocTokenTypes.HTML_COMMENT;
+    }
+
+}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -1,5 +1,6 @@
 at.clause.order=At-clauses have to appear in the order ''{0}''.
 invalid.position=Javadoc comment is placed in the wrong location.
+javadoc.blockTagLocation=The Javadoc block tag ''@{0}'' should be placed at the beginning of the line.
 javadoc.classInfo=Unable to get class information for {0} tag ''{1}''.
 javadoc.duplicateTag=Duplicate {0} tag.
 javadoc.empty=Javadoc has empty description section.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
@@ -1,5 +1,6 @@
 at.clause.order=@-Klauseln müssen in der folgenden Reihenfolge erscheinen: ''{0}''.
 invalid.position=Javadoc-Kommentar wird an der falschen Stelle platziert.
+javadoc.blockTagLocation=Das Javadoc-block-tag ''@{0}'' sollte sich am Anfang der Zeile befinden.
 javadoc.classInfo=Kann für das Tag ''{1}'' keine Klasseninformation zu {0} laden.
 javadoc.duplicateTag=Doppeltes Tag {0}.
 javadoc.empty=Javadoc enthält einen leeren Beschreibungsabschnitt.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
@@ -1,5 +1,6 @@
 at.clause.order=Al-cláusulas tienen que aparecer en el orden ''{0}''.
 invalid.position=El comentario de Javadoc se coloca en la ubicación incorrecta.
+javadoc.blockTagLocation=La etiqueta de bloque ''@{0}'' de Javadoc debe colocarse al principio de la línea.
 javadoc.classInfo=No se puede obtener la información de clase para {0} etiqueta ''{1}''.
 javadoc.duplicateTag=Etiqueta {0} duplicada.
 javadoc.empty=Hay una sección de descripción vacía en el Javadoc.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
@@ -1,5 +1,6 @@
 at.clause.order=At-lausekkeet tarvitse esiintyä järjestyksessä ''{0}''.
 invalid.position=Javadoc-kommentti sijoitetaan väärään paikkaan.
+javadoc.blockTagLocation=Javadoc lohkon tunniste ''@{0}'' olisi sijoitettava rivin alkuun.
 javadoc.classInfo=Luokkatiedot ei saatavilla: {0} tagi ''{1}''.
 javadoc.duplicateTag=Duplikaatti {0}-tagi.
 javadoc.empty=Javadoc on tyhjä §.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
@@ -1,5 +1,6 @@
 at.clause.order=Les balises Javadoc doivent apparaître dans l''ordre ''{0}''.
 invalid.position=Le commentaire Javadoc est placé au mauvais endroit.
+javadoc.blockTagLocation=La balise Javadoc block ''@{0}'' doit être placée au début de la ligne.
 javadoc.classInfo=Impossible d''obtenir les informations relatives à la classe {1} pour la balise ''{0}''.
 javadoc.duplicateTag=Balise Javadoc {0} présente plus d''une fois.
 javadoc.empty=Le commentaire Javadoc est vide.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
@@ -1,5 +1,6 @@
 at.clause.order=Javadoc タグは ''{0}'' の順で並べてください。
 invalid.position=Javadocのコメントが間違った場所に配置されています。
+javadoc.blockTagLocation=Javadocブロックタグ''@{0}''は、行の先頭に配置する必要があります。
 javadoc.classInfo={0} タグの ''{1}'' のクラス情報が取得できません。
 javadoc.duplicateTag={0} タグが重複しています。
 javadoc.empty=Javadocの説明文が空です。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
@@ -1,5 +1,6 @@
 at.clause.order=Cláusulas com `@` deveriam aparecer na ordem ''{0}''.
 invalid.position=O comentário de Javadoc é colocado no local errado.
+javadoc.blockTagLocation=A tag de bloco Javadoc ''@{0}'' deve ser colocada no início da linha.
 javadoc.classInfo=Não foi possível obter informações de classe para {0} tag ''{1}''.
 javadoc.duplicateTag=Tag {0} duplicada.
 javadoc.empty=O javadoc tem uma seção de descrição vazia.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
@@ -1,5 +1,6 @@
 at.clause.order=Cümlecikleri At-düzen `görünmesi zorunda ''{0}''.
 invalid.position=Javadoc yorumu yanlış yere yerleştirildi.
+javadoc.blockTagLocation=Javadoc blok etiketi ''@{0}'' satırın başına yerleştirilmelidir.
 javadoc.classInfo={0} etiketi ''{1}'' için sınıf bilgisi alınamıyor.
 javadoc.duplicateTag={0} etiketi tekrarlanmış.
 javadoc.empty=Javadoc tanım alanı boş bırakılmış.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
@@ -1,5 +1,6 @@
 at.clause.order=@标签应按以下顺序出现：''{0}''。
 invalid.position=Javadoc注释放在错误的位置。
+javadoc.blockTagLocation=Javadoc块标签''@{0}''应该放在行的开头。
 javadoc.classInfo=无法获得 {0} 标签的 ''{1}'' 类信息。
 javadoc.duplicateTag=重复的 Javadoc 注释 {0} 。
 javadoc.empty=Javadoc 描述块不应为空。

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckTest.java
@@ -1,0 +1,112 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2019 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck.MSG_BLOCK_TAG_LOCATION;
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+
+public class JavadocBlockTagLocationCheckTest extends AbstractModuleTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation";
+    }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        final JavadocBlockTagLocationCheck checkObj = new JavadocBlockTagLocationCheck();
+        final int[] expected = {
+            JavadocTokenTypes.TEXT,
+        };
+        assertArrayEquals("Default acceptable tokens are invalid",
+            expected, checkObj.getAcceptableJavadocTokens());
+    }
+
+    @Test
+    public void testCorrect() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(JavadocBlockTagLocationCheck.class);
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig, getPath("InputJavadocBlockTagLocationCorrect.java"), expected);
+    }
+
+    /**
+     * This test is needed to indicate the difference between Javadoc and Checkstyle parsers
+     * when a block tag is inside an inline tag.
+     * Javadoc tool parser sees a block tag here, while Checkstyle parser treat the
+     * inner block tag as plain text. If ever the checkstyle parser is changed,
+     * this test and the check itself should be reviewed.
+     *
+     * @throws Exception if exception occurs during verification process.
+     */
+    @Test
+    public void testMultilineCodeBlock() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(JavadocBlockTagLocationCheck.class);
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig,
+                getPath("InputJavadocBlockTagLocationMultilineCodeBlock.java"), expected);
+    }
+
+    @Test
+    public void testIncorrect() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(JavadocBlockTagLocationCheck.class);
+        final String[] expected = {
+            "9: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "author"),
+            "10: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "since"),
+            "11: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "param"),
+            "13: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "throws"),
+            "14: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "see"),
+            "15: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "return"),
+            "15: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "throws"),
+        };
+        verify(checkConfig,
+                getPath("InputJavadocBlockTagLocationIncorrect.java"), expected);
+    }
+
+    @Test
+    public void testCustomTags() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(JavadocBlockTagLocationCheck.class);
+        checkConfig.addAttribute("tags", "apiNote");
+        checkConfig.addAttribute("tags", "implSpec, implNote");
+        final String[] expected = {
+            "10: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
+            "10: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implNote"),
+            "10: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implSpec"),
+            "12: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
+            "13: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implNote"),
+            "14: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implSpec"),
+        };
+        verify(checkConfig,
+                getPath("InputJavadocBlockTagLocationCustomTags.java"), expected);
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationCorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationCorrect.java
@@ -1,0 +1,24 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
+
+/**
+ * configuration: default
+ */
+public class InputJavadocBlockTagLocationCorrect {
+
+    /**
+     * Summary {@code inline tag}.
+     * Escaped &#64;version
+     * <!-- @see #setRangeProperties -->
+     * {@code @author, @deprecated}
+     * {@literal @see @serial @hidden}
+     * All @customTags should be ignored.
+     * '@return' literal in {@code @return} Javadoc tag.
+     * e-mail@author
+     * (@param in parentheses)
+     * '@param in single quotes'
+     *
+     * @since 1.0
+     */
+    public int field;
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationCustomTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationCustomTags.java
@@ -1,0 +1,20 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
+
+/**
+ * configuration:
+ * tags="apiNote, implSpec, implNote"
+ */
+public class InputJavadocBlockTagLocationCustomTags {
+
+    /**
+     * Text. @apiNote note @implNote note @implSpec spec //warn
+     * {@code @apiNote}
+     * text @apiNote note1 //warn
+     * text text @implNote note2  //warn
+     * text @implSpec  //warn
+     * text @since 1.0
+     */
+    public void method(int param) {
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationIncorrect.java
@@ -1,0 +1,20 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
+
+/**
+ * configuration: default
+ */
+public class InputJavadocBlockTagLocationIncorrect {
+
+    /**
+     * Summary. @author me //warn
+     * <p>Text</p> @since 1.0 //warn
+     * @param param1 a parameter @param, @custom //warn
+     * @param param2 a parameter @custom
+     * * @throws Exception //warn
+    +	 * @see PersistenceContext#setReadOnly(Object,boolean) //warn
+     * text @return one more @throws text again. //warn
+     */
+    public void method(int param1, int param2) {
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationMultilineCodeBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationMultilineCodeBlock.java
@@ -1,0 +1,28 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
+
+/**
+ * configuration: default
+ */
+public class InputJavadocBlockTagLocationMultilineCodeBlock {
+
+    /**
+     * <p>
+     * This javadoc is tricky - it contains block tags inside an inline tag:
+     * </p>
+     * <p>
+     * Default value is {@code @author me
+     * @deprecated, @exception Error,
+     * @param}.
+     * </p>
+     * <p>
+     * Although this is not documented, block tags take precedence over inline tags.
+     * The result is rendered as
+     * </p>
+     * <pre>
+     * Deprecated.
+     * Default value is {&#64;code &#64;author me
+     * </pre>
+     */
+    public int field;
+
+}

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -371,6 +371,10 @@
           Checks that Javadocs are located at the correct position.</td>
       </tr>
       <tr>
+        <td><a href="config_javadoc.html#JavadocBlockTagLocation">JavadocBlockTagLocation</a></td>
+        <td>Checks that a javadoc block tag appears only at the beginning of a line.</td>
+      </tr>
+      <tr>
         <td><a href="config_javadoc.html#JavadocMethod">JavadocMethod</a></td>
         <td>Checks the Javadoc of a method or constructor.</td>
       </tr>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -233,6 +233,168 @@ public class TestClass {
       </subsection>
     </section>
 
+    <section name="JavadocBlockTagLocation">
+      <p>Since Checkstyle 8.24</p>
+      <subsection name="Description" id="JavadocBlockTagLocation_Description">
+        <p>
+          Checks that a
+          <a href="https://docs.oracle.com/en/java/javase/11/docs/specs/doc-comment-spec.html#block-tags">
+          javadoc block tag</a> appears only at the beginning of a line, ignoring
+          leading asterisks and white space. A block tag is a token that starts
+          with <code>@</code> symbol and is preceded by a whitespace. This check
+          ignores block tags in comments and inside inline tags {&#64;code } and
+          {&#64;literal }.
+        </p>
+        <p>
+          Rationale: according to
+          <a href="https://docs.oracle.com/en/java/javase/11/docs/specs/doc-comment-spec.html#block-tags">
+          the specification</a> all javadoc block tags should be placed at the
+          beginning of a line. Tags that are not placed at the beginning are treated
+          as plain text. To recognize intentional tag placement to text area
+          it is better to escape the <code>@</code> symbol, and all non-escaped
+          tags should be located at the beginning of the line. See NOTE section
+          for details on how to escape.
+        </p>
+      </subsection>
+      <subsection name="Notes"  id="JavadocBlockTagLocation_Notes">
+        <p>
+          To place a tag explicitly as text, escape the <code>@</code> symbol
+          with HTML entity &amp;#64; or place it inside <code>{@code }</code>,
+          for example:
+        </p>
+        <source>
+/**
+ * &amp;#64;serial literal in {&#64;code &#64;serial} Javadoc tag.
+ */
+        </source>
+      </subsection>
+      <subsection name="Properties" id="JavadocBlockTagLocation_Properties">
+        <table>
+          <tr>
+            <th>name</th>
+            <th>description</th>
+            <th>type</th>
+            <th>default value</th>
+            <th>since</th>
+          </tr>
+          <tr>
+            <td>tags</td>
+            <td>Specify the javadoc tags to process.</td>
+            <td><a href="property_types.html#stringSet">String Set</a></td>
+            <td><code>author, deprecated, exception, hidden, param, provides, return,
+              see, serial, serialData, serialField, since, throws, uses, version</code></td>
+            <td>8.24</td>
+          </tr>
+          <tr>
+            <td>violateExecutionOnNonTightHtml</td>
+            <td>
+              Control when to print violations if the Javadoc being examined by this check
+              violates the tight html rules defined at
+              <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
+            <td><a href="property_types.html#boolean">Boolean</a></td>
+            <td><code>false</code></td>
+            <td>8.24</td>
+          </tr>
+        </table>
+      </subsection>
+
+      <subsection name="Examples" id="JavadocBlockTagLocation_Examples">
+        <p>
+          To configure the default check:
+        </p>
+        <source>
+&lt;module name=&quot;JavadocBlockTagLocation&quot;/&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+/**
+ * Escaped tag &amp;#64;version (OK)
+ * Plain text with {@code @see} (OK)
+ * A @custom tag (OK)
+ * <!-- @see commented out (OK) -->
+ * email@author (OK)
+ * (@param in parentheses) (OK)
+ * '@param in single quotes' (OK)
+ * @since 1.0 (OK)
+ * text @return (violation)
+ * * @param (violation)
++* @serial (violation)
+ * @see first (OK) @see second (violation)
+ */
+public int field;
+        </source>
+        <p>
+          To configure the check to verify tags from
+          <a href="https://openjdk.java.net/jeps/8068562">JEP 8068562</a> only:
+        </p>
+        <source>
+&lt;module name=&quot;JavadocBlockTagLocation&quot;&gt;
+  &lt;property name=&quot;tags&quot; value=&quot;apiNote, implSpec, implNote&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          To configure the check to verify all default tags and some custom tags in addition:
+        </p>
+        <source>
+&lt;module name=&quot;JavadocBlockTagLocation&quot;&gt;
+  &lt;!-- default tags --&gt;
+  &lt;property name=&quot;tags&quot; value=&quot;author, deprecated, exception, hidden&quot;/&gt;
+  &lt;property name=&quot;tags&quot; value=&quot;param, provides, return, see, serial&quot;/&gt;
+  &lt;property name=&quot;tags&quot; value=&quot;serialData, serialField, since, throws&quot;/&gt;
+  &lt;property name=&quot;tags&quot; value=&quot;uses, version&quot;/&gt;
+  &lt;!-- additional tags used in the project --&gt;
+  &lt;property name=&quot;tags&quot; value=&quot;noinspection&quot;/&gt;
+&lt;/module&gt;
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="JavadocBlockTagLocation_Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocBlockTagLocation">
+              Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Error Messages" id="JavadocBlockTagLocation_Error_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.blockTagLocation%22">
+              javadoc.blockTagLocation</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
+              javadoc.missed.html.close</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.parse.rule.error%22">
+              javadoc.parse.rule.error</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.wrong.singleton.html.tag%22">
+              javadoc.wrong.singleton.html.tag</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="config.html#Custom_messages">see the documentation</a> to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="JavadocBlockTagLocation_Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.javadoc
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="JavadocBlockTagLocation_Parent_Module">
+        <p>
+          <a href="config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+
     <section name="JavadocMethod">
       <subsection name="Description" id="JavadocMethod_Description">
         <p>Since Checkstyle 3.0</p>


### PR DESCRIPTION
Issue #6929 

Regression report: https://pbludov.github.io/issue-6929/
Mostly parse errors. Some catches:
https://pbludov.github.io/issue-6929/Hbase/index.html#A163
https://pbludov.github.io/issue-6929/hibernate-orm/index.html#A82
https://pbludov.github.io/issue-6929/hibernate-orm/index.html#A96
https://pbludov.github.io/issue-6929/hibernate-orm/index.html#A125

To discuss: use this check in google/sun configs?