### PR TITLE
Fix #7187: RightCurlyCheck false positives fixed. 

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -246,7 +246,7 @@ public class RightCurlyCheck extends AbstractCheck {
     private static boolean shouldBeAloneOnLineWithNotAloneOption(Details details,
                                                                  String targetSrcLine) {
         return shouldBeAloneOnLineWithAloneOption(details, targetSrcLine)
-                && !isSingleLineBlock(details);
+                && !isBlockAloneOnSingleLine(details);
     }
 
     /**
@@ -286,15 +286,14 @@ public class RightCurlyCheck extends AbstractCheck {
         return rcurly.getParent().getParent().getType() == TokenTypes.INSTANCE_INIT
                 && details.nextToken.getType() == TokenTypes.RCURLY
                 && rcurly.getLineNo() != Details.getNextToken(tokenAfterNextToken).getLineNo();
-
     }
 
     /**
-     * Checks whether block has a single-line format.
+     * Checks whether block has a single-line format and is alone on a line.
      * @param details for validation.
-     * @return true if block has single-line format.
+     * @return true if block has single-line format and is alone on a line.
      */
-    private static boolean isSingleLineBlock(Details details) {
+    private static boolean isBlockAloneOnSingleLine(Details details) {
         final DetailAST rcurly = details.rcurly;
         final DetailAST lcurly = details.lcurly;
         DetailAST nextToken = details.nextToken;
@@ -306,7 +305,17 @@ public class RightCurlyCheck extends AbstractCheck {
             nextToken = Details.getNextToken(doWhileSemi);
         }
         return rcurly.getLineNo() == lcurly.getLineNo()
-                && rcurly.getLineNo() != nextToken.getLineNo();
+                && (rcurly.getLineNo() != nextToken.getLineNo()
+                || isRightcurlyFollowedBySemicolon(details));
+    }
+
+    /**
+     * Checks whether the right curly is followed by a semicolon.
+     * @param details details for validation.
+     * @return true if the right curly is followed by a semicolon.
+     */
+    private static boolean isRightcurlyFollowedBySemicolon(Details details) {
+        return details.nextToken.getType() == TokenTypes.SEMI;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -252,6 +252,12 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "204:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 77),
             "208:76: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 76),
             "216:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
+            "220:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
+            "223:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "225:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
+            "228:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "231:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
+            "234:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
         };
         verify(checkConfig, getPath("InputRightCurlyAnnotations.java"), expected);
     }
@@ -288,7 +294,6 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "161:55: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 55),
             "164:75: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 75),
             "164:76: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 76),
-            "168:80: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 80),
             "164:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 77),
             "176:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
             "182:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
@@ -459,11 +464,8 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "51:53: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 53),
             "53:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
             "53:52: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 52),
-            "61:42: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 42),
-            "63:43: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 43),
-            "67:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "74:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "74:11: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 11),
+            "66:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "66:11: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 11),
         };
         verify(checkConfig, getPath("InputRightCurlyAlone.java"),
                 expected);
@@ -481,12 +483,54 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "29:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "38:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "42:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
-            "63:43: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 43),
-            "67:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "71:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
+            "63:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
         };
         verify(checkConfig, getPath(
                 "InputRightCurlyAloneOrSingleLine2.java"), expected);
+    }
+
+    @Test
+    public void testBlocksEndingWithSemiOptionSame() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option", RightCurlyOption.SAME.toString());
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF");
+        final String[] expected = {
+            "14:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "19:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "25:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+        };
+        verify(checkConfig, getPath("InputRightCurlySameBlocksWithSemi.java"), expected);
+    }
+
+    @Test
+    public void testBlocksEndingWithSemiOptionAlone() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF");
+        final String[] expected = {
+            "11:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
+            "14:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "16:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
+            "19:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "22:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
+            "25:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+        };
+        verify(checkConfig, getPath("InputRightCurlyAloneBlocksWithSemi.java"), expected);
+    }
+
+    @Test
+    public void testBlocksEndingWithSemiOptionAloneOrSingleLine() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option",
+                RightCurlyOption.ALONE_OR_SINGLELINE.toString());
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF");
+        final String[] expected = {
+            "14:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "19:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "25:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+        };
+        verify(checkConfig,
+                getPath("InputRightCurlyAloneOrSingleLineBlocksWithSemi.java"), expected);
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAlone.java
@@ -58,14 +58,6 @@ public class InputRightCurlyAlone {
                 .collect(java.util.stream.Collectors.toList());
     }
 
-    class TestClass { private int field; }  //violation
-
-    class TestClass2 { private int field; };  //violation
-
-    class TestClass3 {
-        private int field;
-    };  //violation
-
     void method6(int a) {
         java.util.Map<String, String> map3 = new java.util.LinkedHashMap<String, String>() {{
             put("Hello", "World");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneBlocksWithSemi.java
@@ -1,0 +1,32 @@
+/*
+ * Config:
+ * option = alone
+ * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF
+ */
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyAloneBlocksWithSemi {
+
+    public void testMethod() {}; //violation
+
+    public void testMethod1() {
+    }; //violation
+
+    public class TestClass {}; //violation
+
+    public class TestClass1 {
+    }; //violation
+
+    public class TestClass2 {
+        public TestClass2() {}; //violation
+
+        public TestClass2(String someValue) {
+        }; //violation
+    }
+
+    public void testMethod11() {
+    }
+    ;
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLine2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLine2.java
@@ -58,15 +58,7 @@ public class InputRightCurlyAloneOrSingleLine2 {
                 .collect(java.util.stream.Collectors.toList());
     }
 
-    class TestClass { private int field; }
-
-    class TestClass2 { private int field; };  //violation
-
-    class TestClass3 {
-        private int field;
-    };  //violation
-
     class TestClass4 { }
 
-    class TestClass5 { } { }
+    class TestClass5 { } { } //violation
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLineBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLineBlocksWithSemi.java
@@ -1,0 +1,31 @@
+/*
+ * Config:
+ * option = alone_or_singleline
+ * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF
+ */
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyAloneOrSingleLineBlocksWithSemi {
+
+    public void testMethod() {};
+
+    public void testMethod1() {
+    }; //violation
+
+    public class TestClass {};
+
+    public class TestClass1 {
+    }; //violation
+
+    public class TestClass2 {
+        public TestClass2() {};
+
+        public TestClass2(String someValue) {
+        }; //violation
+    }
+
+    public void testMethod11() {
+    }
+    ;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAnnotations.java
@@ -216,4 +216,21 @@ class InputRightCurlyAnnotations
             flag = !flag; } String.CASE_INSENSITIVE_ORDER. //violation
             equals("Xe-xe");
     }
+
+    public void testMethod() {}; //violation
+
+    public void testMethod1() {
+    }; //violation
+
+    public class TestClass {}; //violation
+
+    public class TestClass1 {
+    }; //violation
+
+    public class TestClass2 {
+        public TestClass2() {}; //violation
+
+        public TestClass2(String someValue) {
+        }; //violation
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySame.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySame.java
@@ -29,4 +29,10 @@ public class InputRightCurlySame {
         for (; ; ) {
         }
     }
+
+    public void function(){};
+
+    public class TestClass {};
+
+    public void testMethod() {};
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySameBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySameBlocksWithSemi.java
@@ -1,0 +1,31 @@
+/*
+ * Config:
+ * option = same
+ * tokens = CLASS_DEF, METHOD_DEF, CTOR_DEF
+ */
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlySameBlocksWithSemi {
+
+    public void testMethod() {};
+
+    public void testMethod1() {
+    }; //violation
+
+    public class TestClass {};
+
+    public class TestClass1 {
+    }; //violation
+
+    public class TestClass2 {
+        public TestClass2() {};
+
+        public TestClass2(String someValue) {
+        }; //violation
+    }
+
+    public void testMethod11() {
+    }
+    ;
+}


### PR DESCRIPTION
Fix for issue #7187.
This PR is blocker for PR #7039 .
 
RightCurlyCheck false positives fixed.  For various tokens like `CLASS_DEF`, `METHOD_DEF` etc.

Regression report: 
https://sd1998.github.io/checkstyle-regression/Fix-7187/index.html

Base Config:
https://sd1998.github.io/checkstyle-regression/Fix-7187/base_config.xml

Patch Config:
https://sd1998.github.io/checkstyle-regression/Fix-7187/patch_config.xml

Report repository:
https://github.com/sd1998/checkstyle-regression/tree/master/Fix-7187