### PR TITLE
Issue #6743: fixed unused param not reported when missing description

### DIFF
--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -47,7 +47,7 @@ no-error-orekit)
   # no CI is enforced in project, so to make our build stable we should
   # checkout to latest release/development (annotated tag or hash)
   # git checkout $(git describe --abbrev=0 --tags)
-  git checkout 3a9787ec3f166bd770f9c119cd7724f57
+  git checkout 973d1bd3e4532d2c1d3a7c28136e2713bd057542
   mvn -e compile checkstyle:check -Dorekit.checkstyle.version=${CS_POM_VERSION}
   cd ../
   rm -rf Orekit

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -115,9 +115,6 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             "78:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "Unneeded"),
             "79: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL),
             "87:8: " + getCheckMessage(MSG_DUPLICATE_TAG, "@return"),
-            "109:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
-            "109:55: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aFour"),
-            "109:66: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aFive"),
             "178:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "ThreadDeath"),
             "179:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "ArrayStoreException"),
             "236:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "java.io.FileNotFoundException"),
@@ -128,7 +125,6 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             "305:22: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aParam"),
             "344:5: " + getCheckMessage(MSG_INVALID_INHERIT_DOC),
             "383:8: " + getCheckMessage(MSG_DUPLICATE_TAG, "@return"),
-            "389:37: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "algorithm"),
         };
 
         verify(checkConfig, getPath("InputJavadocMethodTags.java"), expected);
@@ -155,9 +151,6 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             "78:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "Unneeded"),
             "79: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL),
             "87:8: " + getCheckMessage(MSG_DUPLICATE_TAG, "@return"),
-            "109:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
-            "109:55: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aFour"),
-            "109:66: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aFive"),
             "236:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "java.io.FileNotFoundException"),
             "254:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "java.io.FileNotFoundException"),
             "256:28: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IOException"),
@@ -166,7 +159,6 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             "305:22: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aParam"),
             "344:5: " + getCheckMessage(MSG_INVALID_INHERIT_DOC),
             "383:8: " + getCheckMessage(MSG_DUPLICATE_TAG, "@return"),
-            "389:37: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "algorithm"),
         };
         verify(checkConfig, getPath("InputJavadocMethodTags.java"), expected);
     }
@@ -250,9 +242,6 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             "78:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "Unneeded"),
             "79: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL),
             "87:8: " + getCheckMessage(MSG_DUPLICATE_TAG, "@return"),
-            "109:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aOne"),
-            "109:55: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aFour"),
-            "109:66: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aFive"),
             "178:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "ThreadDeath"),
             "179:8: " + getCheckMessage(MSG_UNUSED_TAG, "@throws", "ArrayStoreException"),
             "256:28: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IOException"),
@@ -261,7 +250,6 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             "305:22: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aParam"),
             "344:5: " + getCheckMessage(MSG_INVALID_INHERIT_DOC),
             "383:8: " + getCheckMessage(MSG_DUPLICATE_TAG, "@return"),
-            "389:37: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "algorithm"),
         };
         verify(checkConfig, getPath("InputJavadocMethodTags.java"), expected);
     }
@@ -350,6 +338,23 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             "55:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "<Z>"),
         };
         verify(checkConfig, getPath("InputJavadocMethodTypeParamsTags.java"), expected);
+    }
+
+    @Test
+    public void testAllowUndocumentedParamsTags() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(JavadocMethodCheck.class);
+        final String[] expected = {
+            "17:6: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "unexpectedParam"),
+            "18:6: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "unexpectedParam2"),
+            "20:13: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "unexpectedParam3"),
+            "21:6: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "unexpectedParam4"),
+            "49:7: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "t"),
+            "51:34: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "w"),
+            "60:7: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
+            "61:34: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "y"),
+
+        };
+        verify(checkConfig, getPath("InputJavadocMethodParamsTags.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodParamsTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodParamsTags.java
@@ -1,0 +1,65 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+public class InputJavadocMethodParamsTags {
+
+  /**
+   * A method with an undocumented param and a missing param.
+   * Checkstyle should at least
+   * missingParam, ideally would be nice to have a flag to report
+   * also undocumentedParam
+   *
+   * @param param1 some text
+   * @param param2
+   *                some text for param2 (without space at the end of line)
+   * @param param3
+   *                some text for param3 (with space at the end of line)
+   *
+   * @param unexpectedParam
+   * @param unexpectedParam2
+   *                some text for unexpectedParam2 (without space in the end of line)
+   *        @param unexpectedParam3
+     @param unexpectedParam4
+   */
+  void testEmpty(Object param1, Object param2, Object param3) {
+
+  }
+
+  /**
+   * Set the path to use by reference.
+   *
+   * @param r
+   *            a reference to an
+               existing path */
+  public void setPathRef(Object r) {
+
+  }
+
+  /** @param s
+   a reference to an existing path */
+  public void setPathRef2(Object s) {
+
+  }
+
+  /** @param k
+    */
+  public void setPathRef3(Object k) {
+
+  }
+
+  /** @param t
+   */
+  public void setPathRef4(Object w) {
+
+  }
+
+  /** @param z*/
+  public void setPathRef5(Object z) {
+
+  }
+
+  /** @param x*/
+  public void setPathRef6(Object y) {
+
+  }
+
+}


### PR DESCRIPTION
Added one regexp to check params without docs and test from issue #6743, fixed failed tests, removed unused code.

Checkstyle tester diff report for this branch available here
https://tirex.github.io/checkstyle/diff/