### PR TITLE
Issue #6966: aligned javadoc/xdoc for AvoidEscapedUnicodeCharacters

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -34,16 +34,35 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 /**
  * <p>
  * Restrict using <a href =
- * "https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.3">
- * Unicode escapes</a> (such as <code>&#92;u221e</code>).
+ * "https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.3">
+ * Unicode escapes</a> (such as &#92;u221e).
  * It is possible to allow using escapes for
  * <a href="https://en.wiktionary.org/wiki/Appendix:Control_characters">
- * non-printable(control) characters</a>.
+ * non-printable, control characters</a>.
  * Also, this check can be configured to allow using escapes
  * if trail comment is present. By the option it is possible to
- * allow using escapes if literal contains only them. By the option it
- * is possible to allow using escapes for space literals.
+ * allow using escapes if literal contains only them.
  * </p>
+ * <ul>
+ * <li>
+ * Property {@code allowEscapesForControlCharacters} - Allow use escapes for
+ * non-printable, control characters.
+ * Default value is {@code false}.
+ * </li>
+ * <li>
+ * Property {@code allowByTailComment} - Allow use escapes if trail comment is present.
+ * Default value is {@code false}.
+ * </li>
+ * <li>
+ * Property {@code allowIfAllCharactersEscaped} - Allow if all characters in literal are escaped.
+ * Default value is {@code false}.
+ * </li>
+ * <li>
+ * Property {@code allowNonPrintableEscapes} - Allow use escapes for
+ * non-printable, whitespace characters.
+ * Default value is {@code false}.
+ * </li>
+ * </ul>
  * <p>
  * Examples of using Unicode:</p>
  * <pre>
@@ -57,18 +76,18 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;module name="AvoidEscapedUnicodeCharacters"/&gt;
  * </pre>
  * <p>
- * An example of non-printable(control) characters.
+ * An example of non-printable, control characters.
  * </p>
  * <pre>
  * return '&#92;ufeff' + content; // byte order mark
  * </pre>
  * <p>
  * An example of how to configure the check to allow using escapes
- * for non-printable(control) characters:
+ * for non-printable, control characters:
  * </p>
  * <pre>
  * &lt;module name="AvoidEscapedUnicodeCharacters"&gt;
- *     &lt;property name="allowEscapesForControlCharacters" value="true"/&gt;
+ *   &lt;property name="allowEscapesForControlCharacters" value="true"/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>
@@ -82,7 +101,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </p>
  * <pre>
  * &lt;module name="AvoidEscapedUnicodeCharacters"&gt;
- *     &lt;property name="allowByTailComment" value="true"/&gt;
+ *   &lt;property name="allowByTailComment" value="true"/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>Example of using escapes if literal contains only them:
@@ -95,18 +114,19 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </p>
  * <pre>
  * &lt;module name="AvoidEscapedUnicodeCharacters"&gt;
- *    &lt;property name="allowIfAllCharactersEscaped" value="true"/&gt;
+ *   &lt;property name="allowIfAllCharactersEscaped" value="true"/&gt;
  * &lt;/module&gt;
  * </pre>
- * <p>An example of how to configure the check to allow non-printable escapes:
+ * <p>An example of how to configure the check to allow using escapes
+ * for non-printable, whitespace characters:
  * </p>
  * <pre>
  * &lt;module name="AvoidEscapedUnicodeCharacters"&gt;
- *    &lt;property name="allowNonPrintableEscapes" value="true"/&gt;
+ *   &lt;property name="allowNonPrintableEscapes" value="true"/&gt;
  * &lt;/module&gt;
  * </pre>
  *
- * @noinspection HtmlTagCanBeJavadocTag
+ * @since 5.8
  */
 @FileStatefulCheck
 public class AvoidEscapedUnicodeCharactersCheck
@@ -232,7 +252,7 @@ public class AvoidEscapedUnicodeCharactersCheck
     /** C style comments. */
     private Map<Integer, List<TextBlock>> blockComments;
 
-    /** Allow use escapes for non-printable(control) characters.  */
+    /** Allow use escapes for non-printable, control characters. */
     private boolean allowEscapesForControlCharacters;
 
     /** Allow use escapes if trail comment is present. */
@@ -241,11 +261,11 @@ public class AvoidEscapedUnicodeCharactersCheck
     /** Allow if all characters in literal are escaped. */
     private boolean allowIfAllCharactersEscaped;
 
-    /** Allow escapes for space literals. */
+    /** Allow use escapes for non-printable, whitespace characters. */
     private boolean allowNonPrintableEscapes;
 
     /**
-     * Set allowIfAllCharactersEscaped.
+     * Setter to allow use escapes for non-printable, control characters.
      * @param allow user's value.
      */
     public final void setAllowEscapesForControlCharacters(boolean allow) {
@@ -253,7 +273,7 @@ public class AvoidEscapedUnicodeCharactersCheck
     }
 
     /**
-     * Set allowByTailComment.
+     * Setter to allow use escapes if trail comment is present.
      * @param allow user's value.
      */
     public final void setAllowByTailComment(boolean allow) {
@@ -261,7 +281,7 @@ public class AvoidEscapedUnicodeCharactersCheck
     }
 
     /**
-     * Set allowIfAllCharactersEscaped.
+     * Setter to allow if all characters in literal are escaped.
      * @param allow user's value.
      */
     public final void setAllowIfAllCharactersEscaped(boolean allow) {
@@ -269,7 +289,7 @@ public class AvoidEscapedUnicodeCharactersCheck
     }
 
     /**
-     * Set allowSpaceEscapes.
+     * Setter to allow use escapes for non-printable, whitespace characters.
      * @param allow user's value.
      */
     public final void setAllowNonPrintableEscapes(boolean allow) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -98,7 +98,6 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         "JavaNCSS",
         "NPathComplexity",
         // miscellaneous
-        "AvoidEscapedUnicodeCharacters",
         "CommentsIndentation",
         "DescendantToken",
         "Indentation",

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -156,15 +156,15 @@ public class MyClass {
     </section>
 
     <section name="AvoidEscapedUnicodeCharacters">
+      <p>Since Checkstyle 5.8</p>
       <subsection name="Description" id="AvoidEscapedUnicodeCharacters_Description">
-        <p>Since Checkstyle 5.8</p>
         <p>
           Restrict using
-            <a href = "https://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.3">
-          Unicode escapes</a> (e.g. \u221e).
+          <a href = "https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.3">
+          Unicode escapes</a> (such as \u221e).
           It is possible to allow using escapes for
           <a href="https://en.wiktionary.org/wiki/Appendix:Control_characters">
-              non-printable(control) characters</a>.
+              non-printable, control characters</a>.
           Also, this check can be configured to allow using escapes
           if trail comment is present. By the option it is possible to
           allow using escapes if literal contains only them.
@@ -182,30 +182,30 @@ public class MyClass {
           </tr>
           <tr>
             <td>allowEscapesForControlCharacters</td>
-            <td>Allow use escapes for non-printable(control) characters.</td>
+            <td>Allow use escapes for non-printable, control characters.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td>false</td>
+            <td><code>false</code></td>
             <td>5.8</td>
           </tr>
           <tr>
             <td>allowByTailComment</td>
             <td>Allow use escapes if trail comment is present.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td>false</td>
+            <td><code>false</code></td>
             <td>5.8</td>
           </tr>
           <tr>
             <td>allowIfAllCharactersEscaped</td>
             <td>Allow if all characters in literal are escaped.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td>false</td>
+            <td><code>false</code></td>
             <td>5.8</td>
           </tr>
           <tr>
             <td>allowNonPrintableEscapes</td>
-            <td>Allow non-printable escapes.</td>
+            <td>Allow use escapes for non-printable, whitespace characters.</td>
             <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td>false</td>
+            <td><code>false</code></td>
             <td>5.8</td>
           </tr>
         </table>
@@ -216,8 +216,8 @@ public class MyClass {
           Examples of using Unicode:
         </p>
         <source>
-String unitAbbrev = "μs"; //Best: perfectly clear even without a comment.
-String unitAbbrev = "\u03bcs"; //Poor: the reader has no idea what this is.
+String unitAbbrev = "μs";      // Best: perfectly clear even without a comment.
+String unitAbbrev = "\u03bcs"; // Poor: the reader has no idea what this is.
         </source>
         <p>
           An example of how to configure the check is:
@@ -226,14 +226,14 @@ String unitAbbrev = "\u03bcs"; //Poor: the reader has no idea what this is.
 &lt;module name=&quot;AvoidEscapedUnicodeCharacters&quot;/&gt;
         </source>
         <p>
-          An example of non-printable(control) characters.
+          An example of non-printable, control characters.
         </p>
         <source>
 return '\ufeff' + content; // byte order mark
         </source>
         <p>
           An example of how to configure the check to allow using escapes
-          for non-printable(control) characters:
+          for non-printable, control characters:
         </p>
         <source>
 &lt;module name="AvoidEscapedUnicodeCharacters"&gt;
@@ -271,7 +271,8 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
 &lt;/module&gt;
         </source>
         <p>
-          An example of how to configure the check to allow non-printable escapes:
+          An example of how to configure the check to allow using escapes
+          for non-printable, whitespace characters:
         </p>
         <source>
 &lt;module name="AvoidEscapedUnicodeCharacters"&gt;


### PR DESCRIPTION
Issue #6966 (part of #5750)

No changes in the code, but many changes in the comments.