### PR TITLE
Issue #6210: Use lineWrappingIndentation in multiline method call

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java
@@ -19,10 +19,14 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
+import static com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck.MSG_CHILD_ERROR;
+import static com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck.MSG_ERROR;
+
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractIndentationTestSupport;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class IndentationTest extends AbstractIndentationTestSupport {
@@ -104,6 +108,33 @@ public class IndentationTest extends AbstractIndentationTestSupport {
 
         final Configuration checkConfig = getModuleConfig("Indentation");
         final String filePath = getPath("InputIndentationCorrectWhileDoWhileAndParameter.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void testCorrectChained() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        final Configuration checkConfig = getModuleConfig("Indentation");
+        final String filePath = getPath("ClassWithChainedMethodsCorrect.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void testWarnChained() throws Exception {
+        final String[] expected = {
+            "18: " + getCheckMessage(IndentationCheck.class, MSG_CHILD_ERROR, "method call", 4, 8),
+            "23: " + getCheckMessage(IndentationCheck.class, MSG_ERROR, ".", 4, 8),
+            "24: " + getCheckMessage(IndentationCheck.class, MSG_ERROR, ".", 4, 8),
+            "27: " + getCheckMessage(IndentationCheck.class, MSG_ERROR, "new", 4, 8),
+        };
+
+        final Configuration checkConfig = getModuleConfig("Indentation");
+        final String filePath = getPath("ClassWithChainedMethods.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/ClassWithChainedMethods.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/ClassWithChainedMethods.java
@@ -1,0 +1,32 @@
+package com.google.checkstyle.test.chapter4formatting.rule4841indentation; //indent:0 exp:0
+
+public class ClassWithChainedMethods { //indent:0 exp:0
+
+  public ClassWithChainedMethods(Object... params) { //indent:2 exp:2
+  } //indent:2 exp:2
+
+  public String doNothing(String something, String... uselessParams) { //indent:2 exp:2
+    return something; //indent:4 exp:4
+  } //indent:2 exp:2
+
+  public ClassWithChainedMethods getInstance(String... uselessParams) { //indent:2 exp:2
+    return this; //indent:4 exp:4
+  } //indent:2 exp:2
+
+  public static void main(String[] args) { //indent:2 exp:2
+    new ClassWithChainedMethods().getInstance("string_one") //indent:4 exp:4
+    .doNothing("string_one".trim(), //indent:4 exp:8 warn
+               "string_two"); //indent:15 exp:>=8
+
+    int length = new ClassWithChainedMethods("param1", //indent:4 exp:4
+                                "param2").getInstance() //indent:32 exp:>=8
+    .doNothing("nothing") //indent:4 exp:>=8 warn
+    .length(); //indent:4 exp:>=8 warn
+
+    int length2 =  //indent:4 exp:4
+    new ClassWithChainedMethods("param1","param2") //indent:4 exp:>=8 warn
+        .getInstance() //indent:8 exp:8
+        .doNothing("nothing") //indent:8 exp:8
+        .length(); //indent:8 exp:8
+  } //indent:2 exp:2
+} //indent:0 exp:0

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/ClassWithChainedMethodsCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/ClassWithChainedMethodsCorrect.java
@@ -1,0 +1,36 @@
+package com.google.checkstyle.test.chapter4formatting.rule4841indentation;  //indent:0 exp:0
+
+public class ClassWithChainedMethodsCorrect { //indent:0 exp:0
+  public ClassWithChainedMethodsCorrect() { //indent:2 exp:2
+
+    String someString = ""; //indent:4 exp:4
+
+    String chained1 = //indent:4 exp:4
+        doNothing( //indent:8 exp:8
+            someString //indent:12 exp:12
+                .concat("zyx" //indent:16 exp:16
+                ) //indent:16 exp:16
+                .concat("255, 254, 253" //indent:16 exp:16
+                ) //indent:16 exp:16
+        ); //indent:8 exp:8
+
+    doNothing( //indent:4 exp:4
+        someString //indent:8 exp:8
+            .concat("zyx" //indent:12 exp:12
+            ) //indent:12 exp:12
+            .concat("255, 254, 253" //indent:12 exp:12
+            ) //indent:12 exp:12
+    ); //indent:4 exp:4
+
+  } //indent:2 exp:2
+
+  public String doNothing(String something) { //indent:2 exp:2
+    return something; //indent:4 exp:4
+  } //indent:2 exp:2
+
+  public static void main(String[] args) { //indent:2 exp:2
+    ClassWithChainedMethodsCorrect classWithChainedMethodsCorrect = //indent:4 exp:4
+        new ClassWithChainedMethodsCorrect(); //indent:8 exp:8
+  } //indent:2 exp:2
+
+} //indent:0 exp:0

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -57,7 +57,8 @@ public class MethodCallHandler extends AbstractExpressionHandler {
             // we should increase indentation only if this is the first
             // chained method call which was moved to the next line
             else {
-                indentLevel = new IndentLevel(container.getIndent(), getBasicOffset());
+                indentLevel = new IndentLevel(container.getIndent(),
+                    getIndentCheck().getLineWrappingIndentation());
             }
         }
         else if (getMainAst().getFirstChild().getType() == TokenTypes.LITERAL_NEW) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -2016,6 +2016,30 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         verifyWarns(checkConfig, getPath("InputIndentationNewHandler.java"), expected);
     }
 
+    @Test
+    public void testChainedMethodWithBracketOnNewLine() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+
+        checkConfig.addAttribute("arrayInitIndent", "2");
+        checkConfig.addAttribute("basicOffset", "2");
+        checkConfig.addAttribute("braceAdjustment", "0");
+        checkConfig.addAttribute("caseIndent", "2");
+        checkConfig.addAttribute("forceStrictCondition", "false");
+        checkConfig.addAttribute("lineWrappingIndentation", "4");
+        checkConfig.addAttribute("tabWidth", "2");
+        checkConfig.addAttribute("throwsIndent", "2");
+        final String[] expected = {
+            "44: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 6, 8),
+            "45: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 8, 10),
+            "47: " + getCheckMessage(MSG_ERROR, "method call rparen", 6, 8),
+            "61: " + getCheckMessage(MSG_ERROR, "foo", 5, 8),
+            "82: " + getCheckMessage(MSG_ERROR, "if rcurly", 4, 6),
+            "84: " + getCheckMessage(MSG_CHILD_ERROR, "method def", 2, 4),
+        };
+        final String fileName = "InputIndentationChainedMethodWithBracketOnNewLine.java";
+        verifyWarns(checkConfig, getPath(fileName), expected);
+    }
+
     private static final class IndentAudit implements AuditListener {
 
         private final IndentComment[] comments;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationChainedMethodWithBracketOnNewLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationChainedMethodWithBracketOnNewLine.java
@@ -1,0 +1,91 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
+
+/**                                                                        //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration://indent:1 exp:1
+ *                                                                         //indent:1 exp:1
+ * arrayInitIndent = 2                                                     //indent:1 exp:1
+ * basicOffset = 2                                                         //indent:1 exp:1
+ * braceAdjustment = 0                                                     //indent:1 exp:1
+ * caseIndent = 2                                                          //indent:1 exp:1
+ * forceStrictCondition = false                                            //indent:1 exp:1
+ * lineWrappingIndentation = 4                                             //indent:1 exp:1
+ * tabWidth = 2                                                            //indent:1 exp:1
+ * throwsIndent = 2                                                        //indent:1 exp:1
+ *                                                                         //indent:1 exp:1
+ *                                                                         //indent:1 exp:1
+ */                                                                        //indent:1 exp:1
+
+public class InputIndentationChainedMethodWithBracketOnNewLine {           //indent:0 exp:0
+
+  InputIndentationChainedMethodWithBracketOnNewLine indentation(           //indent:2 exp:2
+      Object... args) {                                                    //indent:6 exp:6
+    return this;                                                           //indent:4 exp:4
+  }                                                                        //indent:2 exp:2
+
+  InputIndentationChainedMethodWithBracketOnNewLine thenReturn(            //indent:2 exp:2
+      InnerClass innerClass) {                                             //indent:6 exp:6
+    return this;                                                           //indent:4 exp:4
+  }                                                                        //indent:2 exp:2
+
+  static InputIndentationChainedMethodWithBracketOnNewLine when() {        //indent:2 exp:2
+    return new InputIndentationChainedMethodWithBracketOnNewLine();        //indent:4 exp:4
+  }                                                                        //indent:2 exp:2
+
+  public static void main(String[] args) {                                 //indent:2 exp:2
+    InputIndentationChainedMethodWithBracketOnNewLine i =                  //indent:4 exp:4
+        new InputIndentationChainedMethodWithBracketOnNewLine();           //indent:8 exp:8
+    i.indentation()                                                        //indent:4 exp:4
+        .indentation(                                                      //indent:8 exp:8
+            "a",                                                           //indent:12 exp:12
+            "b"                                                            //indent:12 exp:12
+        );                                                                 //indent:8 exp:8
+
+    i.indentation()                                                        //indent:4 exp:4
+      .indentation(                                                        //indent:6 exp:8 warn
+        "a",                                                               //indent:8 exp:10 warn
+          "b"                                                              //indent:10 exp:10
+      );                                                                   //indent:6 exp:8 warn
+    when()                                                                 //indent:4 exp:4
+        .thenReturn(                                                       //indent:8 exp:8
+            new InnerClass("response", "{\n" +                             //indent:12 exp:12
+                                       "  \"query\": \"someValue\"\n" +    //indent:39 exp:39
+                                       "}")                                //indent:39 exp:39
+        );                                                                 //indent:8 exp:8
+    when()                                                                 //indent:4 exp:4
+        .thenReturn(                                                       //indent:8 exp:8
+            new InnerClass("response", "")                                 //indent:12 exp:12
+        );                                                                 //indent:8 exp:8
+    String string1 =                                                       //indent:4 exp:4
+        foo("fooooooooooooooo", 0, false);                                 //indent:8 exp:>=8
+    String string2 =                                                       //indent:4 exp:4
+     foo("fooooooooooooooo", 0, false);                                 //indent:5 exp:>=8 warn
+    when().indentation(new String("foo"),                                  //indent:4 exp:4
+                       "bar");                                             //indent:23 exp:>=8
+    when().                                                                //indent:4 exp:4
+        indentation("a","b");                                              //indent:8 exp:8
+    when().indentation("a")                                                //indent:4 exp:4
+        .indentation("b")                                                  //indent:8 exp:8
+        .indentation("c");                                                 //indent:8 exp:8
+  }                                                                        //indent:2 exp:2
+
+  static String foo (String aStr,                                          //indent:2 exp:2
+        int aNnum, boolean aFlag) {                                        //indent:8 exp:>=6
+
+    if (true && true &&                                                    //indent:4 exp:4
+             true && true) {                                               //indent:13 exp:>=8
+
+      String string2 = foo("fooooooo"                                      //indent:6 exp:6
+              + "oooooooo", 0, false);                                     //indent:14 exp:>=10
+      if (false &&                                                         //indent:6 exp:6
+              false && false) {                                            //indent:14 exp:>=10
+
+    }                                                                      //indent:4 exp:6 warn
+    }                                                                      //indent:4 exp:4
+  return "string";                                                         //indent:2 exp:4 warn
+  }                                                                        //indent:2 exp:2
+
+  public static class InnerClass {                                         //indent:2 exp:2
+    public InnerClass(String param1, String param2) {                      //indent:4 exp:4
+    }                                                                      //indent:4 exp:4
+  }                                                                        //indent:2 exp:2
+}                                                                          //indent:0 exp:0


### PR DESCRIPTION
Issue #6210

regression report: https://alinkov.github.io/full_report/reports/diff/index.html

When we set up different values for **lineWrappingIndentation** and **basicOffset** (these values are different in sun checks and google checks) in some cases we have error `'method call rparen' has incorrect indentation`
For example for code
```java
    when(someService.someMethod(any(), any()))
        .thenReturn(
            new SearchResult("val1", "val2")
        );
```