### PR TITLE
minor: catch all exceptions when checking check messages

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -531,7 +531,8 @@ public class AllChecksTest extends AbstractModuleTestSupport {
             try {
                 result = CheckUtil.getCheckMessage(module, locale, messageString);
             }
-            catch (IllegalArgumentException ex) {
+            // -@cs[IllegalCatch] There is no other way to deliver filename that was used
+            catch (Exception ex) {
                 Assert.fail(module.getSimpleName() + " with the message '" + messageString
                         + "' in locale '" + locale.getLanguage() + "' failed with: "
                         + ex.getClass().getSimpleName() + " - " + ex.getMessage());


### PR DESCRIPTION
Split from https://github.com/checkstyle/checkstyle/pull/6862

An improper message during development threw something other than IAE and there was no way to tell which file or message caused the error without placing a breakpoint.
This is simply to make the debugging process easier by catching all exceptions and printing the specifics of where the error occurred.