### PR TITLE
Issue #6207: Add xpath regression test for AvoidInlineConditionals 

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidInlineConditionalsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidInlineConditionalsTest.java
@@ -1,0 +1,119 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2019 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.coding.AvoidInlineConditionalsCheck;
+
+public class XpathRegressionAvoidInlineConditionalsTest extends AbstractXpathTestSupport {
+
+    @Override
+    protected String getCheckName() {
+        return AvoidInlineConditionalsCheck.class.getSimpleName();
+    }
+
+    @Test
+    public void testInlineConditionalsVariableDef() throws Exception {
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionAvoidInlineConditionalsVariableDef.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AvoidInlineConditionalsCheck.class);
+
+        final String[] expectedViolation = {
+            "5:50: " + getCheckMessage(AvoidInlineConditionalsCheck.class,
+                AvoidInlineConditionalsCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='"
+                        + "SuppressionXpathRegressionAvoidInlineConditionalsVariableDef']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='substring']]/SLIST"
+                        + "/VARIABLE_DEF[./IDENT[@text='b']]/ASSIGN/EXPR",
+                "/CLASS_DEF[./IDENT[@text='"
+                        + "SuppressionXpathRegressionAvoidInlineConditionalsVariableDef']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='substring']]/SLIST"
+                        + "/VARIABLE_DEF[./IDENT[@text='b']]/ASSIGN/EXPR/QUESTION"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testInlineConditionalsAssign() throws Exception {
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionAvoidInlineConditionalsAssign.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AvoidInlineConditionalsCheck.class);
+
+        final String[] expectedViolation = {
+            "7:43: " + getCheckMessage(AvoidInlineConditionalsCheck.class,
+                AvoidInlineConditionalsCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/CLASS_DEF[./IDENT[@text='"
+                        + "SuppressionXpathRegressionAvoidInlineConditionalsAssign']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='setB']]/SLIST"
+                        + "/EXPR/ASSIGN[./IDENT[@text='b']]/QUESTION"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testInlineConditionalsAssert() throws Exception {
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionAvoidInlineConditionalsAssert.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AvoidInlineConditionalsCheck.class);
+
+        final String[] expectedViolation = {
+            "8:31: " + getCheckMessage(AvoidInlineConditionalsCheck.class,
+                AvoidInlineConditionalsCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='"
+                        + "SuppressionXpathRegressionAvoidInlineConditionalsAssert']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='assertA']]/SLIST"
+                        + "/LITERAL_ASSERT/EXPR[./QUESTION/METHOD_CALL/DOT/IDENT[@text='a']]",
+                "/CLASS_DEF[./IDENT[@text='"
+                        + "SuppressionXpathRegressionAvoidInlineConditionalsAssert']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='assertA']]/SLIST"
+                        + "/LITERAL_ASSERT/EXPR/QUESTION"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidinlineconditionals/SuppressionXpathRegressionAvoidInlineConditionalsAssert.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidinlineconditionals/SuppressionXpathRegressionAvoidInlineConditionalsAssert.java
@@ -1,0 +1,10 @@
+package org.checkstyle.suppressionxpathfilter.avoidinlineconditionals;
+
+public class SuppressionXpathRegressionAvoidInlineConditionalsAssert {
+
+    void assertA(String a) {
+        // JLS §14.10 - The assert Statement
+        // assert Expression1 : Expression2
+        assert a.equals(null) ? true : false : "Expression2"; // warn
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidinlineconditionals/SuppressionXpathRegressionAvoidInlineConditionalsAssign.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidinlineconditionals/SuppressionXpathRegressionAvoidInlineConditionalsAssign.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.avoidinlineconditionals;
+
+public class SuppressionXpathRegressionAvoidInlineConditionalsAssign {
+    String b;
+
+    void setB(String a) {
+        b = (a == null || a.length() < 1) ? null : a.substring(1); // warn
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidinlineconditionals/SuppressionXpathRegressionAvoidInlineConditionalsVariableDef.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidinlineconditionals/SuppressionXpathRegressionAvoidInlineConditionalsVariableDef.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.avoidinlineconditionals;
+
+public class SuppressionXpathRegressionAvoidInlineConditionalsVariableDef {
+    String substring(String a) {
+        String b = (a == null || a.length() < 1) ? null : a.substring(1); // warn
+        return b;
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidInlineConditionalsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidInlineConditionalsCheck.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  * <pre>
  * String a = getParameter("a");
- * String b = (a==null || a.length&lt;1) ? null : a.substring(1);
+ * String b = (a==null || a.length()&lt;1) ? null : a.substring(1);
  * </pre>
  * <p>
  * Rationale: Some developers find inline conditionals hard to read, so

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -48,7 +48,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
     // Temporal Checks that allowed to have no XPath IT Regression Testing
     // https://github.com/checkstyle/checkstyle/issues/6207
     private static final Set<String> MISSING_CHECK_NAMES = new HashSet<>(Arrays.asList(
-            "AvoidInlineConditionals",
             "AvoidNestedBlocks",
             "BooleanExpressionComplexity",
             "CatchParameterName",

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -181,7 +181,7 @@ int[] a2 = new int[]{
         </p>
         <source>
 String a = getParameter("a");
-String b = (a==null || a.length&lt;1) ? null : a.substring(1);
+String b = (a==null || a.length()&lt;1) ? null : a.substring(1);
         </source>
 
         <p>


### PR DESCRIPTION
This PR adds XPath regression test for suppression filter on [AvoidInlineConditionals](https://checkstyle.org/config_coding.html#AvoidInlineConditionals) check, see #6207. Also, fix related code snippets in documents.