### PR TITLE
Issue #6207: Add xpath regression test for AvoidNestedBlocks

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidNestedBlocksTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidNestedBlocksTest.java
@@ -1,0 +1,142 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2019 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.blocks.AvoidNestedBlocksCheck;
+
+public class XpathRegressionAvoidNestedBlocksTest extends AbstractXpathTestSupport {
+
+    @Override
+    protected String getCheckName() {
+        return AvoidNestedBlocksCheck.class.getSimpleName();
+    }
+
+    @Test
+    public void testEmpty() throws Exception {
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionAvoidNestedBlocksEmpty.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AvoidNestedBlocksCheck.class);
+
+        final String[] expectedViolation = {
+            "6:9: " + getCheckMessage(AvoidNestedBlocksCheck.class,
+                    AvoidNestedBlocksCheck.MSG_KEY_BLOCK_NESTED),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAvoidNestedBlocksEmpty']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='empty']]/SLIST/SLIST"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testVariableAssignment() throws Exception {
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionAvoidNestedBlocksVariable.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AvoidNestedBlocksCheck.class);
+
+        final String[] expectedViolation = {
+            "7:9: " + getCheckMessage(AvoidNestedBlocksCheck.class,
+                    AvoidNestedBlocksCheck.MSG_KEY_BLOCK_NESTED),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAvoidNestedBlocksVariable']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='varAssign']]/SLIST/SLIST"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testSwitchAllowInSwitchCaseFalse() throws Exception {
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionAvoidNestedBlocksSwitch1.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AvoidNestedBlocksCheck.class);
+
+        final String[] expectedViolation = {
+            "9:21: " + getCheckMessage(AvoidNestedBlocksCheck.class,
+                    AvoidNestedBlocksCheck.MSG_KEY_BLOCK_NESTED),
+            "16:13: " + getCheckMessage(AvoidNestedBlocksCheck.class,
+                    AvoidNestedBlocksCheck.MSG_KEY_BLOCK_NESTED),
+            "20:21: " + getCheckMessage(AvoidNestedBlocksCheck.class,
+                    AvoidNestedBlocksCheck.MSG_KEY_BLOCK_NESTED),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAvoidNestedBlocksSwitch1']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='s']]/SLIST/LITERAL_SWITCH"
+                        + "/CASE_GROUP/SLIST",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAvoidNestedBlocksSwitch1']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='s']]/SLIST/LITERAL_SWITCH"
+                        + "/CASE_GROUP/SLIST/SLIST"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testSwitchAllowInSwitchCaseTrue() throws Exception {
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionAvoidNestedBlocksSwitch2.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AvoidNestedBlocksCheck.class);
+        moduleConfig.addAttribute("allowInSwitchCase", "true");
+
+        final String[] expectedViolation = {
+            "9:21: " + getCheckMessage(AvoidNestedBlocksCheck.class,
+                    AvoidNestedBlocksCheck.MSG_KEY_BLOCK_NESTED),
+            "16:13: " + getCheckMessage(AvoidNestedBlocksCheck.class,
+                    AvoidNestedBlocksCheck.MSG_KEY_BLOCK_NESTED),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAvoidNestedBlocksSwitch2']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='s']]/SLIST/LITERAL_SWITCH"
+                        + "/CASE_GROUP/SLIST",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAvoidNestedBlocksSwitch2']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='s']]/SLIST/LITERAL_SWITCH"
+                        + "/CASE_GROUP/SLIST/SLIST"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidnestedblocks/SuppressionXpathRegressionAvoidNestedBlocksEmpty.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidnestedblocks/SuppressionXpathRegressionAvoidNestedBlocksEmpty.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.avoidnestedblocks;
+
+public class SuppressionXpathRegressionAvoidNestedBlocksEmpty {
+
+    void empty() {
+        {} // warn
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidnestedblocks/SuppressionXpathRegressionAvoidNestedBlocksSwitch1.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidnestedblocks/SuppressionXpathRegressionAvoidNestedBlocksSwitch1.java
@@ -1,0 +1,31 @@
+package org.checkstyle.suppressionxpathfilter.avoidnestedblocks;
+
+public class SuppressionXpathRegressionAvoidNestedBlocksSwitch1 {
+
+    int s(int a) {
+        int x;
+        int y;
+        switch (a) {
+            case 0: { // warn: break outside block
+                x = 0;
+                y = 0;
+            }
+            break;
+            case 1:
+                x = 1;
+            { // warn: statement outside block
+                y = -1;
+                break;
+            }
+            case 2: { // warn: allowInSwitchCase=false
+                x = 2;
+                y = -2;
+                break;
+            }
+            default:
+                x = 3;
+                y = -3;
+        }
+        return x + y;
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidnestedblocks/SuppressionXpathRegressionAvoidNestedBlocksSwitch2.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidnestedblocks/SuppressionXpathRegressionAvoidNestedBlocksSwitch2.java
@@ -1,0 +1,31 @@
+package org.checkstyle.suppressionxpathfilter.avoidnestedblocks;
+
+public class SuppressionXpathRegressionAvoidNestedBlocksSwitch2 {
+
+    int s(int a) {
+        int x;
+        int y;
+        switch (a) {
+            case 0: { // warn: break outside block
+                x = 0;
+                y = 0;
+            }
+            break;
+            case 1:
+                x = 1;
+            { // warn: statement outside block
+                y = -1;
+                break;
+            }
+            case 2: { // ok: allowInSwitchCase=true
+                x = 2;
+                y = -2;
+                break;
+            }
+            default:
+                x = 3;
+                y = -3;
+        }
+        return x + y;
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidnestedblocks/SuppressionXpathRegressionAvoidNestedBlocksVariable.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidnestedblocks/SuppressionXpathRegressionAvoidNestedBlocksVariable.java
@@ -1,0 +1,11 @@
+package org.checkstyle.suppressionxpathfilter.avoidnestedblocks;
+
+public class SuppressionXpathRegressionAvoidNestedBlocksVariable {
+
+    void varAssign() {
+        int whichIsWhich = 0;
+        { // warn
+            whichIsWhich = 2;
+        }
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheck.java
@@ -40,7 +40,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * {
  *   int whichIsWhich = 0;
  *   {
- *     int whichIsWhich = 2;
+ *     whichIsWhich = 2;
  *   }
  *   System.out.println("value = " + whichIsWhich);
  * }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -48,7 +48,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
     // Temporal Checks that allowed to have no XPath IT Regression Testing
     // https://github.com/checkstyle/checkstyle/issues/6207
     private static final Set<String> MISSING_CHECK_NAMES = new HashSet<>(Arrays.asList(
-            "AvoidNestedBlocks",
             "BooleanExpressionComplexity",
             "CatchParameterName",
             "ClassDataAbstractionCoupling",

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -42,7 +42,7 @@ public void guessTheOutput()
 {
   int whichIsWhich = 0;
   {
-    int whichIsWhich = 2;
+    whichIsWhich = 2;
   }
   System.out.println("value = " + whichIsWhich);
 }


### PR DESCRIPTION
This PR adds XPath regression test for suppression filter on [AvoidNestedBlocks](https://checkstyle.org/config_blocks.html#AvoidNestedBlocks) check, see #6207.

Also, it fixes a complication error in related code example in documentation.

```
AvoidNestedBlocks $ cat Demo1.java
public class Demo1 {
  public static void main(String[] args) {
    int a = 0;
    {
      int a = 1;
    }
    System.out.println("a=" + a);
  }
}
```
```
AvoidNestedBlocks $ javac Demo1.java
Demo1.java:5: error: variable a is already defined in method main(String[])
      int a = 1;
          ^
1 error
```