### PR TITLE
config: add stack trace to gradle

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1180,7 +1180,7 @@ ssl
 stackexchange
 stackoverflow
 stackoverflowerror
-Stacktrace
+stacktrace
 standalone
 staticvariablename
 Stdlib

--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -224,7 +224,7 @@ no-error-test-sbe)
   sed -i'' \
     "s/'com.puppycrawl.tools:checkstyle:.*'/'com.puppycrawl.tools:checkstyle:$CS_POM_VERSION'/" \
     build.gradle
-  ./gradlew build
+  ./gradlew build --stacktrace
   ;;
 
 no-exception-test-checkstyle-sevntu-checkstyle)


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/7088

Needed stacktrace to see `Property 'allowMissingJavadoc' does not exist, please check the documentation`
Original error was only showing `Unable to create Root Module: config {/home/travis/build/checkstyle/checkstyle/.ci-temp/simple-binary-encoding/config/checkstyle/checkstyle.xml}, classpath {/home/travis/build/checkstyle/checkstyle/.ci-temp/simple-binary-encoding/sbe-benchmarks/build/classes/java/generated:/home/travis/build/checkstyle/checkstyle/.ci-temp/simple-binary-encoding/sbe-benchmarks/build/resources/generated}.`