### PR TITLE
config: use upstream equalsverifier for CI

### DIFF
--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -78,9 +78,8 @@ no-error-equalsverifier)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/equalsverifier.git
+  checkout_from https://github.com/jqno/equalsverifier.git
   cd .ci-temp/equalsverifier
-  git checkout issue_2116
   mvn -e compile checkstyle:check -Dcheckstyle.version=${CS_POM_VERSION}
   cd ../
   rm -rf equalsverifier


### PR DESCRIPTION
it is possible after https://github.com/jqno/equalsverifier/pull/245

after merge, we should delete forked repo.