### PR TITLE
config: fix string to number issue in pr age check

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1061,6 +1061,7 @@ RDz
 reactivex
 README
 Readonly
+rebased
 rebasing
 redundantimport
 redundantmodifier

--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -206,10 +206,13 @@ pr-age)
   PR_MASTER=`git merge-base origin/master HEAD`
   COMMITS_SINCE_MASTER=`git rev-list --count $PR_MASTER..origin/master`
   MAX_ALLOWED=10
-  if [[ $COMMITS_SINCE_MASTER > $MAX_ALLOWED ]];
+
+  echo "The PR is based on a master that is $COMMITS_SINCE_MASTER commit(s) old."
+  echo "The max allowed is $MAX_ALLOWED."
+
+  if (( $COMMITS_SINCE_MASTER > $MAX_ALLOWED ));
   then
-    echo "The PR is based on a master that is $COMMITS_SINCE_MASTER commit(s) old."
-    echo "The max allowed is $MAX_ALLOWED"
+    echo "This PR is too old and should be rebased on origin/master."
     sleep 5s
     false
   fi


### PR DESCRIPTION
Fix for PR age issue. I believe the issue is the number being returned is a string and not integer and so needs to be converted to an integer.
Minor changes to the displays for easier debugging.