### PR TITLE
Issue #6207: Add xpath regression test for AnonInnerLength

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnonInnerLengthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnonInnerLengthTest.java
@@ -1,0 +1,69 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2019 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.sizes.AnonInnerLengthCheck;
+
+public class XpathRegressionAnonInnerLengthTest extends AbstractXpathTestSupport {
+
+    private final String checkName = AnonInnerLengthCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testMaxLength() throws Exception {
+        final int maxLen = 5;
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionAnonInnerLength.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AnonInnerLengthCheck.class);
+        moduleConfig.addAttribute("max", String.valueOf(maxLen));
+
+        final String[] expectedViolation = {
+            "7:41: " + getCheckMessage(AnonInnerLengthCheck.class,
+                    AnonInnerLengthCheck.MSG_KEY, 6, maxLen),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnonInnerLength']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='compare']]/SLIST"
+                        + "/VARIABLE_DEF[./IDENT[@text='comparator']]/ASSIGN/EXPR",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnonInnerLength']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='compare']]/SLIST"
+                        + "/VARIABLE_DEF[./IDENT[@text='comparator']]/ASSIGN/EXPR"
+                        + "/LITERAL_NEW[./IDENT[@text='Comparator']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/anoninnerlength/SuppressionXpathRegressionAnonInnerLength.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/anoninnerlength/SuppressionXpathRegressionAnonInnerLength.java
@@ -1,0 +1,15 @@
+package org.checkstyle.suppressionxpathfilter.anoninnerlength;
+
+import java.util.Comparator;
+
+public class SuppressionXpathRegressionAnonInnerLength {
+    public int compare(String v1, String v2) {
+        Comparator<String> comparator = new Comparator<String>() { // warn: inner class has 6 lines (max=5)
+            @Override
+            public int compare(String s1, String s2) {
+                return s1.compareTo(s2);
+            }
+        };
+        return comparator.compare(v1, v2);
+    }
+}


### PR DESCRIPTION
This PR adds XPath regression test for suppression filter on [AnonInnerLength](https://checkstyle.org/config_sizes.html#AnonInnerLength) check, see #6207.