### PR TITLE
fix release date display

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -62,12 +62,12 @@ h2:hover .anchor, h3:hover .anchor {
   word-wrap: break-word !important;
 }
 
-.section {
+section {
   position: relative;
 }
 
 .releaseDate {
   position: absolute;
-  top: 0;
-  right: 0;
+  top: 2px;
+  right: 6px;
 }


### PR DESCRIPTION
Issue: #7036 

Display release date in upper right corner of release node block:
![image](https://user-images.githubusercontent.com/7516893/68942437-e40a4580-07a8-11ea-8c6e-ab4bff75da62.png)
