### PR TITLE
Issue #7033: Avoid Whitebox.setInternalState which is no longer supported in OpenJDK 12

### DIFF
--- a/.ci/appveyor.bat
+++ b/.ci/appveyor.bat
@@ -26,10 +26,7 @@ mvn -e verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true
 :: powermock doesn't support modifying final fields in JDK12
 if "%OPTION%" ==  "verify_without_checkstyle_JDK12" (
 mvn -e verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true^
- -Dtest=!FileContentsTest#testGetJavadocBefore,!FileTextTest#testFindLine*,^
-!MainFrameModelPowerTest#testOpenFileWithUnknownParseMode,^
-!TokenUtilTest#testTokenValueIncorrect2,^
-!ImportControlLoaderPowerTest#testInputStreamThatFailsOnClose^
+ -Dtest=!ImportControlLoaderPowerTest#testInputStreamThatFailsOnClose^
  -Djacoco.skip=true
   goto :END_CASE
 )
@@ -42,10 +39,7 @@ mvn -e -Pno-validations site
 :: powermock doesn't support modifying final fields in JDK12
 if "%OPTION%" == "site_without_verify_jdk12" (
 mvn -e -Pno-validations site^
- -Dtest=!FileContentsTest#testGetJavadocBefore,!FileTextTest#testFindLine*,^
-!MainFrameModelPowerTest#testOpenFileWithUnknownParseMode,^
-!TokenUtilTest#testTokenValueIncorrect2,^
-!ImportControlLoaderPowerTest#testInputStreamThatFailsOnClose^
+ -Dtest=!ImportControlLoaderPowerTest#testInputStreamThatFailsOnClose^
  -Djacoco.skip=true
   goto :END_CASE
 )

--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -68,12 +68,9 @@ osx-package)
   ;;
 
 osx-jdk12-package)
-  exclude1="!FileContentsTest#testGetJavadocBefore,"
-  exclude2="!MainFrameModelPowerTest#testOpenFileWithUnknownParseMode,"
-  exclude3="!TokenUtilTest#testTokenValueIncorrect2,"
-  exclude4="!ImportControlLoaderPowerTest#testInputStreamThatFailsOnClose"
+  exclude1="!ImportControlLoaderPowerTest#testInputStreamThatFailsOnClose"
   export JAVA_HOME=$(/usr/libexec/java_home)
-  mvn -e package -Dtest=*,${exclude1}${exclude2}${exclude3}${exclude4}
+  mvn -e package -Dtest=*,${exclude1}
   ;;
 
 osx-jdk12-assembly)
@@ -112,13 +109,9 @@ jdk12-assembly-site)
 
 jdk12-verify-limited)
   # powermock doesn't support modifying final fields in JDK12, so need jacoco skip
-  exclude1="!FileContentsTest#testGetJavadocBefore,"
-  exclude2="!MainFrameModelPowerTest#testOpenFileWithUnknownParseMode,"
-  exclude3="!TokenUtilTest#testTokenValueIncorrect2,"
-  exclude4="!ImportControlLoaderPowerTest#testInputStreamThatFailsOnClose"
+  exclude1="!ImportControlLoaderPowerTest#testInputStreamThatFailsOnClose"
   # we skip pmd and spotbugs as they executed in special Travis build
-  mvn -e verify -Dtest=*,$exclude1$exclude2$exclude3$exclude4 -Djacoco.skip=true \
-    -Dpmd.skip=true -Dspotbugs.skip=true
+  mvn -e verify -Dtest=*,$exclude1 -Djacoco.skip=true -Dpmd.skip=true -Dspotbugs.skip=true
   ;;
 
 nondex)

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -136,6 +136,13 @@
       <property name="acceptableDecimalLength" value="6"/>
     </properties>
   </rule>
+  <rule ref="category/java/codestyle.xml/DefaultPackage">
+    <properties>
+      <property name="violationSuppressXPath"
+                value="//ClassOrInterfaceDeclaration[@Image='FileContents'
+        or @Image='FileText' or @Image='TokenUtil']"/>
+    </properties>
+  </rule>
   <rule ref="category/java/codestyle.xml/LongVariable">
     <properties>
       <!-- Nothing bad with the long and descriptive variable names if only they fit the line,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
@@ -40,10 +40,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  */
 public final class TokenUtil {
 
+    /** Maps from a token value to name. */
+    /* package */ static final String[] TOKEN_VALUE_TO_NAME;
+
     /** Maps from a token name to value. */
     private static final Map<String, Integer> TOKEN_NAME_TO_VALUE;
-    /** Maps from a token value to name. */
-    private static final String[] TOKEN_VALUE_TO_NAME;
 
     /** Array of all token IDs. */
     private static final int[] TOKEN_IDS;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -246,12 +247,14 @@ public class FileContentsTest {
     }
 
     @Test
-    public void testGetJavadocBefore() {
+    public void testGetJavadocBefore() throws Exception {
         final FileContents fileContents = new FileContents(
                 new FileText(new File("filename"), Collections.singletonList("    ")));
         final Map<Integer, TextBlock> javadoc = new HashMap<>();
         javadoc.put(0, new Comment(new String[] {"// "}, 2, 1, 2));
-        Whitebox.setInternalState(fileContents, "javadocComments", javadoc);
+        final Field javadocCommentsField = FileContents.class.getDeclaredField("javadocComments");
+        javadocCommentsField.setAccessible(true);
+        javadocCommentsField.set(fileContents, javadoc);
         final TextBlock javadocBefore = fileContents.getJavadocBefore(2);
 
         assertEquals("Invalid before javadoc",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/MainFrameModelPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/MainFrameModelPowerTest.java
@@ -19,24 +19,19 @@
 
 package com.puppycrawl.tools.checkstyle.internal.powermock;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.gui.MainFrameModel;
 import com.puppycrawl.tools.checkstyle.gui.MainFrameModel.ParseMode;
 
@@ -48,18 +43,9 @@ public class MainFrameModelPowerTest extends AbstractModuleTestSupport {
     private static final String FILE_NAME_NON_JAVA = "NotJavaFile.notjava";
     private static final String FILE_NAME_NON_EXISTENT = "non-existent.file";
 
-    private MainFrameModel model;
-    private File testData;
-
     @Override
     protected String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/gui/mainframemodel";
-    }
-
-    @Before
-    public void prepareTestData() throws IOException {
-        model = new MainFrameModel();
-        testData = new File(getPath(FILE_NAME_TEST_DATA));
     }
 
     @Test
@@ -82,30 +68,6 @@ public class MainFrameModelPowerTest extends AbstractModuleTestSupport {
         final File nonExistentFile = new File(getPath(FILE_NAME_NON_EXISTENT));
         assertFalse("MainFrame should not accept nonexistent file",
                 MainFrameModel.shouldAcceptFile(nonExistentFile));
-    }
-
-    @Test
-    public void testOpenFileWithUnknownParseMode() throws CheckstyleException {
-        final ParseMode unknownParseMode = PowerMockito.mock(ParseMode.class);
-        Whitebox.setInternalState(unknownParseMode, "ordinal", 3);
-
-        PowerMockito.when(unknownParseMode.toString()).thenReturn("Unknown parse mode");
-        PowerMockito.mockStatic(ParseMode.class);
-        PowerMockito.when(ParseMode.values()).thenReturn(
-                new ParseMode[] {
-                    ParseMode.PLAIN_JAVA, ParseMode.JAVA_WITH_COMMENTS,
-                    ParseMode.JAVA_WITH_JAVADOC_AND_COMMENTS, unknownParseMode, });
-
-        try {
-            model.setParseMode(unknownParseMode);
-            model.openFile(testData);
-
-            fail("Expected IllegalArgumentException is not thrown.");
-        }
-        catch (IllegalArgumentException ex) {
-            assertEquals("Invalid exception message",
-                    "Unknown mode: Unknown parse mode", ex.getMessage());
-        }
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -149,25 +148,9 @@ public class TokenUtilTest {
     }
 
     @Test
-    public void testTokenValueIncorrect2() throws Exception {
-        final int id = 0;
-        String[] originalValue = null;
-        Field fieldToken = null;
+    public void testTokenValueIncorrect2() {
+        final int id = TokenUtil.TOKEN_VALUE_TO_NAME.length;
         try {
-            // overwrite static field with new value
-            final Field[] fields = TokenUtil.class.getDeclaredFields();
-            for (Field field : fields) {
-                field.setAccessible(true);
-                if ("TOKEN_VALUE_TO_NAME".equals(field.getName())) {
-                    fieldToken = field;
-                    final Field modifiersField = Field.class.getDeclaredField("modifiers");
-                    modifiersField.setAccessible(true);
-                    modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-                    originalValue = (String[]) field.get(null);
-                    field.set(null, new String[] {null});
-                }
-            }
-
             TokenUtil.getTokenName(id);
             fail("IllegalArgumentException is expected");
         }
@@ -175,9 +158,22 @@ public class TokenUtilTest {
             assertEquals("Invalid exception message",
                     "given id " + id, expected.getMessage());
         }
+    }
+
+    @Test
+    public void testTokenValueIncorrect3() {
+        final String original = TokenUtil.TOKEN_VALUE_TO_NAME[0];
+        TokenUtil.TOKEN_VALUE_TO_NAME[0] = null;
+        try {
+            TokenUtil.getTokenName(0);
+            fail("IllegalArgumentException is expected");
+        }
+        catch (IllegalArgumentException expected) {
+            assertEquals("Invalid exception message",
+                    "given id " + 0, expected.getMessage());
+        }
         finally {
-            // restoring original value, to let other tests pass
-            fieldToken.set(null, originalValue);
+            TokenUtil.TOKEN_VALUE_TO_NAME[0] = original;
         }
     }
 


### PR DESCRIPTION
- expose `FileContents.javadocComments` through package-protected getter in order to make code testable
- remove `MainFrameModelPowerTest.testOpenFileWithUnknownParseMode` because it tests a language construct
- simplify overly complex `TokenUtilTest.testTokenValueIncorrect2`

close #7033