### PR TITLE
Issue #7129: use ja-JP for Japanese locale, zh-CN for Chinese locale in travis.sh

### DIFF
--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -39,12 +39,12 @@ test-fr)
 
 test-zh)
   mvn -e clean integration-test failsafe:verify \
-    -DargLine='-Duser.language=zh -Duser.country=ZH -Xms1024m -Xmx2048m'
+    -DargLine='-Duser.language=zh -Duser.country=CN -Xms1024m -Xmx2048m'
   ;;
 
-test-jp)
+test-ja)
   mvn -e clean integration-test failsafe:verify \
-    -DargLine='-Duser.language=jp -Duser.country=JP -Xms1024m -Xmx2048m'
+    -DargLine='-Duser.language=ja -Duser.country=JP -Xms1024m -Xmx2048m'
   ;;
 
 test-pt)

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,7 @@ matrix:
     - jdk: openjdk8
       env:
         - DESC="tests ja"
-        - CMD="./.ci/travis/travis.sh test-jp"
+        - CMD="./.ci/travis/travis.sh test-ja"
         - USE_MAVEN_REPO="true"
     # unit tests in Portuguese locale (openjdk8)
     - jdk: openjdk8

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
@@ -20,10 +20,13 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import static com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_OBJECT_ARRAY;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -31,6 +34,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -52,6 +56,37 @@ import nl.jqno.equalsverifier.EqualsVerifierReport;
 public class LocalizedMessageTest {
 
     private static final Locale DEFAULT_LOCALE = Locale.getDefault();
+
+    /**
+     * Verifies that the language specified with the system property {@code user.language} exists.
+     */
+    @Test
+    public void testLanguageIsValid() {
+        assertThat("Invalid language",
+            Arrays.asList(Locale.getISOLanguages()), hasItem(DEFAULT_LOCALE.getLanguage()));
+    }
+
+    /**
+     * Verifies that the country specified with the system property {@code user.country} exists.
+     */
+    @Test
+    public void testCountryIsValid() {
+        assertThat("Invalid country",
+            Arrays.asList(Locale.getISOCountries()), hasItem(DEFAULT_LOCALE.getCountry()));
+    }
+
+    /**
+     * Verifies that if the language is specified explicitly (and it is not English),
+     * the message does not use the default value.
+     */
+    @Test
+    public void testLocaleIsSupported() {
+        if (!Locale.ENGLISH.getLanguage().equals(DEFAULT_LOCALE.getLanguage())) {
+            final LocalizedMessage localizedMessage = createSampleLocalizedMessage();
+            assertThat("Unsupported language: " + DEFAULT_LOCALE,
+                    localizedMessage.getMessage(), not("Empty statement."));
+        }
+    }
 
     @Test
     public void testEqualsAndHashCode() {


### PR DESCRIPTION
Issue #7129

Fixed mistype in `.ci/travis.sh`

`LocalizedMessageTest` now fails if the specified language or country code are not valid.