### PR TITLE
Issue #7040: spotbugs is not executed in build process

### DIFF
--- a/.ci/appveyor.bat
+++ b/.ci/appveyor.bat
@@ -20,13 +20,12 @@ mvn -e verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true
 )
 
 if "%OPTION%" ==  "verify_without_checkstyle_JDK11" (
-mvn -e verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true
+mvn -e verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true
   goto :END_CASE
 )
-:: Spotbugs check is disabled till https://github.com/spotbugs/spotbugs/issues/259
 :: powermock doesn't support modifying final fields in JDK12
 if "%OPTION%" ==  "verify_without_checkstyle_JDK12" (
-mvn -e verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true^
+mvn -e verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true^
  -Dtest=!FileContentsTest#testGetJavadocBefore,!FileTextTest#testFindLine*,^
 !MainFrameModelPowerTest#testOpenFileWithUnknownParseMode,^
 !TokenUtilTest#testTokenValueIncorrect2,^
@@ -40,7 +39,6 @@ mvn -e -Pno-validations site
   goto :END_CASE
 )
 
-:: Spotbugs check is disabled till https://github.com/spotbugs/spotbugs/issues/259
 :: powermock doesn't support modifying final fields in JDK12
 if "%OPTION%" == "site_without_verify_jdk12" (
 mvn -e -Pno-validations site^

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,20 @@ matrix:
         - CMD="export MAVEN_OPTS='-Xmx2000m' && mvn -e clean compile pmd:check spotbugs:check"
         - USE_MAVEN_REPO="true"
 
+    # spotbugs and pmd (openjdk11)
+    - jdk: openjdk11
+      env:
+        - DESC="spotbugs,pmd"
+        - CMD="export MAVEN_OPTS='-Xmx2000m' && mvn -e clean compile pmd:check spotbugs:check"
+        - USE_MAVEN_REPO="true"
+
+    # spotbugs and pmd (openjdk12)
+    - jdk: openjdk12
+      env:
+        - DESC="spotbugs,pmd"
+        - CMD="export MAVEN_OPTS='-Xmx2000m' && mvn -e clean compile pmd:check spotbugs:check"
+        - USE_MAVEN_REPO="true"
+
     # eclipse static analysis
     - jdk: openjdk8
       env:

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -46,6 +46,54 @@
       <Bug pattern="DM_EXIT" />
     </Match>
     <Match>
+        <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+        <Class name="com.puppycrawl.tools.checkstyle.Main" />
+        <Method name="loadProperties" />
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
+    <Match>
+        <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+        <Class name="com.puppycrawl.tools.checkstyle.PropertyCacheFile" />
+        <Method name="load" />
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
+    <Match>
+        <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+        <Class name="com.puppycrawl.tools.checkstyle.PropertyCacheFile" />
+        <Method name="loadExternalResource" />
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
+    <Match>
+        <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+        <Class name="com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask" />
+        <Method name="createOverridingProperties" />
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
+    <Match>
+        <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+        <Class name="com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck" />
+        <Method name="processFiltered" />
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
+    <Match>
+        <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+        <Class name="com.puppycrawl.tools.checkstyle.checks.TranslationCheck" />
+        <Method name="getTranslationKeys" />
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
+    <Match>
+        <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+        <Class name="com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck" />
+        <Method name="processFiltered" />
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
+    <Match>
+        <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+        <Class name="com.puppycrawl.tools.checkstyle.PropertyCacheFile" />
+        <Method name="loadExternalResource" />
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Match>
+    <Match>
       <!-- have never been a case for years, Eclipse does not show any other classes
            inherited from CommonASTWithHiddenTokens -->
       <Class name="com.puppycrawl.tools.checkstyle.DetailAstImpl" />


### PR DESCRIPTION
#7040

Add exclusions to spotbugs-exclude.xml for Files.newInputStream which can be ignored

I don't know why this doesn't fail on CI, but it blocks usage of `mvn clean install` locally. The messages don't reveal any issues and can be ignored.