### PR TITLE
Issue #6884: Add ID format property to SuppressWithNearbyCommentFilter

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -444,7 +444,20 @@ public class SuppressWithNearbyCommentFilterTest
                 getTagsAfterExecution(filter, "filename", "//SUPPRESS CHECKSTYLE ignore").get(0);
         assertEquals("Invalid toString result",
             "Tag[text='SUPPRESS CHECKSTYLE ignore', firstLine=1, lastLine=1, "
-                    + "tagCheckRegexp=.*, tagMessageRegexp=null]", tag.toString());
+                    + "tagCheckRegexp=.*, tagMessageRegexp=null, tagIdRegexp=null]",
+                    tag.toString());
+    }
+
+    @Test
+    public void testToStringOfTagClassWithId() {
+        final SuppressWithNearbyCommentFilter filter = new SuppressWithNearbyCommentFilter();
+        filter.setIdFormat(".*");
+        final Object tag =
+                getTagsAfterExecution(filter, "filename", "//SUPPRESS CHECKSTYLE ignore").get(0);
+        assertEquals("Invalid toString result",
+            "Tag[text='SUPPRESS CHECKSTYLE ignore', firstLine=1, lastLine=1, "
+                    + "tagCheckRegexp=.*, tagMessageRegexp=null, tagIdRegexp=.*]",
+                    tag.toString());
     }
 
     @Test
@@ -459,11 +472,11 @@ public class SuppressWithNearbyCommentFilterTest
     }
 
     @Test
-    public void testSuppressById() throws Exception {
+    public void testSuppressByCheck() throws Exception {
         final DefaultConfiguration filterConfig =
             createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("commentFormat", "@cs-: (\\w+) \\(\\w+\\)");
-        filterConfig.addAttribute("checkFormat", "$1");
+        filterConfig.addAttribute("checkFormat", "MemberNameCheck");
         filterConfig.addAttribute("influenceFormat", "0");
         final String[] suppressedViolationMessages = {
             "5:17: "
@@ -500,11 +513,174 @@ public class SuppressWithNearbyCommentFilterTest
     }
 
     @Test
+    public void testSuppressById() throws Exception {
+        final DefaultConfiguration filterConfig =
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
+        filterConfig.addAttribute("commentFormat", "@cs-: (\\w+) \\(\\w+\\)");
+        filterConfig.addAttribute("idFormat", "$1");
+        filterConfig.addAttribute("influenceFormat", "0");
+        final String[] suppressedViolationMessages = {
+            "5:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "9:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
+        };
+        final String[] expectedViolationMessages = {
+            "5:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "7:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "abc", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+            "9:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
+            "11:18: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "ID", "^[a-z][a-zA-Z0-9]*$"),
+            "15:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "DEF", "^[a-z][a-zA-Z0-9]*$"),
+            "16:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "XYZ", "^[a-z][a-zA-Z0-9]*$"),
+        };
+
+        verifySuppressed(filterConfig,
+            getPath("InputSuppressWithNearbyCommentFilterById.java"),
+            expectedViolationMessages, suppressedViolationMessages);
+    }
+
+    @Test
+    public void testSuppressByCheckAndId() throws Exception {
+        final DefaultConfiguration filterConfig =
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
+        filterConfig.addAttribute("commentFormat", "@cs-: (\\w+) \\(\\w+\\)");
+        filterConfig.addAttribute("checkFormat", "MemberNameCheck");
+        filterConfig.addAttribute("idFormat", "$1");
+        filterConfig.addAttribute("influenceFormat", "0");
+        final String[] suppressedViolationMessages = {
+            "5:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "9:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
+        };
+        final String[] expectedViolationMessages = {
+            "5:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "7:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "abc", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+            "9:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
+            "11:18: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "ID", "^[a-z][a-zA-Z0-9]*$"),
+            "15:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "DEF", "^[a-z][a-zA-Z0-9]*$"),
+            "16:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "XYZ", "^[a-z][a-zA-Z0-9]*$"),
+        };
+
+        verifySuppressed(filterConfig,
+            getPath("InputSuppressWithNearbyCommentFilterById.java"),
+            expectedViolationMessages, suppressedViolationMessages);
+    }
+
+    @Test
+    public void testSuppressByCheckAndNonMatchingId() throws Exception {
+        final DefaultConfiguration filterConfig =
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
+        filterConfig.addAttribute("commentFormat", "@cs-: (\\w+) \\(\\w+\\)");
+        filterConfig.addAttribute("checkFormat", "MemberNameCheck");
+        filterConfig.addAttribute("idFormat", "emberNa");
+        filterConfig.addAttribute("influenceFormat", "0");
+        final String[] suppressedViolationMessages = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expectedViolationMessages = {
+            "5:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "7:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "abc", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+            "9:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
+            "11:18: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "ID", "^[a-z][a-zA-Z0-9]*$"),
+            "13:57: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "ID3", "^[a-z][a-zA-Z0-9]*$"),
+            "15:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "DEF", "^[a-z][a-zA-Z0-9]*$"),
+            "16:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "XYZ", "^[a-z][a-zA-Z0-9]*$"),
+        };
+
+        verifySuppressed(filterConfig,
+            getPath("InputSuppressWithNearbyCommentFilterById.java"),
+            expectedViolationMessages, suppressedViolationMessages);
+    }
+
+    @Test
     public void tesSuppressByIdAndMessage() throws Exception {
         final DefaultConfiguration filterConfig =
             createModuleConfig(SuppressWithNearbyCommentFilter.class);
         filterConfig.addAttribute("commentFormat", "@cs-: (\\w+) \\(allow (\\w+)\\)");
-        filterConfig.addAttribute("checkFormat", "$1");
+        filterConfig.addAttribute("idFormat", "$1");
+        filterConfig.addAttribute("messageFormat", "$2");
+        filterConfig.addAttribute("influenceFormat", "0");
+        final String[] suppressedViolationMessages = {
+            "15:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "DEF", "^[a-z][a-zA-Z0-9]*$"),
+        };
+        final String[] expectedViolationMessages = {
+            "5:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "A1", "^[a-z][a-zA-Z0-9]*$"),
+            "7:30: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "abc", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+            "9:9: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "line_length", "^[a-z][a-zA-Z0-9]*$"),
+            "11:18: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "ID", "^[a-z][a-zA-Z0-9]*$"),
+            "13:57: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "ID3", "^[a-z][a-zA-Z0-9]*$"),
+            "15:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "DEF", "^[a-z][a-zA-Z0-9]*$"),
+            "16:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "XYZ", "^[a-z][a-zA-Z0-9]*$"),
+        };
+
+        verifySuppressed(filterConfig,
+            getPath("InputSuppressWithNearbyCommentFilterById.java"),
+            expectedViolationMessages, suppressedViolationMessages);
+    }
+
+    @Test
+    public void tesSuppressByCheckAndMessage() throws Exception {
+        final DefaultConfiguration filterConfig =
+            createModuleConfig(SuppressWithNearbyCommentFilter.class);
+        filterConfig.addAttribute("commentFormat", "@cs-: (\\w+) \\(allow (\\w+)\\)");
+        filterConfig.addAttribute("checkFormat", "MemberNameCheck");
         filterConfig.addAttribute("messageFormat", "$2");
         filterConfig.addAttribute("influenceFormat", "0");
         final String[] suppressedViolationMessages = {

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -1937,6 +1937,13 @@ public static void foo() {
                     <td>5.0</td>
                 </tr>
                 <tr>
+                    <td>idFormat</td>
+                    <td>Specify check ID pattern to suppress.</td>
+                    <td><a href="property_types.html#regexp">Regular Expression</a></td>
+                    <td><code>null</code></td>
+                    <td>8.24</td>
+                </tr>
+                <tr>
                     <td>influenceFormat</td>
                     <td>Specify negative/zero/positive value that defines the number of
                         lines preceding/at/following the suppression comment.</td>
@@ -2083,14 +2090,14 @@ public static final int [] array; // @cs.suppress [ConstantName|NoWhitespaceAfte
 &lt;/module&gt;
             </source>
             <p>
-              Example of SuppressWithNearbyCommentFilter configuration (checkFormat which
+              Example of SuppressWithNearbyCommentFilter configuration (idFormat which
               is set to '$1' points that ID of the checks is in the first group of
               commentFormat regular expressions):
             </p>
             <source>
 &lt;module name=&quot;SuppressWithNearbyCommentFilter&quot;&gt;
   &lt;property name=&quot;commentFormat&quot; value=&quot;@cs-: (\w+) \(\w+\)"/&gt;
-  &lt;property name=&quot;checkFormat&quot; value=&quot;$1&quot;/&gt;
+  &lt;property name=&quot;idFormat&quot; value=&quot;$1&quot;/&gt;
   &lt;property name=&quot;influenceFormat&quot; value=&quot;0&quot;/&gt;
 &lt;/module&gt;
             </source>


### PR DESCRIPTION
Issue #6884: This PR adds an `idFormat` property to SuppressWithNearbyCommentFilter. 

Currently, when deciding if an audit event should be suppressed, this filter first matches the event source against the `checkFormat`. If that fails, it matches the event module ID against the `checkFormat`. With this PR, the filter instead matches the event module ID against the new `idFormat` property (additional details in issue description).

Related PR that added an `idFormat` property to SuppressionCommentFilter: #6928 

I will provide regression reports following the same pattern as in that PR.