### PR TITLE
Issue #6724: format sources to pass JavadocSummaryLocationCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -86,8 +86,10 @@ public final class Main {
     /** Exit code returned when execution finishes with {@link CheckstyleException}. */
     private static final int EXIT_WITH_CHECKSTYLE_EXCEPTION_CODE = -2;
 
-    /** Client code should not create instances of this class, but use
-     * {@link #main(String[])} method instead. */
+    /**
+     * Client code should not create instances of this class, but use
+     * {@link #main(String[])} method instead.
+     */
     private Main() {
     }
 
@@ -512,7 +514,9 @@ public final class Main {
         return result;
     }
 
-    /** Enumeration over the possible output formats.
+    /**
+     * Enumeration over the possible output formats.
+     *
      * @noinspection PackageVisibleInnerClass
      */
     // Package-visible for tests.
@@ -540,7 +544,9 @@ public final class Main {
             return result;
         }
 
-        /** Returns the name in lowercase.
+        /**
+         * Returns the name in lowercase.
+         *
          * @return the enum name in lowercase
          */
         @Override
@@ -615,8 +621,10 @@ public final class Main {
                         + "that the suppression should be generated for")
         private String suppressionLineColumnNumber;
 
-        /** Tab character length.
-         *  Suppression: CanBeFinal - we use picocli and it use  reflection to manage such fields
+        /**
+         * Tab character length.
+         * Suppression: CanBeFinal - we use picocli and it use  reflection to manage such fields
+         *
          * @noinspection CanBeFinal
          */
         @Option(names = {"-w", "--tabWidth"}, description = "Sets the length of the tab character. "
@@ -629,8 +637,10 @@ public final class Main {
                         + " violations from user's config")
         private boolean generateXpathSuppressionsFile;
 
-        /** Output format.
-         *  Suppression: CanBeFinal - we use picocli and it use  reflection to manage such fields
+        /**
+         * Output format.
+         * Suppression: CanBeFinal - we use picocli and it use  reflection to manage such fields
+         *
          * @noinspection CanBeFinal
          */
         @Option(names = "-f", description = "Sets the output format. Valid values: "
@@ -662,16 +672,20 @@ public final class Main {
                 description = "Print all debug logging of CheckStyle utility")
         private boolean debug;
 
-        /** Option that allows users to specify a list of paths to exclude.
-         *  Suppression: CanBeFinal - we use picocli and it use  reflection to manage such fields
+        /**
+         * Option that allows users to specify a list of paths to exclude.
+         * Suppression: CanBeFinal - we use picocli and it use  reflection to manage such fields
+         *
          * @noinspection CanBeFinal
          */
         @Option(names = {"-e", "--exclude"},
                 description = "Directory/File path to exclude from CheckStyle")
         private List<File> exclude = new ArrayList<>();
 
-        /** Option that allows users to specify a regex of paths to exclude.
-         *  Suppression: CanBeFinal - we use picocli and it use  reflection to manage such fields
+        /**
+         * Option that allows users to specify a regex of paths to exclude.
+         * Suppression: CanBeFinal - we use picocli and it use  reflection to manage such fields
+         *
          * @noinspection CanBeFinal
          */
         @Option(names = {"-x", "--exclude-regexp"},
@@ -683,16 +697,20 @@ public final class Main {
                 description = "Allows ignored modules to be run.")
         private boolean executeIgnoredModules;
 
-        /** The checker threads number.
-         *  Suppression: CanBeFinal - we use picocli and it use  reflection to manage such fields
+        /**
+         * The checker threads number.
+         * Suppression: CanBeFinal - we use picocli and it use  reflection to manage such fields
+         *
          * @noinspection CanBeFinal
          */
         @Option(names = {"-C", "--checker-threads-number"}, description = "(experimental) The "
                 + "number of Checker threads (must be greater than zero)")
         private int checkerThreadsNumber = DEFAULT_THREAD_COUNT;
 
-        /** The tree walker threads number.
-         *  Suppression: CanBeFinal - we use picocli and it use  reflection to manage such fields
+        /**
+         * The tree walker threads number.
+         * Suppression: CanBeFinal - we use picocli and it use  reflection to manage such fields
+         *
          * @noinspection CanBeFinal
          */
         @Option(names = {"-W", "--tree-walker-threads-number"}, description = "(experimental) The "

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageNamesLoader.java
@@ -59,7 +59,8 @@ public final class PackageNamesLoader
     private static final String DTD_RESOURCE_NAME =
         "com/puppycrawl/tools/checkstyle/packages_1_0.dtd";
 
-    /** Name of default checkstyle package names resource file.
+    /**
+     * Name of default checkstyle package names resource file.
      * The file must be in the classpath.
      */
     private static final String CHECKSTYLE_PACKAGES =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -53,7 +53,8 @@ public final class FileContents implements CommentListener {
     /** The text. */
     private final FileText text;
 
-    /** Map of the Javadoc comments indexed on the last line of the comment.
+    /**
+     * Map of the Javadoc comments indexed on the last line of the comment.
      * The hack is it assumes that there is only one Javadoc comment per line.
      */
     private final Map<Integer, TextBlock> javadocComments = new HashMap<>();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -1212,7 +1212,8 @@ public final class JavadocTokenTypes {
     //------- JAVADOC TAGS DEPENDING ON RULE TYPES OFFSET ----------------------------------------//
     //--------------------------------------------------------------------------------------------//
 
-    /** Rule types offset.
+    /**
+     * Rule types offset.
      * RULE_TYPES_OFFSET constant is used to split lexer tokens types and parser rules types.
      * We need unique numbers for all tokens,
      * ANTLR do not need this and that is why this types are mixed by used values.
@@ -1686,7 +1687,9 @@ public final class JavadocTokenTypes {
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
-    /** Html comment: <code>&lt;&#33;-- --&gt;</code>.
+    /**
+     * Html comment: <code>&lt;&#33;-- --&gt;</code>.
+     *
      * @noinspection HtmlTagCanBeJavadocTag
      */
     public static final int HTML_COMMENT = JavadocParser.RULE_htmlComment

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -81,7 +81,9 @@ public final class LocalizedMessage
     /** Key for the message format. **/
     private final String key;
 
-    /** Arguments for MessageFormat.
+    /**
+     * Arguments for MessageFormat.
+     *
      * @noinspection NonSerializableFieldInSerializableClass
      */
     private final Object[] args;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -123,7 +123,8 @@ public class TrailingCommentCheck extends AbstractCheck {
      */
     public static final String MSG_KEY = "trailing.comments";
 
-    /** Define pattern for text allowed in trailing comments.
+    /**
+     * Define pattern for text allowed in trailing comments.
      * (This pattern will not be applied to multiline comments and the text
      * of the comment will be trimmed before matching.)
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -187,7 +187,8 @@ public class HiddenFieldCheck
      */
     public static final String MSG_KEY = "hidden.field";
 
-    /** Stack of sets of field names,
+    /**
+     * Stack of sets of field names,
      * one for each class of a set of nested classes.
      */
     private FieldFrame frame;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -696,9 +696,11 @@ public class CustomImportOrderCheck extends AbstractCheck {
         return bestMatch.group;
     }
 
-    /** Tries to find better matching regular expression:
+    /**
+     * Tries to find better matching regular expression:
      * longer matching substring wins; in case of the same length,
      * lower position of matching substring wins.
+     *
      * @param importPath
      *      Full import identifier
      * @param group
@@ -934,7 +936,9 @@ public class CustomImportOrderCheck extends AbstractCheck {
         /** Import group for current best match. */
         private String group;
 
-        /** Constructor to initialize the fields.
+        /**
+         * Constructor to initialize the fields.
+         *
          * @param group
          *        Matched group.
          * @param length

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -452,7 +452,8 @@ public class ImportOrderCheck
     private boolean lastImportStatic;
     /** Whether there was any imports. */
     private boolean beforeFirstImport;
-    /** Whether static and type import groups should be split apart.
+    /**
+     * Whether static and type import groups should be split apart.
      * When the {@code option} property is set to {@code INFLOW}, {@code BELOW} or {@code UNDER},
      * both the type and static imports use the properties {@code groups} and {@code separated}.
      * When the {@code option} property is set to {@code TOP} or {@code BOTTOM}, static imports

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -73,7 +73,8 @@ public class JavadocStyleCheck
         Arrays.stream(new String[] {"br", "li", "dt", "dd", "hr", "img", "p", "td", "tr", "th", })
             .collect(Collectors.toCollection(TreeSet::new)));
 
-    /** HTML tags that are allowed in java docs.
+    /**
+     * HTML tags that are allowed in java docs.
      * From https://www.w3schools.com/tags/default.asp
      * The forms and structure tags are not allowed
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
@@ -130,7 +130,8 @@ public class ParameterNumberCheck
         }
     }
 
-    /** Determine whether to ignore number of parameters for the method.
+    /**
+     * Determine whether to ignore number of parameters for the method.
      *
      * @param ast the token to process
      * @return true if this is overridden method and number of parameters should be ignored

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractPathTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractPathTestSupport.java
@@ -63,7 +63,9 @@ public abstract class AbstractPathTestSupport {
         return "/" + getPackageLocation() + "/" + filename;
     }
 
-    /** Reads the contents of a file.
+    /**
+     * Reads the contents of a file.
+     *
      * @param filename the name of the file whose contents are to be read
      * @return contents of the file with all {@code \r\n} replaced by {@code \n}
      * @throws IOException if I/O exception occurs while reading

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -427,9 +427,10 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             expected);
     }
 
-    /** Tests that a non-static import after a static import correctly gives an
-     * error if order=bottom. */
-
+    /**
+     * Tests that a non-static import after a static import correctly gives an
+     * error if order=bottom.
+     */
     @Test
     public void testStaticGroupsAlphabeticalOrderTopNegative() throws Exception {
         final DefaultConfiguration checkConfig =
@@ -445,9 +446,10 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             expected);
     }
 
-    /** Tests that a non-static import before a static import correctly gives an
-     * error if order=top. */
-
+    /**
+     * Tests that a non-static import before a static import correctly gives an
+     * error if order=top.
+     */
     @Test
     public void testStaticGroupsAlphabeticalOrderBottomNegative2() throws Exception {
         final DefaultConfiguration checkConfig =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentationTest.java
@@ -56,11 +56,13 @@ public class CodeSelectorPresentationTest extends AbstractPathTestSupport {
         return "com/puppycrawl/tools/checkstyle/gui/codeselectorpresentation";
     }
 
-    /** Converts lineToPosition from multicharacter to one character line separator
-      * needs to support crossplatform line separators.
-      * @param systemLinesToPosition lines to position mapping for current system
-      * @return lines to position mapping with one character line separator
-      */
+    /**
+     * Converts lineToPosition from multicharacter to one character line separator
+     * needs to support crossplatform line separators.
+     *
+     * @param systemLinesToPosition lines to position mapping for current system
+     * @return lines to position mapping with one character line separator
+     */
     private static List<Integer> convertLinesToPosition(List<Integer> systemLinesToPosition) {
         final List<Integer> convertedLinesToPosition = new ArrayList<>();
         final int lineSeparationCorrection = System.lineSeparator().length() - 1;


### PR DESCRIPTION
Issue #6724 

Formatted all multi-line javadocs. Now summary begin with the second line.