### PR TITLE
Issue #6207: Add xpath regression test for AbstractClassName

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAbstractClassNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAbstractClassNameTest.java
@@ -1,0 +1,120 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2019 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck;
+
+public class XpathRegressionAbstractClassNameTest extends AbstractXpathTestSupport {
+
+    private final String checkName = AbstractClassNameCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testClassNameTop() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionAbstractClassNameTop.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AbstractClassNameCheck.class);
+
+        final String[] expectedViolation = {
+            "3:1: " + getCheckMessage(AbstractClassNameCheck.class,
+                AbstractClassNameCheck.MSG_ILLEGAL_ABSTRACT_CLASS_NAME,
+                    "SuppressionXpathRegressionAbstractClassNameTop", "^Abstract.+$"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAbstractClassNameTop']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAbstractClassNameTop']]"
+                        + "/MODIFIERS",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAbstractClassNameTop']]"
+                        + "/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testClassNameInner() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionAbstractClassNameInner.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AbstractClassNameCheck.class);
+
+        final String[] expectedViolation = {
+            "4:5: " + getCheckMessage(AbstractClassNameCheck.class,
+                AbstractClassNameCheck.MSG_ILLEGAL_ABSTRACT_CLASS_NAME,
+                    "MyClass", "^Abstract.+$"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAbstractClassNameInner']]"
+                        + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='MyClass']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAbstractClassNameInner']]"
+                        + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='MyClass']]/MODIFIERS",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAbstractClassNameInner']]"
+                        + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='MyClass']]/MODIFIERS/ABSTRACT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testClassNameNoModifier() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionAbstractClassNoModifier.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AbstractClassNameCheck.class);
+
+        final String[] expectedViolation = {
+            "4:5: " + getCheckMessage(AbstractClassNameCheck.class,
+                AbstractClassNameCheck.MSG_NO_ABSTRACT_CLASS_MODIFIER,
+                    "AbstractMyClass"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAbstractClassNoModifier']]"
+                        + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='AbstractMyClass']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAbstractClassNoModifier']]"
+                        + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='AbstractMyClass']]/MODIFIERS",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAbstractClassNoModifier']]"
+                        + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='AbstractMyClass']]/LITERAL_CLASS"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/abstractclassname/SuppressionXpathRegressionAbstractClassNameInner.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/abstractclassname/SuppressionXpathRegressionAbstractClassNameInner.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.abstractclassname;
+
+public class SuppressionXpathRegressionAbstractClassNameInner {
+    abstract class MyClass { // warn
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/abstractclassname/SuppressionXpathRegressionAbstractClassNameTop.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/abstractclassname/SuppressionXpathRegressionAbstractClassNameTop.java
@@ -1,0 +1,4 @@
+package org.checkstyle.suppressionxpathfilter.abstractclassname;
+
+public abstract class SuppressionXpathRegressionAbstractClassNameTop { // warn
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/abstractclassname/SuppressionXpathRegressionAbstractClassNoModifier.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/abstractclassname/SuppressionXpathRegressionAbstractClassNoModifier.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.abstractclassname;
+
+public class SuppressionXpathRegressionAbstractClassNoModifier {
+    class AbstractMyClass { // warn
+    }
+}


### PR DESCRIPTION
This PR adds XPath regression test for suppression filter on [AbstractClassName](https://checkstyle.org/config_naming.html#AbstractClassName) check, see #6207.