### PR TITLE
config: fix previous commits check to avoid confusion with master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,13 @@ jobs:
             echo -n "|org.eclipse.jdt.core.prefs" >> .ci-temp/skip_ci_files
             echo -n "|Jenkinsfile" >> .ci-temp/skip_ci_files
             SKIP_CI_BY_FILES=false;
-            if [ $(git diff --name-only HEAD `git merge-base origin/master HEAD` \
+            ## Check if we are working with master to use a different previous commit
+            PREVIOUS_COMMIT="HEAD~1"
+            if [[ $(git branch master --contains `git rev-parse HEAD` \
+                       | wc -c ) > 0 ]]; then
+                 PREVIOUS_COMMIT=`git merge-base origin/master HEAD`
+            fi
+            if [ $(git diff --name-only HEAD $PREVIOUS_COMMIT \
                    | grep -vE $(cat .ci-temp/skip_ci_files) | wc -c) -gt 0 ] ; then
                 SKIP_CI_BY_FILES=false;
               else

--- a/.travis.yml
+++ b/.travis.yml
@@ -300,7 +300,13 @@ script:
   - SKIP_CI_BY_COMMIT="false"
   - |
     if [[ $SKIP_CI_BY_FILES != 'false' ]]; then
-         if [[ $(git diff --name-only HEAD `git merge-base origin/master HEAD` \
+         ## Check if we are working with master to use a different previous commit
+         PREVIOUS_COMMIT="HEAD~1"
+         if [[ $(git branch master --contains `git rev-parse HEAD` \
+                    | wc -c ) > 0 ]]; then
+              PREVIOUS_COMMIT=`git merge-base origin/master HEAD`
+         fi
+         if [[ $(git diff --name-only HEAD $PREVIOUS_COMMIT \
                     | grep -vE "$SKIP_FILES" | cat | wc -c | sed 's/^ *//' ) > 0 ]]; then
               SKIP_CI_BY_FILES="false"
          else

--- a/shippable.yml
+++ b/shippable.yml
@@ -48,7 +48,13 @@ build:
       SKIP_FILES5="|Jenkinsfile"
       SKIP_FILES=$SKIP_FILES1$SKIP_FILES2$SKIP_FILES3$SKIP_FILES4$SKIP_FILES5
       SKIP_CI_BY_FILES=false
-      if [[ $(git diff --name-only HEAD `git merge-base origin/master HEAD` \
+      ## Check if we are working with master to use a different previous commit
+      PREVIOUS_COMMIT="HEAD~1"
+      if [[ $(git branch master --contains `git rev-parse HEAD` \
+                 | wc -c ) > 0 ]]; then
+           PREVIOUS_COMMIT=`git merge-base origin/master HEAD`
+      fi
+      if [[ $(git diff --name-only HEAD $PREVIOUS_COMMIT \
               | grep -vE "$SKIP_FILES" | cat | wc -c) > 0 ]]; then
         SKIP_CI_BY_FILES=false;
       else

--- a/wercker.yml
+++ b/wercker.yml
@@ -36,7 +36,13 @@ build:
         SKIP_FILES6="|test-spelling-unknown-words.sh|Jenkinsfile"
         SKIP_FILES=$SKIP_FILES1$SKIP_FILES2$SKIP_FILES3$SKIP_FILES4$SKIP_FILES5$SKIP_FILES6
         export SKIP_CI_BY_FILES=false;
-        if [[ $(git diff --name-only HEAD `git merge-base origin/master HEAD` \
+        ## Check if we are working with master to use a different previous commit
+        PREVIOUS_COMMIT="HEAD~1"
+        if [[ $(git branch master --contains `git rev-parse HEAD` \
+                   | wc -c ) > 0 ]]; then
+             PREVIOUS_COMMIT=`git merge-base origin/master HEAD`
+        fi
+        if [[ $(git diff --name-only HEAD $PREVIOUS_COMMIT \
                 | grep -vE "$SKIP_FILES" | cat | wc -c) > 0 ]];
           then
             SKIP_CI_BY_FILES=false;


### PR DESCRIPTION
Issue identified at https://github.com/checkstyle/checkstyle/pull/7123#issue-322507527 ,

Fixing CI so we don't skip all master runs.