### PR TITLE
Issue #6207: Track remaing checks to do in xpath IT

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAbstractClassNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAbstractClassNameTest.java
@@ -93,7 +93,7 @@ public class XpathRegressionAbstractClassNameTest extends AbstractXpathTestSuppo
     @Test
     public void testClassNameNoModifier() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionAbstractClassNoModifier.java"));
+                new File(getPath("SuppressionXpathRegressionAbstractClassNameNoModifier.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(AbstractClassNameCheck.class);
@@ -105,11 +105,14 @@ public class XpathRegressionAbstractClassNameTest extends AbstractXpathTestSuppo
         };
 
         final List<String> expectedXpathQueries = Arrays.asList(
-                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAbstractClassNoModifier']]"
+                "/CLASS_DEF[./IDENT[@text='"
+                        + "SuppressionXpathRegressionAbstractClassNameNoModifier']]"
                         + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='AbstractMyClass']]",
-                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAbstractClassNoModifier']]"
+                "/CLASS_DEF[./IDENT[@text='"
+                        + "SuppressionXpathRegressionAbstractClassNameNoModifier']]"
                         + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='AbstractMyClass']]/MODIFIERS",
-                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAbstractClassNoModifier']]"
+                "/CLASS_DEF[./IDENT[@text='"
+                        + "SuppressionXpathRegressionAbstractClassNameNoModifier']]"
                         + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='AbstractMyClass']]/LITERAL_CLASS"
         );
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCyclomaticComplexityTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCyclomaticComplexityTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionCyclomaticComplexityTest extends AbstractXpathTestSu
     public void testOne() throws Exception {
 
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCyclomaticOne.java"));
+                new File(getPath("SuppressionXpathRegressionCyclomaticComplexityOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(CyclomaticComplexityCheck.class);
@@ -53,12 +53,12 @@ public class XpathRegressionCyclomaticComplexityTest extends AbstractXpathTestSu
         };
 
         final List<String> expectedXpathQueries = Arrays.asList(
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionCyclomaticOne']]/OBJBLOCK"
-                + "/METHOD_DEF[./IDENT[@text='test']]",
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionCyclomaticOne']]/OBJBLOCK"
-                + "/METHOD_DEF[./IDENT[@text='test']]/MODIFIERS",
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionCyclomaticOne']]/OBJBLOCK"
-                + "/METHOD_DEF[./IDENT[@text='test']]/MODIFIERS/LITERAL_PUBLIC"
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionCyclomaticComplexityOne']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionCyclomaticComplexityOne']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/MODIFIERS",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionCyclomaticComplexityOne']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/MODIFIERS/LITERAL_PUBLIC"
                 );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -68,7 +68,7 @@ public class XpathRegressionCyclomaticComplexityTest extends AbstractXpathTestSu
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCyclomaticTwo.java"));
+                new File(getPath("SuppressionXpathRegressionCyclomaticComplexityTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(CyclomaticComplexityCheck.class);
@@ -80,12 +80,12 @@ public class XpathRegressionCyclomaticComplexityTest extends AbstractXpathTestSu
         };
 
         final List<String> expectedXpathQueries = Arrays.asList(
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionCyclomaticTwo']]/OBJBLOCK"
-                    + "/METHOD_DEF[./IDENT[@text='foo2']]",
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionCyclomaticTwo']]/OBJBLOCK"
-                    + "/METHOD_DEF[./IDENT[@text='foo2']]/MODIFIERS",
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionCyclomaticTwo']]/OBJBLOCK"
-                    + "/METHOD_DEF[./IDENT[@text='foo2']]/MODIFIERS/LITERAL_PUBLIC"
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionCyclomaticComplexityTwo']]"
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo2']]",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionCyclomaticComplexityTwo']]"
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo2']]/MODIFIERS",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionCyclomaticComplexityTwo']]"
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo2']]/MODIFIERS/LITERAL_PUBLIC"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionDeclarationOrderTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionDeclarationOrderTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionDeclarationOrderTest extends AbstractXpathTestSuppor
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionDeclarationOne.java"));
+                new File(getPath("SuppressionXpathRegressionDeclarationOrderOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(DeclarationOrderCheck.class);
@@ -51,11 +51,11 @@ public class XpathRegressionDeclarationOrderTest extends AbstractXpathTestSuppor
         };
 
         final List<String> expectedXpathQueries = Arrays.asList(
-                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionDeclarationOne']]"
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionDeclarationOrderOne']]"
                         + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='name']]",
-                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionDeclarationOne']]"
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionDeclarationOrderOne']]"
                         + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='name']]/MODIFIERS",
-                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionDeclarationOne']]"
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionDeclarationOrderOne']]"
                         + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='name']]/MODIFIERS/LITERAL_PUBLIC"
         );
 
@@ -66,7 +66,7 @@ public class XpathRegressionDeclarationOrderTest extends AbstractXpathTestSuppor
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionDeclarationTwo.java"));
+                new File(getPath("SuppressionXpathRegressionDeclarationOrderTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(DeclarationOrderCheck.class);
@@ -77,11 +77,11 @@ public class XpathRegressionDeclarationOrderTest extends AbstractXpathTestSuppor
         };
 
         final List<String> expectedXpathQueries = Arrays.asList(
-                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionDeclarationTwo']]"
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionDeclarationOrderTwo']]"
                         + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='MAX']]",
-                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionDeclarationTwo']]"
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionDeclarationOrderTwo']]"
                         + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='MAX']]/MODIFIERS",
-                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionDeclarationTwo']]"
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionDeclarationOrderTwo']]"
                         + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='MAX']]/MODIFIERS/LITERAL_PUBLIC"
         );
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionExplicitInitializationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionExplicitInitializationTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionExplicitInitializationTest extends AbstractXpathTest
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionExplicitOne.java"));
+                new File(getPath("SuppressionXpathRegressionExplicitInitializationOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ExplicitInitializationCheck.class);
@@ -51,7 +51,7 @@ public class XpathRegressionExplicitInitializationTest extends AbstractXpathTest
         };
 
         final List<String> expectedXpathQueries = Collections.singletonList(
-                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionExplicitOne']]"
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionExplicitInitializationOne']]"
                         + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='a']"
         );
 
@@ -62,7 +62,7 @@ public class XpathRegressionExplicitInitializationTest extends AbstractXpathTest
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionExplicitTwo.java"));
+                new File(getPath("SuppressionXpathRegressionExplicitInitializationTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ExplicitInitializationCheck.class);
@@ -73,8 +73,8 @@ public class XpathRegressionExplicitInitializationTest extends AbstractXpathTest
         };
 
         final List<String> expectedXpathQueries = Collections.singletonList(
-                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionExplicitTwo']]/OBJBLOCK"
-                        + "/VARIABLE_DEF/IDENT[@text='bar']"
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionExplicitInitializationTwo']]"
+                        + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='bar']"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionFallThroughTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionFallThroughTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionFallThroughTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionExplicitOne.java"));
+                new File(getPath("SuppressionXpathRegressionFallThroughOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(FallThroughCheck.class);
@@ -51,10 +51,10 @@ public class XpathRegressionFallThroughTest extends AbstractXpathTestSupport {
         };
 
         final List<String> expectedXpathQueries = Arrays.asList(
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionExplicitOne']]/OBJBLOCK"
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionFallThroughOne']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='test']]/SLIST/LITERAL_SWITCH/CASE_GROUP["
                 + "./LITERAL_CASE/EXPR/NUM_INT[@text='2']]",
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionExplicitOne']]/OBJBLOCK"
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionFallThroughOne']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='test']]/SLIST/LITERAL_SWITCH/CASE_GROUP/LITERAL_CASE"
         );
 
@@ -65,7 +65,7 @@ public class XpathRegressionFallThroughTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionExplicitTwo.java"));
+                new File(getPath("SuppressionXpathRegressionFallThroughTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(FallThroughCheck.class);
@@ -77,11 +77,11 @@ public class XpathRegressionFallThroughTest extends AbstractXpathTestSupport {
         };
 
         final List<String> expectedXpathQueries = Arrays.asList(
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionExplicitTwo']]/OBJBLOCK"
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionFallThroughTwo']]/OBJBLOCK"
                 + "/METHOD_DEF["
                 + "./IDENT[@text='methodFallThruCustomWords']]/SLIST/LITERAL_WHILE/SLIST"
                 + "/LITERAL_SWITCH/CASE_GROUP[./SLIST/EXPR/POST_INC/IDENT[@text='i']]",
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionExplicitTwo']]/OBJBLOCK"
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionFallThroughTwo']]/OBJBLOCK"
                 + "/METHOD_DEF["
                 + "./IDENT[@text='methodFallThruCustomWords']]/SLIST/LITERAL_WHILE/SLIST"
                 + "/LITERAL_SWITCH/CASE_GROUP/LITERAL_DEFAULT"

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionGenericWhitespaceTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionGenericWhitespaceTest.java
@@ -40,8 +40,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
     @Test
     public void testProcessEnd() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionProcessEnd.java"));
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionGenericWhitespaceEnd.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -52,8 +52,9 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
         };
 
         final List<String> expectedXpathQueries = Collections.singletonList(
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionProcessEnd']]/OBJBLOCK"
-                + "/METHOD_DEF[./IDENT[@text='bad']]/PARAMETERS/PARAMETER_DEF[./IDENT[@text='cls']]"
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionGenericWhitespaceEnd']]/OBJBLOCK"
+                + "/METHOD_DEF[./IDENT[@text='bad']]"
+                + "/PARAMETERS/PARAMETER_DEF[./IDENT[@text='cls']]"
                 + "/TYPE[./IDENT[@text='Class']]/TYPE_ARGUMENTS/GENERIC_END"
         );
 
@@ -63,8 +64,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
     @Test
     public void testProcessNestedGenericsOne() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionProcessNestedGenericsOne.java"));
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionGenericWhitespaceNestedGenericsOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -76,8 +77,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionProcessNestedGenericsOne']]/OBJBLOCK"
-                + "/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS"
+                + "@text='SuppressionXpathRegressionGenericWhitespaceNestedGenericsOne']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS"
                 + "/TYPE_PARAMETER[./IDENT[@text='E']]"
                 + "/TYPE_UPPER_BOUNDS[./IDENT[@text='Enum']]/TYPE_ARGUMENTS/GENERIC_END"
         );
@@ -88,8 +89,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
     @Test
     public void testProcessNestedGenericsTwo() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionProcessNestedGenericsTwo.java"));
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionGenericWhitespaceNestedGenericsTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -101,8 +102,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionProcessNestedGenericsTwo']]/OBJBLOCK"
-                + "/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS"
+                + "@text='SuppressionXpathRegressionGenericWhitespaceNestedGenericsTwo']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS"
                 + "/TYPE_PARAMETER[./IDENT[@text='E']]"
                 + "/TYPE_UPPER_BOUNDS[./IDENT[@text='Enum']]/TYPE_ARGUMENTS/GENERIC_END"
         );
@@ -113,8 +114,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
     @Test
     public void testProcessNestedGenericsThree() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionProcessNestedGenericsThree.java"));
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionGenericWhitespaceNestedGenericsThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -126,8 +127,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionProcessNestedGenericsThree']]/OBJBLOCK"
-                + "/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS"
+                + "@text='SuppressionXpathRegressionGenericWhitespaceNestedGenericsThree']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS"
                 + "/TYPE_PARAMETER[./IDENT[@text='E']]"
                 + "/TYPE_UPPER_BOUNDS[./IDENT[@text='Enum']]/TYPE_ARGUMENTS/GENERIC_END"
         );
@@ -138,8 +139,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
     @Test
     public void testProcessSingleGenericOne() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionProcessSingleGenericOne.java"));
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionGenericWhitespaceSingleGenericOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -151,8 +152,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionProcessSingleGenericOne']]/OBJBLOCK"
-                + "/VARIABLE_DEF[./IDENT[@text='bad']]/ASSIGN/EXPR/METHOD_CALL"
+                + "@text='SuppressionXpathRegressionGenericWhitespaceSingleGenericOne']]"
+                + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='bad']]/ASSIGN/EXPR/METHOD_CALL"
                 + "/DOT[./IDENT[@text='Collections']]"
                 + "/TYPE_ARGUMENTS/GENERIC_END"
         );
@@ -163,8 +164,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
     @Test
     public void testProcessSingleGenericTwo() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionProcessSingleGenericTwo.java"));
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionGenericWhitespaceSingleGenericTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -176,8 +177,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionProcessSingleGenericTwo']]/OBJBLOCK"
-                + "/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS/GENERIC_END"
+                + "@text='SuppressionXpathRegressionGenericWhitespaceSingleGenericTwo']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS/GENERIC_END"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -186,8 +187,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
     @Test
     public void testProcessStartOne() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionProcessStartOne.java"));
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionGenericWhitespaceStartOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -198,10 +199,10 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
         };
 
         final List<String> expectedXpathQueries = Arrays.asList(
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionProcessStartOne']]/OBJBLOCK"
-                + "/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS",
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionProcessStartOne']]/OBJBLOCK"
-                + "/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS/GENERIC_START"
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionGenericWhitespaceStartOne']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionGenericWhitespaceStartOne']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS/GENERIC_START"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -210,8 +211,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
     @Test
     public void testProcessStartTwo() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionProcessStartTwo.java"));
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionGenericWhitespaceStartTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -222,12 +223,12 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
         };
 
         final List<String> expectedXpathQueries = Arrays.asList(
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionProcessStartTwo']]/OBJBLOCK"
-                + "/METHOD_DEF[./IDENT[@text='bad']]/PARAMETERS"
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionGenericWhitespaceStartTwo']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/PARAMETERS"
                 + "/PARAMETER_DEF[./IDENT[@text='consumer']]"
                 + "/TYPE[./IDENT[@text='Consumer']]/TYPE_ARGUMENTS",
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionProcessStartTwo']]/OBJBLOCK"
-                + "/METHOD_DEF[./IDENT[@text='bad']]/PARAMETERS"
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionGenericWhitespaceStartTwo']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/PARAMETERS"
                 + "/PARAMETER_DEF[./IDENT[@text='consumer']]"
                 + "/TYPE[./IDENT[@text='Consumer']]/TYPE_ARGUMENTS/GENERIC_START"
         );
@@ -238,8 +239,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
     @Test
     public void testProcessStartThree() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionProcessStartThree.java"));
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionGenericWhitespaceStartThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -250,14 +251,14 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
         };
 
         final List<String> expectedXpathQueries = Arrays.asList(
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionProcessStartThree']]/OBJBLOCK/"
-                + "METHOD_DEF[./IDENT[@text='bad']]",
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionProcessStartThree']]/OBJBLOCK/"
-                + "METHOD_DEF[./IDENT[@text='bad']]/MODIFIERS",
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionProcessStartThree']]/OBJBLOCK/"
-                + "METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS",
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionProcessStartThree']]/OBJBLOCK/"
-                + "METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS/GENERIC_START"
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionGenericWhitespaceStartThree']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionGenericWhitespaceStartThree']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/MODIFIERS",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionGenericWhitespaceStartThree']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionGenericWhitespaceStartThree']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='bad']]/TYPE_PARAMETERS/GENERIC_START"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionHiddenFieldTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionHiddenFieldTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionHiddenFieldTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionExplicitOne.java"));
+                new File(getPath("SuppressionXpathRegressionHiddenFieldOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(HiddenFieldCheck.class);
@@ -51,7 +51,7 @@ public class XpathRegressionHiddenFieldTest extends AbstractXpathTestSupport {
         };
 
         final List<String> expectedXpathQueries = Collections.singletonList(
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionExplicitOne']]/OBJBLOCK"
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionHiddenFieldOne']]/OBJBLOCK"
                 + "/INSTANCE_INIT/SLIST/EXPR/METHOD_CALL/ELIST/LAMBDA/PARAMETERS"
                 + "/PARAMETER_DEF/IDENT[@text='value']"
         );
@@ -63,7 +63,7 @@ public class XpathRegressionHiddenFieldTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionExplicitTwo.java"));
+                new File(getPath("SuppressionXpathRegressionHiddenFieldTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(HiddenFieldCheck.class);
@@ -74,7 +74,7 @@ public class XpathRegressionHiddenFieldTest extends AbstractXpathTestSupport {
         };
 
         final List<String> expectedXpathQueries = Collections.singletonList(
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionExplicitTwo']]/OBJBLOCK"
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionHiddenFieldTwo']]/OBJBLOCK"
                 + "/METHOD_DEF[./IDENT[@text='method']]/PARAMETERS/PARAMETER_DEF"
                 + "/IDENT[@text='other']"
         );

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMultipleVariableDeclarationsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMultipleVariableDeclarationsTest.java
@@ -39,8 +39,8 @@ public class XpathRegressionMultipleVariableDeclarationsTest extends AbstractXpa
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMultipleVariableDeclarationOne.java"));
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionMultipleVariableDeclarationsOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(MultipleVariableDeclarationsCheck.class);
@@ -52,28 +52,28 @@ public class XpathRegressionMultipleVariableDeclarationsTest extends AbstractXpa
 
         final List<String> expectedXpathQueries = Arrays.asList(
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationOne']]/OBJBLOCK"
+                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationsOne']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='i']]",
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationOne']]/OBJBLOCK"
+                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationsOne']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='i']]/MODIFIERS",
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationOne']]/OBJBLOCK"
+                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationsOne']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='i']]/TYPE",
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationOne']]/OBJBLOCK"
+                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationsOne']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='i']]/TYPE/LITERAL_INT",
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationOne']]/OBJBLOCK"
+                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationsOne']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='j']]",
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationOne']]/OBJBLOCK"
+                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationsOne']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='j']]/MODIFIERS",
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationOne']]/OBJBLOCK"
+                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationsOne']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='j']]/TYPE",
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationOne']]/OBJBLOCK"
+                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationsOne']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='j']]/TYPE/LITERAL_INT"
         );
 
@@ -83,8 +83,8 @@ public class XpathRegressionMultipleVariableDeclarationsTest extends AbstractXpa
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMultipleVariableDeclarationTwo.java"));
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionMultipleVariableDeclarationsTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(MultipleVariableDeclarationsCheck.class);
@@ -96,16 +96,16 @@ public class XpathRegressionMultipleVariableDeclarationsTest extends AbstractXpa
 
         final List<String> expectedXpathQueries = Arrays.asList(
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationTwo']]/OBJBLOCK"
+                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationsTwo']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='i1']]",
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationTwo']]/OBJBLOCK"
+                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationsTwo']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='i1']]/MODIFIERS",
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationTwo']]/OBJBLOCK"
+                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationsTwo']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='i1']]/TYPE",
             "/CLASS_DEF[./IDENT["
-                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationTwo']]/OBJBLOCK"
+                + "@text='SuppressionXpathRegressionMultipleVariableDeclarationsTwo']]/OBJBLOCK"
                 + "/VARIABLE_DEF[./IDENT[@text='i1']]/TYPE/LITERAL_INT"
         );
 

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/abstractclassname/SuppressionXpathRegressionAbstractClassNameNoModifier.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/abstractclassname/SuppressionXpathRegressionAbstractClassNameNoModifier.java
@@ -1,6 +1,6 @@
 package org.checkstyle.suppressionxpathfilter.abstractclassname;
 
-public class SuppressionXpathRegressionAbstractClassNoModifier {
+public class SuppressionXpathRegressionAbstractClassNameNoModifier {
     class AbstractMyClass { // warn
     }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/cyclomaticcomplexity/SuppressionXpathRegressionCyclomaticComplexityOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/cyclomaticcomplexity/SuppressionXpathRegressionCyclomaticComplexityOne.java
@@ -1,6 +1,6 @@
 package org.checkstyle.suppressionxpathfilter.cyclomaticcomplexity;
 
-public class SuppressionXpathRegressionCyclomaticOne {
+public class SuppressionXpathRegressionCyclomaticComplexityOne {
     public void test(int a, int b) { //warn
         if (a > b) {
 

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/cyclomaticcomplexity/SuppressionXpathRegressionCyclomaticComplexityTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/cyclomaticcomplexity/SuppressionXpathRegressionCyclomaticComplexityTwo.java
@@ -1,6 +1,6 @@
 package org.checkstyle.suppressionxpathfilter.cyclomaticcomplexity;
 
-public class SuppressionXpathRegressionCyclomaticTwo {
+public class SuppressionXpathRegressionCyclomaticComplexityTwo {
 
 
     public void foo2() { //warn

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/declarationorder/SuppressionXpathRegressionDeclarationOrderOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/declarationorder/SuppressionXpathRegressionDeclarationOrderOne.java
@@ -1,6 +1,6 @@
 package org.checkstyle.suppressionxpathfilter.declarationorder;
 
-public class SuppressionXpathRegressionDeclarationOne {
+public class SuppressionXpathRegressionDeclarationOrderOne {
     private int age;
     public String name;  //warn
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/declarationorder/SuppressionXpathRegressionDeclarationOrderTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/declarationorder/SuppressionXpathRegressionDeclarationOrderTwo.java
@@ -1,6 +1,6 @@
 package org.checkstyle.suppressionxpathfilter.declarationorder;
 
-public class SuppressionXpathRegressionDeclarationTwo {
+public class SuppressionXpathRegressionDeclarationOrderTwo {
     public static void foo1() {}
     public static final double MAX = 0.60; //warn
     public static void foo2() {}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/explicitinitialization/SuppressionXpathRegressionExplicitInitializationOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/explicitinitialization/SuppressionXpathRegressionExplicitInitializationOne.java
@@ -1,5 +1,5 @@
 package org.checkstyle.suppressionxpathfilter.explicitinitialization;
 
-public class SuppressionXpathRegressionExplicitOne {
+public class SuppressionXpathRegressionExplicitInitializationOne {
     private int a = 0; //warn
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/explicitinitialization/SuppressionXpathRegressionExplicitInitializationTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/explicitinitialization/SuppressionXpathRegressionExplicitInitializationTwo.java
@@ -1,6 +1,6 @@
 package org.checkstyle.suppressionxpathfilter.explicitinitialization;
 
-public class SuppressionXpathRegressionExplicitTwo {
+public class SuppressionXpathRegressionExplicitInitializationTwo {
     private int a;
 
     private Object bar = null; //warn

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/fallthrough/SuppressionXpathRegressionFallThroughOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/fallthrough/SuppressionXpathRegressionFallThroughOne.java
@@ -1,6 +1,6 @@
 package org.checkstyle.suppressionxpathfilter.fallthrough;
 
-public class SuppressionXpathRegressionExplicitOne {
+public class SuppressionXpathRegressionFallThroughOne {
     public void test() {
         int id = 0;
         switch (id) {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/fallthrough/SuppressionXpathRegressionFallThroughTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/fallthrough/SuppressionXpathRegressionFallThroughTwo.java
@@ -1,6 +1,6 @@
 package org.checkstyle.suppressionxpathfilter.fallthrough;
 
-public class SuppressionXpathRegressionExplicitTwo {
+public class SuppressionXpathRegressionFallThroughTwo {
     void methodFallThruCustomWords(int i, int j, boolean cond) {
         while (true) {
             switch (i){

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceEnd.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceEnd.java
@@ -2,7 +2,7 @@ package org.checkstyle.suppressionxpathfilter.genericwhitespace;
 
 import java.util.Collections;
 
-public class SuppressionXpathRegressionProcessEnd {
+public class SuppressionXpathRegressionGenericWhitespaceEnd {
     void bad(Class<? > cls) {//warn
     }
     void good(Class<?> cls) {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceNestedGenericsOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceNestedGenericsOne.java
@@ -2,7 +2,7 @@ package org.checkstyle.suppressionxpathfilter.genericwhitespace;
 
 import java.io.Serializable;
 
-public class SuppressionXpathRegressionProcessNestedGenericsOne {
+public class SuppressionXpathRegressionGenericWhitespaceNestedGenericsOne {
     <E extends Enum<E>& Serializable> void bad() {//warn
     }
     <E extends Enum<E> & Serializable> void good() {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceNestedGenericsThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceNestedGenericsThree.java
@@ -2,7 +2,7 @@ package org.checkstyle.suppressionxpathfilter.genericwhitespace;
 
 import java.io.Serializable;
 
-public class SuppressionXpathRegressionProcessNestedGenericsThree {
+public class SuppressionXpathRegressionGenericWhitespaceNestedGenericsThree {
     <E extends Enum<E> , X> void bad() {//warn
     }
     <E extends Enum<E>, X> void good() {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceNestedGenericsTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceNestedGenericsTwo.java
@@ -2,7 +2,7 @@ package org.checkstyle.suppressionxpathfilter.genericwhitespace;
 
 import java.io.Serializable;
 
-public class SuppressionXpathRegressionProcessNestedGenericsTwo {
+public class SuppressionXpathRegressionGenericWhitespaceNestedGenericsTwo {
     <E extends Enum<E>  & Serializable> void bad() {//warn
     }
     <E extends Enum<E> & Serializable> void good() {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceSingleGenericOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceSingleGenericOne.java
@@ -2,7 +2,7 @@ package org.checkstyle.suppressionxpathfilter.genericwhitespace;
 
 import java.util.Collections;
 
-public class SuppressionXpathRegressionProcessSingleGenericOne {
+public class SuppressionXpathRegressionGenericWhitespaceSingleGenericOne {
     Object bad = Collections.<Object> emptySet();//warn
     Object good = Collections.<Object>emptySet();
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceSingleGenericTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceSingleGenericTwo.java
@@ -2,7 +2,7 @@ package org.checkstyle.suppressionxpathfilter.genericwhitespace;
 
 import java.io.Serializable;
 
-public class SuppressionXpathRegressionProcessSingleGenericTwo {
+public class SuppressionXpathRegressionGenericWhitespaceSingleGenericTwo {
     <E>void bad() {//warn
     }
     <E> void good() {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceStartOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceStartOne.java
@@ -2,7 +2,7 @@ package org.checkstyle.suppressionxpathfilter.genericwhitespace;
 
 import java.util.Collections;
 
-public class SuppressionXpathRegressionProcessStartOne {
+public class SuppressionXpathRegressionGenericWhitespaceStartOne {
     public<E> void bad() {//warn
     }
     public <E> void good() {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceStartThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceStartThree.java
@@ -2,7 +2,7 @@ package org.checkstyle.suppressionxpathfilter.genericwhitespace;
 
 import java.util.Collections;
 
-public class SuppressionXpathRegressionProcessStartThree {
+public class SuppressionXpathRegressionGenericWhitespaceStartThree {
     < E> void bad() {//warn
     }
     <E> void good() {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceStartTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/genericwhitespace/SuppressionXpathRegressionGenericWhitespaceStartTwo.java
@@ -2,7 +2,7 @@ package org.checkstyle.suppressionxpathfilter.genericwhitespace;
 
 import java.util.function.Consumer;
 
-public class SuppressionXpathRegressionProcessStartTwo {
+public class SuppressionXpathRegressionGenericWhitespaceStartTwo {
     public <E> void bad(Consumer <E> consumer) {//warn
     }
     public <E> void good(Consumer<E> consumer) {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/hiddenfield/SuppressionXpathRegressionHiddenFieldOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/hiddenfield/SuppressionXpathRegressionHiddenFieldOne.java
@@ -3,7 +3,7 @@ package org.checkstyle.suppressionxpathfilter.hiddenfield;
 import java.util.Arrays;
 import java.util.List;
 
-public class SuppressionXpathRegressionExplicitOne {
+public class SuppressionXpathRegressionHiddenFieldOne {
     List<Integer> numbers = Arrays.asList(1, 2, 3, 4, 5, 6);
     Integer value = new Integer(1);
     {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/hiddenfield/SuppressionXpathRegressionHiddenFieldTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/hiddenfield/SuppressionXpathRegressionHiddenFieldTwo.java
@@ -1,6 +1,6 @@
 package org.checkstyle.suppressionxpathfilter.hiddenfield;
 
-public class SuppressionXpathRegressionExplicitTwo {
+public class SuppressionXpathRegressionHiddenFieldTwo {
     static int someField;
     static Object other = null;
     Object field = null;

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/multiplevariabledeclarations/SuppressionXpathRegressionMultipleVariableDeclarationsOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/multiplevariabledeclarations/SuppressionXpathRegressionMultipleVariableDeclarationsOne.java
@@ -1,5 +1,5 @@
 package org.checkstyle.suppressionxpathfilter.multiplevariabledeclarations;
 
-public class SuppressionXpathRegressionMultipleVariableDeclarationOne {
+public class SuppressionXpathRegressionMultipleVariableDeclarationsOne {
     int i, j; //warn
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/multiplevariabledeclarations/SuppressionXpathRegressionMultipleVariableDeclarationsTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/multiplevariabledeclarations/SuppressionXpathRegressionMultipleVariableDeclarationsTwo.java
@@ -1,5 +1,5 @@
 package org.checkstyle.suppressionxpathfilter.multiplevariabledeclarations;
 
-public class SuppressionXpathRegressionMultipleVariableDeclarationTwo {
+public class SuppressionXpathRegressionMultipleVariableDeclarationsTwo {
     int i1; int j1; //warn
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -1,0 +1,209 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2019 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.internal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
+
+public class XpathRegressionTest extends AbstractModuleTestSupport {
+
+    // Temporal Checks that allowed to have no XPath IT Regression Testing
+    // https://github.com/checkstyle/checkstyle/issues/6207
+    private static final Set<String> MISSING_CHECK_NAMES = new HashSet<>(Arrays.asList(
+            "AvoidInlineConditionals",
+            "AvoidNestedBlocks",
+            "BooleanExpressionComplexity",
+            "CatchParameterName",
+            "ClassDataAbstractionCoupling",
+            "ClassFanOutComplexity",
+            "ClassTypeParameterName",
+            "ConstantName",
+            "CovariantEquals",
+            "DescendantToken",
+            "DesignForExtension",
+            "EmptyBlock",
+            "EmptyStatement",
+            "EqualsAvoidNull",
+            "EqualsHashCode",
+            "ExecutableStatementCount",
+            "FinalLocalVariable",
+            "FinalParameters",
+            "HideUtilityClassConstructor",
+            "IllegalInstantiation",
+            "IllegalToken",
+            "IllegalTokenText",
+            "IllegalType",
+            "InnerAssignment",
+            "InnerTypeLast",
+            "InterfaceTypeParameterName",
+            "JavaNCSS",
+            "IllegalImport",
+            "LocalFinalVariableName",
+            "LocalVariableName",
+            "MagicNumber",
+            "MemberName",
+            "MethodLength",
+            "MethodName",
+            "MethodTypeParameterName",
+            "ModifiedControlVariable",
+            "ModifierOrder",
+            "MultipleStringLiterals",
+            "MutableException",
+            "OperatorWrap",
+            "PackageName",
+            "ParameterAssignment",
+            "ParameterName",
+            "ParameterNumber",
+            "RedundantImport",
+            "RedundantModifier",
+            "ReturnCount",
+            "SeparatorWrap",
+            "SimplifyBooleanExpression",
+            "SimplifyBooleanReturn",
+            "StaticVariableName",
+            "StringLiteralEquality",
+            "SuperClone",
+            "SuperFinalize",
+            "SuppressWarnings",
+            "ThrowsCount",
+            "TypeName",
+            "VisibilityModifier"
+    ));
+
+    private static Set<String> simpleCheckNames;
+    private static Map<String, String> allowedDirectoryAndChecks;
+
+    private Path javaDir;
+    private Path inputDir;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws IOException {
+        simpleCheckNames = CheckUtil.getSimpleNames(CheckUtil.getCheckstyleChecks());
+
+        allowedDirectoryAndChecks = simpleCheckNames
+                .stream()
+                .collect(Collectors.toMap(id -> id.toLowerCase(Locale.ENGLISH), id -> id));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        javaDir = Paths.get("src/it/java/" + getPackageLocation());
+        inputDir = Paths.get(getPath(""));
+    }
+
+    @Override
+    protected String getPackageLocation() {
+        return "org/checkstyle/suppressionxpathfilter";
+    }
+
+    @Override
+    protected String getResourceLocation() {
+        return "it";
+    }
+
+    @Test
+    public void validateIntegrationTestClassNames() throws Exception {
+        final Pattern pattern = Pattern.compile("^XpathRegression(.+)Test\\.java$");
+        try (DirectoryStream<Path> javaPaths = Files.newDirectoryStream(javaDir)) {
+            for (Path path : javaPaths) {
+                assertTrue(path + " is not a regular file", Files.isRegularFile(path));
+                final String filename = path.toFile().getName();
+                if (filename.startsWith("Abstract")) {
+                    continue;
+                }
+
+                final Matcher matcher = pattern.matcher(filename);
+                assertTrue("Invalid test file: " + filename + ", expected pattern: " + pattern,
+                        matcher.matches());
+
+                final String check = matcher.group(1);
+                assertTrue("Unknown check '" + check + "' in test file: " + filename,
+                        simpleCheckNames.contains(check));
+
+                assertFalse("Check '" + check + "' is now tested. Please update the todo list in"
+                        + " XpathRegressionTest.MISSING_CHECK_NAMES",
+                        MISSING_CHECK_NAMES.contains(check));
+            }
+        }
+    }
+
+    @Test
+    public void validateInputFiles() throws Exception {
+        try (DirectoryStream<Path> dirs = Files.newDirectoryStream(inputDir)) {
+            for (Path dir : dirs) {
+                // input directory must be named in lower case
+                assertTrue(dir + " is not a directory", Files.isDirectory(dir));
+                final String dirName = dir.toFile().getName();
+                assertTrue("Invalid directory name: " + dirName,
+                        allowedDirectoryAndChecks.containsKey(dirName));
+
+                // input directory must be connected to an existing test
+                final String check = allowedDirectoryAndChecks.get(dirName);
+                final Path javaPath = javaDir.resolve("XpathRegression" + check + "Test.java");
+                assertTrue("Input directory '" + dir + "' is not connected to Java test case: "
+                        + javaPath, Files.exists(javaPath));
+
+                // input files should named correctly
+                validateInputDirectory(dir);
+            }
+        }
+    }
+
+    private static void validateInputDirectory(Path checkDir) throws IOException {
+        final Pattern pattern = Pattern.compile("^SuppressionXpathRegression(.+)\\.java$");
+        final String check = allowedDirectoryAndChecks.get(checkDir.toFile().getName());
+
+        try (DirectoryStream<Path> inputPaths = Files.newDirectoryStream(checkDir)) {
+            for (Path inputPath : inputPaths) {
+                final String filename = inputPath.toFile().getName();
+                if (filename.endsWith("java")) {
+                    final Matcher matcher = pattern.matcher(filename);
+                    assertTrue("Invalid input file '" + inputPath + "', expected pattern:"
+                            + pattern, matcher.matches());
+
+                    final String remaining = matcher.group(1);
+                    assertTrue("Check name '" + check + "' should be included in input file: "
+                            + inputPath, remaining.startsWith(check));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This unit test aims to ~~provide validation~~ keep track of remaining check on XPath related integration itests (IT). This idea is proposed by @romani in https://github.com/checkstyle/checkstyle/issues/6207#issuecomment-521500309 :

> it would be awesome is you create UT with list like - https://github.com/checkstyle/checkstyle/pull/6969/files#diff-67a0806621fe751520ab842060ba14fcL106 , see whole change of #6969 it show how @pbludov improve step by step , but it is very enforced validation on each change, new Checks already come in better form in first commit.
so list of what is not done will be self controlled by UTs and nobody will forget to add such tests during new Check is created. We recently missed such tests creation ... .