### PR TITLE
Issue #6771: update xdoc files to use violation term instead of error

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -502,8 +502,8 @@ public class XdocsPagesTest {
                 validatePropertySection(fileName, sectionName, null, instance);
                 subSectionPos++;
             }
-            if (subSectionPos == 4 && !"Error Messages".equals(subSectionName)) {
-                validateErrorSection(fileName, sectionName, null, instance);
+            if (subSectionPos == 4 && !"Violation Messages".equals(subSectionName)) {
+                validateViolationSection(fileName, sectionName, null, instance);
                 subSectionPos++;
             }
 
@@ -519,7 +519,7 @@ public class XdocsPagesTest {
                     validateUsageExample(fileName, sectionName, subSection);
                     break;
                 case 4:
-                    validateErrorSection(fileName, sectionName, subSection, instance);
+                    validateViolationSection(fileName, sectionName, subSection, instance);
                     break;
                 case 5:
                     validatePackageSection(fileName, sectionName, subSection, instance);
@@ -571,7 +571,7 @@ public class XdocsPagesTest {
                 result = "Example of Usage";
                 break;
             case 4:
-                result = "Error Messages";
+                result = "Violation Messages";
                 break;
             case 5:
                 result = "Package";
@@ -1238,8 +1238,9 @@ public class XdocsPagesTest {
         return result;
     }
 
-    private static void validateErrorSection(String fileName, String sectionName, Node subSection,
-            Object instance) throws Exception {
+    private static void validateViolationSection(String fileName, String sectionName,
+                                                 Node subSection,
+                                                 Object instance) throws Exception {
         final Class<?> clss = instance.getClass();
         final Set<Field> fields = CheckUtil.getCheckMessages(clss);
         final Set<String> list = new TreeSet<>();

--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -33,7 +33,7 @@
       <ul>
 
         <li><em>FileSetChecks</em> - modules that take a set of input
-        files and fire error messages.</li>
+        files and fire violation messages.</li>
 
         <li><em>Filters</em>
 
@@ -819,7 +819,7 @@
         The obvious question is how do you know which message keys a
         Check uses, so that you can override them? You can examine all
         keys in the check's specific <a href="checks.html">configuration
-        documentation</a>. Each check has a section called 'Error Messages'.
+        documentation</a>. Each check has a section called 'Violation Messages'.
         This section lists every key the check uses and links to the default
         message used by checkstyle.
       </p>

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -207,7 +207,7 @@ public String getNameIfPresent() { ... }
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="AnnotationLocation_Error_Messages">
+      <subsection name="Violation Messages" id="AnnotationLocation_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.location%22">
@@ -337,7 +337,7 @@ public int foo() { ... }
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="AnnotationOnSameLine_Error_Messages">
+      <subsection name="Violation Messages" id="AnnotationOnSameLine_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.same.line%22">
@@ -505,7 +505,7 @@ public int foo() { ... }
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="AnnotationUseStyle_Error_Messages">
+      <subsection name="Violation Messages" id="AnnotationUseStyle_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.incorrect.style%22">
@@ -628,7 +628,7 @@ public static final int COUNTER = 10; // violation
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MissingDeprecated_Error_Messages">
+      <subsection name="Violation Messages" id="MissingDeprecated_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.missing.deprecated%22">
@@ -750,7 +750,7 @@ public static final int COUNTER = 10; // violation
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MissingOverride_Error_Messages">
+      <subsection name="Violation Messages" id="MissingOverride_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.missing.override%22">
@@ -813,7 +813,7 @@ public static final int COUNTER = 10; // violation
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="PackageAnnotation_Error_Messages">
+      <subsection name="Violation Messages" id="PackageAnnotation_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.package.location%22">
@@ -987,7 +987,7 @@ public static final int COUNTER = 10; // violation
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="SuppressWarnings_Error_Messages">
+      <subsection name="Violation Messages" id="SuppressWarnings_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22suppressed.warning.not.allowed%22">
@@ -1103,7 +1103,7 @@ public void someFunctionWithInvalidStyle() {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="SuppressWarningsHolder_Error_Messages">
+      <subsection name="Violation Messages" id="SuppressWarningsHolder_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22suppress.warnings.invalid.target%22">

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -129,7 +129,7 @@ switch (a)
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="AvoidNestedBlocks_Error_Messages">
+      <subsection name="Violation Messages" id="AvoidNestedBlocks_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22block.nested%22">
@@ -302,7 +302,7 @@ switch (a) {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="EmptyBlock_Error_Messages">
+      <subsection name="Violation Messages" id="EmptyBlock_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22block.empty%22">
@@ -491,7 +491,7 @@ try {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="EmptyCatchBlock_Error_Messages">
+      <subsection name="Violation Messages" id="EmptyCatchBlock_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22catch.block.empty%22">
@@ -688,7 +688,7 @@ try {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="LeftCurly_Error_Messages">
+      <subsection name="Violation Messages" id="LeftCurly_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22line.break.after%22">
@@ -901,7 +901,7 @@ allowedFuture.addCallback(result -> {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="NeedBraces_Error_Messages">
+      <subsection name="Violation Messages" id="NeedBraces_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22needBraces%22">
@@ -1052,7 +1052,7 @@ allowedFuture.addCallback(result -> {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="RightCurly_Error_Messages">
+      <subsection name="Violation Messages" id="RightCurly_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22line.alone%22">

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -147,7 +147,7 @@ int[] a2 = new int[]{
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ArrayTrailingComma_Error_Messages">
+      <subsection name="Violation Messages" id="ArrayTrailingComma_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22array.trailing.comma%22">
@@ -208,7 +208,7 @@ String b = (a==null || a.length()&lt;1) ? null : a.substring(1);
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="AvoidInlineConditionals_Error_Messages">
+      <subsection name="Violation Messages" id="AvoidInlineConditionals_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22inline.conditional.avoid%22">
@@ -332,7 +332,7 @@ class Test {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="CovariantEquals_Error_Messages">
+      <subsection name="Violation Messages" id="CovariantEquals_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22covariant.equals%22">
@@ -485,7 +485,7 @@ class K {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="DeclarationOrder_Error_Messages">
+      <subsection name="Violation Messages" id="DeclarationOrder_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22declaration.order.access%22">
@@ -605,7 +605,7 @@ switch (i) {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="DefaultComesLast_Error_Messages">
+      <subsection name="Violation Messages" id="DefaultComesLast_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22default.comes.last%22">
@@ -671,7 +671,7 @@ doUnconditionalStuff();
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="EmptyStatement_Error_Messages">
+      <subsection name="Violation Messages" id="EmptyStatement_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22empty.statement%22">
@@ -770,7 +770,7 @@ String nullString = null;
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="EqualsAvoidNull_Error_Messages">
+      <subsection name="Violation Messages" id="EqualsAvoidNull_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22equals.avoid.null%22">
@@ -843,7 +843,7 @@ String nullString = null;
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="EqualsHashCode_Error_Messages">
+      <subsection name="Violation Messages" id="EqualsHashCode_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22equals.noEquals%22">
@@ -967,7 +967,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ExplicitInitialization_Error_Messages">
+      <subsection name="Violation Messages" id="ExplicitInitialization_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22explicit.init%22">
@@ -1115,7 +1115,7 @@ case 6:
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="FallThrough_Error_Messages">
+      <subsection name="Violation Messages" id="FallThrough_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22fall.through%22">
@@ -1286,7 +1286,7 @@ public class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="FinalLocalVariable_Error_Messages">
+      <subsection name="Violation Messages" id="FinalLocalVariable_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22final.variable%22">
@@ -1533,7 +1533,7 @@ class SomeClass
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="HiddenField_Error_Messages">
+      <subsection name="Violation Messages" id="HiddenField_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22hidden.field%22">
@@ -1615,7 +1615,7 @@ class SomeClass
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="IllegalCatch_Error_Messages">
+      <subsection name="Violation Messages" id="IllegalCatch_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22illegal.catch%22">
@@ -1737,7 +1737,7 @@ class SomeClass
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="IllegalInstantiation_Error_Messages">
+      <subsection name="Violation Messages" id="IllegalInstantiation_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22instantiation.avoid%22">
@@ -1853,7 +1853,7 @@ class SomeClass
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="IllegalThrows_Error_Messages">
+      <subsection name="Violation Messages" id="IllegalThrows_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22illegal.throw%22">
@@ -1944,7 +1944,7 @@ class SomeClass
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="IllegalToken_Error_Messages">
+      <subsection name="Violation Messages" id="IllegalToken_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22illegal.token%22">
@@ -2075,7 +2075,7 @@ class SomeClass
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="IllegalTokenText_Error_Messages">
+      <subsection name="Violation Messages" id="IllegalTokenText_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22illegal.token.text%22">
@@ -2318,7 +2318,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="IllegalType_Error_Messages">
+      <subsection name="Violation Messages" id="IllegalType_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22illegal.type%22">
@@ -2397,7 +2397,7 @@ while ((line = bufferedReader.readLine()) != null) {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="InnerAssignment_Error_Messages">
+      <subsection name="Violation Messages" id="InnerAssignment_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22assignment.inner.avoid%22">
@@ -2667,7 +2667,7 @@ class TestMethodCall {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MagicNumber_Error_Messages">
+      <subsection name="Violation Messages" id="MagicNumber_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22magic.number%22">
@@ -2720,7 +2720,7 @@ class TestMethodCall {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MissingCtor_Error_Messages">
+      <subsection name="Violation Messages" id="MissingCtor_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22missing.ctor%22">
@@ -2789,7 +2789,7 @@ class TestMethodCall {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MissingSwitchDefault_Error_Messages">
+      <subsection name="Violation Messages" id="MissingSwitchDefault_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22missing.switch.default%22">
@@ -2914,7 +2914,7 @@ for (String line: lines) {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ModifiedControlVariable_Error_Messages">
+      <subsection name="Violation Messages" id="ModifiedControlVariable_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22modified.control.variable%22">
@@ -3050,7 +3050,7 @@ for (String line: lines) {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MultipleStringLiterals_Error_Messages">
+      <subsection name="Violation Messages" id="MultipleStringLiterals_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22multiple.string.literal%22">
@@ -3118,7 +3118,7 @@ for (String line: lines) {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MultipleVariableDeclarations_Error_Messages">
+      <subsection name="Violation Messages" id="MultipleVariableDeclarations_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22multiple.variable.declarations%22">
@@ -3203,7 +3203,7 @@ for (String line: lines) {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="NestedForDepth_Error_Messages">
+      <subsection name="Violation Messages" id="NestedForDepth_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22nested.for.depth%22">
@@ -3283,7 +3283,7 @@ for (String line: lines) {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="NestedIfDepth_Error_Messages">
+      <subsection name="Violation Messages" id="NestedIfDepth_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22nested.if.depth%22">
@@ -3363,7 +3363,7 @@ for (String line: lines) {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="NestedTryDepth_Error_Messages">
+      <subsection name="Violation Messages" id="NestedTryDepth_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22nested.try.depth%22">
@@ -3512,7 +3512,7 @@ System.out.println(s2 instanceof Square); //true
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="NoClone_Error_Messages">
+      <subsection name="Violation Messages" id="NoClone_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22avoid.clone.method%22">
@@ -3579,7 +3579,7 @@ System.out.println(s2 instanceof Square); //true
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="NoFinalizer_Error_Messages">
+      <subsection name="Violation Messages" id="NoFinalizer_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22avoid.finalizer.method%22">
@@ -3717,7 +3717,7 @@ try (Reader r = new PipedReader(); s2; Reader s3 = new PipedReader() // violatio
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="OneStatementPerLine_Error_Messages">
+      <subsection name="Violation Messages" id="OneStatementPerLine_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22multiple.statements.line%22">
@@ -3782,7 +3782,7 @@ public void foo(int i, String s) {}
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="OverloadMethodsDeclarationOrder_Error_Messages">
+      <subsection name="Violation Messages" id="OverloadMethodsDeclarationOrder_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22overload.methods.declaration%22">
@@ -3891,7 +3891,7 @@ public class AnnotationLocationCheck extends AbstractCheck {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="PackageDeclaration_Error_Messages">
+      <subsection name="Violation Messages" id="PackageDeclaration_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22mismatch.package.directory%22">
@@ -3951,7 +3951,7 @@ public class AnnotationLocationCheck extends AbstractCheck {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ParameterAssignment_Error_Messages">
+      <subsection name="Violation Messages" id="ParameterAssignment_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22parameter.assignment%22">
@@ -4192,7 +4192,7 @@ class C {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="RequireThis_Error_Messages">
+      <subsection name="Violation Messages" id="RequireThis_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22require.this.method%22">
@@ -4382,7 +4382,7 @@ class C {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ReturnCount_Error_Messages">
+      <subsection name="Violation Messages" id="ReturnCount_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22return.count%22">
@@ -4449,7 +4449,7 @@ class C {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="SimplifyBooleanExpression_Error_Messages">
+      <subsection name="Violation Messages" id="SimplifyBooleanExpression_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22simplify.expression%22">
@@ -4524,7 +4524,7 @@ return !valid();
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="SimplifyBooleanReturn_Error_Messages">
+      <subsection name="Violation Messages" id="SimplifyBooleanReturn_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22simplify.boolReturn%22">
@@ -4589,7 +4589,7 @@ if (&quot;something&quot;.equals(x))
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="StringLiteralEquality_Error_Messages">
+      <subsection name="Violation Messages" id="StringLiteralEquality_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22string.literal.equality%22">
@@ -4649,7 +4649,7 @@ if (&quot;something&quot;.equals(x))
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="SuperClone_Error_Messages">
+      <subsection name="Violation Messages" id="SuperClone_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22missing.super.call%22">
@@ -4711,7 +4711,7 @@ if (&quot;something&quot;.equals(x))
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="SuperFinalize_Error_Messages">
+      <subsection name="Violation Messages" id="SuperFinalize_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22missing.super.call%22">
@@ -4900,7 +4900,7 @@ if (&quot;something&quot;.equals(x))
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="UnnecessaryParentheses_Error_Messages">
+      <subsection name="Violation Messages" id="UnnecessaryParentheses_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.paren.assign%22">
@@ -5055,8 +5055,8 @@ class A {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages"
-                  id="UnnecessarySemicolonAfterTypeMemberDeclaration_Error_Messages">
+      <subsection name="Violation Messages"
+                  id="UnnecessarySemicolonAfterTypeMemberDeclaration_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.semicolon%22">
@@ -5147,7 +5147,8 @@ enum NoSemicolon {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="UnnecessarySemicolonInEnumeration_Error_Messages">
+      <subsection name="Violation Messages"
+                  id="UnnecessarySemicolonInEnumeration_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.semicolon%22">
@@ -5258,7 +5259,8 @@ class A {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="UnnecessarySemicolonInTryWithResources_Error_Messages">
+      <subsection name="Violation Messages"
+                  id="UnnecessarySemicolonInTryWithResources_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.semicolon%22">
@@ -5485,7 +5487,8 @@ for (int i = 0; i &lt; 20; i++) {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="VariableDeclarationUsageDistance_Error_Messages">
+      <subsection name="Violation Messages"
+                  id="VariableDeclarationUsageDistance_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22variable.declaration.usage.distance%22">

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -232,7 +232,7 @@ public class FooTest {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="DesignForExtension_Error_Messages">
+      <subsection name="Violation Messages" id="DesignForExtension_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22design.forExtension%22">
@@ -290,7 +290,7 @@ public class FooTest {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="FinalClass_Error_Messages">
+      <subsection name="Violation Messages" id="FinalClass_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22final.class%22">
@@ -374,7 +374,7 @@ public class StringUtils // not final to allow subclassing
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="HideUtilityClassConstructor_Error_Messages">
+      <subsection name="Violation Messages" id="HideUtilityClassConstructor_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22hide.utility.class%22">
@@ -427,7 +427,7 @@ public class StringUtils // not final to allow subclassing
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="InnerTypeLast_Error_Messages">
+      <subsection name="Violation Messages" id="InnerTypeLast_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22arrangement.members.before.inner%22">
@@ -521,7 +521,7 @@ public class StringUtils // not final to allow subclassing
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="InterfaceIsType_Error_Messages">
+      <subsection name="Violation Messages" id="InterfaceIsType_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22interface.type%22">
@@ -618,7 +618,7 @@ public class StringUtils // not final to allow subclassing
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MutableException_Error_Messages">
+      <subsection name="Violation Messages" id="MutableException_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22mutable.exception%22">
@@ -716,7 +716,7 @@ public class Foo{
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="OneTopLevelClass_Error_Messages">
+      <subsection name="Violation Messages" id="OneTopLevelClass_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22one.top.level.class%22">
@@ -828,7 +828,7 @@ public class Foo{
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ThrowsCount_Error_Messages">
+      <subsection name="Violation Messages" id="ThrowsCount_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22throws.count%22">
@@ -1262,7 +1262,7 @@ public class InputPublicImmutable {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="VisibilityModifier_Error_Messages">
+      <subsection name="Violation Messages" id="VisibilityModifier_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22variable.notPrivate%22">

--- a/src/xdocs/config_header.xml
+++ b/src/xdocs/config_header.xml
@@ -160,7 +160,7 @@ line 5: ////////////////////////////////////////////////////////////////////
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="Header_Error_Messages">
+      <subsection name="Violation Messages" id="Header_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fheader+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22header.mismatch%22">
@@ -402,7 +402,7 @@ public class ThisWillPass { }
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="RegexpHeader_Error_Messages">
+      <subsection name="Violation Messages" id="RegexpHeader_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fheader+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22header.mismatch%22">

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -112,7 +112,7 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Error Messages" id="AvoidStarImport_Error_Messages">
+      <subsection name="Violation Messages" id="AvoidStarImport_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.avoidStar%22">
@@ -204,7 +204,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="AvoidStaticImport_Error_Messages">
+      <subsection name="Violation Messages" id="AvoidStaticImport_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.avoidStatic%22">
@@ -560,7 +560,7 @@ import android.*;
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="CustomImportOrder_Error_Messages">
+      <subsection name="Violation Messages" id="CustomImportOrder_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22custom.import.order%22">
@@ -852,7 +852,7 @@ public class InputIllegalImport { }
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="IllegalImport_Error_Messages">
+      <subsection name="Violation Messages" id="IllegalImport_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.illegal%22">
@@ -1317,7 +1317,7 @@ import java.util.stream.IntStream;
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ImportControl_Error_Messages">
+      <subsection name="Violation Messages" id="ImportControl_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.control.disallowed%22">
@@ -1728,7 +1728,7 @@ public class InputEclipseStaticImportsOrder { }
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ImportOrder_Error_Messages">
+      <subsection name="Violation Messages" id="ImportOrder_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.groups.separated.internally%22">
@@ -1807,7 +1807,7 @@ public class InputEclipseStaticImportsOrder { }
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="RedundantImport_Error_Messages">
+      <subsection name="Violation Messages" id="RedundantImport_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.duplicate%22">
@@ -1941,7 +1941,7 @@ class FooBar {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="UnusedImports_Error_Messages">
+      <subsection name="Violation Messages" id="UnusedImports_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.unused%22">

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -116,7 +116,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="AtclauseOrder_Error_Messages">
+      <subsection name="Violation Messages" id="AtclauseOrder_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22at.clause.order%22">
@@ -207,7 +207,7 @@ public class TestClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="InvalidJavadocPosition_Error_Messages">
+      <subsection name="Violation Messages" id="InvalidJavadocPosition_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22invalid.position%22">
@@ -357,7 +357,7 @@ public int field;
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="JavadocBlockTagLocation_Error_Messages">
+      <subsection name="Violation Messages" id="JavadocBlockTagLocation_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.blockTagLocation%22">
@@ -711,7 +711,7 @@ public boolean isSomething()
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="JavadocMethod_Error_Messages">
+      <subsection name="Violation Messages" id="JavadocMethod_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.classInfo%22">
@@ -827,7 +827,7 @@ public boolean isSomething()
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="JavadocPackage_Error_Messages">
+      <subsection name="Violation Messages" id="JavadocPackage_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.legacyPackageHtml%22">
@@ -954,7 +954,7 @@ public boolean isSomething()
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="JavadocParagraph_Error_Messages">
+      <subsection name="Violation Messages" id="JavadocParagraph_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
@@ -1224,7 +1224,7 @@ public boolean isSomething()
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="JavadocStyle_Error_Messages">
+      <subsection name="Violation Messages" id="JavadocStyle_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.empty%22">
@@ -1331,7 +1331,8 @@ public boolean isSomething()
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="JavadocTagContinuationIndentation_Error_Messages">
+      <subsection name="Violation Messages"
+                  id="JavadocTagContinuationIndentation_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
@@ -1563,7 +1564,7 @@ class DatabaseConfiguration {}
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="JavadocType_Error_Messages">
+      <subsection name="Violation Messages" id="JavadocType_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unknownTag%22">
@@ -1714,7 +1715,7 @@ class DatabaseConfiguration {}
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="JavadocVariable_Error_Messages">
+      <subsection name="Violation Messages" id="JavadocVariable_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missing%22">
@@ -1919,7 +1920,7 @@ public boolean isSomething()
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MissingJavadocMethod_Error_Messages">
+      <subsection name="Violation Messages" id="MissingJavadocMethod_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missing%22">
@@ -1989,7 +1990,7 @@ package com.checkstyle.api; // violation
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MissingJavadocPackage_Error_Messages">
+      <subsection name="Violation Messages" id="MissingJavadocPackage_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22package.javadoc.missing%22">
@@ -2169,7 +2170,7 @@ class DatabaseConfiguration {}
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MissingJavadocType_Error_Messages">
+      <subsection name="Violation Messages" id="MissingJavadocType_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missing%22">
@@ -2277,7 +2278,7 @@ class DatabaseConfiguration {}
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="NonEmptyAtclauseDescription_Error_Messages">
+      <subsection name="Violation Messages" id="NonEmptyAtclauseDescription_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
@@ -2392,7 +2393,7 @@ class DatabaseConfiguration {}
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="SingleLineJavadoc_Error_Messages">
+      <subsection name="Violation Messages" id="SingleLineJavadoc_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
@@ -2559,7 +2560,7 @@ public class TestClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="SummaryJavadoc_Error_Messages">
+      <subsection name="Violation Messages" id="SummaryJavadoc_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
@@ -2717,7 +2718,7 @@ public class TestClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="WriteTag_Error_Messages">
+      <subsection name="Violation Messages" id="WriteTag_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.writeTag%22">

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -132,7 +132,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="BooleanExpressionComplexity_Error_Messages">
+      <subsection name="Violation Messages" id="BooleanExpressionComplexity_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmetrics+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22booleanExpressionComplexity%22">
@@ -451,7 +451,7 @@ public class Foo {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ClassDataAbstractionCoupling_Error_Messages">
+      <subsection name="Violation Messages" id="ClassDataAbstractionCoupling_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmetrics+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22classDataAbstractionCoupling%22">
@@ -656,7 +656,7 @@ public class Foo {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ClassFanOutComplexity_Error_Messages">
+      <subsection name="Violation Messages" id="ClassFanOutComplexity_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmetrics+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22classFanOutComplexity%22">
@@ -888,7 +888,7 @@ class SwitchExample {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="CyclomaticComplexity_Error_Messages">
+      <subsection name="Violation Messages" id="CyclomaticComplexity_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmetrics+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22cyclomaticComplexity%22">
@@ -1013,7 +1013,7 @@ class SwitchExample {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="JavaNCSS_Error_Messages">
+      <subsection name="Violation Messages" id="JavaNCSS_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmetrics+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ncss.class%22">
@@ -1172,7 +1172,7 @@ class SwitchExample {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="NPathComplexity_Error_Messages">
+      <subsection name="Violation Messages" id="NPathComplexity_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmetrics+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22npathComplexity%22">

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -129,7 +129,7 @@ public class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ArrayTypeStyle_Error_Messages">
+      <subsection name="Violation Messages" id="ArrayTypeStyle_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22array.type.style%22">
@@ -294,7 +294,7 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="AvoidEscapedUnicodeCharacters_Error_Messages">
+      <subsection name="Violation Messages" id="AvoidEscapedUnicodeCharacters_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22forbid.escaped.unicode.char%22">
@@ -543,7 +543,7 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="CommentsIndentation_Error_Messages">
+      <subsection name="Violation Messages" id="CommentsIndentation_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Findentation+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22comments.indentation.block%22">
@@ -893,7 +893,7 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="DescendantToken_Error_Messages">
+      <subsection name="Violation Messages" id="DescendantToken_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22descendant.token.max%22">
@@ -1033,7 +1033,7 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="FinalParameters_Error_Messages">
+      <subsection name="Violation Messages" id="FinalParameters_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22final.parameter%22">
@@ -1198,7 +1198,7 @@ void foo(String aFooString,
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="Indentation_Error_Messages">
+      <subsection name="Violation Messages" id="Indentation_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Findentation+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22indentation.child.error%22">
@@ -1357,7 +1357,7 @@ StaticMethodCandidateCheck.name = Static Method Candidate
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="NewlineAtEndOfFile_Error_Messages">
+      <subsection name="Violation Messages" id="NewlineAtEndOfFile_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22noNewlineAtEOF%22">
@@ -1475,7 +1475,7 @@ key.png =value - violation
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="OrderedProperties_Error_Messages">
+      <subsection name="Violation Messages" id="OrderedProperties_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22properties.notSorted.property%22">
@@ -1537,7 +1537,7 @@ key.png =value - violation
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="OuterTypeFilename_Error_Messages">
+      <subsection name="Violation Messages" id="OuterTypeFilename_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22type.file.mismatch%22">
@@ -1635,7 +1635,7 @@ key.png =value - violation
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="TodoComment_Error_Messages">
+      <subsection name="Violation Messages" id="TodoComment_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22todo.match%22">
@@ -1781,7 +1781,7 @@ d = e / f;        // Another comment for this line
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="TrailingComment_Error_Messages">
+      <subsection name="Violation Messages" id="TrailingComment_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22trailing.comments%22">
@@ -1983,7 +1983,7 @@ messages_home_fr_CA_UNIX.properties
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="Translation_Error_Messages">
+      <subsection name="Violation Messages" id="Translation_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22translation.missingKey%22">
@@ -2078,7 +2078,7 @@ messages_home_fr_CA_UNIX.properties
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="UncommentedMain_Error_Messages">
+      <subsection name="Violation Messages" id="UncommentedMain_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22uncommented.main%22">
@@ -2158,7 +2158,7 @@ messages_home_fr_CA_UNIX.properties
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="UniqueProperties_Error_Messages">
+      <subsection name="Violation Messages" id="UniqueProperties_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22properties.duplicate.property%22">
@@ -2230,7 +2230,7 @@ messages_home_fr_CA_UNIX.properties
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="UpperEll_Error_Messages">
+      <subsection name="Violation Messages" id="UpperEll_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22upperEll%22">

--- a/src/xdocs/config_modifier.xml
+++ b/src/xdocs/config_modifier.xml
@@ -127,7 +127,7 @@ public final class Person {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ClassMemberImpliedModifier_Error_Messages">
+      <subsection name="Violation Messages" id="ClassMemberImpliedModifier_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmodifier+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22class.implied.modifier%22">
@@ -372,7 +372,7 @@ public interface RoadFeature {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="InterfaceMemberImpliedModifier_Error_Messages">
+      <subsection name="Violation Messages" id="InterfaceMemberImpliedModifier_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmodifier+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22interface.implied.modifier%22">
@@ -479,7 +479,7 @@ public interface RoadFeature {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ModifierOrder_Error_Messages">
+      <subsection name="Violation Messages" id="ModifierOrder_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmodifier+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.order%22">
@@ -716,7 +716,7 @@ public class ClassExtending extends ClassExample {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="RedundantModifier_Error_Messages">
+      <subsection name="Violation Messages" id="RedundantModifier_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmodifier+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22redundantModifier%22">

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -228,7 +228,7 @@ public class MyClass { // OK, ignore checking the class name
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="AbbreviationAsWordInName_Error_Messages">
+      <subsection name="Violation Messages" id="AbbreviationAsWordInName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22abbreviation.as.word%22">
@@ -335,7 +335,7 @@ class AbstractThirdClass {} // OK, no "abstract" modifier
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="AbstractClassName_Error_Messages">
+      <subsection name="Violation Messages" id="AbstractClassName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22illegal.abstract.class.name%22">
@@ -460,7 +460,7 @@ public class MyTest {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="CatchParameterName_Error_Messages">
+      <subsection name="Violation Messages" id="CatchParameterName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -548,7 +548,7 @@ class MyClass3&lt;abc&gt; {} // violation, the class type parameter
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ClassTypeParameterName_Error_Messages">
+      <subsection name="Violation Messages" id="ClassTypeParameterName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -699,7 +699,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ConstantName_Error_Messages">
+      <subsection name="Violation Messages" id="ConstantName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -792,7 +792,7 @@ interface ThirdInterface&lt;type&gt; {} // violation, name 'type' must
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="InterfaceTypeParameterName_Error_Messages">
+      <subsection name="Violation Messages" id="InterfaceTypeParameterName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -891,7 +891,7 @@ public class TestClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="LambdaParameterName_Error_Messages">
+      <subsection name="Violation Messages" id="LambdaParameterName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -1035,7 +1035,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="LocalFinalVariableName_Error_Messages">
+      <subsection name="Violation Messages" id="LocalFinalVariableName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -1237,7 +1237,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="LocalVariableName_Error_Messages">
+      <subsection name="Violation Messages" id="LocalVariableName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -1406,7 +1406,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MemberName_Error_Messages">
+      <subsection name="Violation Messages" id="MemberName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -1612,7 +1612,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MethodName_Error_Messages">
+      <subsection name="Violation Messages" id="MethodName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22method.name.equals.class.name%22">
@@ -1714,7 +1714,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MethodTypeParameterName_Error_Messages">
+      <subsection name="Violation Messages" id="MethodTypeParameterName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -1832,7 +1832,7 @@ package com._checkstyle.checks_; // violation, name 'com._checkstyle.checks_' mu
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="PackageName_Error_Messages">
+      <subsection name="Violation Messages" id="PackageName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -1987,7 +1987,7 @@ public boolean equals(Object o) {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ParameterName_Error_Messages">
+      <subsection name="Violation Messages" id="ParameterName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -2098,7 +2098,7 @@ public boolean equals(Object o) {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="StaticVariableName_Error_Messages">
+      <subsection name="Violation Messages" id="StaticVariableName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -2256,7 +2256,7 @@ public boolean equals(Object o) {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="TypeName_Error_Messages">
+      <subsection name="Violation Messages" id="TypeName_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">

--- a/src/xdocs/config_regexp.xml
+++ b/src/xdocs/config_regexp.xml
@@ -457,7 +457,7 @@ public static final int A_SETPOINT = 1;
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="Regexp_Error_Messages">
+      <subsection name="Violation Messages" id="Regexp_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fregexp+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22duplicate.regexp%22">
@@ -581,7 +581,7 @@ public static final int A_SETPOINT = 1;
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="RegexpMultiline_Error_Messages">
+      <subsection name="Violation Messages" id="RegexpMultiline_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fregexp+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22regexp.StackOverflowError%22">
@@ -790,7 +790,7 @@ public static final int A_SETPOINT = 1;
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="RegexpOnFilename_Error_Messages">
+      <subsection name="Violation Messages" id="RegexpOnFilename_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fregexp+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22regexp.filename.match%22">
@@ -943,7 +943,7 @@ public static final int A_SETPOINT = 1;
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="RegexpSingleline_Error_Messages">
+      <subsection name="Violation Messages" id="RegexpSingleline_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fregexp+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22regexp.exceeded%22">
@@ -1075,7 +1075,7 @@ public static final int A_SETPOINT = 1;
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="RegexpSinglelineJava_Error_Messages">
+      <subsection name="Violation Messages" id="RegexpSinglelineJava_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fregexp+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22regexp.exceeded%22">

--- a/src/xdocs/config_reporting.xml
+++ b/src/xdocs/config_reporting.xml
@@ -62,7 +62,7 @@
         The property <code>checkstyle.basedir</code>
         specifies a base directory which files are then reported
         relative to. For example, if a base directory is specified as
-        <code>c:\projects\checkstyle</code>, then an error
+        <code>c:\projects\checkstyle</code>, then a violation
         in the file <code>c:\projects\checkstyle\src\dir\subdir\File.java</code>
         will be reported as <code>src\dir\subdir\File.java</code>. The property type
         is <a href="property_types.html#string">string</a> and defaults

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -77,7 +77,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="AnonInnerLength_Error_Messages">
+      <subsection name="Violation Messages" id="AnonInnerLength_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22maxLen.anonInner%22">
@@ -185,7 +185,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ExecutableStatementCount_Error_Messages">
+      <subsection name="Violation Messages" id="ExecutableStatementCount_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22executableStatementCount%22">
@@ -275,7 +275,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="FileLength_Error_Messages">
+      <subsection name="Violation Messages" id="FileLength_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22maxLen.file%22">
@@ -398,7 +398,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="LineLength_Error_Messages">
+      <subsection name="Violation Messages" id="LineLength_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22maxLineLen%22">
@@ -590,7 +590,7 @@ public class ExampleClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MethodCount_Error_Messages">
+      <subsection name="Violation Messages" id="MethodCount_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22too.many.methods%22">
@@ -743,7 +743,7 @@ public class ExampleClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MethodLength_Error_Messages">
+      <subsection name="Violation Messages" id="MethodLength_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22maxLen.method%22">
@@ -830,7 +830,7 @@ public class ExampleClass {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="OuterTypeNumber_Error_Messages">
+      <subsection name="Violation Messages" id="OuterTypeNumber_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22maxOuterTypes%22">
@@ -969,7 +969,7 @@ public void needsLotsOfParameters(int a, int b, int c, int d, int e, int f, int 
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ParameterNumber_Error_Messages">
+      <subsection name="Violation Messages" id="ParameterNumber_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22maxParam%22">

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -85,7 +85,7 @@ for (
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="EmptyForInitializerPad_Error_Messages">
+      <subsection name="Violation Messages" id="EmptyForInitializerPad_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.notPreceded%22">
@@ -184,7 +184,7 @@ for (Iterator foo = very.long.line.iterator();
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="EmptyForIteratorPad_Error_Messages">
+      <subsection name="Violation Messages" id="EmptyForIteratorPad_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.followed%22">
@@ -466,7 +466,7 @@ class Foo
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="EmptyLineSeparator_Error_Messages">
+      <subsection name="Violation Messages" id="EmptyLineSeparator_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22empty.line.separator%22">
@@ -592,7 +592,7 @@ class Foo
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="FileTabCharacter_Error_Messages">
+      <subsection name="Violation Messages" id="FileTabCharacter_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22containsTab%22">
@@ -695,7 +695,7 @@ sort(list, Comparable::&lt;String&gt;compareTo);
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="GenericWhitespace_Error_Messages">
+      <subsection name="Violation Messages" id="GenericWhitespace_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.followed%22">
@@ -854,7 +854,7 @@ sort(list, Comparable::&lt;String&gt;compareTo);
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="MethodParamPad_Error_Messages">
+      <subsection name="Violation Messages" id="MethodParamPad_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22line.previous%22">
@@ -991,7 +991,7 @@ import static java.math.BigInteger.ZERO;
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="NoLineWrap_Error_Messages">
+      <subsection name="Violation Messages" id="NoLineWrap_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22no.line.wrap%22">
@@ -1169,7 +1169,7 @@ public void foo(final char @NotNull [] param) {} // No violation
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="NoWhitespaceAfter_Error_Messages">
+      <subsection name="Violation Messages" id="NoWhitespaceAfter_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.followed%22">
@@ -1304,7 +1304,7 @@ public void foo(final char @NotNull [] param) {} // No violation
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="NoWhitespaceBefore_Error_Messages">
+      <subsection name="Violation Messages" id="NoWhitespaceBefore_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.preceded%22">
@@ -1527,7 +1527,7 @@ public void foo(final char @NotNull [] param) {} // No violation
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="OperatorWrap_Error_Messages">
+      <subsection name="Violation Messages" id="OperatorWrap_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22line.new%22">
@@ -1743,7 +1743,7 @@ try (Closeable resource = acquire(); ) // no check before right parenthesis
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="ParenPad_Error_Messages">
+      <subsection name="Violation Messages" id="ParenPad_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.followed%22">
@@ -1915,7 +1915,7 @@ Arrays.sort(stringArray, String
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="SeparatorWrap_Error_Messages">
+      <subsection name="Violation Messages" id="SeparatorWrap_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22line.new%22">
@@ -2026,7 +2026,7 @@ public long toMicros(long d) { return d / (C1 / C0); }
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="SingleSpaceSeparator_Error_Messages">
+      <subsection name="Violation Messages" id="SingleSpaceSeparator_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22single.space.separator%22">
@@ -2112,7 +2112,7 @@ public long toMicros(long d) { return d / (C1 / C0); }
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="TypecastParenPad_Error_Messages">
+      <subsection name="Violation Messages" id="TypecastParenPad_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.followed%22">
@@ -2253,7 +2253,7 @@ public long toMicros(long d) { return d / (C1 / C0); }
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="WhitespaceAfter_Error_Messages">
+      <subsection name="Violation Messages" id="WhitespaceAfter_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.notFollowed%22">
@@ -2727,7 +2727,7 @@ try {
         </ul>
       </subsection>
 
-      <subsection name="Error Messages" id="WhitespaceAround_Error_Messages">
+      <subsection name="Violation Messages" id="WhitespaceAround_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.notFollowed%22">

--- a/src/xdocs/writingchecks.xml
+++ b/src/xdocs/writingchecks.xml
@@ -515,7 +515,7 @@ public class MethodLimitCheck extends AbstractCheck
 
     </section>
 
-    <section name="Logging errors">
+    <section name="Logging violations">
 
       <p>
         Detecting violation is one thing, presenting them to the user is
@@ -544,7 +544,7 @@ public class MethodLimitCheck extends AbstractCheck
           example</a>)
         , i.e. the
         Java file and the properties files should be in the same
-        directory.  Add a symbolic error code and an English
+        directory.  Add a symbolic violation code and an English
         representation to the messages.properties. The file should
         contain the following line: <code>too.many.methods=Too many methods, only {0} are
         allowed</code>.  Then replace the verbatim violation message with
@@ -685,7 +685,7 @@ public class MethodLimitCheck extends AbstractCheck
       and override the abstract
       <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.html#processFiltered-java.io.File-java.util.List-">
               <code>processFiltered(java.io.File, java.util.List)</code></a> method and you&#39;re
-      done. A very simple example could fire an error if the number of files
+      done. A very simple example could fire a violation if the number of files
       exceeds a certain limit. Here is a FileSetCheck that does just that:</p>
 
       <source>

--- a/src/xdocs/writinglisteners.xml.vm
+++ b/src/xdocs/writinglisteners.xml.vm
@@ -53,7 +53,7 @@
         interface. During an audit, a <code>Checker</code>
         informs its attached <code>AuditListeners</code> of
         six kinds of events: audit started/ended, file started/ended,
-        and logging of an error/exception.
+        and logging of an error(violation)/exception.
       </p>
 
       <p>
@@ -64,7 +64,7 @@
         violation logging has a message, a severity level, a message source
         such as the name of a <code>Check</code>, and file
         line and column numbers that may be relevant to the violation. The
-        notification of an exception to a <code>AuditListener</code> includes an error
+        notification of an exception to a <code>AuditListener</code> includes a violation
         <code>AuditEvent</code> and the details of the exception. Here is a UML diagram for
         classes <code>AuditListener</code> and <code>AuditEvent</code>.
       </p>
@@ -88,8 +88,8 @@
       <p>
         The custom listener that we demonstrate here is a verbose
         listener that simply prints each event notification to an output
-        stream, and reports the number of errors per audited file and
-        the total number of errors. The default output stream is <code>System.out</code>.
+        stream, and reports the number of violations per audited file and
+        the total number of violations. The default output stream is <code>System.out</code>.
         In order to enable the specification of output to a file through property
         <code>file</code>, the class extends <code>AutomaticBean</code> and defines method
         <code>setFile(String)</code>.


### PR DESCRIPTION
Issue #6771 , this is not a final fix, just fixes over `xdoc` folder.

please review https://github.com/checkstyle/checkstyle/issues/6771#issuecomment-524585694

most interesting changes are at the bottom of github change page.