### PR TITLE
config: upgrade eclipse static analysis

### DIFF
--- a/.ci/eclipse-compiler-javac.sh
+++ b/.ci/eclipse-compiler-javac.sh
@@ -7,8 +7,8 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-ECJ_JAR="ecj-4.10.jar"
-ECJ_MAVEN_VERSION="R-4.10-201812060815"
+ECJ_JAR="ecj-4.11.jar"
+ECJ_MAVEN_VERSION="R-4.11-201903070500"
 ECJ_PATH=~/.m2/repository/$ECJ_MAVEN_VERSION/$ECJ_JAR
 
 if [ ! -f $ECJ_PATH ]; then


### PR DESCRIPTION
Identified at https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/779 ,

4.10 doesn't exist on the server anymore, 4.11 is the lowest version.
We need to identify why our CI didn't pick this up. I looked at some previous builds and eclipse analysis was being skipped in them.
My local fails the same as sevntu.