### PR TITLE
Issue #7041: ANNOTATION_DEF support added in RightCurlyCheck

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -265,6 +265,7 @@
       <property name="tokens" value="LITERAL_FINALLY"/>
       <property name="tokens" value="LITERAL_IF"/>
       <property name="tokens" value="LITERAL_TRY"/>
+      <property name="tokens" value="ANNOTATION_DEF"/>
       <property name="option" value="alone"/>
     </module>
     <module name="RightCurly">

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
@@ -87,6 +87,9 @@ public class RightCurlyTest extends AbstractGoogleModuleTestSupport {
             "108:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 6),
             "122:5: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 5),
             "122:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 6),
+            "148:39: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 39),
+            "150:61: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 61),
+            "153:28: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 28),
         };
 
         final Configuration checkConfig = getModuleConfig("RightCurly", "RightCurlyAlone");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyOtherAlone.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyOtherAlone.java
@@ -143,3 +143,19 @@ class WithArraysAlone {
     String[] s4 =
         {"foo", "foo"}; // ok
 }
+
+class Interface {
+    public @interface TestAnnotation {} //warn
+
+    public @interface TestAnnotation1 { String someValue(); } //warn
+
+    public @interface TestAnnotation2 {
+        String someValue();} //warn
+
+    public @interface TestAnnotation3 {
+        String someValue();
+    } //ok
+
+    public @interface TestAnnotation4 { String someValue();
+    } //ok
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -34,7 +34,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * Checks the placement of right curly braces (<code>'}'</code>)
  * for if-else, try-catch-finally blocks, while-loops, for-loops,
  * method definitions, class definitions, constructor definitions,
- * instance and static initialization blocks.
+ * instance, static initialization blocks and annotation definitions.
  * For right curly brace of expression blocks please follow issue
  * <a href="https://github.com/checkstyle/checkstyle/issues/5945">#5945</a>.
  * </p>
@@ -142,6 +142,7 @@ public class RightCurlyCheck extends AbstractCheck {
             TokenTypes.LITERAL_DO,
             TokenTypes.STATIC_INIT,
             TokenTypes.INSTANCE_INIT,
+            TokenTypes.ANNOTATION_DEF,
         };
     }
 
@@ -453,8 +454,8 @@ public class RightCurlyCheck extends AbstractCheck {
         }
 
         /**
-         * Collects validation details for CLASS_DEF, METHOD DEF, CTOR_DEF, STATIC_INIT, and
-         * INSTANCE_INIT.
+         * Collects validation details for CLASS_DEF, METHOD DEF, CTOR_DEF, STATIC_INIT,
+         * INSTANCE_INIT and ANNOTATION_DEF.
          * @param ast a {@code DetailAST} value
          * @return an object containing all details to make a validation
          */
@@ -462,7 +463,7 @@ public class RightCurlyCheck extends AbstractCheck {
             DetailAST rcurly = null;
             final DetailAST lcurly;
             final int tokenType = ast.getType();
-            if (tokenType == TokenTypes.CLASS_DEF) {
+            if (tokenType == TokenTypes.CLASS_DEF || tokenType == TokenTypes.ANNOTATION_DEF) {
                 final DetailAST child = ast.getLastChild();
                 lcurly = child.getFirstChild();
                 rcurly = child.getLastChild();

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -93,7 +93,7 @@
             <property name="option" value="alone"/>
             <property name="tokens"
              value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
-                    INSTANCE_INIT"/>
+                    INSTANCE_INIT, ANNOTATION_DEF"/>
         </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -93,7 +93,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.SAME.toString());
         checkConfig.addAttribute("tokens", "LITERAL_DO, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,"
-                + "INSTANCE_INIT, CLASS_DEF, METHOD_DEF, CTOR_DEF");
+                + "INSTANCE_INIT, CLASS_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_DEF");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputRightCurlySame.java"), expected);
     }
@@ -123,7 +123,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     public void testNewLine() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
-        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF");
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_DEF");
         final String[] expected = {
             "111:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "111:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
@@ -143,7 +143,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     public void testShouldStartLine2() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.ALONE_OR_SINGLELINE.toString());
-        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF");
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, ANNOTATION_DEF");
         final String[] expected = {
             "111:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
             "122:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
@@ -183,7 +183,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
         checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, "
-            + "LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT");
+            + "LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT, ANNOTATION_DEF");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputRightCurlyEmptyAbstractMethod.java"), expected);
     }
@@ -194,7 +194,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
         checkConfig.addAttribute("tokens", "LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, "
             + "LITERAL_IF, LITERAL_ELSE, CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, "
-            + "LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT");
+            + "LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT, ANNOTATION_DEF");
         final String[] expected = {
             "8:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 77),
             "11:65: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 65),
@@ -258,6 +258,14 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "228:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "231:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
             "234:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "237:38: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 38),
+            "239:56: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 56),
+            "242:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
+            "252:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
+            "254:40: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 40),
+            "258:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "261:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "263:61: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 61),
         };
         verify(checkConfig, getPath("InputRightCurlyAnnotations.java"), expected);
     }
@@ -268,7 +276,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", RightCurlyOption.ALONE_OR_SINGLELINE.toString());
         checkConfig.addAttribute("tokens", "LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, "
             + "LITERAL_IF, LITERAL_ELSE, CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, "
-            + "LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT");
+            + "LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT, ANNOTATION_DEF");
         final String[] expected = {
             "60:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 26),
             "74:42: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 42),
@@ -306,6 +314,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "204:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "209:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "210:53: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 53),
+            "218:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
         };
         verify(checkConfig, getPath("InputRightCurlyAloneOrSingleline.java"), expected);
     }
@@ -450,7 +459,8 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
         checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, LITERAL_IF, LITERAL_ELSE, "
-                + "LITERAL_DO, LITERAL_WHILE, LITERAL_FOR, STATIC_INIT, INSTANCE_INIT");
+                + "LITERAL_DO, LITERAL_WHILE, LITERAL_FOR, STATIC_INIT, "
+                + "INSTANCE_INIT, ANNOTATION_DEF");
         final String[] expected = {
             "7:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
             "8:21: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 21),
@@ -466,6 +476,9 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "53:52: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 52),
             "66:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "66:11: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 11),
+            "70:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
+            "72:56: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 56),
+            "75:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
         };
         verify(checkConfig, getPath("InputRightCurlyAlone.java"),
                 expected);
@@ -476,7 +489,8 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.ALONE_OR_SINGLELINE.toString());
         checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, LITERAL_IF, LITERAL_ELSE, "
-                + "LITERAL_DO, LITERAL_WHILE, LITERAL_FOR, STATIC_INIT, INSTANCE_INIT");
+                + "LITERAL_DO, LITERAL_WHILE, LITERAL_FOR, STATIC_INIT, "
+                + "INSTANCE_INIT, ANNOTATION_DEF");
         final String[] expected = {
             "12:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 26),
             "21:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
@@ -493,11 +507,15 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     public void testBlocksEndingWithSemiOptionSame() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.SAME.toString());
-        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF");
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, "
+                + "CTOR_DEF, ANNOTATION_DEF");
         final String[] expected = {
             "14:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "19:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "25:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "33:29: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 29),
+            "39:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "42:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
         };
         verify(checkConfig, getPath("InputRightCurlySameBlocksWithSemi.java"), expected);
     }
@@ -506,7 +524,8 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     public void testBlocksEndingWithSemiOptionAlone() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
-        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF");
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, "
+                + "CTOR_DEF, ANNOTATION_DEF");
         final String[] expected = {
             "11:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
             "14:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
@@ -514,6 +533,11 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "19:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "22:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
             "25:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "33:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
+            "35:40: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 40),
+            "39:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "42:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "44:61: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 61),
         };
         verify(checkConfig, getPath("InputRightCurlyAloneBlocksWithSemi.java"), expected);
     }
@@ -523,11 +547,15 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option",
                 RightCurlyOption.ALONE_OR_SINGLELINE.toString());
-        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF");
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, "
+                + "CTOR_DEF, ANNOTATION_DEF");
         final String[] expected = {
             "14:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "19:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "25:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "33:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
+            "39:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "42:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
         };
         verify(checkConfig,
                 getPath("InputRightCurlyAloneOrSingleLineBlocksWithSemi.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAlone.java
@@ -66,4 +66,18 @@ public class InputRightCurlyAlone {
         }{}; // violation
         };
     }
+
+    public @interface TestAnnotation {} //violation
+
+    public @interface TestAnnotation1{ String value(); } //violation
+
+    public @interface TestAnnotation2 {
+        String value();} //violation
+
+    public @interface TestAnnotation3 {
+        String value();
+    }
+
+    public @interface TestAnnottation4 { String value();
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneBlocksWithSemi.java
@@ -1,7 +1,7 @@
 /*
  * Config:
  * option = alone
- * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF
+ * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_DEF
  */
 
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
@@ -28,5 +28,19 @@ public class InputRightCurlyAloneBlocksWithSemi {
     public void testMethod11() {
     }
     ;
+
+    public @interface TestAnnnotation5 {
+        String someValue(); }; //violation
+
+    public @interface TestAnnotation6 {}; //violation
+
+    public @interface TestAnnotation7 {
+        String someValue();
+    }; //violation
+
+    public @interface TestAnnotation8 { String someValue();
+    }; //violation
+
+    public @interface TestAnnotation9 { String someValue(); }; //violation
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLineBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLineBlocksWithSemi.java
@@ -1,7 +1,7 @@
 /*
  * Config:
  * option = alone_or_singleline
- * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF
+ * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_DEF
  */
 
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
@@ -28,4 +28,18 @@ public class InputRightCurlyAloneOrSingleLineBlocksWithSemi {
     public void testMethod11() {
     }
     ;
+
+    public @interface TestAnnnotation5 {
+        String someValue(); }; //violation
+
+    public @interface TestAnnotation6 {};
+
+    public @interface TestAnnotation7 {
+        String someValue();
+    }; //violation
+
+    public @interface TestAnnotation8 { String someValue();
+    }; //violation
+
+    public @interface TestAnnotation9 { String someValue(); };
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleline.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleline.java
@@ -209,4 +209,18 @@ public class InputRightCurlyAloneOrSingleline {
         }; // violation
         for (int i = 0; i < 1; i++) { new Object(); }; // violation
     }
+
+    public @interface TestAnnotation {}
+
+    public @interface TestAnnotation1{ String value(); }
+
+    public @interface TestAnnotation2 {
+        String value();} //violation
+
+    public @interface TestAnnotation3 {
+        String value();
+    }
+
+    public @interface TestAnnottation4 { String value();
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAnnotations.java
@@ -233,4 +233,32 @@ class InputRightCurlyAnnotations
         public TestClass2(String someValue) {
         }; //violation
     }
+
+   public @interface TestAnnotation {} //violation
+
+    public @interface TestAnnotation1{ String value(); } //violation
+
+    public @interface TestAnnotation2 {
+        String value();} //violation
+
+    public @interface TestAnnotation3 {
+        String value();
+    }
+
+    public @interface TestAnnottation4 { String value();
+    }
+
+    public @interface TestAnnnotation5 {
+        String someValue(); }; //violation
+
+    public @interface TestAnnotation6 {}; //violation
+
+    public @interface TestAnnotation7 {
+        String someValue();
+    }; //violation
+
+    public @interface TestAnnotation8 { String someValue();
+    }; //violation
+
+    public @interface TestAnnotation9 { String someValue(); }; //violation
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySame.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySame.java
@@ -35,4 +35,15 @@ public class InputRightCurlySame {
     public class TestClass {};
 
     public void testMethod() {};
+
+    public @interface TestAnnotation {}
+
+    public @interface TestAnnotation1 { String someValue(); }
+
+    public @interface TestAnnotation3 {
+        String someValue();
+    }
+
+    public @interface TestAnnotation4 {String someValue();
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySameBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySameBlocksWithSemi.java
@@ -1,7 +1,7 @@
 /*
  * Config:
  * option = same
- * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF
+ * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_DEF
  */
 
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
@@ -28,4 +28,18 @@ public class InputRightCurlySameBlocksWithSemi {
     public void testMethod11() {
     }
     ;
+
+    public @interface TestAnnnotation5 {
+        String someValue(); }; //violation
+
+    public @interface TestAnnotation6 {};
+
+    public @interface TestAnnotation7 {
+        String someValue();
+    }; //violation
+
+    public @interface TestAnnotation8 { String someValue();
+    }; //violation
+
+    public @interface TestAnnotation9 { String someValue(); };
 }

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -944,7 +944,7 @@ allowedFuture.addCallback(result -> {
           Checks the placement of right curly braces (<code>'}'</code>)
           for if-else, try-catch-finally blocks, while-loops, for-loops,
           method definitions, class definitions, constructor definitions,
-          instance and static initialization blocks.
+          instance, static initialization blocks and annotation definitions.
           For right curly brace of expression blocks please follow issue
           <a href="https://github.com/checkstyle/checkstyle/issues/5945">#5945</a>.
         </p>
@@ -1008,7 +1008,10 @@ allowedFuture.addCallback(result -> {
                   STATIC_INIT</a>,
               <a
                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
-                  INSTANCE_INIT</a>.</td>
+                  INSTANCE_INIT</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                  ANNOTATION_DEF</a>.</td>
 
               <td><a
                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">


### PR DESCRIPTION
ANNOTATION_DEF support added in RightCurlyCheck. Fix #7041.

Regression:
https://sd1998.github.io/checkstyle-regression/Fix-7041/