### PR TITLE
Issue #6982: kill mutation survival at Main.listFiles() over canRead()

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1202,6 +1202,7 @@ subelements
 subext
 subscope
 sudo
+sudoers
 suitebuilder
 sukhodolsky
 summaryjavadoc

--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -70,7 +70,6 @@ pitest-header)
 pitest-main)
   mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
   declare -a ignoredItems=(
-  "Main.java.html:<td class='covered'><pre><span  class='survived'>        if (node.canRead()) {</span></pre></td></tr>"
   "Main.java.html:<td class='covered'><pre><span  class='survived'>        if (outputPath == null) {</span></pre></td></tr>"
   );
   checkPitestReport "${ignoredItems[@]}"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -265,6 +265,18 @@ public class MainTest {
     }
 
     @Test
+    public void testExistingTargetFileButWithoutReadAccess()
+            throws Exception {
+        exit.expectSystemExitWithStatus(-1);
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("Unexpected output log", "Files to process must be specified, found 0."
+                + System.lineSeparator(), systemOut.getLog());
+            assertEquals("Unexpected system error log", "", systemErr.getLog());
+        });
+        Main.main("-c", "/google_checks.xml", "/etc/sudoers");
+    }
+
+    @Test
     public void testNonExistentConfigFile()
             throws Exception {
         exit.expectSystemExitWithStatus(-1);


### PR DESCRIPTION
Issue #6982

it will not work on Windows, but our pitests are so linux dependent, so I think it is ok.
creation of file that user does not have access , will result in pollution on users filesystem (as we will not be able to remove it), it is not good.

![image](https://user-images.githubusercontent.com/812984/63219589-a0f8f180-c129-11e9-9aa5-04e840068086.png)

![image](https://user-images.githubusercontent.com/812984/63219596-c685fb00-c129-11e9-9dc9-bd2bbc8e2339.png)
