### PR TITLE
Issue #6947: eclipse violation over javadoc of AtclauseOrderCheck.java

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -65,8 +65,8 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </li>
  * <li>
  * Property {@code tagOrder} - Specify the order by tags.
- * Default value is {@code @author, @deprecated, @exception, @param, @return,
- * @see, @serial, @serialData, @serialField, @since, @throws, @version}.
+ * Default value is
+ * {@code @author, @deprecated, @exception, @param, @return, @see, @serial, @serialData, @serialField, @since, @throws, @version}.
  * </li>
  * </ul>
  * <p>


### PR DESCRIPTION
Issue #6947: this seems like a bug in Eclipse, but as a workaround I think we can just move the `{@code}` block onto one line.