### PR TITLE
Issue #4545: deprecate test only FileText constructor

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -166,7 +166,9 @@ public final class FileText {
      * @param file the name of the file
      * @param lines the lines of the text, without terminators
      * @throws NullPointerException if the lines array is null
+     * @deprecated Use {@link #FileText(File, String)} to load the file directly.
      */
+    @Deprecated
     public FileText(File file, List<String> lines) {
         final StringBuilder buf = new StringBuilder(1024);
         for (final String line : lines) {


### PR DESCRIPTION
Issue #4545

Constructor is only used by tests.
New issue should be created to fully remove this method.