### PR TITLE
Issue #7161: ENUM_DEF support added for RightCurlyCheck

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -266,6 +266,7 @@
       <property name="tokens" value="LITERAL_IF"/>
       <property name="tokens" value="LITERAL_TRY"/>
       <property name="tokens" value="ANNOTATION_DEF"/>
+      <property name="tokens" value="ENUM_DEF"/>
       <property name="option" value="alone"/>
     </module>
     <module name="RightCurly">

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
@@ -81,15 +81,20 @@ public class RightCurlyTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testRightCurlyAloneOther() throws Exception {
         final String[] expected = {
+            "72:5: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 5),
             "97:5: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 5),
             "97:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 6),
             "108:5: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 5),
             "108:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 6),
             "122:5: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 5),
             "122:6: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 6),
+            "125:57: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 57),
             "148:39: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 39),
             "150:61: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 61),
             "153:28: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 28),
+            "163:16: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 16),
+            "165:30: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 30),
+            "168:16: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 16),
         };
 
         final Configuration checkConfig = getModuleConfig("RightCurly", "RightCurlyAlone");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyOtherAlone.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyOtherAlone.java
@@ -69,7 +69,7 @@ class InputRightCurlyOtherAlone
     {
         HELLO,
         GOODBYE
-    }; //ok
+    }; //warn
 
     void method2()
     {
@@ -122,7 +122,7 @@ class FooInnerAlone
     }} //warn
 
 class EnumContainerAlone {
-    private enum Suit { CLUBS, HEARTS, SPADES, DIAMONDS } // ok
+    private enum Suit { CLUBS, HEARTS, SPADES, DIAMONDS } // warn
 }
 
 class WithArraysAlone {
@@ -158,4 +158,18 @@ class Interface {
 
     public @interface TestAnnotation4 { String someValue();
     } //ok
+}
+
+enum TestEnum {} //warn
+
+enum TestEnum1 { SOME_VALUE; } //warn
+
+enum TestEnum2 {
+    SOME_VALUE;} //warn
+
+enum TestEnum3 {
+    SOME_VALUE;
+}
+
+enum TestEnum4 { SOME_VALUE;
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.blocks;
 
+import java.util.Arrays;
 import java.util.Locale;
 
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
@@ -34,7 +35,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * Checks the placement of right curly braces (<code>'}'</code>)
  * for if-else, try-catch-finally blocks, while-loops, for-loops,
  * method definitions, class definitions, constructor definitions,
- * instance, static initialization blocks and annotation definitions.
+ * instance, static initialization blocks, annotation definitions and enum definitions.
  * For right curly brace of expression blocks please follow issue
  * <a href="https://github.com/checkstyle/checkstyle/issues/5945">#5945</a>.
  * </p>
@@ -143,6 +144,7 @@ public class RightCurlyCheck extends AbstractCheck {
             TokenTypes.STATIC_INIT,
             TokenTypes.INSTANCE_INIT,
             TokenTypes.ANNOTATION_DEF,
+            TokenTypes.ENUM_DEF,
         };
     }
 
@@ -337,6 +339,15 @@ public class RightCurlyCheck extends AbstractCheck {
      */
     private static final class Details {
 
+        /**
+         * Token types that identify tokens that will never have SLIST in their AST.
+         */
+        private static final int[] TOKENS_WITH_NO_CHILD_SLIST = {
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.ANNOTATION_DEF,
+        };
+
         /** Right curly. */
         private final DetailAST rcurly;
         /** Left curly. */
@@ -455,7 +466,7 @@ public class RightCurlyCheck extends AbstractCheck {
 
         /**
          * Collects validation details for CLASS_DEF, METHOD DEF, CTOR_DEF, STATIC_INIT,
-         * INSTANCE_INIT and ANNOTATION_DEF.
+         * INSTANCE_INIT, ANNOTATION_DEF and ENUM_DEF.
          * @param ast a {@code DetailAST} value
          * @return an object containing all details to make a validation
          */
@@ -463,7 +474,7 @@ public class RightCurlyCheck extends AbstractCheck {
             DetailAST rcurly = null;
             final DetailAST lcurly;
             final int tokenType = ast.getType();
-            if (tokenType == TokenTypes.CLASS_DEF || tokenType == TokenTypes.ANNOTATION_DEF) {
+            if (isTokenWithNoChildSlist(tokenType)) {
                 final DetailAST child = ast.getLastChild();
                 lcurly = child.getFirstChild();
                 rcurly = child.getLastChild();
@@ -476,6 +487,16 @@ public class RightCurlyCheck extends AbstractCheck {
                 }
             }
             return new Details(lcurly, rcurly, getNextToken(ast), true);
+        }
+
+        /**
+         * Tests whether the provided tokenType will never have a SLIST as child in its AST.
+         * Like CLASS_DEF, ANNOTATION_DEF etc.
+         * @param tokenType the tokenType to test against.
+         * @return weather provided tokenType is definition token.
+         */
+        private static boolean isTokenWithNoChildSlist(int tokenType) {
+            return Arrays.stream(TOKENS_WITH_NO_CHILD_SLIST).anyMatch(token -> token == tokenType);
         }
 
         /**

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -93,7 +93,7 @@
             <property name="option" value="alone"/>
             <property name="tokens"
              value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
-                    INSTANCE_INIT, ANNOTATION_DEF"/>
+                    INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF"/>
         </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -67,12 +67,14 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.SAME.toString());
         checkConfig.addAttribute("tokens", "LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, "
-                + "LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO");
+                + "LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, "
+                + "ANNOTATION_DEF, ENUM_DEF");
         final String[] expected = {
             "25:17: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 17),
             "28:17: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 17),
             "40:13: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 13),
             "44:13: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 13),
+            "86:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "93:27: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 27),
             "188:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "189:53: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 53),
@@ -93,7 +95,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.SAME.toString());
         checkConfig.addAttribute("tokens", "LITERAL_DO, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,"
-                + "INSTANCE_INIT, CLASS_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_DEF");
+                + "INSTANCE_INIT, CLASS_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_DEF, ENUM_DEF");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputRightCurlySame.java"), expected);
     }
@@ -123,8 +125,10 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     public void testNewLine() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
-        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_DEF");
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF, "
+                + "ANNOTATION_DEF, ENUM_DEF");
         final String[] expected = {
+            "86:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "111:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "111:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
             "122:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
@@ -143,8 +147,10 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     public void testShouldStartLine2() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.ALONE_OR_SINGLELINE.toString());
-        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, ANNOTATION_DEF");
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, "
+                + "ANNOTATION_DEF, ENUM_DEF");
         final String[] expected = {
+            "86:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "111:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
             "122:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "122:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
@@ -183,7 +189,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
         checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, "
-            + "LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT, ANNOTATION_DEF");
+            + "LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputRightCurlyEmptyAbstractMethod.java"), expected);
     }
@@ -194,7 +200,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
         checkConfig.addAttribute("tokens", "LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, "
             + "LITERAL_IF, LITERAL_ELSE, CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, "
-            + "LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT, ANNOTATION_DEF");
+            + "LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF");
         final String[] expected = {
             "8:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 77),
             "11:65: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 65),
@@ -276,7 +282,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", RightCurlyOption.ALONE_OR_SINGLELINE.toString());
         checkConfig.addAttribute("tokens", "LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, "
             + "LITERAL_IF, LITERAL_ELSE, CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, "
-            + "LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT, ANNOTATION_DEF");
+            + "LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF");
         final String[] expected = {
             "60:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 26),
             "74:42: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 42),
@@ -460,7 +466,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
         checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, LITERAL_IF, LITERAL_ELSE, "
                 + "LITERAL_DO, LITERAL_WHILE, LITERAL_FOR, STATIC_INIT, "
-                + "INSTANCE_INIT, ANNOTATION_DEF");
+                + "INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF");
         final String[] expected = {
             "7:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
             "8:21: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 21),
@@ -490,7 +496,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", RightCurlyOption.ALONE_OR_SINGLELINE.toString());
         checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, LITERAL_IF, LITERAL_ELSE, "
                 + "LITERAL_DO, LITERAL_WHILE, LITERAL_FOR, STATIC_INIT, "
-                + "INSTANCE_INIT, ANNOTATION_DEF");
+                + "INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF");
         final String[] expected = {
             "12:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 26),
             "21:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
@@ -508,7 +514,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.SAME.toString());
         checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, "
-                + "CTOR_DEF, ANNOTATION_DEF");
+                + "CTOR_DEF, ANNOTATION_DEF, ENUM_DEF");
         final String[] expected = {
             "14:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "19:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
@@ -516,6 +522,9 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "33:29: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 29),
             "39:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "42:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "49:20: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 20),
+            "55:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "58:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
         };
         verify(checkConfig, getPath("InputRightCurlySameBlocksWithSemi.java"), expected);
     }
@@ -525,7 +534,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
         checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, "
-                + "CTOR_DEF, ANNOTATION_DEF");
+                + "CTOR_DEF, ANNOTATION_DEF, ENUM_DEF");
         final String[] expected = {
             "11:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
             "14:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
@@ -538,6 +547,11 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "39:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "42:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "44:61: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 61),
+            "46:19: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 19),
+            "49:20: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 20),
+            "51:34: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 34),
+            "55:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "58:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
         };
         verify(checkConfig, getPath("InputRightCurlyAloneBlocksWithSemi.java"), expected);
     }
@@ -548,7 +562,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option",
                 RightCurlyOption.ALONE_OR_SINGLELINE.toString());
         checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, "
-                + "CTOR_DEF, ANNOTATION_DEF");
+                + "CTOR_DEF, ANNOTATION_DEF, ENUM_DEF");
         final String[] expected = {
             "14:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "19:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
@@ -556,9 +570,48 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "33:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
             "39:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "42:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "49:20: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 20),
+            "55:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "58:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
         };
         verify(checkConfig,
                 getPath("InputRightCurlyAloneOrSingleLineBlocksWithSemi.java"), expected);
+    }
+
+    @Test
+    public void testNewTokensAlone() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
+        checkConfig.addAttribute("tokens", "ENUM_DEF");
+        final String[] expected = {
+            "11:19: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 19),
+            "14:20: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 20),
+            "16:34: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 34),
+        };
+        verify(checkConfig, getPath("InputRightCurlyAloneNewTokens.java"), expected);
+    }
+
+    @Test
+    public void testNewTokensAloneOrSingleLine() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option",
+                RightCurlyOption.ALONE_OR_SINGLELINE.toString());
+        checkConfig.addAttribute("tokens", "ENUM_DEF");
+        final String[] expected = {
+            "14:20: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 20),
+        };
+        verify(checkConfig, getPath("InputRightCurlyAloneOrSingleLineNewTokens.java"), expected);
+    }
+
+    @Test
+    public void testNewTokensSame() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option", RightCurlyOption.SAME.toString());
+        checkConfig.addAttribute("tokens", "ENUM_DEF");
+        final String[] expected = {
+            "14:20: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 20),
+        };
+        verify(checkConfig, getPath("InputRightCurlySameNewTokens.java"), expected);
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneBlocksWithSemi.java
@@ -1,7 +1,7 @@
 /*
  * Config:
  * option = alone
- * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_DEF
+ * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_DEF, ENUM_DEF
  */
 
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
@@ -42,5 +42,19 @@ public class InputRightCurlyAloneBlocksWithSemi {
     }; //violation
 
     public @interface TestAnnotation9 { String someValue(); }; //violation
+
+    enum TestEnum{}; //violation
+
+    enum TestEnum1{
+        SOME_VALUE;}; //violation
+
+    enum TestEnum2 { SOME_VALUE; }; //violation
+
+    enum TestEnum3{
+        SOME_VALUE;
+    }; //violation
+
+    enum TestEnum4{ SOME_VALUE;
+    }; //violation
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneNewTokens.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneNewTokens.java
@@ -1,0 +1,24 @@
+/*
+ * Config:
+ * option = alone
+ * tokens = ENUM_DEF
+ */
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyAloneNewTokens {
+
+    enum TestEnum{} //violation
+
+    enum TestEnum1{
+        SOME_VALUE;} //violation
+
+    enum TestEnum2 { SOME_VALUE; } //violation
+
+    enum TestEnum3{
+        SOME_VALUE;
+    }
+
+    enum TestEnum4{ SOME_VALUE;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLineBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLineBlocksWithSemi.java
@@ -1,7 +1,7 @@
 /*
  * Config:
  * option = alone_or_singleline
- * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_DEF
+ * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_DEF, ENUM_DEF
  */
 
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
@@ -42,4 +42,18 @@ public class InputRightCurlyAloneOrSingleLineBlocksWithSemi {
     }; //violation
 
     public @interface TestAnnotation9 { String someValue(); };
+
+    enum TestEnum{};
+
+    enum TestEnum1{
+        SOME_VALUE;}; //violation
+
+    enum TestEnum2 { SOME_VALUE; };
+
+    enum TestEnum3{
+        SOME_VALUE;
+    }; //violation
+
+    enum TestEnum4{ SOME_VALUE;
+    }; //violation
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLineNewTokens.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLineNewTokens.java
@@ -1,0 +1,24 @@
+/*
+ * Config:
+ * option = alone_or_singleline
+ * tokens = ENUM_DEF
+ */
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyAloneOrSingleLineNewTokens {
+
+    enum TestEnum{}
+
+    enum TestEnum1{
+        SOME_VALUE;} //violation
+
+    enum TestEnum2 { SOME_VALUE; }
+
+    enum TestEnum3{
+        SOME_VALUE;
+    }
+
+    enum TestEnum4{ SOME_VALUE;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeft.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeft.java
@@ -83,7 +83,7 @@ class InputRightCurlyLeft
     {
         HELLO,
         GOODBYE
-    };
+    }; //violation
 
     void method2()
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySame.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySame.java
@@ -30,20 +30,33 @@ public class InputRightCurlySame {
         }
     }
 
-    public void function(){};
+    public void function() {
+    }
 
-    public class TestClass {};
+    ;
 
-    public void testMethod() {};
+    public class TestClass {
+    }
 
-    public @interface TestAnnotation {}
+    ;
 
-    public @interface TestAnnotation1 { String someValue(); }
+    public void testMethod() {
+    }
+
+    ;
+
+    public @interface TestAnnotation {
+    }
+
+    public @interface TestAnnotation1 {
+        String someValue();
+    }
 
     public @interface TestAnnotation3 {
         String someValue();
     }
 
-    public @interface TestAnnotation4 {String someValue();
+    public @interface TestAnnotation4 {
+        String someValue();
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySameBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySameBlocksWithSemi.java
@@ -1,7 +1,7 @@
 /*
  * Config:
  * option = same
- * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_DEF
+ * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_DEF, ENUM_DEF
  */
 
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
@@ -42,4 +42,18 @@ public class InputRightCurlySameBlocksWithSemi {
     }; //violation
 
     public @interface TestAnnotation9 { String someValue(); };
+
+    enum TestEnum{};
+
+    enum TestEnum1{
+        SOME_VALUE;}; //violation
+
+    enum TestEnum2 { SOME_VALUE; };
+
+    enum TestEnum3{
+        SOME_VALUE;
+    }; //violation
+
+    enum TestEnum4{ SOME_VALUE;
+    }; //violation
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySameNewTokens.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySameNewTokens.java
@@ -1,0 +1,24 @@
+/*
+ * Config:
+ * option = same
+ * tokens = ENUM_DEF
+ */
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlySameNewTokens {
+
+    enum TestEnum{}
+
+    enum TestEnum1{
+        SOME_VALUE;} //violation
+
+    enum TestEnum2 { SOME_VALUE; }
+
+    enum TestEnum3{
+        SOME_VALUE;
+    }
+
+    enum TestEnum4{ SOME_VALUE;
+    }
+}

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -944,7 +944,7 @@ allowedFuture.addCallback(result -> {
           Checks the placement of right curly braces (<code>'}'</code>)
           for if-else, try-catch-finally blocks, while-loops, for-loops,
           method definitions, class definitions, constructor definitions,
-          instance, static initialization blocks and annotation definitions.
+          instance, static initialization blocks, annotation definitions and enum definitions.
           For right curly brace of expression blocks please follow issue
           <a href="https://github.com/checkstyle/checkstyle/issues/5945">#5945</a>.
         </p>
@@ -1011,8 +1011,10 @@ allowedFuture.addCallback(result -> {
                   INSTANCE_INIT</a>,
               <a
                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                  ANNOTATION_DEF</a>.</td>
-
+                  ANNOTATION_DEF</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>.</td>
               <td><a
                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
                   LITERAL_TRY</a>,


### PR DESCRIPTION
ENUM_DEF support added in RightCurlyCheck. Fix #7161.

Regression Report: 
https://sd1998.github.io/checkstyle-regression/Fix-7161/index.html

Base config:
https://sd1998.github.io/checkstyle-regression/Fix-7161/base_config.xml

Patch config:
https://sd1998.github.io/checkstyle-regression/Fix-7161/patch_config.xml

Regression Repo:
https://github.com/sd1998/checkstyle-regression/tree/master/Fix-7161