### PR TITLE
config: fix Travis items to do more jdk11 and jdk12 builds

### DIFF
--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -73,7 +73,7 @@ osx-jdk12-package)
   exclude3="!TokenUtilTest#testTokenValueIncorrect2,"
   exclude4="!ImportControlLoaderPowerTest#testInputStreamThatFailsOnClose"
   export JAVA_HOME=$(/usr/libexec/java_home)
-  mvn -e package -Dlinkcheck.skip=true -Dtest=${exclude1}${exclude2}${exclude3}${exclude4}
+  mvn -e package -Dtest=*,${exclude1}${exclude2}${exclude3}${exclude4}
   ;;
 
 osx-jdk12-assembly)
@@ -105,15 +105,20 @@ javac8)
   done
   ;;
 
-jdk12)
-  # powermock doesn't support modifying final fields in JDK12
-  exclude1="\!FileContentsTest#testGetJavadocBefore,\!FileTextTest#testFindLine*,"
-  exclude2="\!MainFrameModelPowerTest#testOpenFileWithUnknownParseMode,"
-  exclude3="\!TokenUtilTest#testTokenValueIncorrect2,"
-  exclude4="\!ImportControlLoaderPowerTest#testInputStreamThatFailsOnClose"
+jdk12-assembly-site)
+  mvn -e package -Passembly
+  mvn -e site -Pno-validations
+  ;;
 
-  mvn -e package -Passembly -Dtest=$exclude1$exclude2$exclude3$exclude4
-  mvn -e site -Dlinkcheck.skip=true
+jdk12-verify-limited)
+  # powermock doesn't support modifying final fields in JDK12, so need jacoco skip
+  exclude1="!FileContentsTest#testGetJavadocBefore,!FileTextTest#testFindLine*,"
+  exclude2="!MainFrameModelPowerTest#testOpenFileWithUnknownParseMode,"
+  exclude3="!TokenUtilTest#testTokenValueIncorrect2,"
+  exclude4="!ImportControlLoaderPowerTest#testInputStreamThatFailsOnClose"
+  # we skip pmd and spotbugs as they executed in special Travis build
+  mvn -e verify -Dtest=*,$exclude1$exclude2$exclude3$exclude4 -Djacoco.skip=true \
+    -Dpmd.skip=true -Dspotbugs.skip=true
   ;;
 
 nondex)

--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -64,7 +64,7 @@ osx-assembly)
 
 osx-package)
   export JAVA_HOME=$(/usr/libexec/java_home)
-  mvn -e package -Dlinkcheck.skip=true
+  mvn -e package
   ;;
 
 osx-jdk12-package)
@@ -77,11 +77,7 @@ osx-jdk12-package)
   ;;
 
 osx-jdk12-assembly)
-  exclude1="!FileContentsTest#testGetJavadocBefore,!FileTextTest#testFindLine*,"
-  exclude2="!MainFrameModelPowerTest#testOpenFileWithUnknownParseMode,"
-  exclude3="!TokenUtilTest#testTokenValueIncorrect2,"
-  export JAVA_HOME=$(/usr/libexec/java_home)
-  mvn -e package -Passembly -Dtest=${exclude1}${exclude2}${exclude3}
+  mvn -e package -Passembly
   ;;
 
 site)

--- a/.travis.yml
+++ b/.travis.yml
@@ -264,7 +264,14 @@ matrix:
       env:
         - DESC="build with OpenJDK12"
         - USE_MAVEN_REPO="true"
-        - CMD="./.ci/travis/travis.sh jdk12"
+        - CMD="./.ci/travis/travis.sh jdk12-assembly-site"
+
+    # OpenJDK12 verify limited
+    - jdk: openjdk12
+      env:
+        - DESC="verify limited with OpenJDK12"
+        - USE_MAVEN_REPO="true"
+        - CMD="./.ci/travis/travis.sh jdk12-verify-limited"
 
     # OpenJDK9 compile input files with jdk9 specific syntax
     - jdk: openjdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -245,24 +245,17 @@ matrix:
         - CMD="./.ci/travis/travis.sh versions"
         - SKIP_JOB_BY_FILES="false"
 
-    # OpenJDK9 build
-    - jdk: openjdk9
-      env:
-        - DESC="build with OpenJDK9"
-        - USE_MAVEN_REPO="true"
-        - CMD="mvn -e package -Passembly && mvn -e site -Dlinkcheck.skip=true"
-
-    # OpenJDK10 build
-    - jdk: openjdk10
-      env:
-        - DESC="build with OpenJDK10"
-        - USE_MAVEN_REPO="true"
-        - CMD="mvn -e package -Passembly && mvn -e site -Dlinkcheck.skip=true"
-
-    # OpenJDK11 build
+    # OpenJDK11 verify
     - jdk: openjdk11
       env:
-        - DESC="build with OpenJDK11"
+        - DESC="verify with OpenJDK11"
+        - USE_MAVEN_REPO="true"
+        - CMD="mvn -e verify"
+
+    # OpenJDK11 assembly/site
+    - jdk: openjdk11
+      env:
+        - DESC="assembly/site with OpenJDK11"
         - USE_MAVEN_REPO="true"
         - CMD="mvn -e package -Passembly && mvn -e site -Dlinkcheck.skip=true"
 


### PR DESCRIPTION
this is requirements to understand how to deal with #7033 .

it is refactoring and cleanup.
Main points:
1) we do not need jdk9 and jdk10, as jdk11 is available now and it will be our next JDK, we can use only latest jdk in non LTS jdk in travis to keep amount of builds limited.
2) `package -Passembly` do skip of tests as I use this only during release to generate "xxxxx-all.jar" 
3) `-Dlinkcheck.skip=true` it is execution of link check plugin that is running during `site` phase.
4) `\!` is bash is required only when it is used in command line directly, as we keep suppressions in special string constants it is not required. Escaping of it make regex be `\!` - so it simply does not work. I verified this by `-X` execution, and execution of `mvn -e package -Dtest=....` now actually executes tests and skip only defined.
5) `*,` in front of excludes is correct way to configure it - http://maven.apache.org/surefire/maven-surefire-plugin/examples/single-test.html , https://blog.jdriven.com/2017/10/run-one-or-exclude-one-test-with-maven/ , as it is property for what to run, NOT on what to exclude. So we run ALL except for items that are negated by `!`. 