### PR TITLE
WIP: Issue #3744: Handle slashes on Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -805,6 +805,7 @@
                 <rule>
                   <element>CLASS</element>
                   <excludes>
+                    <exclude>com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement</exclude>
                     <!-- Parser related classes -->
                     <exclude>
                       com.puppycrawl.tools.checkstyle.grammar.GeneratedJavaRecognizer
@@ -936,6 +937,26 @@
                       <counter>BRANCH</counter>
                       <value>COVEREDRATIO</value>
                       <minimum>1.00</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+                <rule>
+                  <element>CLASS</element>
+                  <includes>
+                    <include>
+                      com.puppycrawl.tools.checkstyle.filters.SuppressFilterElement
+                    </include>
+                  </includes>
+                  <limits>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>1.00</minimum>
+                    </limit>
+                    <limit>
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.96</minimum>
                     </limit>
                   </limits>
                 </rule>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElementTest.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -199,6 +201,31 @@ public class SuppressFilterElementTest {
     }
 
     @Test
+    public void testCheckForwardSlashedPath() {
+        // This test can only run on windows.
+        if (File.separatorChar == '\\') {
+            final LocalizedMessage message =
+                    new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
+            final AuditEvent ev = new AuditEvent(this, "path\\to\\ATest.java", message);
+            final SuppressFilterElement myFilter =
+                    new SuppressFilterElement("path/to/", null, null, null, null, null);
+            assertFalse("Filter should not accept invalid event", myFilter.accept(ev));
+        }
+    }
+
+    @Test
+    public void testCheckForwardSlashedPathMiss() {
+        final LocalizedMessage message =
+                new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
+        final AuditEvent ev = new AuditEvent(this, "path\\to\\ATest.java", message);
+        System.setProperty("com.puppycrawl.convertFilePathToForwardSlashedOnMismatch", "false");
+        final SuppressFilterElement myFilter =
+                new SuppressFilterElement("path/to/", null, null, null, null, null);
+        System.clearProperty("com.puppycrawl.convertFilePathToForwardSlashedOnMismatch");
+        assertTrue("Filter should not accept invalid event", myFilter.accept(ev));
+    }
+
+    @Test
     public void testEquals() {
         // filterBased is used instead of filter field only to satisfy IntelliJ IDEA Inspection
         // Inspection "Arguments to assertEquals() in wrong order "
@@ -227,6 +254,12 @@ public class SuppressFilterElementTest {
         assertEquals("filter, filter2", filterBased2, filter23);
         assertNotEquals("filter, filter2", filterBased2, filter2);
         assertEquals("filter, filter2", filterBased2, filter23);
+
+        System.setProperty("com.puppycrawl.convertFilePathToForwardSlashedOnMismatch", "false");
+        final SuppressFilterElement filter4 =
+                new SuppressFilterElement("Test", "Test", null, null, null, null);
+        assertNotEquals("filter, filter2", filterBased, filter4);
+        System.clearProperty("com.puppycrawl.convertFilePathToForwardSlashedOnMismatch");
     }
 
     @Test


### PR DESCRIPTION
This is a WIP for #3744. 

If on windows (or rather if `File.separatorChar == '\\'`) any failed suppression file matches will retry with all backslashes in the path replaced with forward slashes.

The plan is to use this to test performance to determine if this can be enabled by default and what kind of toggle is needed to turn this feature off.

I've tested performance on my employers main project and couldn't see any significant difference in runtimes (If anything 8.26-SNAPSHOT is faster than 8.25, but that could be other changes since the last release).
(Did five runs of each version and sorted the runtimes.)

>Checkstyle 8.25
>15.237 s
>15.990 s
>16.133 s
>16.497 s
>17.905 s

>Checkstyle 8.26-SNAPSHOT, unmodified suppressions (still using `[/\\]` in paths)
>15.164 s
>15.399 s
>15.757 s
>15.776 s
>16.063 s

>Checkstyle 8.26-SNAPSHOT, modified suppressions (replaced `[/\\]` with `/` in paths) 
>14.941 s
>15.344 s
>15.480 s
>15.654 s
>16.889 s

However that project might not be the best test case for this change.
Anyone have a good candidate project to do performance tests on?
Let me know and can run some more tests.
